### PR TITLE
Add GitHub Pages landing page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "site/**"
+      - ".github/workflows/pages.yml"
+  pull_request:
+    paths:
+      - "site/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  deploy:
+    if: github.event_name != 'pull_request'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="AI-powered job application assistant for Claude Code. Fill out job applications automatically on LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.">
+  <link rel="canonical" href="https://neonwatty.github.io/job-apply-plugin/">
+  <meta property="og:title" content="Job Apply Plugin - AI-powered job application assistant for Claude Code">
+  <meta property="og:description" content="Fill out job applications automatically using your resume. Supports LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://neonwatty.github.io/job-apply-plugin/">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Job Apply Plugin - AI-powered job application assistant for Claude Code">
+  <meta name="twitter:description" content="Fill out job applications automatically using your resume. Supports LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
+  <title>Job Apply Plugin - AI-powered job application assistant for Claude Code</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <a class="brand" href="#main" aria-label="Job Apply Plugin home">
+      <span class="brand-mark">J</span>
+      <span>Job Apply</span>
+    </a>
+    <nav aria-label="Primary navigation">
+      <a href="#skills">Skills</a>
+      <a href="#requirements">Requirements</a>
+      <a href="#install">Install</a>
+      <a href="https://github.com/neonwatty/job-apply-plugin">GitHub</a>
+    </nav>
+  </header>
+
+  <main id="main">
+    <section class="hero">
+      <div class="hero-copy">
+        <p class="eyebrow">AI-powered job application assistant for Claude Code</p>
+        <h1>Fill out job applications automatically using your resume.</h1>
+        <p class="lede">
+          Supports LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday. One-time profile setup from your resume, then apply to jobs with a single command.
+        </p>
+        <div class="actions" aria-label="Primary actions">
+          <a class="button primary" href="#install">Get started</a>
+          <a class="button secondary" href="https://github.com/neonwatty/job-apply-plugin">View on GitHub</a>
+        </div>
+      </div>
+
+      <div class="product-shot" aria-label="Job Apply Plugin terminal preview">
+        <div class="mac-strip">
+          <span class="mac-dot red"></span>
+          <span class="mac-dot yellow"></span>
+          <span class="mac-dot green"></span>
+        </div>
+        <div class="terminal">
+          <div class="terminal-title">Claude Code</div>
+          <div class="prompt">$ /job-apply</div>
+          <div class="output output-dim">Paste the job URL you'd like to apply to:</div>
+          <div class="prompt">https://linkedin.com/jobs/view/4019283746</div>
+          <div class="output">
+            <div>Loading profile from ~/.claude-job-profile.json</div>
+            <div class="output-dim" style="margin: 6px 0;">Navigating to job listing...</div>
+            <div>Filling application fields:</div>
+          </div>
+          <div class="panel">
+            <div class="panel-title">Application Progress</div>
+            <div class="field-row"><span class="check">&#10003;</span> Full name</div>
+            <div class="field-row"><span class="check">&#10003;</span> Email address</div>
+            <div class="field-row"><span class="check">&#10003;</span> Phone number</div>
+            <div class="field-row"><span class="check">&#10003;</span> Resume uploaded</div>
+            <div class="field-row"><span class="check">&#10003;</span> Work authorization</div>
+            <div class="field-row"><span class="active">&#9654;</span> Cover letter</div>
+          </div>
+          <div class="output output-confirm">Ready to submit. Review and confirm?</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section intro">
+      <p>
+        Job Apply Plugin turns Claude Code into a job application assistant. Extract your profile once from a resume, then let Claude fill out applications across six major job platforms while you review and confirm.
+      </p>
+    </section>
+
+    <section id="skills" class="section">
+      <div class="section-heading">
+        <p class="eyebrow">Two skills</p>
+        <h2>Apply to jobs and discover new opportunities.</h2>
+      </div>
+      <div class="skills-grid">
+        <article class="skill-card">
+          <div class="skill-header">
+            <span class="skill-badge">/job-apply</span>
+          </div>
+          <h3>Fill out applications automatically</h3>
+          <ul class="feature-bullets">
+            <li>One-time profile setup from your resume (PDF, DOCX, or TXT)</li>
+            <li>Multi-platform: LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, Workday</li>
+            <li>Smart field mapping from your profile to form fields</li>
+            <li>Dual-tool architecture: Chrome MCP for authenticated sites, Playwright MCP for forms</li>
+            <li>Never submits without your explicit confirmation</li>
+          </ul>
+        </article>
+        <article class="skill-card">
+          <div class="skill-header">
+            <span class="skill-badge">/job-search</span>
+          </div>
+          <h3>Find jobs where you have an advantage</h3>
+          <ul class="feature-bullets">
+            <li>Auto-generates search keywords from your resume</li>
+            <li>Finds jobs at companies where you have connections</li>
+            <li>Identifies jobs with hiring managers listed</li>
+            <li>Auto-inferred location and experience level filters</li>
+            <li>Results saved to <code>~/.claude-job-searches/</code> as JSON</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="section platforms">
+      <div class="section-heading">
+        <p class="eyebrow">Supported platforms</p>
+        <h2>Works where the jobs are.</h2>
+      </div>
+      <div class="platform-grid">
+        <div class="platform-pill">LinkedIn Easy Apply</div>
+        <div class="platform-pill">Greenhouse</div>
+        <div class="platform-pill">Ashby</div>
+        <div class="platform-pill">Lever</div>
+        <div class="platform-pill">Rippling</div>
+        <div class="platform-pill">Workday</div>
+      </div>
+    </section>
+
+    <section id="requirements" class="section split">
+      <div class="section-heading">
+        <p class="eyebrow">Requirements</p>
+        <h2>Three tools, zero config.</h2>
+      </div>
+      <div class="feature-list">
+        <article>
+          <h3>Claude Code</h3>
+          <p>The CLI that runs the plugin and orchestrates the entire workflow.</p>
+        </article>
+        <article>
+          <h3>Claude in Chrome</h3>
+          <p>MCP server for authenticated browser sessions, used for LinkedIn where login is required.</p>
+        </article>
+        <article>
+          <h3>Playwright MCP</h3>
+          <p>Headless browser automation for form filling, file uploads, and iframe interaction on external ATS platforms.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="install" class="section install">
+      <div>
+        <p class="eyebrow">Install</p>
+        <h2>Add the plugin and start applying.</h2>
+        <p>
+          Install from the Claude Code plugin marketplace, then invoke <code>/job-apply</code> with a job URL. Your profile is extracted once and reused across all applications.
+        </p>
+      </div>
+      <div class="code-card">
+        <pre><code>claude plugin marketplace add neonwatty/job-apply-plugin
+claude plugin install job-apply@neonwatty-plugins
+
+# Then in Claude Code:
+/job-apply</code></pre>
+      </div>
+    </section>
+
+    <section class="section safety">
+      <div class="section-heading">
+        <p class="eyebrow">Safety first</p>
+        <h2>You stay in control at every step.</h2>
+      </div>
+      <div class="constraint-grid">
+        <article>
+          <h3>Never submits without confirmation</h3>
+          <p>Every application shows a full summary and waits for your explicit approval before submitting.</p>
+        </article>
+        <article>
+          <h3>Never enters passwords</h3>
+          <p>If a site requires login, the plugin stops and asks you to sign in first.</p>
+        </article>
+        <article>
+          <h3>Never enters payment info</h3>
+          <p>Premium features and paid prompts are skipped automatically.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <span>Job Apply Plugin is MIT licensed.</span>
+    <a href="https://discord.gg/7xsxU4ZG6A">Discord</a>
+    <a href="https://github.com/neonwatty/job-apply-plugin">GitHub</a>
+  </footer>
+</body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,536 @@
+:root {
+  --bg: #f6f7f9;
+  --surface: #ffffff;
+  --surface-strong: #111317;
+  --text: #15181d;
+  --muted: #5d6673;
+  --line: #d9dee7;
+  --accent: #0891b2;
+  --accent-dark: #065f73;
+  --accent-light: #e0f7fa;
+  --green: #2f9d68;
+  --code: #171a20;
+  --shadow: 0 24px 70px rgba(20, 30, 50, 0.16);
+  color-scheme: light;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  letter-spacing: 0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.skip-link {
+  position: absolute;
+  left: 12px;
+  top: 12px;
+  z-index: 10;
+  transform: translateY(-160%);
+  border-radius: 7px;
+  padding: 10px 12px;
+  color: #fff;
+  background: var(--surface-strong);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+code,
+pre,
+.terminal {
+  font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+}
+
+.site-header,
+.site-footer {
+  width: min(1120px, calc(100% - 40px));
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+}
+
+.site-header {
+  min-height: 72px;
+  justify-content: space-between;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+}
+
+.brand-mark {
+  width: 30px;
+  height: 30px;
+  border-radius: 7px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  background: var(--accent);
+}
+
+nav {
+  display: flex;
+  gap: 22px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+nav a:hover,
+.site-footer a:hover {
+  color: var(--accent);
+}
+
+.hero {
+  width: min(1120px, calc(100% - 40px));
+  min-height: calc(100vh - 96px);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(400px, 1.1fr);
+  gap: 48px;
+  align-items: center;
+  padding: 40px 0 72px;
+}
+
+.hero-copy {
+  max-width: 610px;
+  min-width: 0;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--accent-dark);
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 18px;
+  font-size: clamp(42px, 7vw, 76px);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-bottom: 14px;
+  font-size: clamp(30px, 4vw, 48px);
+  line-height: 1.03;
+  letter-spacing: 0;
+}
+
+h3 {
+  margin-bottom: 8px;
+  font-size: 18px;
+}
+
+.lede,
+.intro p,
+.section p {
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1.55;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 28px;
+}
+
+.button {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 7px;
+  padding: 0 18px;
+  font-weight: 700;
+  border: 1px solid transparent;
+}
+
+.button.primary {
+  color: #fff;
+  background: var(--accent);
+}
+
+.button.primary:hover {
+  background: var(--accent-dark);
+}
+
+.button.secondary {
+  color: var(--text);
+  background: var(--surface);
+  border-color: var(--line);
+}
+
+.product-shot {
+  min-width: 0;
+  border: 1px solid rgba(17, 19, 23, 0.1);
+  border-radius: 8px;
+  overflow: hidden;
+  background: #e8ebf1;
+  box-shadow: var(--shadow);
+}
+
+.mac-strip {
+  height: 38px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 13px;
+  background: #f4f5f7;
+  border-bottom: 1px solid #d7dce4;
+}
+
+.mac-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+}
+
+.red { background: #ef665e; }
+.yellow { background: #e7b948; }
+.green { background: #55bd6a; }
+
+.terminal {
+  padding: 18px;
+  background: var(--code);
+  color: #e9edf5;
+}
+
+.terminal-title {
+  margin-bottom: 14px;
+  color: #fff;
+  font-weight: 700;
+}
+
+.panel {
+  border: 1px solid #38404d;
+  border-radius: 7px;
+  padding: 12px;
+  margin: 8px 0;
+  background: #1e232b;
+}
+
+.panel-title {
+  margin-bottom: 9px;
+  color: #67e8f9;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.field-row {
+  color: #cdd5e3;
+  font-size: 13px;
+  line-height: 1.8;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.check {
+  color: #90d7ad;
+  font-weight: 700;
+}
+
+.active {
+  color: #67e8f9;
+  font-size: 10px;
+}
+
+.prompt {
+  color: #67e8f9;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.output {
+  color: #90d7ad;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.output-dim {
+  color: #788395;
+}
+
+.output-confirm {
+  margin-top: 8px;
+  color: #e8bd62;
+  font-weight: 700;
+}
+
+.section {
+  width: min(1120px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 74px 0;
+}
+
+.intro {
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.intro p {
+  max-width: 880px;
+  font-size: clamp(24px, 3vw, 36px);
+  line-height: 1.25;
+  color: var(--text);
+}
+
+.section-heading {
+  max-width: 760px;
+  min-width: 0;
+  margin-bottom: 28px;
+}
+
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 18px;
+}
+
+.skill-card {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 22px;
+  background: var(--surface);
+}
+
+.skill-header {
+  margin-bottom: 14px;
+}
+
+.skill-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 5px;
+  background: var(--accent-light);
+  color: var(--accent-dark);
+  font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.feature-bullets {
+  margin: 0;
+  padding: 0 0 0 18px;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.feature-bullets code {
+  font-size: 13px;
+  background: var(--bg);
+  padding: 2px 5px;
+  border-radius: 4px;
+}
+
+.platforms {
+  border-top: 1px solid var(--line);
+}
+
+.platform-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.platform-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  border-radius: 7px;
+  padding: 0 18px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: 0.72fr 1fr;
+  gap: 42px;
+  align-items: start;
+}
+
+.feature-list {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+
+.feature-list article {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 22px;
+  background: var(--surface);
+}
+
+.feature-list p {
+  font-size: 15px;
+}
+
+.constraint-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+
+.constraint-grid article {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 22px;
+  background: var(--surface);
+}
+
+.constraint-grid p {
+  font-size: 15px;
+}
+
+.install {
+  display: grid;
+  grid-template-columns: 0.85fr 1fr;
+  gap: 42px;
+  align-items: center;
+  border-top: 1px solid var(--line);
+}
+
+.install > *,
+.split > * {
+  min-width: 0;
+}
+
+.code-card {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 22px;
+  background: var(--surface-strong);
+  color: #edf2fb;
+}
+
+pre {
+  margin: 0;
+  overflow-x: auto;
+  line-height: 1.65;
+  font-size: 14px;
+}
+
+.site-footer {
+  width: min(1120px, calc(100% - 40px));
+  margin: 0 auto;
+  min-height: 96px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  color: var(--muted);
+  border-top: 1px solid var(--line);
+}
+
+.site-footer span {
+  margin-right: auto;
+}
+
+@media (max-width: 920px) {
+  .site-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 16px;
+    padding: 18px 0;
+  }
+
+  nav {
+    flex-wrap: wrap;
+    gap: 14px;
+  }
+
+  .hero,
+  .split,
+  .install {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    min-height: 0;
+    padding-top: 24px;
+  }
+
+  .skills-grid,
+  .feature-list,
+  .constraint-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .site-header,
+  .site-footer,
+  .hero,
+  .section {
+    width: min(100% - 28px, 1120px);
+  }
+
+  h1 {
+    font-size: 44px;
+  }
+
+  .actions {
+    flex-direction: column;
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  .terminal {
+    padding: 12px;
+  }
+
+  pre {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
+  .site-footer {
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .site-footer span {
+    margin-right: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a static landing page at `site/` following the fleet site design system (light theme, clean typography, system fonts, responsive)
- Accent color: professional blue-green (#0891b2) for the job/career context
- Page content: hero with tagline, two skills section (/job-apply and /job-search), supported platforms, requirements, install instructions, safety features, and footer with Discord/GitHub links
- Adds GitHub Actions workflow for Pages deployment on push to main

## Test plan
- [ ] Verify HTML renders correctly by opening `site/index.html` locally
- [ ] Check responsive behavior at mobile, tablet, and desktop widths
- [ ] Confirm Pages workflow deploys successfully after merge
- [ ] Enable GitHub Pages (source: GitHub Actions) in repo settings if not already configured