### PR TITLE
Polish plugin onboarding, safety, and verification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,6 @@
         "repo": "neonwatty/job-apply-plugin"
       },
       "description": "AI-powered job application assistant for LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday",
-      "version": "1.0.0",
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "job-apply",
-  "version": "1.0.0",
   "description": "AI-powered job application assistant for LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday",
   "author": {
     "name": "Jeremy Watt",

--- a/.github/ISSUE_TEMPLATE/ats-failure.yml
+++ b/.github/ISSUE_TEMPLATE/ats-failure.yml
@@ -1,0 +1,75 @@
+name: ATS workflow failure
+description: Report a redacted problem with a guided ATS workflow.
+title: "[ATS]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ATS forms change frequently, so a clear redacted report helps. Do not attach a resume, profile file, screenshot with applicant data, credentials, passwords, or a full application URL.
+
+  - type: checkboxes
+    id: redaction
+    attributes:
+      label: Privacy check
+      options:
+        - label: I removed credentials, passwords, resume content, full application URLs, company-specific tokens, and personal applicant data.
+          required: true
+
+  - type: dropdown
+    id: ats_family
+    attributes:
+      label: ATS family
+      options:
+        - LinkedIn Easy Apply
+        - Greenhouse
+        - Ashby
+        - Lever
+        - Rippling
+        - Workday
+        - Unknown or other
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Claude Code, operating system, and browser versions
+      placeholder: "Example: Claude Code 2.x, macOS 15, Chrome 138"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: stage
+    attributes:
+      label: Workflow stage
+      options:
+        - Page navigation
+        - Login or user-only checkpoint
+        - Form reading
+        - Field entry
+        - File upload
+        - Review-page handoff
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Redacted behavior
+      description: Explain what was visible, what you expected, and what happened. Use generic field labels and omit employer or applicant details.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Redacted reproduction steps
+      description: Give the smallest safe sequence using an ATS family and generic field names, not a full application URL.
+      placeholder: |
+        1. Opened a Greenhouse form.
+        2. Reached a generic location field.
+        3. The control was not detected.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest a privacy-conscious improvement to the plugin.
+title: "[Feature]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Keep examples generic. Do not include resumes, profile files, credentials, passwords, full application URLs, or personal applicant data.
+
+  - type: checkboxes
+    id: redaction
+    attributes:
+      label: Privacy check
+      options:
+        - label: I removed credentials, passwords, resume content, full application URLs, and personal applicant data.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem should this solve?
+      description: Describe the general user need without identifying a person, employer, or application.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Explain what a successful, safe experience would look like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional workarounds or approaches you have considered, using generic examples only.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/setup-help.yml
+++ b/.github/ISSUE_TEMPLATE/setup-help.yml
@@ -1,0 +1,66 @@
+name: Setup help
+description: Get help installing or connecting the plugin without sharing private applicant data.
+title: "[Setup]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for asking for help. Do not attach a resume or profile file. Remove credentials, passwords, names, contact details, full application URLs, and other applicant data from every response and log excerpt.
+
+  - type: checkboxes
+    id: redaction
+    attributes:
+      label: Privacy check
+      options:
+        - label: I removed credentials, passwords, resume content, full application URLs, and personal applicant data.
+          required: true
+
+  - type: input
+    id: claude_version
+    attributes:
+      label: Claude Code version
+      description: Run `claude --version` and share only the version number.
+      placeholder: "Example: 2.x.x"
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Operating system and browser
+      placeholder: "Example: macOS 15, Chrome 138"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: setup_stage
+    attributes:
+      label: Where did setup stop?
+      options:
+        - Marketplace add
+        - Plugin install
+        - Skill invocation
+        - Claude in Chrome connection
+        - Profile setup
+        - Other setup step
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the expected and actual behavior using redacted details only.
+      placeholder: "The setup stopped after... I expected... Instead..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Redacted diagnostics
+      description: Optional short error text or steps already tried. Remove paths containing names and all applicant data.
+      render: shell
+    validations:
+      required: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,3 +31,9 @@ jobs:
           echo "Validating marketplace.json..."
           python3 -m json.tool .claude-plugin/marketplace.json > /dev/null
           echo "All JSON files are valid"
+
+      - name: Run isolated plugin smoke test
+        run: bash scripts/smoke-plugin.sh
+
+      - name: Check documentation links
+        run: bash scripts/check-links.sh

--- a/README.md
+++ b/README.md
@@ -8,31 +8,38 @@ AI-powered job application assistant that automatically fills out job applicatio
 
 | Skill | Description |
 |-------|-------------|
-| `/job-apply` | Fill out job applications automatically using your resume |
-| `/job-search` | Search LinkedIn for jobs with connections and hiring manager insights |
+| `/job-apply:job-apply` | Fill out job applications automatically using your resume |
+| `/job-apply:job-search` | Search LinkedIn, Hacker News, and Twitter/X for jobs, then rank results against your preferences |
+| `/job-apply:job-preferences` | Set the titles, salary, remote-work, and filtering preferences used by job search |
 
 ## Features
 
-### Job Apply (`/job-apply`)
+### Job Apply (`/job-apply:job-apply`)
 - **One-time profile setup**: Extract your information from a resume (PDF, DOCX, or TXT)
-- **Multi-platform support**: LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, Workday
-- **Dual-tool architecture**: Chrome MCP for authenticated sites, Playwright MCP for form filling and file uploads
+- **Guided ATS coverage**: Workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday, with current forms unverified
+- **Visible browser automation**: Claude in Chrome fills forms in the browser session you can see and control
 - **Smart field mapping**: Automatically matches your profile to form fields
-- **Safety first**: Never submits without your explicit confirmation
+- **Manual submission**: Stops at final review so only you can click Submit or Send
 - **Resume storage**: Profile saved locally for reuse across applications
 
-### Job Search (`/job-search`)
-- **Smart keyword suggestions**: Auto-generates search terms from your resume
+### Job Search (`/job-apply:job-search`)
+- **Preference-based search**: Searches for the titles, salary range, remote options, and time range you saved
 - **Connection insights**: Finds jobs at companies where you have connections
 - **Hiring manager discovery**: Identifies jobs with hiring managers listed
-- **Auto-inferred filters**: Location and experience level from your profile
-- **Results saved**: All searches saved to `~/.claude-job-searches/` as JSON
+- **Multi-source discovery**: Searches LinkedIn, Hacker News Who's Hiring, and Twitter/X
+- **Results saved**: Full search results saved to `~/.claude-job-searches/` as Markdown
+
+### Job Preferences (`/job-apply:job-preferences`)
+- **Reusable search settings**: Save target titles, salary floor, remote preference, exclusion patterns, and time range
+- **Shared profile**: Preferences are stored in `~/.claude-job-profile.json` without replacing resume profile data
+- **Selective updates**: Change individual preferences while preserving the rest
 
 ## Requirements
 
 - [Claude Code](https://claude.ai/code) CLI
-- [Claude in Chrome](https://chromewebstore.google.com/detail/claude-in-chrome) MCP server for authenticated browser sessions (LinkedIn)
-- [Playwright MCP](https://github.com/anthropics/claude-code/tree/main/.claude/plugins/playwright) server for form filling, file uploads, and iframe interaction
+- [Claude in Chrome](https://chromewebstore.google.com/detail/claude-in-chrome) for visible browser navigation, authenticated sessions, form filling, and local file uploads
+
+Playwright is not required. If you already have a Playwright integration configured, the skill may use it as a fallback when Chrome cannot reach a site-specific iframe or control. Otherwise, it leaves that field for you to complete manually.
 
 ## Installation
 
@@ -47,7 +54,7 @@ claude plugin install job-apply@neonwatty-plugins
 
 1. Invoke the skill:
    ```
-   /job-apply
+   /job-apply:job-apply
    ```
 
 2. Provide your resume path when prompted:
@@ -63,7 +70,7 @@ Once your profile is set up:
 
 1. Invoke the skill:
    ```
-   /job-apply
+   /job-apply:job-apply
    ```
 
 2. Provide a job URL:
@@ -73,50 +80,55 @@ Once your profile is set up:
 
 3. Watch as Claude fills out the application
 
-4. Review the summary and confirm submission
+4. Inspect the final review page and the field summary, then click Submit or Send yourself if everything is correct
 
 ### Searching for Jobs
 
-Use `/job-search` to find jobs where you have an advantage:
+First run `/job-apply:job-preferences` to save your search preferences. Then use `/job-apply:job-search` to search LinkedIn, Hacker News, and Twitter/X and rank matching jobs:
 
-1. Invoke the skill:
+1. Set or update your preferences:
    ```
-   /job-search
-   ```
-
-2. Claude will suggest keywords based on your resume:
-   ```
-   Based on your resume, I suggest searching for:
-   - Keywords: "Senior Software Engineer", "Staff Engineer"
-   - Location: San Francisco, CA
-   - Experience: Mid-Senior (7 years)
-
-   Ready to search, or would you like to adjust?
+   /job-apply:job-preferences
    ```
 
-3. Confirm or modify the suggestions
+2. Invoke the search skill:
+   ```
+   /job-apply:job-search
+   ```
 
-4. Review results prioritized by:
+3. Review the active search configuration loaded from your preferences:
+   ```
+   Search config:
+   - Titles: Senior Software Engineer, Staff Engineer
+   - Salary floor: $200K
+   - Remote: Remote preferred
+   - Time range: Last week
+   - Sources: LinkedIn, HN, Twitter
+   ```
+
+4. Review ranked results, including:
    - Jobs with hiring managers listed (highest priority)
    - Jobs with 1st-degree connections
-   - Jobs with alumni connections
+   - Matching Hacker News and Twitter/X opportunities
 
 Results are automatically saved to `~/.claude-job-searches/`.
 
-## Supported Platforms
+## Compatibility and Verification Status
 
-| Platform | URL Pattern | Tool | Status |
-|----------|-------------|------|--------|
-| LinkedIn Easy Apply | `linkedin.com/jobs/view/*` | Chrome MCP | Supported |
-| Greenhouse | `boards.greenhouse.io/*` | Playwright MCP | Supported |
-| Ashby | `jobs.ashbyhq.com/*` | Playwright MCP | Supported |
-| Lever | `jobs.lever.co/*` | Playwright MCP | Supported |
-| Rippling | `*.rippling.com/*` | Playwright MCP | Supported |
-| Workday | `*.myworkdayjobs.com/*` | Playwright MCP | Supported |
+The plugin includes guided workflows for six ATS families. Repository instructions and Claude in Chrome guidance were reviewed on **2026-07-18**, but this pass did not submit live applications or verify every current ATS form. Individual flows remain unverified and may drift as sites change.
+
+| Platform | URL Pattern | Default browser path | Verification status |
+|----------|-------------|----------------------|---------------------|
+| LinkedIn Easy Apply | `linkedin.com/jobs/view/*` | Claude in Chrome | Guided; current ATS flow unverified |
+| Greenhouse | `boards.greenhouse.io/*` | Claude in Chrome | Guided; current ATS flow unverified |
+| Ashby | `jobs.ashbyhq.com/*` | Claude in Chrome | Guided; current ATS flow unverified |
+| Lever | `jobs.lever.co/*` | Claude in Chrome | Guided; current ATS flow unverified |
+| Rippling | `*.rippling.com/*` | Claude in Chrome | Guided; current ATS flow unverified |
+| Workday | `*.myworkdayjobs.com/*` | Claude in Chrome | Guided; current ATS flow unverified |
 
 ## Profile Storage
 
-Your profile is stored at `~/.claude-job-profile.json` and includes:
+Your profile is stored as **plaintext** at `~/.claude-job-profile.json` and includes sensitive personal information such as:
 
 - Personal information (name, email, phone, location)
 - Work history
@@ -124,10 +136,20 @@ Your profile is stored at `~/.claude-job-profile.json` and includes:
 - Skills
 - Social links (LinkedIn, GitHub, portfolio)
 
-To reset your profile:
+The repository contains no telemetry or analytics integration, and the profile file is not uploaded to a plugin service. It remains on your computer until you direct Claude to use its values in browser forms or searches; those third-party sites receive the information you choose to enter there.
+
+Protect the file like a resume. Do not attach it to issues or share it in logs. On macOS or Linux, you can restrict access to your user account:
+
+```bash
+chmod 600 ~/.claude-job-profile.json
 ```
-/job-apply reset profile
+
+To replace the stored profile from a new resume:
 ```
+/job-apply:job-apply reset profile
+```
+
+To delete it completely, close Claude Code and remove only that file with `rm -i ~/.claude-job-profile.json`. Search-result Markdown files are separate under `~/.claude-job-searches/`; review and remove them independently if needed.
 
 ## Search Results Storage
 
@@ -135,8 +157,8 @@ Job search results are saved to `~/.claude-job-searches/` with timestamped filen
 
 ```
 ~/.claude-job-searches/
-  search-2026-01-06T10-30-00.json
-  search-2026-01-07T14-15-00.json
+  search-2026-01-06T10-30-00.md
+  search-2026-01-07T14-15-00.md
 ```
 
 Each file contains:
@@ -147,11 +169,30 @@ Each file contains:
 
 ## Safety Features
 
-- **Never enters passwords** - Stops if login is required
-- **Never creates accounts** - You must create accounts yourself
-- **Never submits without confirmation** - Always shows summary first
+- **Never handles credentials** - Pauses for you to complete login, password, CAPTCHA, or MFA steps
+- **Never creates accounts** - Pauses so you can decide whether to create an account yourself
+- **Never submits applications** - Stops at final review, summarizes entered fields, and leaves Submit or Send for you
 - **Never enters payment info** - Skips premium features
 - **Confirms sensitive questions** - Salary, visa status, etc.
+
+## Setup Check and Troubleshooting
+
+Before applying:
+
+1. Open Chrome and confirm Claude in Chrome is installed, enabled, and connected to Claude Code.
+2. Sign in to the job site yourself in the Chrome tab you want Claude to use.
+3. Keep your resume at a readable local path, then run `/job-apply:job-apply` and provide a test or intended job URL.
+4. Confirm Claude can read the page before allowing it to fill any fields.
+
+If the skill cannot see the page, reconnect Claude in Chrome and refresh the tab. If login, CAPTCHA, MFA, or account creation appears, complete it yourself and then tell Claude to continue. ATS markup changes frequently; if Chrome cannot reach an iframe, upload widget, or custom control, use an already-configured Playwright integration as an optional fallback or complete the remaining field manually. The plugin does not bypass blocked controls or guarantee every form on a platform will work.
+
+## Get Help or Share Feedback
+
+- [Ask for setup help](https://github.com/neonwatty/job-apply-plugin/issues/new?template=setup-help.yml)
+- [Report a redacted ATS failure](https://github.com/neonwatty/job-apply-plugin/issues/new?template=ats-failure.yml)
+- [Request an improvement](https://github.com/neonwatty/job-apply-plugin/issues/new?template=feature-request.yml)
+
+Before posting, remove names, email addresses, phone numbers, resume content, credentials, passwords, full application URLs, and other applicant data. The issue forms include a required redaction acknowledgment.
 
 ## License
 
@@ -160,6 +201,17 @@ MIT License - See [LICENSE](LICENSE) for details.
 ## Contributing
 
 Contributions welcome! Please open an issue or PR on GitHub.
+
+Before opening a PR, run the same deterministic checks used by CI:
+
+```bash
+bash scripts/smoke-plugin.sh
+bash scripts/check-links.sh
+claude plugin validate .
+git diff --check
+```
+
+The smoke test installs a temporary working-tree marketplace fixture under an isolated `CLAUDE_CONFIG_DIR` and removes it on exit. It does not alter your normal Claude configuration.
 
 ## Author
 

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LINK_TEMP_FILE="$(mktemp "${TMPDIR:-/tmp}/job-apply-links.XXXXXX")"
+
+cleanup() {
+  rm -f -- "$LINK_TEMP_FILE"
+}
+trap cleanup EXIT
+
+python3 - "$REPO_ROOT" > "$LINK_TEMP_FILE" <<'PY'
+import re
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+root = Path(sys.argv[1])
+sources = (root / "README.md", root / "site/index.html")
+
+class Links(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.targets = []
+        self.ids = set()
+
+    def handle_starttag(self, tag, attrs):
+        values = dict(attrs)
+        if "id" in values:
+            self.ids.add(values["id"])
+        if "name" in values:
+            self.ids.add(values["name"])
+        for key in ("href", "src"):
+            if key in values:
+                self.targets.append(values[key])
+
+remote = set()
+errors = []
+
+for source in sources:
+    text = source.read_text()
+    if source.suffix == ".md":
+        targets = re.findall(r"!?\[[^\]]*\]\(([^\s)]+)", text)
+        ids = set()
+    else:
+        parser = Links()
+        parser.feed(text)
+        targets = parser.targets
+        ids = parser.ids
+
+    for target in targets:
+        target = target.strip("<>")
+        parsed = urlsplit(target)
+        if parsed.scheme in {"http", "https"}:
+            remote.add(target)
+            continue
+        if parsed.scheme or target.startswith("//"):
+            continue
+        if not parsed.path:
+            if parsed.fragment and parsed.fragment not in ids:
+                errors.append(f"{source.relative_to(root)}: missing anchor #{parsed.fragment}")
+            continue
+        destination = (source.parent / unquote(parsed.path)).resolve()
+        try:
+            destination.relative_to(root.resolve())
+        except ValueError:
+            errors.append(f"{source.relative_to(root)}: target escapes repository: {target}")
+            continue
+        if not destination.exists():
+            errors.append(f"{source.relative_to(root)}: missing local target: {target}")
+
+if errors:
+    raise SystemExit("\n".join(errors))
+
+print("\n".join(sorted(remote)))
+PY
+
+echo "Local link targets passed"
+
+while IFS= read -r url; do
+  [ -n "$url" ] || continue
+  status="$(curl --head --location --max-redirs 3 --connect-timeout 5 --max-time 15 \
+    --retry 1 --retry-delay 1 --user-agent 'job-apply-plugin-link-check/1.0' \
+    --silent --show-error --output /dev/null --write-out '%{http_code}' "$url" || true)"
+  case "$status" in
+    2??|3??|401|403|405|429)
+      echo "Remote link reachable ($status): $url"
+      ;;
+    *)
+      echo "Remote link failed ($status): $url" >&2
+      exit 1
+      ;;
+  esac
+done < "$LINK_TEMP_FILE"
+
+echo "Link checks passed"

--- a/scripts/smoke-plugin.sh
+++ b/scripts/smoke-plugin.sh
@@ -91,7 +91,7 @@ CLAUDE_CONFIG_DIR="$SMOKE_CONFIG_DIR" claude plugin details job-apply@neonwatty-
   | tee "$SMOKE_TEMP_ROOT/plugin-details.txt"
 
 for skill in job-apply job-search job-preferences; do
-  if ! rg -q "$skill" "$SMOKE_TEMP_ROOT/plugin-details.txt"; then
+  if ! grep -Fq -- "$skill" "$SMOKE_TEMP_ROOT/plugin-details.txt"; then
     echo "Installed plugin details did not list $skill" >&2
     exit 1
   fi

--- a/scripts/smoke-plugin.sh
+++ b/scripts/smoke-plugin.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SMOKE_TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/job-apply-smoke.XXXXXX")"
+SMOKE_CONFIG_DIR="$SMOKE_TEMP_ROOT/claude-config"
+SMOKE_FIXTURE_DIR="$SMOKE_TEMP_ROOT/plugin-fixture"
+
+cleanup() {
+  rm -rf -- "$SMOKE_TEMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$SMOKE_CONFIG_DIR" "$SMOKE_FIXTURE_DIR"
+
+echo "Validating plugin manifest"
+claude plugin validate "$REPO_ROOT"
+
+python3 - "$REPO_ROOT" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+expected = {"job-apply", "job-search", "job-preferences"}
+
+for relative in (".claude-plugin/plugin.json", ".claude-plugin/marketplace.json"):
+    data = json.loads((root / relative).read_text())
+    if "version" in data:
+        raise SystemExit(f"{relative} must omit version for commit-resolved updates")
+    for plugin in data.get("plugins", []):
+        if "version" in plugin:
+            raise SystemExit(f"{relative} plugin entries must omit version")
+
+skill_dirs = {path.name for path in (root / "skills").iterdir() if path.is_dir()}
+if skill_dirs != expected:
+    raise SystemExit(f"skill directories differ: expected {sorted(expected)}, got {sorted(skill_dirs)}")
+
+for skill in expected:
+    content = (root / "skills" / skill / "SKILL.md").read_text()
+    match = re.search(r"(?m)^name:\s*([^\s]+)\s*$", content)
+    if not match or match.group(1) != skill:
+        raise SystemExit(f"skills/{skill}/SKILL.md frontmatter name is missing or incorrect")
+
+invocation_pattern = re.compile(r"/job-apply:(job-apply|job-search|job-preferences)")
+for relative in ("README.md", "site/index.html"):
+    found = set(invocation_pattern.findall((root / relative).read_text()))
+    if found != expected:
+        raise SystemExit(f"{relative} inventory differs: expected {sorted(expected)}, got {sorted(found)}")
+
+application_skill = (root / "skills/job-apply/SKILL.md").read_text()
+required_contract = (
+    "User confirmation never authorizes this skill to click Submit, Send, "
+    "or any equivalent final-action button."
+)
+if required_contract not in application_skill:
+    raise SystemExit("hard manual-submit contract is missing")
+
+safety_words = re.compile(
+    r"\b(never|not|do not|don't|stop|before|manual(?:ly)?|untouched|leaves?)\b",
+    re.IGNORECASE,
+)
+final_action = re.compile(r"\b(submit|send)\b", re.IGNORECASE)
+for number, line in enumerate(application_skill.splitlines(), 1):
+    if final_action.search(line) and not safety_words.search(line):
+        raise SystemExit(f"unsafe final-action instruction at skills/job-apply/SKILL.md:{number}: {line}")
+
+print("Static smoke assertions passed")
+PY
+
+echo "Creating isolated working-tree marketplace fixture"
+tar --exclude='./.git' --exclude='./docs/goals' -cf - -C "$REPO_ROOT" . \
+  | tar -xf - -C "$SMOKE_FIXTURE_DIR"
+
+python3 - "$SMOKE_FIXTURE_DIR/.claude-plugin/marketplace.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = Path(sys.argv[1])
+data = json.loads(manifest.read_text())
+data["plugins"][0]["source"] = "./"
+manifest.write_text(json.dumps(data, indent=2) + "\n")
+PY
+
+echo "Installing fixture with isolated CLAUDE_CONFIG_DIR=$SMOKE_CONFIG_DIR"
+CLAUDE_CONFIG_DIR="$SMOKE_CONFIG_DIR" claude plugin marketplace add "$SMOKE_FIXTURE_DIR"
+CLAUDE_CONFIG_DIR="$SMOKE_CONFIG_DIR" claude plugin install job-apply@neonwatty-plugins
+CLAUDE_CONFIG_DIR="$SMOKE_CONFIG_DIR" claude plugin details job-apply@neonwatty-plugins \
+  | tee "$SMOKE_TEMP_ROOT/plugin-details.txt"
+
+for skill in job-apply job-search job-preferences; do
+  if ! rg -q "$skill" "$SMOKE_TEMP_ROOT/plugin-details.txt"; then
+    echo "Installed plugin details did not list $skill" >&2
+    exit 1
+  fi
+done
+
+CLAUDE_CONFIG_DIR="$SMOKE_CONFIG_DIR" claude plugin list --json \
+  > "$SMOKE_TEMP_ROOT/plugin-list.json"
+python3 - "$SMOKE_TEMP_ROOT/plugin-list.json" <<'PY'
+import json
+import sys
+
+plugins = json.load(open(sys.argv[1]))
+serialized = json.dumps(plugins)
+if "job-apply@neonwatty-plugins" not in serialized:
+    raise SystemExit("isolated plugin list does not contain job-apply@neonwatty-plugins")
+print("Isolated local marketplace install passed")
+PY
+
+echo "Plugin smoke checks passed"

--- a/site/index.html
+++ b/site/index.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="AI-powered job application assistant for Claude Code. Fill out job applications automatically on LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.">
+  <meta name="description" content="AI-powered job application assistant for Claude Code with guided workflows for LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.">
   <link rel="canonical" href="https://neonwatty.github.io/job-apply-plugin/">
   <meta property="og:title" content="Job Apply Plugin - AI-powered job application assistant for Claude Code">
-  <meta property="og:description" content="Fill out job applications automatically using your resume. Supports LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
+  <meta property="og:description" content="Guided resume-based workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://neonwatty.github.io/job-apply-plugin/">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Job Apply Plugin - AI-powered job application assistant for Claude Code">
-  <meta name="twitter:description" content="Fill out job applications automatically using your resume. Supports LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
+  <meta name="twitter:description" content="Guided resume-based workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
   <title>Job Apply Plugin - AI-powered job application assistant for Claude Code</title>
   <link rel="stylesheet" href="styles.css">
 </head>
@@ -36,7 +36,7 @@
         <p class="eyebrow">AI-powered job application assistant for Claude Code</p>
         <h1>Fill out job applications automatically using your resume.</h1>
         <p class="lede">
-          Supports LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday. One-time profile setup from your resume, then apply to jobs with a single command.
+          Guided workflows cover LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday. Set up your profile once, then start a guided application with a single command.
         </p>
         <div class="actions" aria-label="Primary actions">
           <a class="button primary" href="#install">Get started</a>
@@ -52,7 +52,7 @@
         </div>
         <div class="terminal">
           <div class="terminal-title">Claude Code</div>
-          <div class="prompt">$ /job-apply</div>
+          <div class="prompt">$ /job-apply:job-apply</div>
           <div class="output output-dim">Paste the job URL you'd like to apply to:</div>
           <div class="prompt">https://linkedin.com/jobs/view/4019283746</div>
           <div class="output">
@@ -69,47 +69,60 @@
             <div class="field-row"><span class="check">&#10003;</span> Work authorization</div>
             <div class="field-row"><span class="active">&#9654;</span> Cover letter</div>
           </div>
-          <div class="output output-confirm">Ready to submit. Review and confirm?</div>
+          <div class="output output-confirm">Final review ready. Inspect the fields, then submit manually.</div>
         </div>
       </div>
     </section>
 
     <section class="section intro">
       <p>
-        Job Apply Plugin turns Claude Code into a job application assistant. Extract your profile once from a resume, then let Claude fill out applications across six major job platforms while you review and confirm.
+        Job Apply Plugin turns Claude Code into a job application assistant. Extract your profile once from a resume, then use guided form filling across six ATS families while you review every step and submit manually.
       </p>
     </section>
 
     <section id="skills" class="section">
       <div class="section-heading">
-        <p class="eyebrow">Two skills</p>
-        <h2>Apply to jobs and discover new opportunities.</h2>
+        <p class="eyebrow">Three skills</p>
+        <h2>Set your preferences, discover opportunities, and apply.</h2>
       </div>
       <div class="skills-grid">
         <article class="skill-card">
           <div class="skill-header">
-            <span class="skill-badge">/job-apply</span>
+            <span class="skill-badge">/job-apply:job-apply</span>
           </div>
           <h3>Fill out applications automatically</h3>
           <ul class="feature-bullets">
             <li>One-time profile setup from your resume (PDF, DOCX, or TXT)</li>
             <li>Multi-platform: LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, Workday</li>
             <li>Smart field mapping from your profile to form fields</li>
-            <li>Dual-tool architecture: Chrome MCP for authenticated sites, Playwright MCP for forms</li>
-            <li>Never submits without your explicit confirmation</li>
+            <li>Visible automation in your Claude in Chrome session</li>
+            <li>Stops at final review so only you can submit</li>
           </ul>
         </article>
         <article class="skill-card">
           <div class="skill-header">
-            <span class="skill-badge">/job-search</span>
+            <span class="skill-badge">/job-apply:job-search</span>
           </div>
           <h3>Find jobs where you have an advantage</h3>
           <ul class="feature-bullets">
-            <li>Auto-generates search keywords from your resume</li>
+            <li>Searches using your saved titles and filters</li>
             <li>Finds jobs at companies where you have connections</li>
             <li>Identifies jobs with hiring managers listed</li>
-            <li>Auto-inferred location and experience level filters</li>
-            <li>Results saved to <code>~/.claude-job-searches/</code> as JSON</li>
+            <li>Searches LinkedIn, Hacker News, and Twitter/X</li>
+            <li>Results saved to <code>~/.claude-job-searches/</code> as Markdown</li>
+          </ul>
+        </article>
+        <article class="skill-card">
+          <div class="skill-header">
+            <span class="skill-badge">/job-apply:job-preferences</span>
+          </div>
+          <h3>Save reusable search preferences</h3>
+          <ul class="feature-bullets">
+            <li>Sets target titles and minimum base salary</li>
+            <li>Records remote-work and time-range preferences</li>
+            <li>Filters out unwanted titles and seniority levels</li>
+            <li>Stores preferences with your local profile</li>
+            <li>Updates selected settings without replacing the rest</li>
           </ul>
         </article>
       </div>
@@ -117,8 +130,8 @@
 
     <section class="section platforms">
       <div class="section-heading">
-        <p class="eyebrow">Supported platforms</p>
-        <h2>Works where the jobs are.</h2>
+        <p class="eyebrow">Guided ATS workflows</p>
+        <h2>Six families, with honest limits.</h2>
       </div>
       <div class="platform-grid">
         <div class="platform-pill">LinkedIn Easy Apply</div>
@@ -128,12 +141,15 @@
         <div class="platform-pill">Rippling</div>
         <div class="platform-pill">Workday</div>
       </div>
+      <p>
+        Repository and browser guidance was reviewed on July 18, 2026. This pass did not submit live applications or verify every current ATS form; individual flows remain unverified and may drift as sites change.
+      </p>
     </section>
 
     <section id="requirements" class="section split">
       <div class="section-heading">
         <p class="eyebrow">Requirements</p>
-        <h2>Three tools, zero config.</h2>
+        <h2>One browser integration required.</h2>
       </div>
       <div class="feature-list">
         <article>
@@ -142,11 +158,11 @@
         </article>
         <article>
           <h3>Claude in Chrome</h3>
-          <p>MCP server for authenticated browser sessions, used for LinkedIn where login is required.</p>
+          <p>The visible default for browser navigation, authenticated sessions, form filling, and local file uploads.</p>
         </article>
         <article>
-          <h3>Playwright MCP</h3>
-          <p>Headless browser automation for form filling, file uploads, and iframe interaction on external ATS platforms.</p>
+          <h3>Optional fallback</h3>
+          <p>If already configured, Playwright may help with a site-specific iframe or control Chrome cannot reach. It is not required.</p>
         </article>
       </div>
     </section>
@@ -156,7 +172,7 @@
         <p class="eyebrow">Install</p>
         <h2>Add the plugin and start applying.</h2>
         <p>
-          Install from the Claude Code plugin marketplace, then invoke <code>/job-apply</code> with a job URL. Your profile is extracted once and reused across all applications.
+          Install from the Claude Code plugin marketplace, then invoke <code>/job-apply:job-apply</code> with a job URL. Your profile is extracted once and reused across all applications.
         </p>
       </div>
       <div class="code-card">
@@ -164,7 +180,7 @@
 claude plugin install job-apply@neonwatty-plugins
 
 # Then in Claude Code:
-/job-apply</code></pre>
+/job-apply:job-apply</code></pre>
       </div>
     </section>
 
@@ -175,16 +191,41 @@ claude plugin install job-apply@neonwatty-plugins
       </div>
       <div class="constraint-grid">
         <article>
-          <h3>Never submits without confirmation</h3>
-          <p>Every application shows a full summary and waits for your explicit approval before submitting.</p>
+          <h3>Only you submit</h3>
+          <p>Every application stops at final review with a field summary. You inspect the page and click Submit or Send yourself.</p>
         </article>
         <article>
           <h3>Never enters passwords</h3>
-          <p>If a site requires login, the plugin stops and asks you to sign in first.</p>
+          <p>The plugin pauses for login, password, CAPTCHA, MFA, or account creation so you can handle it yourself.</p>
         </article>
         <article>
           <h3>Never enters payment info</h3>
           <p>Premium features and paid prompts are skipped automatically.</p>
+        </article>
+        <article>
+          <h3>Changing ATS controls</h3>
+          <p>If Chrome cannot reach a site-specific field, the plugin reports it and leaves it for you unless an optional fallback is already configured.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-heading">
+        <p class="eyebrow">Privacy and support</p>
+        <h2>Know what stays local, and where to get help.</h2>
+      </div>
+      <div class="constraint-grid">
+        <article>
+          <h3>Plaintext local profile</h3>
+          <p>Your profile is stored at <code>~/.claude-job-profile.json</code>. Protect or delete it like a resume; never attach it to a public issue.</p>
+        </article>
+        <article>
+          <h3>No plugin telemetry</h3>
+          <p>The repository defines no telemetry service. Information is shared with third-party sites only when you direct Claude to use it in browser or search workflows.</p>
+        </article>
+        <article>
+          <h3>Friendly, redacted support</h3>
+          <p><a href="https://github.com/neonwatty/job-apply-plugin/issues/new/choose">Use a guided GitHub issue form</a> for setup help, ATS failures, or feature requests.</p>
         </article>
       </div>
     </section>

--- a/skills/job-apply/SKILL.md
+++ b/skills/job-apply/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: job-apply
-description: Fill out job applications automatically using your resume. Use when the user wants to apply for jobs on LinkedIn Easy Apply, Greenhouse, Ashby, or Workday.
+description: Fill out job applications automatically using your resume. Use when the user wants to apply for jobs on LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, or Workday.
 allowed-tools: Read, Write, Bash, mcp__claude-in-chrome__*, mcp__plugin_playwright_playwright__*
 ---
 
@@ -14,7 +14,7 @@ When this skill is invoked, first check if a profile exists at `~/.claude-job-pr
 
 **If NO profile exists**, say:
 
-> Welcome to the Job Application Assistant! I'll help you fill out job applications on LinkedIn, Greenhouse, and Workday.
+> Welcome to the Job Application Assistant! I'll help you fill out job applications on LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.
 >
 > First, I need to set up your profile. This is a one-time process — your information will be saved for future applications.
 >
@@ -48,73 +48,27 @@ Your extracted profile is stored at `~/.claude-job-profile.json` for reuse acros
 
 ---
 
-## Dual-Tool Architecture
+## Browser Routing
 
-This skill uses **two browser automation tools** together because each has capabilities the other lacks:
+Use **Claude in Chrome** as the default and only required browser integration. Work in the visible Chrome session so the user can see navigation, authenticated state, entered values, uploads, and the final review page.
 
-| Capability | Chrome MCP | Playwright MCP |
-|---|---|---|
-| Authenticated sessions (LinkedIn) | Yes | No — runs a separate browser with no login |
-| File uploads | No — opens OS file picker that can't be controlled | Yes — `setInputFiles` and `browser_file_upload` |
-| Iframe interaction | Limited — can't reliably reach iframe content | Yes — snapshots include iframe elements transparently |
-| JavaScript injection | Yes — `javascript_tool` | Yes — `browser_evaluate` and `browser_run_code` |
-| Dropdown/combobox interaction | Limited | Yes — `browser_fill_form` and `browser_click` |
+### Chrome-First Rules
 
-### Tool Routing Rules
+- Use Claude in Chrome for LinkedIn and every external application portal.
+- Use the user's existing authenticated Chrome session, but never ask for, read, store, or enter credentials.
+- Pause for the user to handle login, password, CAPTCHA, MFA, consent prompts, or account creation.
+- Use Chrome's visible form controls and local file-upload support. Confirm the selected filename after an upload.
+- If an Apply link opens an external portal or a new tab, continue there in Claude in Chrome.
 
-**Use Chrome MCP (`mcp__claude-in-chrome__*`) for:**
-- LinkedIn navigation (requires logged-in session)
-- Any site requiring authentication
-- JavaScript injection to capture external URLs
-- Reading LinkedIn job details
+### Optional Playwright Fallback
 
-**Use Playwright MCP (`mcp__plugin_playwright_playwright__*`) for:**
-- External application portals (Greenhouse, Ashby, Lever, Rippling, Workday)
-- File uploads (resume, cover letter)
-- Forms embedded in iframes
-- Dropdown and combobox interaction
-- Any form filling on non-authenticated pages
+Playwright is not required. Use it only when **all** of the following are true:
 
-### The Handoff Pattern
+1. The user already has a Playwright integration configured.
+2. Chrome cannot reach a specific iframe, upload widget, or custom control after a reasonable visible attempt.
+3. The fallback does not require transferring login state or credentials.
 
-1. **Chrome MCP** navigates to the LinkedIn job listing (authenticated)
-2. **Chrome MCP** clicks Apply — if it's an external application, captures the external URL via JavaScript interception
-3. **Playwright MCP** opens the captured URL and fills the form, uploads files, and submits
-
----
-
-## LinkedIn → External URL Extraction
-
-When a LinkedIn job uses an external application portal, the Apply button opens a new tab. Use JavaScript interception to capture that URL.
-
-### Pattern A: Button with `window.open` (most common)
-
-```javascript
-// Step 1: Set up interceptor in Chrome MCP
-var originalOpen = window.open;
-window.open = function(url, target, features) {
-  document.title = 'CAPTURED:' + url;
-  var w = originalOpen.call(window, url, target, features);
-  return w;
-};
-
-// Step 2: Click the Apply button
-document.querySelector('button.jobs-apply-button').click();
-
-// Step 3: Read document.title — it will start with "CAPTURED:" followed by the URL
-```
-
-### Pattern B: Link with `target="_blank"` (fallback)
-
-```javascript
-// Remove target="_blank" so it navigates in the same tab
-var link = document.querySelector('a.jobs-apply-button');
-link.removeAttribute('target');
-link.click();
-// Read the URL from the Chrome tab after navigation
-```
-
-After capturing the URL, pass it to Playwright MCP via `browser_navigate`.
+Use the fallback only for the blocked control, then return to the visible review workflow. If these conditions are not met, explain which field is blocked and leave it for the user to complete manually.
 
 ---
 
@@ -140,18 +94,18 @@ If no profile exists at `~/.claude-job-profile.json`, or if the user requests a 
 ### Phase 2: Application Filling
 
 1. **Load profile** from `~/.claude-job-profile.json`
-2. **Determine starting point**:
-   - If URL is LinkedIn (`linkedin.com`) → use **Chrome MCP** to navigate (authenticated)
-   - If URL is a direct external portal → skip to step 5 with **Playwright MCP**
-3. **Chrome MCP**: Navigate to LinkedIn job listing, click Apply
-4. **Chrome MCP**: If external portal, capture URL using JS interception pattern (see above)
-5. **Playwright MCP**: Navigate to external URL with `browser_navigate`
-6. **Playwright MCP**: Detect platform, read form structure with `browser_snapshot`
-7. **Playwright MCP**: Fill fields with `browser_fill_form`, handle dropdowns with `browser_click`
-8. **Playwright MCP**: Upload resume with `browser_file_upload` or `browser_run_code` using `setInputFiles`
-9. **Playwright MCP**: Take snapshot to verify all fields are filled correctly
-10. **Present summary** to user showing all filled values, wait for explicit confirmation
-11. **Playwright MCP**: Click Submit
+2. **Open the URL in Claude in Chrome** and identify the job site and application flow
+3. **Pause for user-only steps** if login, password, CAPTCHA, MFA, consent, or account creation appears
+4. **Open the application form**; if an Apply link opens an external portal, continue in that visible Chrome tab
+5. **Read the form** and fill only values supported by the confirmed profile
+6. **Ask before sensitive answers** such as salary, work authorization, visa status, demographic information, or disability disclosure
+7. **Upload the resume** through the visible file control and verify the selected filename
+8. **Handle inaccessible controls** using the optional fallback rules above, or leave the field for the user
+9. **Advance through non-final steps** only when the control is clearly Next, Continue, Save, or Review
+10. **Stop at final review** before any Submit, Send, or equivalent final-action button
+11. **Summarize every entered value**, identify anything incomplete or uncertain, and tell the user to inspect the page and submit manually
+
+User confirmation never authorizes this skill to click Submit, Send, or any equivalent final-action button.
 
 ---
 
@@ -173,7 +127,7 @@ If no profile exists at `~/.claude-job-profile.json`, or if the user requests a 
    - Work authorization questions (dropdowns)
    - Custom screening questions (varies by employer)
 4. Click "Next" to advance, "Review" on final step
-5. Screenshot the review page before "Submit application"
+5. Stop on the review page, summarize all entered fields, and leave "Submit application" untouched for the user
 
 **Field patterns to look for:**
 - `input[name*="phone"]` - Phone number
@@ -187,20 +141,20 @@ If no profile exists at `~/.claude-job-profile.json`, or if the user requests a 
 - Single long-form page with sections
 - Clear field labels
 - Often has "Add another" for work history/education
-- **Frequently embedded in iframes** on company career sites — Playwright handles this transparently
+- May be embedded in an iframe on a company career site
 
-**Approach (use Playwright MCP):**
-1. Navigate to URL with `browser_navigate`
-2. Use `browser_snapshot` to read full form — iframe content appears with `f54eXX` refs
-3. Fill from top to bottom using `browser_fill_form`
+**Approach (Chrome first):**
+1. Navigate to the application URL in Claude in Chrome
+2. Read the visible form; if an embedded form is inaccessible, follow the optional fallback rules or leave it for the user
+3. Fill from top to bottom
 4. **Phone country code**: Click the country code toggle → select "United States: +1" from the listbox → the phone field auto-formats with +1 prefix
 5. For work history sections:
    - Fill most recent position
    - Click "Add another" if form allows and user has more history
 6. Education section similar pattern
 7. Handle custom questions at bottom
-8. Upload resume via `browser_file_upload` or `browser_run_code` with `setInputFiles`
-9. Single "Submit Application" button at end
+8. Upload the resume through the visible file control and confirm the filename
+9. Stop before the final "Submit Application" button, summarize the fields, and hand control to the user
 
 **Field patterns:**
 - Standard `<input>` and `<select>` elements
@@ -214,14 +168,14 @@ If no profile exists at `~/.claude-job-profile.json`, or if the user requests a 
 - Fields: name, phone, email, location (combobox), LinkedIn URL, resume upload
 - Has both a resume upload field and a separate autofill file input — use the resume field, not the autofill one
 
-**Approach (use Playwright MCP):**
-1. Navigate to URL with `browser_navigate`
-2. Use `browser_snapshot` to read form structure
-3. Fill text fields with `browser_fill_form` (name, phone, email, LinkedIn URL)
+**Approach (Chrome first):**
+1. Navigate to the URL in Claude in Chrome
+2. Read the visible form structure
+3. Fill text fields (name, phone, email, LinkedIn URL)
 4. **Location combobox**: Type the location to trigger suggestions, then click the matching option
-5. **Resume upload**: Use `browser_run_code` with `page.locator('#_systemfield_resume').setInputFiles('/path/to/resume.pdf')` — target `#_systemfield_resume` specifically, not the autofill input
-6. Verify with `browser_snapshot`
-7. Submit
+5. **Resume upload**: Use the resume field, not the separate autofill file input, and verify the filename
+6. Review all visible values
+7. Stop before the final action, summarize the fields, and let the user submit manually
 
 ### Lever
 
@@ -231,23 +185,13 @@ If no profile exists at `~/.claude-job-profile.json`, or if the user requests a 
 - Text fields for name, email, phone, LinkedIn, etc.
 - Radio buttons for screening questions — often use custom overlays that intercept clicks
 
-**Approach (use Playwright MCP):**
-1. Navigate to URL with `browser_navigate`
+**Approach (Chrome first):**
+1. Navigate to the URL in Claude in Chrome
 2. Scroll down to find the application form (usually below job description)
-3. Use `browser_snapshot` to read form structure
-4. Fill text fields with `browser_fill_form`
-5. **Radio buttons**: If `browser_click` doesn't work (overlay intercepts), use `browser_evaluate` with:
-   ```javascript
-   element.click();
-   element.dispatchEvent(new Event('change', {bubbles: true}));
-   ```
-6. **Resume upload**: Use `browser_run_code` to find the hidden file input and call `setInputFiles`:
-   ```javascript
-   async (page) => {
-     await page.locator('input[type="file"][name="resume"]').setInputFiles('/path/to/resume.pdf');
-   }
-   ```
-7. Verify with `browser_snapshot`, then submit
+3. Read the visible form structure and fill text fields
+4. **Radio buttons**: If a custom overlay blocks a control, follow the optional fallback rules or leave it for the user
+5. **Resume upload**: Use the visible resume file control and verify the filename
+6. Review all fields, stop before the final action, and let the user submit manually
 
 ### Rippling
 
@@ -256,33 +200,33 @@ If no profile exists at `~/.claude-job-profile.json`, or if the user requests a 
 - Upload resume first, then verify/correct auto-filled data
 - Location uses a typeahead combobox
 
-**Approach (use Playwright MCP):**
-1. Navigate to URL with `browser_navigate`
+**Approach (Chrome first):**
+1. Navigate to the URL in Claude in Chrome
 2. **Upload resume first** — Rippling will auto-parse and fill fields
-3. Use `browser_snapshot` to see what was auto-filled
-4. Correct any mis-parsed fields with `browser_fill_form`
+3. Read the visible form to see what was auto-filled
+4. Correct any mis-parsed fields
 5. **Location combobox**: Clear existing value, type the correct location, wait for dropdown, click match
 6. Fill any remaining required fields
-7. Verify with `browser_snapshot`, then submit
+7. Review the parsed and entered values, stop before the final action, and let the user submit manually
 
 ### Workday
 
 **Characteristics:**
 - Multi-page wizard with heavy JavaScript
 - Non-standard UI components (custom dropdowns, date pickers)
-- Often requires account creation (STOP and inform user - do not create accounts)
+- Often requires account creation (pause so the user can decide and handle it)
 
-**Approach (use Playwright MCP):**
-1. If login/account creation required, STOP and inform user they must handle this
+**Approach (Chrome first):**
+1. If login, CAPTCHA, MFA, or account creation is required, pause for the user; never handle credentials or create the account
 2. Navigate through "My Information" → "My Experience" → "Application Questions"
-3. Use `browser_snapshot` to read form structure on each page
-4. For dropdowns: `browser_click` to open, then `browser_snapshot` to read options, then `browser_click` option
+3. Read the visible form structure on each page
+4. For dropdowns: open the field, read the visible options, then choose the supported value
 5. For date fields: May need to click calendar icon, then select date
-6. Watch for "Save and Continue" vs "Submit" buttons
-7. Upload resume via `browser_file_upload` or `browser_run_code`
+6. Use "Save and Continue" for intermediate steps, but stop before "Submit" or any equivalent final action
+7. Upload the resume through the visible file control and verify the filename
 
 **Special handling:**
-- Workday dropdowns: Click field → wait → read options with `browser_snapshot` → click option
+- Workday dropdowns: Click field → wait → read the visible options → click the supported option
 - Date pickers: Often format-sensitive, try MM/DD/YYYY
 - Required fields marked with asterisk or red border after validation
 
@@ -309,127 +253,36 @@ If no profile exists at `~/.claude-job-profile.json`, or if the user requests a 
 
 ---
 
-## Chrome MCP Tool Usage
+## Browser Tool Usage
 
-### Reading Forms
-```
-Use read_page with filter: "interactive" to see all form fields
-Use find with natural language: "email input field", "submit button"
-```
+### Claude in Chrome (Default)
 
-### Filling Fields
-```
-Use form_input for standard inputs and selects:
-  - ref: element reference from read_page
-  - value: the value to set
+1. Read the visible page and identify interactive fields.
+2. Fill standard fields and use visible controls for dropdowns, radio buttons, and checkboxes.
+3. Upload the resume through the page's file control and verify the displayed filename.
+4. After each non-final Next, Continue, or Save action, read the new page before proceeding.
+5. When Review, Submit, Send, or an equivalent final action appears, stop and summarize the application for the user.
 
-Use computer with action: "left_click" for custom dropdowns:
-  1. Click to open dropdown
-  2. read_page to see options
-  3. Click the correct option
-```
+### Playwright (Optional Fallback Only)
 
-### File Upload (Resume)
-```
-Use find to locate file input: "resume upload field"
-Use form_input or computer to trigger file picker
-Note: May need to use upload_image tool for some implementations
-```
-
-### Multi-Page Navigation
-```
-After filling current page:
-1. find "next button" or "continue button"
-2. Take screenshot for record
-3. Click next
-4. read_page on new step
-5. Repeat until review/submit page
-```
-
----
-
-## Playwright MCP Tool Usage
-
-### Reading Forms
-```
-Use browser_snapshot to get the full accessibility tree, including iframe content.
-Iframe elements appear with refs like "f54eXX" — these refs work with all Playwright tools.
-```
-
-### Filling Fields
-```
-Use browser_fill_form with ref/value pairs from the snapshot:
-  - fields: [{ name: "First Name", type: "textbox", ref: "ref123", value: "John" }]
-
-For multiple fields at once, pass an array of field objects.
-```
-
-### Dropdowns and Comboboxes
-```
-1. browser_click on the dropdown toggle/button to open it
-2. browser_snapshot to read the available options
-3. browser_click on the correct option
-
-For comboboxes (typeahead): type into the field first, then click the matching suggestion.
-```
-
-### File Upload
-Two patterns depending on the form:
-
-**Pattern A: Direct setInputFiles (preferred)**
-```
-Use browser_run_code:
-  async (page) => {
-    await page.locator('#resume-input').setInputFiles('/path/to/resume.pdf');
-  }
-Replace '#resume-input' with the actual selector for the file input.
-```
-
-**Pattern B: File chooser interception**
-```
-Use browser_run_code:
-  async (page) => {
-    const [fileChooser] = await Promise.all([
-      page.waitForEvent('filechooser'),
-      page.locator('button:has-text("Upload")').click()
-    ]);
-    await fileChooser.setFiles('/path/to/resume.pdf');
-  }
-
-If a modal appears after upload, use browser_file_upload to complete it.
-```
-
-### Iframe Interaction
-```
-Playwright handles iframes transparently.
-browser_snapshot shows iframe content with refs (e.g., "f54eXX").
-These refs work directly with browser_fill_form, browser_click, etc.
-No special handling needed — just use the refs from the snapshot.
-```
-
-### Custom Radio Buttons
-```
-If browser_click is intercepted by overlays, use browser_evaluate:
-  element.click();
-  element.dispatchEvent(new Event('change', {bubbles: true}));
-Pass the ref of the radio input element.
-```
+If Playwright is already configured and Chrome cannot reach a specific iframe or custom control, it may be used only for that blocked field. Do not require it, do not transfer authenticated state or credentials, and do not use it to activate Submit, Send, or any equivalent final action. If the fallback is unavailable or unsuccessful, leave the field for the user.
 
 ---
 
 ## Safety Rules
 
-1. **Never enter passwords** - If login required, stop and instruct user
-2. **Never create accounts** - Stop and inform user they must create accounts themselves
-3. **Never click Submit without confirmation** - Always take a snapshot and get explicit "yes"
+1. **Never handle credentials** - Pause for the user to complete login, password, CAPTCHA, and MFA steps
+2. **Never create accounts** - Pause so the user can decide and create an account themselves
+3. **Never submit applications** - Stop at final review; confirmation does not authorize clicking Submit, Send, or an equivalent final action
 4. **Never enter payment information** - Some applications have optional premium features
 5. **Handle sensitive questions carefully** - Salary expectations, visa status, disability disclosure should be confirmed with user before filling
-6. **Always use Chrome MCP for LinkedIn** - Playwright cannot access authenticated sessions
-7. **Never store or pass login credentials between tools** - Each tool uses its own browser context
+6. **Use Claude in Chrome by default** - Playwright is only an already-configured fallback for a specific inaccessible control
+7. **Never store or pass login credentials between tools** - Authentication remains a user-only step in the visible Chrome session
 
 ---
 
 ## Example Invocation
 
 ```
-User: Help me apply to this job: https://www.linkedin.com/jobs/view/123456789
+User: /job-apply:job-apply https://www.linkedin.com/jobs/view/123456789
+```

--- a/skills/job-preferences/SKILL.md
+++ b/skills/job-preferences/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: job-preferences
-description: Set or update your job search preferences (titles, salary, remote, filters). Used by /job-search and other skills.
+description: Set or update your job search preferences (titles, salary, remote, filters). Used by /job-apply:job-search and other skills.
 allowed-tools: Read, Write
 ---
 
 # Job Preferences
 
-A Claude Code skill for managing persistent job search preferences. Set your target titles, salary floor, remote preference, and exclusion filters once — `/job-search` and other skills reuse them automatically.
+A Claude Code skill for managing persistent job search preferences. Set your target titles, salary floor, remote preference, and exclusion filters once — `/job-apply:job-search` and other skills reuse them automatically.
 
 ---
 
@@ -77,7 +77,7 @@ Use `AskUserQuestion` to collect all fields. Ask up to 4 questions at a time (th
 
 ### Step 4: Save Preferences
 
-Write the collected values into `~/.claude-job-profile.json` under the `preferences` key. Preserve all other existing keys in the file (like profile data used by `/job-apply`).
+Write the collected values into `~/.claude-job-profile.json` under the `preferences` key. Preserve all other existing keys in the file (like profile data used by `/job-apply:job-apply`).
 
 **Schema:**
 
@@ -99,18 +99,18 @@ Display the saved preferences and confirm:
 
 > **Preferences saved to `~/.claude-job-profile.json`.**
 >
-> These will be used automatically by `/job-search`. Run `/job-preferences` again any time to update them.
+> These will be used automatically by `/job-apply:job-search`. Run `/job-apply:job-preferences` again any time to update them.
 
 ---
 
 ## Updating Preferences
 
-When the user runs `/job-preferences` and preferences already exist, show current values and let them update selectively. Only overwrite the fields they change — keep the rest intact.
+When the user runs `/job-apply:job-preferences` and preferences already exist, show current values and let them update selectively. Only overwrite the fields they change — keep the rest intact.
 
 ---
 
 ## Safety Rules
 
 1. **Never overwrite non-preference data** — only read/write the `preferences` key in the profile JSON
-2. **Preserve existing profile** — `/job-apply` stores resume data in the same file; never delete or modify those keys
+2. **Preserve existing profile** — `/job-apply:job-apply` stores resume data in the same file; never delete or modify those keys
 3. **No defaults without user input** — always ask the user, never assume values

--- a/skills/job-search/SKILL.md
+++ b/skills/job-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: job-search
 description: Search LinkedIn, Hacker News, and Twitter/X for jobs with connections, hiring manager insights, and preference-based scoring. Use when the user wants to find jobs, search for positions, or explore job opportunities.
-allowed-tools: Read, Write, Bash, WebSearch, WebFetch, mcp__claude-in-chrome__*, mcp__plugin_playwright_playwright__*
+allowed-tools: Read, Write, Bash, WebSearch, WebFetch, mcp__claude-in-chrome__*
 ---
 
 # Multi-Source Job Search
@@ -18,7 +18,7 @@ Read `~/.claude-job-profile.json`. Check for the `preferences` key.
 
 **If no preferences found**, say:
 
-> No search preferences found. Run `/job-preferences` first to set your target titles, salary range, and filters.
+> No search preferences found. Run `/job-apply:job-preferences` first to set your target titles, salary range, and filters.
 
 Then **STOP**. Do not prompt the user to set preferences inline.
 
@@ -331,7 +331,7 @@ If confirmed, append to `application_queue.md` under a new "## Tier 3 — Auto-D
 
 ## Safety Rules
 
-1. **Never enter credentials** — if login is required, stop and instruct user to log in manually
+1. **Never handle credentials** — pause for the user to complete login, password, CAPTCHA, or MFA steps manually
 2. **Never click Apply** — this skill is for searching only, not applying
 3. **Never create accounts** — stop and inform user if account creation is required
 4. **Respect rate limits per source**:
@@ -350,30 +350,30 @@ If confirmed, append to `application_queue.md` under a new "## Tier 3 — Auto-D
 
 **Standard search (all sources):**
 ```
-User: /job-search
+User: /job-apply:job-search
 Claude: [Loads preferences, searches LinkedIn + HN + Twitter, displays ranked results]
 ```
 
 **With time range override:**
 ```
-User: /job-search 2 weeks
+User: /job-apply:job-search 2 weeks
 Claude: [Uses 2-week time range instead of default]
 ```
 
 **Single source:**
 ```
-User: /job-search hn
+User: /job-apply:job-search hn
 Claude: [Searches only Hacker News Who's Hiring]
 ```
 
 **Multiple source filter:**
 ```
-User: /job-search linkedin hn
+User: /job-apply:job-search linkedin hn
 Claude: [Searches LinkedIn and HN, skips Twitter]
 ```
 
 **With extra keywords:**
 ```
-User: /job-search agentic systems
+User: /job-apply:job-search agentic systems
 Claude: [Adds "agentic systems" to title-based keywords]
 ```


### PR DESCRIPTION
## What changed

- Correct all documented plugin invocations to use the `/job-apply:*` namespace and document the full three-skill inventory.
- Remove duplicate `1.0.0` version pins so Git-backed installs can resolve updates by commit.
- Make Claude in Chrome the default browser path, with Playwright documented only as an optional fallback.
- Stop every application at final review so only the user can click Submit or Send.
- Add honest ATS verification status, plaintext-profile privacy guidance, troubleshooting, and redaction-safe issue forms.
- Add isolated clean-install smoke coverage, bounded link checks, and run both in CI.

## Why

The repository had accumulated several onboarding and trust gaps: unnamespaced commands that do not match installed plugin skills, a missing third skill in public docs, stale version pins that could prevent updates, a broken mandatory Playwright link, JSON/Markdown output contradictions, and application instructions that could cross the intended human-submit boundary.

This pass makes the public setup path match the actual plugin package while keeping current ATS coverage claims deliberately conservative.

## User and developer impact

New users get accurate installation and invocation instructions, a simpler visible-browser setup, an explicit manual-submit boundary, and safer support paths. Maintainers get deterministic checks for manifest versions, skill inventory, documentation consistency, links, and isolated installation behavior.

No live application was submitted during verification, and the six ATS workflows remain labeled as currently unverified because those sites can drift.

## Validation

- `bash scripts/smoke-plugin.sh`
- `bash scripts/check-links.sh`
- `claude plugin validate .`
- JSON parsing for both manifests
- YAML parsing for workflows and issue forms
- `bash -n scripts/smoke-plugin.sh scripts/check-links.sh`
- `git diff --check`

The smoke test installs a temporary working-tree marketplace fixture under an isolated `CLAUDE_CONFIG_DIR`, confirms exactly three skills, and removes the fixture afterward.