### PR TITLE
Add dual-tool (Chrome + Playwright) workflow for job applications

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "neonwatty-plugins",
   "description": "Claude Code plugins by Jeremy Watt",
   "owner": {
@@ -12,9 +13,9 @@
         "source": "github",
         "repo": "neonwatty/job-apply-plugin"
       },
-      "description": "AI-powered job application assistant for LinkedIn, Greenhouse, Ashby, and Workday",
+      "description": "AI-powered job application assistant for LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday",
       "version": "1.0.0",
-      "tags": ["productivity", "job-search", "browser-automation"]
+      "category": "productivity"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "job-apply",
   "version": "1.0.0",
-  "description": "AI-powered job application assistant for LinkedIn Easy Apply, Greenhouse, Ashby, and Workday",
+  "description": "AI-powered job application assistant for LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday",
   "author": {
     "name": "Jeremy Watt",
     "url": "https://github.com/neonwatty"
@@ -13,6 +13,8 @@
     "greenhouse",
     "workday",
     "ashby",
+    "lever",
+    "rippling",
     "browser-automation",
     "resume"
   ],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Job Apply Plugin for Claude Code
 
-AI-powered job application assistant that automatically fills out job applications on LinkedIn Easy Apply, Greenhouse, Ashby, and Workday using browser automation.
+AI-powered job application assistant that automatically fills out job applications on LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday using browser automation.
 
 ## Skills
 
@@ -13,7 +13,8 @@ AI-powered job application assistant that automatically fills out job applicatio
 
 ### Job Apply (`/job-apply`)
 - **One-time profile setup**: Extract your information from a resume (PDF, DOCX, or TXT)
-- **Multi-platform support**: LinkedIn Easy Apply, Greenhouse, Ashby, Workday
+- **Multi-platform support**: LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, Workday
+- **Dual-tool architecture**: Chrome MCP for authenticated sites, Playwright MCP for form filling and file uploads
 - **Smart field mapping**: Automatically matches your profile to form fields
 - **Safety first**: Never submits without your explicit confirmation
 - **Resume storage**: Profile saved locally for reuse across applications
