### PR TITLE
Add Discord community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Job Apply Plugin for Claude Code
 
+[![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.gg/7xsxU4ZG6A)
+
 AI-powered job application assistant that automatically fills out job applications on LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday using browser automation.
 
 ## Skills


### PR DESCRIPTION
## Summary
- Add Discord badge linking to the neonwatty projects community server
- Points to #general channel with a permanent invite link