### PR TITLE
feat: add /hidden-jobs skill for hidden-market job hunting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ AI-powered job application assistant that automatically fills out job applicatio
 | Skill | Description |
 |-------|-------------|
 | `/job-apply` | Fill out job applications automatically using your resume |
-| `/job-search` | Search LinkedIn for jobs with connections and hiring manager insights |
+| `/job-search` | Search LinkedIn, Hacker News, and Twitter/X for jobs with connections and hiring manager insights |
+| `/job-preferences` | Set and save target titles, salary, remote, and filters used by the other skills |
+| `/hidden-jobs` | Hunt the hidden market — niche boards, small-company ATS pages, and direct-to-hiring-manager posts; drafts outreach |
 
 ## Features
 
@@ -27,6 +29,14 @@ AI-powered job application assistant that automatically fills out job applicatio
 - **Hiring manager discovery**: Identifies jobs with hiring managers listed
 - **Auto-inferred filters**: Location and experience level from your profile
 - **Results saved**: All searches saved to `~/.claude-job-searches/` as JSON
+
+### Hidden Jobs (`/hidden-jobs`)
+- **ATS board APIs**: Pulls small companies' Greenhouse / Lever / Ashby boards (public JSON, no auth)
+- **Niche aggregators**: RemoteOK, Remotive, WeWorkRemotely — remote-first, startup-heavy
+- **Direct-contact posts**: LinkedIn / Twitter-X / Reddit posts where a hiring manager gives an email or "DM me"
+- **Contact-priority scoring**: Rewards a direct line to a human and low-competition roles over ATS black holes
+- **Outreach drafts**: Generates a personalized message for every direct-contact role (you review and send)
+- **Fetcher**: `skills/hidden-jobs/scripts/hunt.py` — stdlib Python, no dependencies
 
 ## Requirements
 