@@ -28,44 +29,15 @@ AI-powered job application assistant that automatically fills out job applicatio
 ## Requirements
 
 - [Claude Code](https://claude.ai/code) CLI
-- [Claude in Chrome](https://chromewebstore.google.com/detail/claude-in-chrome) MCP server for browser automation
+- [Claude in Chrome](https://chromewebstore.google.com/detail/claude-in-chrome) MCP server for authenticated browser sessions (LinkedIn)
+- [Playwright MCP](https://github.com/anthropics/claude-code/tree/main/.claude/plugins/playwright) server for form filling, file uploads, and iframe interaction
 
 ## Installation
 
-### From GitHub Marketplace
-
 ```bash
-/plugin marketplace add neonwatty/job-apply-plugin
-/plugin install job-apply
+claude plugin marketplace add neonwatty/job-apply-plugin
+claude plugin install job-apply-plugin@job-apply
 ```
-
-### Manual Installation
-
-Clone this repository to your local machine:
-
-```bash
-git clone https://github.com/neonwatty/job-apply-plugin.git
-cd job-apply-plugin
-```
-
-Then in Claude Code:
-```bash
-/plugin install /path/to/job-apply-plugin
-```
-
-### Claude Desktop Installation
-
-Claude Desktop requires manual skill upload:
-
-1. **Download the ZIP file** from the [latest release](https://github.com/neonwatty/job-apply-plugin/releases/latest)
-
-2. **Open Claude Desktop** and go to **Settings**
-
-3. **Click "Upload skill"** and select the downloaded `.zip` file
-
-4. **Restart Claude Desktop** to load the skill
-
-> **Note:** Claude Desktop does not have marketplace support. You'll need to manually download updates from the releases page.
 
 ## Usage
 
@@ -131,13 +103,14 @@ Results are automatically saved to `~/.claude-job-searches/`.
 
 ## Supported Platforms
 
-| Platform | URL Pattern | Status |
-|----------|-------------|--------|
-| LinkedIn Easy Apply | `linkedin.com/jobs/view/*` | Supported |
-| Greenhouse | `boards.greenhouse.io/*` | Supported |
-| Ashby | `jobs.ashbyhq.com/*` | Supported |
-| Workday | `*.myworkdayjobs.com/*` | Supported |
-| Lever | `jobs.lever.co/*` | Supported |
+| Platform | URL Pattern | Tool | Status |
+|----------|-------------|------|--------|
+| LinkedIn Easy Apply | `linkedin.com/jobs/view/*` | Chrome MCP | Supported |
+| Greenhouse | `boards.greenhouse.io/*` | Playwright MCP | Supported |
+| Ashby | `jobs.ashbyhq.com/*` | Playwright MCP | Supported |
+| Lever | `jobs.lever.co/*` | Playwright MCP | Supported |
+| Rippling | `*.rippling.com/*` | Playwright MCP | Supported |
+| Workday | `*.myworkdayjobs.com/*` | Playwright MCP | Supported |
 
 ## Profile Storage
 

--- a/skills/job-apply/SKILL.md
+++ b/skills/job-apply/SKILL.md
@@ -1,8 +1,12 @@
+---
+name: job-apply
+description: Fill out job applications automatically using your resume. Use when the user wants to apply for jobs on LinkedIn Easy Apply, Greenhouse, Ashby, or Workday.
+allowed-tools: Read, Write, Bash, mcp__claude-in-chrome__*, mcp__plugin_playwright_playwright__*
+---
+
 # Job Application Assistant
 
-A Claude Code skill for filling job applications on LinkedIn Easy Apply, Greenhouse, and Workday using browser automation.
-
----
+A Claude Code skill for filling job applications on LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday using browser automation.
 
 ## Initial Prompt
 
@@ -44,6 +48,76 @@ Your extracted profile is stored at `~/.claude-job-profile.json` for reuse acros
 
 ---
 
+## Dual-Tool Architecture
+
+This skill uses **two browser automation tools** together because each has capabilities the other lacks:
+
+| Capability | Chrome MCP | Playwright MCP |
+|---|---|---|
+| Authenticated sessions (LinkedIn) | Yes | No — runs a separate browser with no login |
+| File uploads | No — opens OS file picker that can't be controlled | Yes — `setInputFiles` and `browser_file_upload` |
+| Iframe interaction | Limited — can't reliably reach iframe content | Yes — snapshots include iframe elements transparently |
+| JavaScript injection | Yes — `javascript_tool` | Yes — `browser_evaluate` and `browser_run_code` |
+| Dropdown/combobox interaction | Limited | Yes — `browser_fill_form` and `browser_click` |
+
+### Tool Routing Rules
+
+**Use Chrome MCP (`mcp__claude-in-chrome__*`) for:**
+- LinkedIn navigation (requires logged-in session)
+- Any site requiring authentication
+- JavaScript injection to capture external URLs
+- Reading LinkedIn job details
+
+**Use Playwright MCP (`mcp__plugin_playwright_playwright__*`) for:**
+- External application portals (Greenhouse, Ashby, Lever, Rippling, Workday)
+- File uploads (resume, cover letter)
+- Forms embedded in iframes
+- Dropdown and combobox interaction
+- Any form filling on non-authenticated pages
+
+### The Handoff Pattern
+
+1. **Chrome MCP** navigates to the LinkedIn job listing (authenticated)
+2. **Chrome MCP** clicks Apply — if it's an external application, captures the external URL via JavaScript interception
+3. **Playwright MCP** opens the captured URL and fills the form, uploads files, and submits
+
+---
+
+## LinkedIn → External URL Extraction
+
+When a LinkedIn job uses an external application portal, the Apply button opens a new tab. Use JavaScript interception to capture that URL.
+
+### Pattern A: Button with `window.open` (most common)
+
+```javascript
+// Step 1: Set up interceptor in Chrome MCP
+var originalOpen = window.open;
+window.open = function(url, target, features) {
+  document.title = 'CAPTURED:' + url;
+  var w = originalOpen.call(window, url, target, features);
+  return w;
+};
+
+// Step 2: Click the Apply button
+document.querySelector('button.jobs-apply-button').click();
+
+// Step 3: Read document.title — it will start with "CAPTURED:" followed by the URL
+```
+
+### Pattern B: Link with `target="_blank"` (fallback)
+
+```javascript
+// Remove target="_blank" so it navigates in the same tab
+var link = document.querySelector('a.jobs-apply-button');
+link.removeAttribute('target');
+link.click();
+// Read the URL from the Chrome tab after navigation
+```
+
+After capturing the URL, pass it to Playwright MCP via `browser_navigate`.
+
+---
+
 ## Workflow
 
 ### Phase 1: Profile Setup
@@ -59,23 +133,25 @@ If no profile exists at `~/.claude-job-profile.json`, or if the user requests a 
    - `workHistory[]`: array of { company, title, startDate, endDate, current, description }
    - `education[]`: array of { school, degree, field, startDate, endDate, gpa }
    - `skills[]`: array of skill strings
+   - `resumePath`: absolute path to the resume file on disk
 3. **Present extracted data to user** for review and correction
 4. **Save confirmed profile** to `~/.claude-job-profile.json`
 
 ### Phase 2: Application Filling
 
 1. **Load profile** from `~/.claude-job-profile.json`
-2. **Navigate to job URL** using Chrome MCP
-3. **Detect platform type**:
-   - LinkedIn Easy Apply: Look for "Easy Apply" button or modal
-   - Greenhouse: URL contains `boards.greenhouse.io` or `jobs.lever.co`
-   - Workday: URL contains `myworkdayjobs.com` or `wd5.myworkdaycdn.com`
-4. **Read the form structure** using `read_page` tool
-5. **Map and fill fields** (see Platform-Specific Guidance below)
-6. **Handle multi-page forms**: Click "Next" or "Continue" between sections
-7. **Take screenshot** of completed form
-8. **Present summary** to user showing all filled values
-9. **Wait for explicit confirmation** before clicking Submit/Apply
+2. **Determine starting point**:
+   - If URL is LinkedIn (`linkedin.com`) → use **Chrome MCP** to navigate (authenticated)
+   - If URL is a direct external portal → skip to step 5 with **Playwright MCP**
+3. **Chrome MCP**: Navigate to LinkedIn job listing, click Apply
+4. **Chrome MCP**: If external portal, capture URL using JS interception pattern (see above)
+5. **Playwright MCP**: Navigate to external URL with `browser_navigate`
+6. **Playwright MCP**: Detect platform, read form structure with `browser_snapshot`
+7. **Playwright MCP**: Fill fields with `browser_fill_form`, handle dropdowns with `browser_click`
+8. **Playwright MCP**: Upload resume with `browser_file_upload` or `browser_run_code` using `setInputFiles`
+9. **Playwright MCP**: Take snapshot to verify all fields are filled correctly
+10. **Present summary** to user showing all filled values, wait for explicit confirmation
+11. **Playwright MCP**: Click Submit
 
 ---
 
@@ -111,21 +187,83 @@ If no profile exists at `~/.claude-job-profile.json`, or if the user requests a 
 - Single long-form page with sections
 - Clear field labels
 - Often has "Add another" for work history/education
+- **Frequently embedded in iframes** on company career sites — Playwright handles this transparently
 
-**Approach:**
-1. Scroll to read full form structure first
-2. Fill from top to bottom
-3. For work history sections:
+**Approach (use Playwright MCP):**
+1. Navigate to URL with `browser_navigate`
+2. Use `browser_snapshot` to read full form — iframe content appears with `f54eXX` refs
+3. Fill from top to bottom using `browser_fill_form`
+4. **Phone country code**: Click the country code toggle → select "United States: +1" from the listbox → the phone field auto-formats with +1 prefix
+5. For work history sections:
    - Fill most recent position
    - Click "Add another" if form allows and user has more history
-4. Education section similar pattern
-5. Handle custom questions at bottom
-6. Single "Submit Application" button at end
+6. Education section similar pattern
+7. Handle custom questions at bottom
+8. Upload resume via `browser_file_upload` or `browser_run_code` with `setInputFiles`
+9. Single "Submit Application" button at end
 
 **Field patterns:**
 - Standard `<input>` and `<select>` elements
 - `#first_name`, `#last_name`, `#email`, `#phone` common IDs
 - `.field-container` or `.field` wrapping each question
+
+### Ashby
+
+**Characteristics:**
+- Simple single-page form
+- Fields: name, phone, email, location (combobox), LinkedIn URL, resume upload
+- Has both a resume upload field and a separate autofill file input — use the resume field, not the autofill one
+
+**Approach (use Playwright MCP):**
+1. Navigate to URL with `browser_navigate`
+2. Use `browser_snapshot` to read form structure
+3. Fill text fields with `browser_fill_form` (name, phone, email, LinkedIn URL)
+4. **Location combobox**: Type the location to trigger suggestions, then click the matching option
+5. **Resume upload**: Use `browser_run_code` with `page.locator('#_systemfield_resume').setInputFiles('/path/to/resume.pdf')` — target `#_systemfield_resume` specifically, not the autofill input
+6. Verify with `browser_snapshot`
+7. Submit
+
+### Lever
+
+**Characteristics:**
+- Often hosted on the company's own domain (e.g., `company.com/careers/...?lever-source=LinkedIn`)
+- Form typically at the bottom of a long job description page
+- Text fields for name, email, phone, LinkedIn, etc.
+- Radio buttons for screening questions — often use custom overlays that intercept clicks
+
+**Approach (use Playwright MCP):**
+1. Navigate to URL with `browser_navigate`
+2. Scroll down to find the application form (usually below job description)
+3. Use `browser_snapshot` to read form structure
+4. Fill text fields with `browser_fill_form`
+5. **Radio buttons**: If `browser_click` doesn't work (overlay intercepts), use `browser_evaluate` with:
+   ```javascript
+   element.click();
+   element.dispatchEvent(new Event('change', {bubbles: true}));
+   ```
+6. **Resume upload**: Use `browser_run_code` to find the hidden file input and call `setInputFiles`:
+   ```javascript
+   async (page) => {
+     await page.locator('input[type="file"][name="resume"]').setInputFiles('/path/to/resume.pdf');
+   }
+   ```
+7. Verify with `browser_snapshot`, then submit
+
+### Rippling
+
+**Characteristics:**
+- Auto-parses uploaded resume to pre-fill fields
+- Upload resume first, then verify/correct auto-filled data
+- Location uses a typeahead combobox
+
+**Approach (use Playwright MCP):**
+1. Navigate to URL with `browser_navigate`
+2. **Upload resume first** — Rippling will auto-parse and fill fields
+3. Use `browser_snapshot` to see what was auto-filled
+4. Correct any mis-parsed fields with `browser_fill_form`
+5. **Location combobox**: Clear existing value, type the correct location, wait for dropdown, click match
+6. Fill any remaining required fields
+7. Verify with `browser_snapshot`, then submit
 
 ### Workday
 
@@ -134,16 +272,17 @@ If no profile exists at `~/.claude-job-profile.json`, or if the user requests a 
 - Non-standard UI components (custom dropdowns, date pickers)
 - Often requires account creation (STOP and inform user - do not create accounts)
 
-**Approach:**
+**Approach (use Playwright MCP):**
 1. If login/account creation required, STOP and inform user they must handle this
 2. Navigate through "My Information" → "My Experience" → "Application Questions"
-3. For dropdowns: Click to open, then use `find` to locate option, then click
-4. For date fields: May need to click calendar icon, then select date
-5. Use `computer` tool with clicks for non-standard components
+3. Use `browser_snapshot` to read form structure on each page
+4. For dropdowns: `browser_click` to open, then `browser_snapshot` to read options, then `browser_click` option
+5. For date fields: May need to click calendar icon, then select date
 6. Watch for "Save and Continue" vs "Submit" buttons
+7. Upload resume via `browser_file_upload` or `browser_run_code`
 
 **Special handling:**
-- Workday dropdowns: Click field → wait → read options with `read_page` → click option
+- Workday dropdowns: Click field → wait → read options with `browser_snapshot` → click option
 - Date pickers: Often format-sensitive, try MM/DD/YYYY
 - Required fields marked with asterisk or red border after validation
 
@@ -209,13 +348,84 @@ After filling current page:
 
 ---
 
+## Playwright MCP Tool Usage
+
+### Reading Forms
+```
+Use browser_snapshot to get the full accessibility tree, including iframe content.
+Iframe elements appear with refs like "f54eXX" — these refs work with all Playwright tools.
+```
+
+### Filling Fields
+```
+Use browser_fill_form with ref/value pairs from the snapshot:
+  - fields: [{ name: "First Name", type: "textbox", ref: "ref123", value: "John" }]
+
+For multiple fields at once, pass an array of field objects.
+```
+
+### Dropdowns and Comboboxes
+```
+1. browser_click on the dropdown toggle/button to open it
+2. browser_snapshot to read the available options
+3. browser_click on the correct option
+
+For comboboxes (typeahead): type into the field first, then click the matching suggestion.
+```
+
+### File Upload
+Two patterns depending on the form:
+
+**Pattern A: Direct setInputFiles (preferred)**
+```
+Use browser_run_code:
+  async (page) => {
+    await page.locator('#resume-input').setInputFiles('/path/to/resume.pdf');
+  }
+Replace '#resume-input' with the actual selector for the file input.
+```
+
+**Pattern B: File chooser interception**
+```
+Use browser_run_code:
+  async (page) => {
+    const [fileChooser] = await Promise.all([
+      page.waitForEvent('filechooser'),
+      page.locator('button:has-text("Upload")').click()
+    ]);
+    await fileChooser.setFiles('/path/to/resume.pdf');
+  }
+
+If a modal appears after upload, use browser_file_upload to complete it.
+```
+
+### Iframe Interaction
+```
+Playwright handles iframes transparently.
+browser_snapshot shows iframe content with refs (e.g., "f54eXX").
+These refs work directly with browser_fill_form, browser_click, etc.
+No special handling needed — just use the refs from the snapshot.
+```
+
+### Custom Radio Buttons
+```
+If browser_click is intercepted by overlays, use browser_evaluate:
+  element.click();
+  element.dispatchEvent(new Event('change', {bubbles: true}));
+Pass the ref of the radio input element.
+```
+
+---
+
 ## Safety Rules
 
 1. **Never enter passwords** - If login required, stop and instruct user
 2. **Never create accounts** - Stop and inform user they must create accounts themselves
-3. **Never click Submit without confirmation** - Always screenshot and get explicit "yes"
+3. **Never click Submit without confirmation** - Always take a snapshot and get explicit "yes"
 4. **Never enter payment information** - Some applications have optional premium features
 5. **Handle sensitive questions carefully** - Salary expectations, visa status, disability disclosure should be confirmed with user before filling
+6. **Always use Chrome MCP for LinkedIn** - Playwright cannot access authenticated sessions
+7. **Never store or pass login credentials between tools** - Each tool uses its own browser context
 
 ---
 

--- a/skills/job-search/SKILL.md
+++ b/skills/job-search/SKILL.md
@@ -1,8 +1,12 @@
+---
+name: job-search
+description: Search LinkedIn for jobs with connections and hiring manager insights. Use when the user wants to find jobs, search for positions, or explore job opportunities.
+allowed-tools: Read, Write, Bash, mcp__claude-in-chrome__*
+---
+
 # Job Search Assistant
 
 A Claude Code skill for searching LinkedIn jobs with a focus on finding positions where you have network connections or hiring managers are listed.
-
----
 
 ## Initial Prompt
 


### PR DESCRIPTION
## Summary

- **Adds Playwright MCP** alongside Chrome MCP to enable end-to-end job applications — Chrome MCP can't upload files (OS file picker) or interact with iframes, Playwright MCP can't access authenticated LinkedIn sessions, so both are needed
- **Codifies the dual-tool handoff pattern**: Chrome MCP navigates LinkedIn and captures external portal URLs via JS interception, then Playwright MCP fills forms, uploads resumes, and handles iframes on the external portal
- **Adds platform-specific guidance** for Ashby, Lever, and Rippling (previously missing), and updates Greenhouse/Workday sections to use Playwright tools

## Changes

- `skills/job-apply/SKILL.md`: Dual-Tool Architecture section, LinkedIn URL extraction recipes, rewritten Phase 2 workflow, Playwright MCP Tool Usage section, new platform sections (Ashby, Lever, Rippling), updated safety rules
- `skills/job-search/SKILL.md`: Added YAML frontmatter (name, description, allowed-tools)
- `.claude-plugin/plugin.json`: Simplified config (removed redundant fields)
- `.claude-plugin/marketplace.json`: Added schema, simplified plugin entry

## Test plan

- [ ] Start a new Claude Code session and invoke `/job-apply` — verify skill loads with dual-tool content
- [ ] Test with a LinkedIn job URL to confirm Chrome MCP is used for navigation
- [ ] Test with a direct Greenhouse/Ashby URL to confirm Playwright MCP is used for form filling
- [ ] Verify `/job-search` still loads correctly with new frontmatter