### PR TITLE
Fix install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ AI-powered job application assistant that automatically fills out job applicatio
 
 ```bash
 claude plugin marketplace add neonwatty/job-apply-plugin
-claude plugin install job-apply-plugin@job-apply
+claude plugin install job-apply@neonwatty-plugins
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

- Fixes the plugin install command from `job-apply-plugin@job-apply` to `job-apply@neonwatty-plugins` (correct format: `plugin@marketplace`)

## Test plan

- [ ] Run `claude plugin install job-apply@neonwatty-plugins` and verify it installs correctly