--- a/skills/hidden-jobs/SKILL.md
+++ b/skills/hidden-jobs/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: hidden-jobs
+description: Hunt the hidden job market — roles on niche boards, small-company ATS pages, and LinkedIn/Twitter/Reddit posts where a hiring manager drops a direct email for resumes. Scores results to reward direct-contact, low-competition roles and drafts personalized outreach. Use when the user wants hidden, unadvertised, or direct-to-hiring-manager roles, or wants to skip the saturated public listings.
+allowed-tools: Read, Write, Bash, WebSearch, WebFetch, mcp__claude-in-chrome__*, mcp__plugin_playwright_playwright__*
+---
+
+# Hidden Job Hunt
+
+Finds roles the saturated public listings miss:
+
+- **ATS board APIs** — small companies' Greenhouse / Lever / Ashby boards (public JSON, no auth)
+- **Niche aggregators** — RemoteOK, Remotive, WeWorkRemotely (remote-first, startup-heavy)
+- **Direct-contact posts** — LinkedIn / Twitter-X / Reddit posts where a hiring manager writes "send your resume to <email>" or "DM me"
+- **Small-company careers pages** — direct, for a user-supplied target list
+
+It scores results to **reward a direct line to a human** (an email or named hiring manager beats an ATS black hole), dedups across channels, and drafts a personalized outreach email for every direct-contact role.
+
+---
+
+## Phase 1: Load Preferences & Parse Overrides
+
+### Step 1: Load Profile
+
+Read `~/.claude-job-profile.json`. Check for `preferences`.
+
+**If no preferences found**, say:
+
+> No preferences found. Run `/job-preferences` first to set target titles and filters.
+
+Then **STOP**.
+
+**If preferences exist**, load `targetTitles`, `remotePreference`, `excludePatterns`, `defaultTimeRange`, `keywords`, `needsRemoteOrVisa`, `basedIn`, and `atsCompanyTokens`. Also load top-level `name`, `email`, `links`, `topSkills`, `headline` — these feed the outreach drafts in Phase 6.
+
+### Step 2: Parse Overrides
+
+The user may pass, when invoking:
+
+- **Channels**: `ats`, `aggregators`, `social`, `careers` (or combinations). Default: all.
+- **Time range**: `last week`, `2 weeks`, `month` → overrides `defaultTimeRange`.
+- **Companies**: a list of company names → triggers ATS-token discovery + careers-page channel.
+- **Keywords**: extra search terms.
+
+Display the active config before proceeding (titles, remote, exclude, time range, channels).
+
+---
+
+## Phase 2: ATS Board APIs (Bash — `scripts/hunt.py`)
+
+Most startups host roles on **public, auth-free** ATS JSON endpoints. The fetcher hits them and normalizes the output.
+
+### Seed company tokens
+
+`hunt.py` reads `preferences.atsCompanyTokens` from the profile:
+
+```json
+"atsCompanyTokens": {
+  "greenhouse": ["companytoken1", "companytoken2"],
+  "lever": ["companytoken3"],
+  "ashby": ["companytoken4"]
+}
+```
+
+A company's **token** is the slug in its board URL:
+
+| Provider | Board URL | API endpoint | Token |
+|----------|-----------|--------------|-------|
+| Greenhouse | `boards.greenhouse.io/{token}` | `boards-api.greenhouse.io/v1/boards/{token}/jobs?content=true` | `{token}` |
+| Lever | `jobs.lever.co/{token}` | `api.lever.co/v0/postings/{token}?mode=json` | `{token}` |
+| Ashby | `jobs.ashbyhq.com/{token}` | `api.ashbyhq.com/posting-api/job-board/{token}` | `{token}` |
+
+**To grow the token list** for the user's targets:
+1. If the user named companies, `WebSearch` `"{company} greenhouse OR lever OR ashby careers"` and read the board URL to extract the token, then add it to `atsCompanyTokens` (Write back to profile).
+2. For startup breadth, seed from public YC / startup lists the user provides.
+3. If a company uses a different ATS (Workable, SmartRecruiters, Rippling), fetch its `/careers` page directly in Phase 5 instead.
+
+### Run the fetcher
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/hidden-jobs/scripts/hunt.py" --channels ats,aggregators --since-days {N}
+```
+
+(Use the absolute path to this skill's `scripts/hunt.py`.) It prints JSON: `{jobs, errors, counts, total, with_email}`. Each job: `source, company, title, location, remote, salary, url, email, posted, description`. The fetcher already extracts any email embedded in a job description and dedups.
+
+---
+
+## Phase 3: Niche Aggregators (same fetcher)
+
+The `aggregators` channel (included in the call above) pulls:
+
+- **RemoteOK** — `remoteok.com/api`
+- **Remotive** — `remotive.com/api/remote-jobs`
+- **WeWorkRemotely** — programming-jobs RSS
+
+All remote-first, startup-heavy — strong for an international / remote-needed candidate. No auth.
+
+---
+
+## Phase 4: Direct-Contact Posts (the core "hidden" channel)
+
+Posts where a hiring manager gives a **direct email or DM** for resumes. This is where competition is lowest.
+
+### 4a: LinkedIn post search (Chrome MCP)
+
+1. `tabs_context_mcp` → `tabs_create_mcp`, navigate to LinkedIn.
+2. Verify logged in via `read_page`; if not, ask the user to log in and **wait**.
+3. Search **content/posts** (not the jobs tab). Navigate to:
+   `https://www.linkedin.com/search/results/content/?keywords={query}&datePosted=%22past-week%22` (or `past-month`).
+   Build `{query}` from hiring intent + titles, e.g.:
+   `("we're hiring" OR "now hiring" OR "looking for") ("backend" OR "full stack" OR "software engineer") ("send your resume" OR "send your CV" OR "DM me" OR "email me")`
+4. `read_page` the feed; for each post extract: author name, author title, author profile URL, post text, post URL.
+5. **Extract email** from post text with regex `[\w.+-]+@[\w.-]+\.\w{2,}`. Capture "DM" intent if no email.
+6. 2-3s delays. Max ~25 posts.
+
+### 4b: Twitter/X post search (Chrome MCP)
+
+1. If logged in, navigate to `x.com/search` with:
+   `("hiring" OR "we're hiring") ("backend" OR "software engineer" OR "ML engineer") ("send" OR "DM" OR "email") ("resume" OR "CV") since:YYYY-MM-DD -is:reply`
+2. Switch to **Latest**. Extract tweet text, author handle, URL, engagement.
+3. Extract email via the same regex. If none, note the handle for a DM.
+4. Skip gracefully if not logged in or rate-limited.
+
+### 4c: Reddit hiring threads (WebFetch)
+
+Reddit blocks datacenter IPs, so do **not** use the Bash fetcher for Reddit — use `WebFetch` (different egress):
+
+1. `WebFetch` `https://www.reddit.com/r/forhire/search.json?q=hiring&restrict_sr=1&sort=new&limit=50` and likewise for `r/remotejs`, `r/hiring`.
+2. If WebFetch is also blocked, fall back to Chrome MCP on `old.reddit.com/r/forhire/`.
+3. Keep only `[Hiring]` posts. Extract title, body, permalink, and email via regex.
+
+For every direct-contact hit, store `email` (or `dmHandle`) — these score highest.
+
+---
+
+## Phase 5: Small-Company Careers Pages (optional, user supplies companies)
+
+For each company the user named that wasn't resolved to an ATS token in Phase 2:
+
+1. `WebSearch` `"{company} careers"` → find the careers URL.
+2. `WebFetch` the careers page; extract role titles, locations, and any apply email.
+3. If it's an ATS board, capture the token and prefer the API (Phase 2) next time.
+
+---
+
+## Phase 6: Normalize, Filter, Score
+
+### Filter against preferences
+
+Drop any role that:
+- Matches an `excludePatterns` term in the title (e.g. `principal`, `staff`, `director`).
+- Doesn't fuzzy-match a `targetTitle` or `keyword`.
+- Violates `remotePreference` (if "remote only", keep only remote — critical when `needsRemoteOrVisa` is true).
+
+### Scoring rubric (reward direct contact + low competition)
+
+| Category | Points | Notes |
+|----------|--------|-------|
+| **Direct email present** | **+30** | the whole point — a line to a human |
+| **Named hiring manager (social)** | +15 | author of a hiring post |
+| Title match (exact vs partial) | 0-20 | |
+| Remote / location-fit | 0-15 | weight up when `needsRemoteOrVisa` |
+| Visa / sponsorship mentioned | +10 | when relevant to the user |
+| Small company / non-FAANG | +10 | hidden-market bonus |
+| Recency | 0-5 | newer = higher |
+| Low-competition signal | 0-5 | few applicants / niche board |
+
+Sum, cap at 100. A role from a niche board with the hiring manager's email and a title match should land 80+.
+
+### Dedup
+
+Already deduped within the Bash fetcher; when merging social + careers results, dedup again on `(company, title)` and on `email`.
+
+---
+
+## Phase 7: Output
+
+### 1. Terminal — ranked table
+
+```
+============================================================
+  Hidden Job Hunt — Results
+============================================================
+  Titles: Backend Engineer, Full Stack Engineer, ML Engineer
+  Filters: Remote only | Last month
+  Channels: ATS (12), Aggregators (40), Social (7), Careers (3)
+  Total: 62 after filter | 9 with direct contact
+============================================================
+
+Score | Source         | Title                   | Company     | Contact            | Remote
+----- | -------------- | ----------------------- | ----------- | ------------------ | ------
+  91  | linkedin-post  | Backend Engineer        | Nimbus AI   | jane@nimbus.ai     | Yes
+  86  | remoteok       | Full Stack Engineer     | Pier        | apply link         | Yes
+  84  | greenhouse     | Software Engineer       | Loopwork    | careers form       | Yes
+  ...
+============================================================
+  9 direct-contact roles → outreach drafts below
+  Saved to: ~/.claude-job-searches/hidden-{timestamp}.md
+============================================================
+```
+
+### 2. Markdown file — `~/.claude-job-searches/hidden-{timestamp}.md`
+
+For each role: score, source, company, title, location/remote, salary, URL, **contact (email or DM handle)**, description snippet. Create the directory if missing.
+
+### 3. Outreach drafts (direct-contact roles only)
+
+For every role with an `email` or `dmHandle`, draft a short, personalized message using the profile (`name`, `email`, `links`, `topSkills`, `headline`) and the role's text. Keep it ~120 words, specific to the role, with the user's relevant experience and links. Save under an `## Outreach Drafts` section in the same MD file. **Never send** — hand the drafts to the user to review and send themselves.
+
+Template:
+
+```
+Subject: {Role} — {User Name}
+
+Hi {Hiring Manager / there},
+
+Saw your post about {role} at {company}. I'm a {headline} — recently {one
+relevant line from experience matching the role's stack}.
+
+A few things that map to what you described:
+- {relevant skill/project 1}
+- {relevant skill/project 2}
+
+Resume: {link} · GitHub: {github} · Portfolio: {portfolio}
+Open to {remote / the role's arrangement}. Would love to talk.
+
+{User Name}
+{email}
+```
+
+### 4. Queue append (optional, user confirms)
+
+If any roles scored 70+, ask before appending to `~/Desktop/jobs/application_queue.md` under `## Hidden-Market`. **Never modify it without confirmation.**
+
+---
+
+## Safety Rules
+
+1. **Never enter credentials** — if a login is needed, stop and ask the user to log in.
+2. **Never send outreach or click Apply** — this skill discovers and drafts only. The user sends.
+3. **Never create accounts.**
+4. **Respect rate limits** — 2-3s between LinkedIn/Twitter interactions; the Bash fetcher already paces API calls.
+5. **Reddit**: never hit it from the Bash fetcher (datacenter IPs are blocked). Use WebFetch or Chrome MCP.
+6. **Graceful degradation** — if a channel fails, skip it and report which channels succeeded/failed.
+7. **Email handling** — only extract emails the poster published publicly for applications. Never scrape private contact info or guess addresses.
+8. **Never modify `application_queue.md` without explicit confirmation.**
+
+---
+
+## Example Invocations
+
+```
+/hidden-jobs                          # all channels, default time range
+/hidden-jobs social                   # only direct-contact posts (LinkedIn/X/Reddit)
+/hidden-jobs ats aggregators 2 weeks  # boards only, last 2 weeks
+/hidden-jobs companies: Linear, Resend, Supabase   # discover their ATS + careers pages
+```

--- a/skills/hidden-jobs/scripts/hunt.py
+++ b/skills/hidden-jobs/scripts/hunt.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+hidden-jobs fetcher — queries auth-free "hidden market" channels and emits
+normalized job records as JSON to stdout. No third-party deps (urllib only).
+
+Channels:
+  - ATS public board APIs: Greenhouse, Lever, Ashby (small-company goldmine)
+  - Niche aggregators: RemoteOK, Remotive, WeWorkRemotely (RSS)
+  - Reddit hiring threads: r/forhire, r/remotejs, r/hiring (JSON API)
+
+Social channels (LinkedIn posts, Twitter/X) are handled by the skill via
+Chrome MCP, not here — they need an authenticated browser.
+
+Usage:
+  python3 hunt.py --channels ats,aggregators,reddit --since-days 30
+  python3 hunt.py --profile ~/.claude-job-profile.json
+
+Reads ATS company tokens + keywords from the profile's preferences block.
+Prints a JSON object: {"jobs": [...], "errors": [...], "counts": {...}}
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.request
+import urllib.error
+from html.parser import HTMLParser
+from xml.etree import ElementTree
+
+UA = "Mozilla/5.0 (hidden-jobs/1.0; +https://github.com/neonwatty/job-apply-plugin)"
+EMAIL_RE = re.compile(r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}")
+TAG_RE = re.compile(r"<[^>]+>")
+
+
+def get(url, timeout=20, as_json=True):
+    req = urllib.request.Request(url, headers={"User-Agent": UA, "Accept": "*/*"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        data = r.read().decode("utf-8", "replace")
+    return json.loads(data) if as_json else data
+
+
+def strip_html(s):
+    if not s:
+        return ""
+    s = TAG_RE.sub(" ", s)
+    s = re.sub(r"&amp;", "&", s)
+    s = re.sub(r"&lt;", "<", s)
+    s = re.sub(r"&gt;", ">", s)
+    s = re.sub(r"&#\d+;", " ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def find_email(*texts):
+    for t in texts:
+        if not t:
+            continue
+        m = EMAIL_RE.search(t)
+        if m:
+            # skip obvious noise
+            e = m.group(0)
+            if not e.lower().endswith((".png", ".jpg", ".gif", ".svg")):
+                return e
+    return None
+
+
+def is_remote(*texts):
+    blob = " ".join(t.lower() for t in texts if t)
+    return any(k in blob for k in ("remote", "anywhere", "worldwide", "work from home"))
+
+
+def rec(source, company, title, location, remote, salary, url, email, posted, desc):
+    return {
+        "source": source,
+        "company": company or "",
+        "title": (title or "").strip(),
+        "location": location or "",
+        "remote": bool(remote),
+        "salary": salary or "",
+        "url": url or "",
+        "email": email or "",
+        "posted": posted or "",
+        "description": (strip_html(desc) or "")[:600],
+    }
+
+
+# ---------- ATS board APIs ----------
+def fetch_greenhouse(token, errors):
+    out = []
+    try:
+        data = get(f"https://boards-api.greenhouse.io/v1/boards/{token}/jobs?content=true")
+        for j in data.get("jobs", []):
+            loc = (j.get("location") or {}).get("name", "")
+            content = j.get("content", "")
+            out.append(rec("greenhouse", token, j.get("title"), loc,
+                           is_remote(loc, content), "", j.get("absolute_url"),
+                           find_email(content), j.get("updated_at", ""), content))
+    except Exception as e:
+        errors.append(f"greenhouse:{token}: {e}")
+    return out
+
+
+def fetch_lever(token, errors):
+    out = []
+    try:
+        data = get(f"https://api.lever.co/v0/postings/{token}?mode=json")
+        for j in data:
+            cat = j.get("categories", {}) or {}
+            loc = cat.get("location", "")
+            desc = j.get("descriptionPlain") or j.get("description", "")
+            out.append(rec("lever", token, j.get("text"), loc,
+                           is_remote(loc, j.get("workplaceType", ""), desc), "",
+                           j.get("hostedUrl"), find_email(desc),
+                           "", desc))
+    except Exception as e:
+        errors.append(f"lever:{token}: {e}")
+    return out
+
+
+def fetch_ashby(token, errors):
+    out = []
+    try:
+        data = get(f"https://api.ashbyhq.com/posting-api/job-board/{token}?includeCompensation=true")
+        for j in data.get("jobs", []):
+            loc = j.get("location", "")
+            desc = j.get("descriptionPlain") or ""
+            comp = j.get("compensation") or {}
+            salary = ""
+            try:
+                tiers = comp.get("compensationTierSummary", "")
+                salary = tiers or ""
+            except Exception:
+                pass
+            out.append(rec("ashby", token, j.get("title"), loc,
+                           bool(j.get("isRemote")) or is_remote(loc, desc), salary,
+                           j.get("jobUrl") or j.get("applyUrl"), find_email(desc),
+                           j.get("publishedAt", ""), desc))
+    except Exception as e:
+        errors.append(f"ashby:{token}: {e}")
+    return out
+
+
+# ---------- Niche aggregators ----------
+def fetch_remoteok(errors):
+    out = []
+    try:
+        data = get("https://remoteok.com/api")
+        for j in data:
+            if not isinstance(j, dict) or "position" not in j:
+                continue
+            desc = j.get("description", "")
+            out.append(rec("remoteok", j.get("company"), j.get("position"),
+                           j.get("location", "Remote"), True,
+                           f"${j.get('salary_min','')}-${j.get('salary_max','')}" if j.get("salary_min") else "",
+                           j.get("url"), find_email(desc), j.get("date", ""), desc))
+    except Exception as e:
+        errors.append(f"remoteok: {e}")
+    return out
+
+
+def fetch_remotive(errors):
+    out = []
+    try:
+        data = get("https://remotive.com/api/remote-jobs?limit=200")
+        for j in data.get("jobs", []):
+            desc = j.get("description", "")
+            out.append(rec("remotive", j.get("company_name"), j.get("title"),
+                           j.get("candidate_required_location", "Remote"), True,
+                           j.get("salary", ""), j.get("url"), find_email(desc),
+                           j.get("publication_date", ""), desc))
+    except Exception as e:
+        errors.append(f"remotive: {e}")
+    return out
+
+
+def fetch_wwr(errors):
+    out = []
+    try:
+        xml = get("https://weworkremotely.com/categories/remote-programming-jobs.rss", as_json=False)
+        root = ElementTree.fromstring(xml)
+        for item in root.iter("item"):
+            title = (item.findtext("title") or "")
+            company, role = (title.split(":", 1) + [""])[:2] if ":" in title else ("", title)
+            desc = item.findtext("description") or ""
+            link = item.findtext("link") or ""
+            out.append(rec("weworkremotely", company.strip(), role.strip(),
+                           "Remote", True, "", link, find_email(desc),
+                           item.findtext("pubDate", ""), desc))
+    except Exception as e:
+        errors.append(f"weworkremotely: {e}")
+    return out
+
+
+# ---------- Reddit hiring threads ----------
+def fetch_reddit(errors, subs=("forhire", "remotejs", "hiring")):
+    out = []
+    for sub in subs:
+        try:
+            data = get(f"https://www.reddit.com/r/{sub}/search.json?q=hiring&restrict_sr=1&sort=new&limit=50")
+            for child in data.get("data", {}).get("children", []):
+                p = child.get("data", {})
+                title = p.get("title", "")
+                # r/forhire convention: [Hiring] posts are employers seeking
+                if "[hiring]" not in title.lower() and "hiring" not in title.lower():
+                    continue
+                body = p.get("selftext", "")
+                out.append(rec("reddit/" + sub, "", title, "", is_remote(title, body),
+                               "", "https://www.reddit.com" + p.get("permalink", ""),
+                               find_email(title, body), str(p.get("created_utc", "")), body))
+            time.sleep(0.5)
+        except Exception as e:
+            errors.append(f"reddit/{sub}: {e}")
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    # reddit excluded by default: reddit blocks datacenter IPs (403), so the
+    # skill fetches Reddit threads via WebFetch / Chrome MCP instead. Pass
+    # --channels reddit explicitly to attempt it from here anyway.
+    ap.add_argument("--channels", default="ats,aggregators")
+    ap.add_argument("--profile", default=os.path.expanduser("~/.claude-job-profile.json"))
+    ap.add_argument("--since-days", type=int, default=30)
+    args = ap.parse_args()
+
+    prefs = {}
+    try:
+        with open(args.profile) as f:
+            prefs = json.load(f).get("preferences", {})
+    except Exception:
+        pass
+
+    tokens = prefs.get("atsCompanyTokens", {}) or {}
+    channels = set(c.strip() for c in args.channels.split(","))
+    jobs, errors = [], []
+
+    if "ats" in channels:
+        for t in tokens.get("greenhouse", []):
+            jobs += fetch_greenhouse(t, errors)
+        for t in tokens.get("lever", []):
+            jobs += fetch_lever(t, errors)
+        for t in tokens.get("ashby", []):
+            jobs += fetch_ashby(t, errors)
+
+    if "aggregators" in channels:
+        jobs += fetch_remoteok(errors)
+        jobs += fetch_remotive(errors)
+        jobs += fetch_wwr(errors)
+
+    if "reddit" in channels:
+        jobs += fetch_reddit(errors)
+
+    # dedup on (company|title|url)
+    seen, deduped = set(), []
+    for j in jobs:
+        key = (j["company"].lower().strip(), j["title"].lower().strip(), j["url"])
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(j)
+
+    counts = {}
+    for j in deduped:
+        src = j["source"].split("/")[0]
+        counts[src] = counts.get(src, 0) + 1
+
+    print(json.dumps({
+        "jobs": deduped,
+        "errors": errors,
+        "counts": counts,
+        "total": len(deduped),
+        "with_email": sum(1 for j in deduped if j["email"]),
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
New skill that surfaces roles the saturated public listings miss:
- ATS board APIs (Greenhouse/Lever/Ashby) — public JSON, no auth
- Niche aggregators (RemoteOK, Remotive, WeWorkRemotely)
- Direct-contact posts (LinkedIn/Twitter-X/Reddit) where a hiring manager drops an email or "DM me" — extracted via regex
- Small-company careers pages for a user-supplied target list

Contact-priority scoring rewards a direct line to a human and low-competition roles over ATS black holes. Generates a personalized outreach draft for every direct-contact role (user reviews and sends).

Fetcher scripts/hunt.py is stdlib-only Python (no deps). Reddit is routed through WebFetch/Chrome since it blocks datacenter IPs.