### PR TITLE
Add local answer memory and trust layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ AI-powered job application assistant that automatically fills out job applicatio
 | Skill | Description |
 |-------|-------------|
 | `/job-apply:job-apply` | Fill out job applications automatically using your resume |
+| `/job-apply:answer-memory` | Safely manage your local profile, reusable answers, application history, and resumable sessions |
 | `/job-apply:job-search` | Search LinkedIn, Hacker News, and Twitter/X for jobs, then rank results against your preferences |
 | `/job-apply:job-preferences` | Set the titles, salary, remote-work, and filtering preferences used by job search |
 
@@ -19,8 +20,17 @@ AI-powered job application assistant that automatically fills out job applicatio
 - **Guided ATS coverage**: Workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday, with current forms unverified
 - **Visible browser automation**: Claude in Chrome fills forms in the browser session you can see and control
 - **Smart field mapping**: Automatically matches your profile to form fields
+- **Confidence-aware answer reuse**: Reuses confirmed non-sensitive answers and flags inferred, missing, or sensitive answers for review
+- **Resumable progress**: Saves application step metadata and answer references without copying answer values
 - **Manual submission**: Stops at final review so only you can click Submit or Send
 - **Resume storage**: Profile saved locally for reuse across applications
+
+### Answer Memory (`/job-apply:answer-memory`)
+- **One local contract**: All Job Apply skills use the same bundled storage helper
+- **Reusable answers**: Records confirmed, inferred, missing, and sensitive states with provenance and scope
+- **Separate remember consent**: A sensitive answer is never retained merely because it was used in a form
+- **Minimal history**: Application events and sessions reference answer keys instead of duplicating values
+- **Non-destructive migration**: Imports an existing legacy profile once and leaves the original file untouched
 
 ### Job Search (`/job-apply:job-search`)
 - **Preference-based search**: Searches for the titles, salary range, remote options, and time range you saved
@@ -31,7 +41,7 @@ AI-powered job application assistant that automatically fills out job applicatio
 
 ### Job Preferences (`/job-apply:job-preferences`)
 - **Reusable search settings**: Save target titles, salary floor, remote preference, exclusion patterns, and time range
-- **Shared profile**: Preferences are stored in `~/.claude-job-profile.json` without replacing resume profile data
+- **Shared profile**: Preferences are stored in `~/.job-apply/profile.json` without replacing resume profile data
 - **Selective updates**: Change individual preferences while preserving the rest
 
 ## Requirements
@@ -128,7 +138,25 @@ The plugin includes guided workflows for six ATS families. Repository instructio
 
 ## Profile Storage
 
-Your profile is stored as **plaintext** at `~/.claude-job-profile.json` and includes sensitive personal information such as:
+Job Apply stores data as **plaintext local files** under `~/.job-apply/`:
+
+```text
+~/.job-apply/
+  profile.json
+  answers.json
+  applications.jsonl
+  sessions/
+    <application-id>.json
+```
+
+| File | Purpose |
+|------|---------|
+| `profile.json` | Resume facts and job-search preferences |
+| `answers.json` | Reusable answers with confirmation, source, scope, and sensitivity state |
+| `applications.jsonl` | Minimal append-only application lifecycle events |
+| `sessions/*.json` | Resumable workflow metadata and answer-key references |
+
+These files can include sensitive personal information such as:
 
 - Personal information (name, email, phone, location)
 - Work history
@@ -136,20 +164,27 @@ Your profile is stored as **plaintext** at `~/.claude-job-profile.json` and incl
 - Skills
 - Social links (LinkedIn, GitHub, portfolio)
 
-The repository contains no telemetry or analytics integration, and the profile file is not uploaded to a plugin service. It remains on your computer until you direct Claude to use its values in browser forms or searches; those third-party sites receive the information you choose to enter there.
+The repository contains no telemetry or analytics integration, and the store is not uploaded to a plugin service. It remains on your computer until you direct Claude to use values in browser forms or searches; those third-party sites receive the information you choose to enter there.
 
-Protect the file like a resume. Do not attach it to issues or share it in logs. On macOS or Linux, you can restrict access to your user account:
+Protect the directory like a resume. Do not attach its files to issues or share them in logs. The helper creates user-only permissions on supported systems. On macOS or Linux, you can verify or restore them with:
 
 ```bash
-chmod 600 ~/.claude-job-profile.json
+chmod 700 ~/.job-apply
+chmod 600 ~/.job-apply/profile.json ~/.job-apply/answers.json ~/.job-apply/applications.jsonl
 ```
+
+On first use, an existing `~/.claude-job-profile.json` is copied into the new versioned profile without modifying or deleting the legacy file. Once `~/.job-apply/profile.json` exists it is authoritative; later legacy-file changes are not re-imported. Verify the new profile before deciding whether to archive or remove the old file.
+
+All plugin skills access this data through the bundled `scripts/job-apply-store.py` helper. Canonical JSON updates are atomic, corrupt or future-version files fail closed, and application history and sessions do not duplicate reusable answer values.
+
+Only matching, non-sensitive `confirmed` answers may be reused without asking. Inferred and missing answers require review. Sensitive answers are reconfirmed before every use and are stored only when you separately ask Job Apply to remember that specific value.
 
 To replace the stored profile from a new resume:
 ```
 /job-apply:job-apply reset profile
 ```
 
-To delete it completely, close Claude Code and remove only that file with `rm -i ~/.claude-job-profile.json`. Search-result Markdown files are separate under `~/.claude-job-searches/`; review and remove them independently if needed.
+To remove Job Apply data, close Claude Code and first move the directory to a private backup so recovery remains possible, for example `mv ~/.job-apply ~/.job-apply.backup`. Search-result Markdown files are separate under `~/.claude-job-searches/`; review them independently. The legacy `~/.claude-job-profile.json` is also separate and is never deleted automatically.
 
 ## Search Results Storage
 
@@ -174,6 +209,7 @@ Each file contains:
 - **Never submits applications** - Stops at final review, summarizes entered fields, and leaves Submit or Send for you
 - **Never enters payment info** - Skips premium features
 - **Confirms sensitive questions** - Salary, visa status, etc.
+- **Separates use from storage consent** - Filling a sensitive answer once never automatically remembers it
 
 ## Setup Check and Troubleshooting
 

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -33,7 +33,8 @@ class Links(HTMLParser):
             self.ids.add(values["name"])
         for key in ("href", "src"):
             if key in values:
-                self.targets.append(values[key])
+                kind = "link" if key == "href" else "asset"
+                self.targets.append((kind, values[key]))
 
 remote = set()
 errors = []
@@ -41,7 +42,16 @@ errors = []
 for source in sources:
     text = source.read_text()
     if source.suffix == ".md":
-        targets = re.findall(r"!?\[[^\]]*\]\(([^\s)]+)", text)
+        image_pattern = r"!\[[^\]]*\]\(([^\s)]+)\)"
+        targets = [
+            ("asset", target)
+            for target in re.findall(image_pattern, text)
+        ]
+        text_without_images = re.sub(image_pattern, "", text)
+        targets.extend(
+            ("link", target)
+            for target in re.findall(r"\[[^\]]*\]\(([^\s)]+)", text_without_images)
+        )
         ids = set()
     else:
         parser = Links()
@@ -49,11 +59,14 @@ for source in sources:
         targets = parser.targets
         ids = parser.ids
 
-    for target in targets:
+    for kind, target in targets:
         target = target.strip("<>")
         parsed = urlsplit(target)
         if parsed.scheme in {"http", "https"}:
-            remote.add(target)
+            # Remote images and badges are cosmetic and often served by flaky CDNs.
+            # Continue validating local assets and all navigational links.
+            if kind == "link":
+                remote.add(target)
             continue
         if parsed.scheme or target.startswith("//"):
             continue

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -1,0 +1,817 @@
+#!/usr/bin/env python3
+"""Local, versioned storage helper for the Job Apply plugin.
+
+All successful commands emit JSON on stdout. Errors are deliberately terse and
+never include stored values. The helper uses only the Python standard library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+import unicodedata
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+STORE_ENV = "JOB_APPLY_STORE_DIR"
+ANSWER_STATES = {"confirmed", "inferred", "missing", "sensitive"}
+SENSITIVITY_LEVELS = {"none", "personal", "high"}
+HISTORY_EVENTS = {
+    "started",
+    "progressed",
+    "reviewed",
+    "completed",
+    "abandoned",
+    "failed",
+}
+SESSION_STATUSES = {"active", "review", "completed", "abandoned"}
+SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+class StoreError(Exception):
+    """An expected, safe-to-display storage failure."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _require_object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise StoreError(f"{label} must be a JSON object")
+    return value
+
+
+def _set_private_mode(path: Path, mode: int) -> None:
+    if os.name != "nt":
+        os.chmod(path, mode)
+
+
+def _ensure_private_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    _set_private_mode(path, 0o700)
+
+
+def _fsync_directory(path: Path) -> None:
+    if os.name == "nt":
+        return
+    try:
+        descriptor = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+
+
+def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Replace a JSON document atomically without risking the previous file."""
+
+    _ensure_private_dir(path.parent)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            json.dump(payload, temporary, indent=2, sort_keys=True, ensure_ascii=False)
+            temporary.write("\n")
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        _set_private_mode(temporary_path, 0o600)
+        os.replace(temporary_path, path)
+        temporary_path = None
+        _set_private_mode(path, 0o600)
+        _fsync_directory(path.parent)
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def read_json_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as source:
+            value = json.load(source)
+    except (OSError, json.JSONDecodeError) as error:
+        raise StoreError(f"cannot read valid {label} JSON at {path}") from error
+    return _require_object(value, label)
+
+
+def validate_version(document: dict[str, Any], label: str) -> None:
+    version = document.get("schemaVersion")
+    if not isinstance(version, int):
+        raise StoreError(f"{label} has no valid schemaVersion")
+    if version > SCHEMA_VERSION:
+        raise StoreError(f"{label} uses unsupported future schemaVersion {version}")
+    if version != SCHEMA_VERSION:
+        raise StoreError(f"{label} uses unsupported schemaVersion {version}")
+
+
+def normalize_question(question: str) -> str:
+    if not isinstance(question, str) or not question.strip():
+        raise StoreError("question must be a non-empty string")
+    normalized = unicodedata.normalize("NFKC", question).lower().strip()
+    normalized = re.sub(r"[^\w\s]", " ", normalized, flags=re.UNICODE)
+    return " ".join(normalized.split())
+
+
+def answer_key(question: str, scope: dict[str, Any] | None = None) -> str:
+    normalized = normalize_question(question)
+    scope_json = json.dumps(scope or {}, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(
+        f"v1\0{normalized}\0{scope_json}".encode("utf-8")
+    ).hexdigest()
+    return f"question.{digest}"
+
+
+def _safe_session_id(application_id: str) -> str:
+    if (
+        not isinstance(application_id, str)
+        or not SESSION_ID.fullmatch(application_id)
+        or ".." in application_id
+    ):
+        raise StoreError("application id contains unsupported characters")
+    return application_id
+
+
+def _validate_optional_strings(
+    document: dict[str, Any], fields: set[str], label: str
+) -> None:
+    for field in fields:
+        if field in document and document[field] is not None and not isinstance(
+            document[field], str
+        ):
+            raise StoreError(f"{label}.{field} must be a string")
+
+
+def _validate_answer_record(key: str, value: Any) -> dict[str, Any]:
+    record = _require_object(value, "answer record")
+    if record.get("key") != key:
+        raise StoreError("answer record key does not match its index")
+    if record.get("state") not in ANSWER_STATES:
+        raise StoreError("answer record state is unsupported")
+    sensitivity = record.get("sensitivity", "none")
+    if sensitivity not in SENSITIVITY_LEVELS:
+        raise StoreError("answer record sensitivity is unsupported")
+    question = record.get("question")
+    if question is not None and not isinstance(question, str):
+        raise StoreError("answer record question must be a string")
+    aliases = record.get("aliases", [])
+    if not isinstance(aliases, list) or not all(
+        isinstance(alias, str) for alias in aliases
+    ):
+        raise StoreError("answer record aliases must be strings")
+    _require_object(record.get("scope", {}), "answer record scope")
+    value_present = record.get("value") is not None
+    if record["state"] == "confirmed" and not value_present:
+        raise StoreError("confirmed answer record has no value")
+    if record["state"] == "missing" and value_present:
+        raise StoreError("missing answer record contains a value")
+    if value_present and (
+        record["state"] == "sensitive" or sensitivity != "none"
+    ):
+        consent = record.get("rememberedWithConsentAt")
+        if not isinstance(consent, str) or not consent:
+            raise StoreError("sensitive answer record has no remember consent marker")
+    _validate_optional_strings(
+        record,
+        {
+            "source",
+            "confirmedAt",
+            "updatedAt",
+            "rememberedWithConsentAt",
+        },
+        "answer record",
+    )
+    return record
+
+
+def _validate_history_event(event: dict[str, Any]) -> None:
+    allowed = {
+        "schemaVersion",
+        "eventId",
+        "applicationId",
+        "event",
+        "company",
+        "role",
+        "ats",
+        "status",
+        "answerKeys",
+        "at",
+    }
+    if set(event) - allowed:
+        raise StoreError("history event contains unsupported fields")
+    _safe_session_id(event.get("applicationId", ""))
+    if event.get("event") not in HISTORY_EVENTS:
+        raise StoreError("history event type is unsupported")
+    answer_keys = event.get("answerKeys", [])
+    if not isinstance(answer_keys, list) or not all(
+        isinstance(item, str) for item in answer_keys
+    ):
+        raise StoreError("history answerKeys must be strings")
+    _validate_optional_strings(
+        event,
+        {"eventId", "company", "role", "ats", "status", "at"},
+        "history event",
+    )
+
+
+def _validate_session_document(session: dict[str, Any]) -> None:
+    allowed = {
+        "schemaVersion",
+        "applicationId",
+        "status",
+        "ats",
+        "company",
+        "role",
+        "url",
+        "step",
+        "answerKeys",
+        "pendingFields",
+        "createdAt",
+        "updatedAt",
+    }
+    if set(session) - allowed:
+        raise StoreError("session contains unsupported fields")
+    _safe_session_id(session.get("applicationId", ""))
+    if session.get("status") not in SESSION_STATUSES:
+        raise StoreError("session status is unsupported")
+    answer_keys = session.get("answerKeys", [])
+    if not isinstance(answer_keys, list) or not all(
+        isinstance(item, str) for item in answer_keys
+    ):
+        raise StoreError("session answerKeys must be strings")
+    pending_fields = session.get("pendingFields", [])
+    if not isinstance(pending_fields, list):
+        raise StoreError("session pendingFields must be a list")
+    pending_allowed = {"question", "state", "answerKey", "sensitive"}
+    for value in pending_fields:
+        field = _require_object(value, "pending field")
+        if set(field) - pending_allowed:
+            raise StoreError("pending field contains unsupported fields")
+        _validate_optional_strings(
+            field, {"question", "state", "answerKey"}, "pending field"
+        )
+        if "state" in field and field["state"] not in ANSWER_STATES:
+            raise StoreError("pending field state is unsupported")
+        if "sensitive" in field and not isinstance(field["sensitive"], bool):
+            raise StoreError("pending field sensitive must be a boolean")
+    _validate_optional_strings(
+        session,
+        {
+            "applicationId",
+            "status",
+            "ats",
+            "company",
+            "role",
+            "url",
+            "step",
+            "createdAt",
+            "updatedAt",
+        },
+        "session",
+    )
+
+
+def _read_input(path: str) -> dict[str, Any]:
+    try:
+        if path == "-":
+            value = json.load(sys.stdin)
+        else:
+            with Path(path).expanduser().open(encoding="utf-8") as source:
+                value = json.load(source)
+    except (OSError, json.JSONDecodeError) as error:
+        raise StoreError("input is not a readable JSON object") from error
+    return _require_object(value, "input")
+
+
+class Store:
+    def __init__(self, root: Path, legacy_profile: Path | None = None):
+        self.root = root.expanduser()
+        self.profile_path = self.root / "profile.json"
+        self.answers_path = self.root / "answers.json"
+        self.history_path = self.root / "applications.jsonl"
+        self.sessions_path = self.root / "sessions"
+        self.legacy_profile = (
+            legacy_profile.expanduser()
+            if legacy_profile is not None
+            else Path.home() / ".claude-job-profile.json"
+        )
+
+    def paths(self) -> dict[str, Any]:
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "root": str(self.root),
+            "profile": str(self.profile_path),
+            "answers": str(self.answers_path),
+            "history": str(self.history_path),
+            "sessions": str(self.sessions_path),
+            "legacyProfile": str(self.legacy_profile),
+        }
+
+    def initialize(self) -> dict[str, Any]:
+        """Validate existing documents, then create only missing store files."""
+
+        if self.profile_path.exists():
+            self._load_profile_document()
+        if self.answers_path.exists():
+            self._load_answers_document()
+        if self.history_path.exists():
+            self.read_history()
+
+        _ensure_private_dir(self.root)
+        _ensure_private_dir(self.sessions_path)
+        migrated = False
+
+        if not self.profile_path.exists():
+            profile: dict[str, Any] = {}
+            metadata: dict[str, Any] = {
+                "createdAt": utc_now(),
+                "updatedAt": utc_now(),
+            }
+            if self.legacy_profile.exists():
+                profile = read_json_object(self.legacy_profile, "legacy profile")
+                metadata["migratedFrom"] = "~/.claude-job-profile.json"
+                metadata["migratedAt"] = utc_now()
+                migrated = True
+            atomic_write_json(
+                self.profile_path,
+                {
+                    "schemaVersion": SCHEMA_VERSION,
+                    "profile": profile,
+                    "metadata": metadata,
+                },
+            )
+
+        if not self.answers_path.exists():
+            now = utc_now()
+            atomic_write_json(
+                self.answers_path,
+                {
+                    "schemaVersion": SCHEMA_VERSION,
+                    "answers": {},
+                    "metadata": {"createdAt": now, "updatedAt": now},
+                },
+            )
+
+        if not self.history_path.exists():
+            descriptor = os.open(
+                self.history_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+            )
+            os.close(descriptor)
+        _set_private_mode(self.history_path, 0o600)
+
+        return {"initialized": True, "migratedLegacyProfile": migrated, **self.paths()}
+
+    def _load_profile_document(self) -> dict[str, Any]:
+        document = read_json_object(self.profile_path, "profile")
+        validate_version(document, "profile")
+        _require_object(document.get("profile"), "profile.profile")
+        _require_object(document.get("metadata"), "profile.metadata")
+        return document
+
+    def _load_answers_document(self) -> dict[str, Any]:
+        document = read_json_object(self.answers_path, "answers")
+        validate_version(document, "answers")
+        answers = _require_object(document.get("answers"), "answers.answers")
+        _require_object(document.get("metadata"), "answers.metadata")
+        for key, record in answers.items():
+            if not isinstance(key, str) or not key:
+                raise StoreError("answer index keys must be non-empty strings")
+            _validate_answer_record(key, record)
+        return document
+
+    def get_profile(self) -> dict[str, Any]:
+        self.initialize()
+        return self._load_profile_document()["profile"]
+
+    def replace_profile(self, profile: dict[str, Any]) -> dict[str, Any]:
+        self.initialize()
+        document = self._load_profile_document()
+        document["profile"] = _require_object(profile, "profile")
+        document["metadata"]["updatedAt"] = utc_now()
+        atomic_write_json(self.profile_path, document)
+        return document["profile"]
+
+    def get_preferences(self) -> dict[str, Any]:
+        preferences = self.get_profile().get("preferences", {})
+        return _require_object(preferences, "profile.preferences")
+
+    def set_preferences(
+        self, preferences: dict[str, Any], replace: bool = False
+    ) -> dict[str, Any]:
+        self.initialize()
+        document = self._load_profile_document()
+        profile = document["profile"]
+        incoming = _require_object(preferences, "preferences")
+        if replace:
+            updated = dict(incoming)
+        else:
+            current = profile.get("preferences", {})
+            updated = dict(_require_object(current, "profile.preferences"))
+            updated.update(incoming)
+        profile["preferences"] = updated
+        document["metadata"]["updatedAt"] = utc_now()
+        atomic_write_json(self.profile_path, document)
+        return updated
+
+    def get_answer(self, key: str) -> dict[str, Any] | None:
+        self.initialize()
+        answers = self._load_answers_document()["answers"]
+        answer = answers.get(key)
+        if answer is None:
+            return None
+        return _require_object(answer, "answer record")
+
+    def find_answer(
+        self, question: str, scope: dict[str, Any] | None = None
+    ) -> dict[str, Any] | None:
+        self.initialize()
+        normalized = normalize_question(question)
+        document = self._load_answers_document()
+        for record in document["answers"].values():
+            item = _require_object(record, "answer record")
+            candidates = []
+            if isinstance(item.get("question"), str):
+                candidates.append(normalize_question(item["question"]))
+            aliases = item.get("aliases", [])
+            if not isinstance(aliases, list) or not all(
+                isinstance(alias, str) for alias in aliases
+            ):
+                raise StoreError("answer record aliases must be strings")
+            candidates.extend(normalize_question(alias) for alias in aliases)
+            if normalized in candidates and item.get("scope", {}) == (scope or {}):
+                return item
+        return document["answers"].get(answer_key(question, scope))
+
+    def put_answer(
+        self, incoming: dict[str, Any], remember_sensitive: bool = False
+    ) -> dict[str, Any]:
+        self.initialize()
+        question = incoming.get("question")
+        scope = incoming.get("scope", {})
+        if not isinstance(scope, dict):
+            raise StoreError("answer scope must be a JSON object")
+        key = incoming.get("key")
+        if key is None:
+            if not isinstance(question, str):
+                raise StoreError("answer requires a question or explicit key")
+            key = answer_key(question, scope)
+        if not isinstance(key, str) or not key.strip():
+            raise StoreError("answer key must be a non-empty string")
+
+        state = incoming.get("state")
+        if state not in ANSWER_STATES:
+            raise StoreError("answer state is unsupported")
+        sensitivity = incoming.get(
+            "sensitivity", "high" if state == "sensitive" else "none"
+        )
+        if sensitivity not in SENSITIVITY_LEVELS:
+            raise StoreError("answer sensitivity is unsupported")
+        value = incoming.get("value")
+        if state == "confirmed" and value is None:
+            raise StoreError("confirmed answers require a value")
+        if state == "missing" and value is not None:
+            raise StoreError("missing answers cannot contain a value")
+        requires_consent = value is not None and (
+            state == "sensitive" or sensitivity != "none"
+        )
+        if requires_consent and not remember_sensitive:
+            raise StoreError(
+                "sensitive answer value requires explicit remember consent"
+            )
+
+        aliases = incoming.get("aliases", [])
+        if not isinstance(aliases, list) or not all(
+            isinstance(alias, str) for alias in aliases
+        ):
+            raise StoreError("answer aliases must be strings")
+        normalized_aliases: list[str] = []
+        for alias in aliases:
+            normalized = normalize_question(alias)
+            if normalized not in normalized_aliases:
+                normalized_aliases.append(normalized)
+
+        document = self._load_answers_document()
+        current = document["answers"].get(key, {})
+        record = dict(_require_object(current, "answer record"))
+        record.update(
+            {
+                "key": key,
+                "question": question,
+                "aliases": normalized_aliases,
+                "value": value,
+                "state": state,
+                "source": incoming.get("source", "user"),
+                "scope": scope,
+                "sensitivity": sensitivity,
+                "updatedAt": utc_now(),
+            }
+        )
+        if state == "confirmed":
+            record["confirmedAt"] = incoming.get("confirmedAt") or utc_now()
+        else:
+            record["confirmedAt"] = incoming.get("confirmedAt")
+        if requires_consent:
+            record["rememberedWithConsentAt"] = utc_now()
+        else:
+            record.pop("rememberedWithConsentAt", None)
+
+        document["answers"][key] = record
+        document["metadata"]["updatedAt"] = utc_now()
+        atomic_write_json(self.answers_path, document)
+        return record
+
+    def read_history(self) -> list[dict[str, Any]]:
+        if not self.history_path.exists():
+            return []
+        events: list[dict[str, Any]] = []
+        try:
+            with self.history_path.open(encoding="utf-8") as source:
+                for number, line in enumerate(source, 1):
+                    if not line.strip():
+                        continue
+                    event = json.loads(line)
+                    _require_object(event, f"history line {number}")
+                    validate_version(event, f"history line {number}")
+                    _validate_history_event(event)
+                    events.append(event)
+        except (OSError, json.JSONDecodeError) as error:
+            raise StoreError(f"cannot read valid history JSONL at {self.history_path}") from error
+        return events
+
+    def append_history(self, incoming: dict[str, Any]) -> dict[str, Any]:
+        self.initialize()
+        allowed = {
+            "applicationId",
+            "event",
+            "company",
+            "role",
+            "ats",
+            "status",
+            "answerKeys",
+            "at",
+        }
+        unexpected = set(incoming) - allowed
+        if unexpected:
+            raise StoreError("history event contains unsupported fields")
+        application_id = _safe_session_id(incoming.get("applicationId", ""))
+        event_name = incoming.get("event")
+        answer_keys = incoming.get("answerKeys", [])
+
+        event = {
+            "schemaVersion": SCHEMA_VERSION,
+            "eventId": str(uuid.uuid4()),
+            "at": incoming.get("at") or utc_now(),
+            **incoming,
+            "applicationId": application_id,
+            "event": event_name,
+            "answerKeys": answer_keys,
+        }
+        _validate_history_event(event)
+        encoded = (json.dumps(event, sort_keys=True, ensure_ascii=False) + "\n").encode(
+            "utf-8"
+        )
+        descriptor = os.open(
+            self.history_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600
+        )
+        try:
+            written = os.write(descriptor, encoded)
+            if written != len(encoded):
+                raise StoreError("history append was incomplete")
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        _set_private_mode(self.history_path, 0o600)
+        return event
+
+    def _session_path(self, application_id: str) -> Path:
+        return self.sessions_path / f"{_safe_session_id(application_id)}.json"
+
+    def save_session(
+        self, application_id: str, incoming: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.initialize()
+        allowed = {
+            "applicationId",
+            "status",
+            "ats",
+            "company",
+            "role",
+            "url",
+            "step",
+            "answerKeys",
+            "pendingFields",
+            "createdAt",
+            "updatedAt",
+        }
+        if set(incoming) - allowed:
+            raise StoreError("session contains unsupported fields")
+        application_id = _safe_session_id(application_id)
+        supplied_id = incoming.get("applicationId", application_id)
+        if supplied_id != application_id:
+            raise StoreError("session application id does not match path")
+        status = incoming.get("status", "active")
+        if status not in SESSION_STATUSES:
+            raise StoreError("session status is unsupported")
+        answer_keys = incoming.get("answerKeys", [])
+        if not isinstance(answer_keys, list) or not all(
+            isinstance(item, str) for item in answer_keys
+        ):
+            raise StoreError("session answerKeys must be strings")
+        pending_fields = incoming.get("pendingFields", [])
+
+        path = self._session_path(application_id)
+        created_at = incoming.get("createdAt")
+        if path.exists():
+            existing = self.load_session(application_id)
+            created_at = created_at or existing.get("createdAt")
+        session = {
+            "schemaVersion": SCHEMA_VERSION,
+            **incoming,
+            "applicationId": application_id,
+            "status": status,
+            "answerKeys": answer_keys,
+            "pendingFields": pending_fields,
+            "createdAt": created_at or utc_now(),
+            "updatedAt": utc_now(),
+        }
+        _validate_session_document(session)
+        atomic_write_json(path, session)
+        return session
+
+    def load_session(self, application_id: str) -> dict[str, Any]:
+        self.initialize()
+        path = self._session_path(application_id)
+        if not path.exists():
+            raise StoreError("session does not exist")
+        session = read_json_object(path, "session")
+        validate_version(session, "session")
+        _validate_session_document(session)
+        if session["applicationId"] != application_id:
+            raise StoreError("session application id does not match path")
+        return session
+
+    def list_sessions(self) -> list[dict[str, Any]]:
+        self.initialize()
+        sessions: list[dict[str, Any]] = []
+        for path in sorted(self.sessions_path.glob("*.json")):
+            session = read_json_object(path, "session")
+            validate_version(session, "session")
+            _validate_session_document(session)
+            if path.stem != session["applicationId"]:
+                raise StoreError("session application id does not match path")
+            sessions.append(session)
+        return sessions
+
+    def delete_session(self, application_id: str) -> dict[str, Any]:
+        self.initialize()
+        path = self._session_path(application_id)
+        if not path.exists():
+            return {"deleted": False, "applicationId": application_id}
+        path.unlink()
+        _fsync_directory(self.sessions_path)
+        return {"deleted": True, "applicationId": application_id}
+
+
+def _scope(value: str) -> dict[str, Any]:
+    try:
+        return _require_object(json.loads(value), "scope")
+    except json.JSONDecodeError as error:
+        raise StoreError("scope must be a JSON object") from error
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        help=f"store directory (default: ${STORE_ENV} or ~/.job-apply)",
+    )
+    parser.add_argument("--legacy-profile", help="legacy profile path override")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    commands.add_parser("init")
+    commands.add_parser("paths")
+    commands.add_parser("profile-get")
+    profile_replace = commands.add_parser("profile-replace")
+    profile_replace.add_argument("--input", required=True)
+    commands.add_parser("preferences-get")
+    preferences_set = commands.add_parser("preferences-set")
+    preferences_set.add_argument("--input", required=True)
+    preferences_set.add_argument("--replace", action="store_true")
+
+    key = commands.add_parser("answer-key")
+    key.add_argument("--question", required=True)
+    key.add_argument("--scope", default="{}")
+    put = commands.add_parser("answer-put")
+    put.add_argument("--input", required=True)
+    put.add_argument("--remember-sensitive", action="store_true")
+    get = commands.add_parser("answer-get")
+    get.add_argument("--key", required=True)
+    find = commands.add_parser("answer-find")
+    find.add_argument("--question", required=True)
+    find.add_argument("--scope", default="{}")
+
+    history_append = commands.add_parser("history-append")
+    history_append.add_argument("--input", required=True)
+    commands.add_parser("history-list")
+
+    session_save = commands.add_parser("session-save")
+    session_save.add_argument("--id", required=True)
+    session_save.add_argument("--input", required=True)
+    session_load = commands.add_parser("session-load")
+    session_load.add_argument("--id", required=True)
+    commands.add_parser("session-list")
+    session_delete = commands.add_parser("session-delete")
+    session_delete.add_argument("--id", required=True)
+    return parser
+
+
+def resolve_store(args: argparse.Namespace) -> Store:
+    configured = args.root or os.environ.get(STORE_ENV)
+    root = Path(configured).expanduser() if configured else Path.home() / ".job-apply"
+    legacy = Path(args.legacy_profile).expanduser() if args.legacy_profile else None
+    return Store(root, legacy)
+
+
+def run(args: argparse.Namespace) -> Any:
+    store = resolve_store(args)
+    command = args.command
+    if command == "init":
+        return store.initialize()
+    if command == "paths":
+        return store.paths()
+    if command == "profile-get":
+        return store.get_profile()
+    if command == "profile-replace":
+        return store.replace_profile(_read_input(args.input))
+    if command == "preferences-get":
+        return store.get_preferences()
+    if command == "preferences-set":
+        return store.set_preferences(_read_input(args.input), args.replace)
+    if command == "answer-key":
+        return {"key": answer_key(args.question, _scope(args.scope))}
+    if command == "answer-put":
+        return store.put_answer(
+            _read_input(args.input), remember_sensitive=args.remember_sensitive
+        )
+    if command == "answer-get":
+        return store.get_answer(args.key)
+    if command == "answer-find":
+        return store.find_answer(args.question, _scope(args.scope))
+    if command == "history-append":
+        return store.append_history(_read_input(args.input))
+    if command == "history-list":
+        store.initialize()
+        return store.read_history()
+    if command == "session-save":
+        return store.save_session(args.id, _read_input(args.input))
+    if command == "session-load":
+        return store.load_session(args.id)
+    if command == "session-list":
+        return store.list_sessions()
+    if command == "session-delete":
+        return store.delete_session(args.id)
+    raise StoreError("unsupported command")
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        result = run(args)
+    except StoreError as error:
+        print(f"job-apply-store: {error}", file=sys.stderr)
+        return 2
+    except OSError:
+        print("job-apply-store: storage operation failed", file=sys.stderr)
+        return 2
+    json.dump(result, sys.stdout, indent=2, sort_keys=True, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke-plugin.sh
+++ b/scripts/smoke-plugin.sh
@@ -16,6 +16,8 @@ mkdir -p "$SMOKE_CONFIG_DIR" "$SMOKE_FIXTURE_DIR"
 echo "Validating plugin manifest"
 claude plugin validate "$REPO_ROOT"
 
+python3 "$REPO_ROOT/scripts/job-apply-store.py" --help >/dev/null
+
 python3 - "$REPO_ROOT" <<'PY'
 import json
 import re
@@ -23,7 +25,7 @@ import sys
 from pathlib import Path
 
 root = Path(sys.argv[1])
-expected = {"job-apply", "job-search", "job-preferences"}
+expected = {"answer-memory", "job-apply", "job-search", "job-preferences"}
 
 for relative in (".claude-plugin/plugin.json", ".claude-plugin/marketplace.json"):
     data = json.loads((root / relative).read_text())
@@ -43,13 +45,25 @@ for skill in expected:
     if not match or match.group(1) != skill:
         raise SystemExit(f"skills/{skill}/SKILL.md frontmatter name is missing or incorrect")
 
-invocation_pattern = re.compile(r"/job-apply:(job-apply|job-search|job-preferences)")
+invocation_pattern = re.compile(r"/job-apply:(answer-memory|job-apply|job-search|job-preferences)")
 for relative in ("README.md", "site/index.html"):
     found = set(invocation_pattern.findall((root / relative).read_text()))
     if found != expected:
         raise SystemExit(f"{relative} inventory differs: expected {sorted(expected)}, got {sorted(found)}")
 
 application_skill = (root / "skills/job-apply/SKILL.md").read_text()
+answer_memory_skill = (root / "skills/answer-memory/SKILL.md").read_text()
+helper_reference = 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py"'
+for skill in expected:
+    content = (root / "skills" / skill / "SKILL.md").read_text()
+    if "job-apply-store.py" not in content:
+        raise SystemExit(f"skills/{skill}/SKILL.md does not use the shared storage helper")
+if helper_reference not in answer_memory_skill:
+    raise SystemExit("answer-memory skill does not use the plugin-root helper path")
+if "--remember-sensitive" not in answer_memory_skill:
+    raise SystemExit("answer-memory skill is missing explicit sensitive remember consent")
+if "Permission to fill is not permission to remember" not in answer_memory_skill:
+    raise SystemExit("answer-memory skill does not separate fill consent from storage consent")
 required_contract = (
     "User confirmation never authorizes this skill to click Submit, Send, "
     "or any equivalent final-action button."
@@ -90,7 +104,7 @@ CLAUDE_CONFIG_DIR="$SMOKE_CONFIG_DIR" claude plugin install job-apply@neonwatty-
 CLAUDE_CONFIG_DIR="$SMOKE_CONFIG_DIR" claude plugin details job-apply@neonwatty-plugins \
   | tee "$SMOKE_TEMP_ROOT/plugin-details.txt"
 
-for skill in job-apply job-search job-preferences; do
+for skill in answer-memory job-apply job-search job-preferences; do
   if ! grep -Fq -- "$skill" "$SMOKE_TEMP_ROOT/plugin-details.txt"; then
     echo "Installed plugin details did not list $skill" >&2
     exit 1

--- a/site/index.html
+++ b/site/index.html
@@ -56,7 +56,7 @@
           <div class="output output-dim">Paste the job URL you'd like to apply to:</div>
           <div class="prompt">https://linkedin.com/jobs/view/4019283746</div>
           <div class="output">
-            <div>Loading profile from ~/.claude-job-profile.json</div>
+            <div>Loading profile and confirmed answers from ~/.job-apply/</div>
             <div class="output-dim" style="margin: 6px 0;">Navigating to job listing...</div>
             <div>Filling application fields:</div>
           </div>
@@ -76,14 +76,14 @@
 
     <section class="section intro">
       <p>
-        Job Apply Plugin turns Claude Code into a job application assistant. Extract your profile once from a resume, then use guided form filling across six ATS families while you review every step and submit manually.
+        Job Apply Plugin turns Claude Code into a job application assistant. Extract your profile once, reuse confirmed answers, and let uncertain or sensitive fields come back to you for review before you submit manually.
       </p>
     </section>
 
     <section id="skills" class="section">
       <div class="section-heading">
-        <p class="eyebrow">Three skills</p>
-        <h2>Set your preferences, discover opportunities, and apply.</h2>
+        <p class="eyebrow">Four skills</p>
+        <h2>Remember trusted answers, set preferences, discover opportunities, and apply.</h2>
       </div>
       <div class="skills-grid">
         <article class="skill-card">
@@ -97,6 +97,19 @@
             <li>Smart field mapping from your profile to form fields</li>
             <li>Visible automation in your Claude in Chrome session</li>
             <li>Stops at final review so only you can submit</li>
+          </ul>
+        </article>
+        <article class="skill-card">
+          <div class="skill-header">
+            <span class="skill-badge">/job-apply:answer-memory</span>
+          </div>
+          <h3>Reuse answers without losing control</h3>
+          <ul class="feature-bullets">
+            <li>Stores profile data and reusable answers locally</li>
+            <li>Distinguishes confirmed, inferred, missing, and sensitive answers</li>
+            <li>Requires separate consent before remembering sensitive values</li>
+            <li>Saves resumable progress without copying answer values</li>
+            <li>Migrates the legacy profile non-destructively</li>
           </ul>
         </article>
         <article class="skill-card">
@@ -172,7 +185,7 @@
         <p class="eyebrow">Install</p>
         <h2>Add the plugin and start applying.</h2>
         <p>
-          Install from the Claude Code plugin marketplace, then invoke <code>/job-apply:job-apply</code> with a job URL. Your profile is extracted once and reused across all applications.
+          Install from the Claude Code plugin marketplace, then invoke <code>/job-apply:job-apply</code> with a job URL. Your profile and explicitly confirmed answers are stored locally and reused when their scope still matches.
         </p>
       </div>
       <div class="code-card">
@@ -203,6 +216,10 @@ claude plugin install job-apply@neonwatty-plugins
           <p>Premium features and paid prompts are skipped automatically.</p>
         </article>
         <article>
+          <h3>Sensitive answers stay deliberate</h3>
+          <p>Using a sensitive answer once never stores it automatically. Remembering it requires a separate explicit choice, and future use is still reconfirmed.</p>
+        </article>
+        <article>
           <h3>Changing ATS controls</h3>
           <p>If Chrome cannot reach a site-specific field, the plugin reports it and leaves it for you unless an optional fallback is already configured.</p>
         </article>
@@ -216,8 +233,8 @@ claude plugin install job-apply@neonwatty-plugins
       </div>
       <div class="constraint-grid">
         <article>
-          <h3>Plaintext local profile</h3>
-          <p>Your profile is stored at <code>~/.claude-job-profile.json</code>. Protect or delete it like a resume; never attach it to a public issue.</p>
+          <h3>Plaintext local store</h3>
+          <p>Your profile, answer bank, minimal history, and resumable sessions live under <code>~/.job-apply/</code>. Protect it like a resume; never attach its files to a public issue.</p>
         </article>
         <article>
           <h3>No plugin telemetry</h3>

--- a/skills/answer-memory/SKILL.md
+++ b/skills/answer-memory/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: answer-memory
+description: Manage Job Apply's local profile, reusable answers, application history, and resumable sessions. Use whenever a Job Apply workflow needs to initialize, migrate, read, or update persistent applicant data.
+allowed-tools: Read, Write, Bash
+---
+
+# Answer Memory
+
+Use this skill as the storage contract for every Job Apply workflow. It manages local files through the bundled helper; it does not browse job sites or submit applications.
+
+## Non-negotiable interface
+
+Run the helper from the installed plugin root:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" <command>
+```
+
+Do not directly create, parse, patch, append to, or replace files under `~/.job-apply/`. Do not recreate question normalization, answer keys, migration logic, permissions, or atomic writes in the agent. Use only helper commands described here and in [the storage contract](references/storage-contract.md).
+
+Successful data commands return JSON on stdout. If the helper returns nonzero, stop the storage operation, preserve the existing files, and explain the failure without printing stored values.
+
+## Initialize and locate the store
+
+Start every workflow that needs persistent state with:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" init
+```
+
+This creates the local store if needed and non-destructively migrates an existing `~/.claude-job-profile.json`. The legacy file is never deleted or rewritten. To inspect resolved locations:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" paths
+```
+
+The default layout is:
+
+```text
+~/.job-apply/
+  profile.json
+  answers.json
+  applications.jsonl
+  sessions/
+    <application-id>.json
+```
+
+## Supplying JSON input
+
+Commands that accept `--input` require a JSON object. Use a user-only temporary file, remove it after the helper returns, and never print its contents to logs. The helper also accepts `--input -` when a caller already has a safe private stdin channel.
+
+Do not place passwords, credentials, authentication tokens, CAPTCHA answers, payment data, or browser session data in any input.
+
+## Profile and preferences
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" profile-get
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" profile-replace --input <profile.json>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" preferences-get
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" preferences-set --input <preferences.json>
+```
+
+`preferences-set` merges supplied keys and preserves all other profile and preference fields. Use `--replace` only after the user explicitly chooses to replace the full preferences object.
+
+## Reusable answers
+
+Answer states have distinct behavior:
+
+| State | Meaning | May fill without asking? |
+|---|---|---|
+| `confirmed` | The user confirmed this value | Yes, only when non-sensitive and scope still matches |
+| `inferred` | A candidate derived from context | No; show it and ask |
+| `missing` | No supported answer is known | No; ask |
+| `sensitive` | Salary, authorization, visa, demographic, disability, or similar | Never; ask before every use |
+
+Look up the exact question and relevant scope before filling:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" answer-find \
+  --question "Are you authorized to work in the United States?" \
+  --scope '{"country":"US"}'
+```
+
+Store a reviewed non-sensitive answer with `answer-put --input <answer.json>`. The helper owns stable keys and aliases; omit `key` for a dynamic question unless a documented semantic key already exists.
+
+### Sensitive answers require two decisions
+
+Ask separately:
+
+1. May I use this answer in the current form?
+2. Would you like me to remember this specific answer for later applications?
+
+Permission to fill is not permission to remember. If the user approves current use but not storage, do not persist the value. You may record a `sensitive` placeholder with `"value": null`.
+
+Persist a non-null sensitive value only after explicit field-specific remember consent in the current interaction:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" answer-put \
+  --input <sensitive-answer.json> \
+  --remember-sensitive
+```
+
+Even a remembered sensitive answer must be shown and reconfirmed before each future form entry.
+
+## Application history
+
+Append minimal lifecycle events using `history-append --input <event.json>`. History may contain application metadata and `answerKeys`; it must never duplicate answer values, profile data, credentials, or browser state.
+
+Use `reviewed` when Job Apply reaches final review. Do not record `completed` unless the user later confirms that they personally submitted the application.
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" history-list
+```
+
+## Resumable sessions
+
+Use `session-save --id <application-id> --input <session.json>` after meaningful non-final progress. Sessions may contain ATS/role/step metadata, `answerKeys`, and pending-field descriptions; they must not contain answer values.
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" session-list
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" session-load --id <application-id>
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" session-delete --id <application-id>
+```
+
+Delete a session after the user confirms submission or explicitly abandons it. History remains separate.
+
+## Safety rules
+
+1. Never bypass the helper for persistent data mutations.
+2. Never print profile or answer values merely to diagnose storage.
+3. Never infer remember consent from permission to fill a form.
+4. Never copy answer values into history or sessions.
+5. Never downgrade or overwrite corrupt or future-version files; report the helper error.
+6. Never store credentials, authentication state, CAPTCHA/MFA data, or payment information.
+7. Answer memory never changes the rule that only the user may submit an application.

--- a/skills/answer-memory/references/storage-contract.md
+++ b/skills/answer-memory/references/storage-contract.md
@@ -1,0 +1,34 @@
+# Local storage contract
+
+The bundled helper is the sole supported mutation interface:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" --help
+```
+
+## Files
+
+- `~/.job-apply/profile.json`: versioned canonical profile and preferences.
+- `~/.job-apply/answers.json`: versioned answer records with state, source, scope, aliases, sensitivity, and confirmation metadata.
+- `~/.job-apply/applications.jsonl`: append-only minimal application events.
+- `~/.job-apply/sessions/<application-id>.json`: resumable workflow metadata with answer-key references.
+
+Directories use user-only permissions and canonical files use `0600` where the platform supports POSIX modes. JSON writes use a same-directory temporary file and atomic replacement.
+
+## Migration
+
+On first initialization, if the new profile does not exist and `~/.claude-job-profile.json` does, the helper copies the complete legacy object into `profile.json`. It preserves unknown keys and leaves the legacy file untouched. Once the new profile exists it is authoritative, so later changes to the legacy file are not re-imported.
+
+## Versions and corruption
+
+Current documents use `schemaVersion: 1`. A corrupt document, invalid shape, or future schema version causes the helper to fail non-destructively. Agents must not repair canonical files with text editing; preserve the file and explain the error.
+
+## Answer identity
+
+Known semantic fields may use documented keys. Dynamic questions receive `question.<sha256>` keys generated from versioned Unicode/whitespace/punctuation normalization plus canonical scope JSON. The helper also checks stored normalized aliases. Agents must call `answer-key` or `answer-find`, never implement this algorithm themselves.
+
+Only a non-sensitive `confirmed` answer with matching scope may be reused without asking. `inferred`, `missing`, and every `sensitive` record require review. A stored sensitive value must carry the helper-generated consent timestamp, and the agent still reconfirms it before use.
+
+## Data minimization
+
+History and sessions reference answer keys instead of copying values. Their input schemas are closed: arbitrary nested applicant payloads are rejected. Credentials, browser state, CAPTCHA/MFA data, and payment information are never valid storage inputs.

--- a/skills/job-apply/SKILL.md
+++ b/skills/job-apply/SKILL.md
@@ -10,9 +10,9 @@ A Claude Code skill for filling job applications on LinkedIn Easy Apply, Greenho
 
 ## Initial Prompt
 
-When this skill is invoked, first check if a profile exists at `~/.claude-job-profile.json`.
+When this skill is invoked, first follow `/job-apply:answer-memory`: run the bundled helper's `init` command, then load the profile with `profile-get`. Never read or write persistent Job Apply files directly.
 
-**If NO profile exists**, say:
+**If the returned profile object is empty**, say:
 
 > Welcome to the Job Application Assistant! I'll help you fill out job applications on LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.
 >
@@ -24,9 +24,9 @@ When this skill is invoked, first check if a profile exists at `~/.claude-job-pr
 
 Then wait for the user to provide the path before proceeding with profile extraction.
 
-**If a profile DOES exist**, say:
+**If the profile contains applicant data**, say:
 
-> Welcome back! Your profile is loaded from `~/.claude-job-profile.json`.
+> Welcome back! Your local Job Apply profile and answer memory are ready.
 >
 > **Provide a job URL** and I'll help you apply. For example:
 > - LinkedIn: `https://www.linkedin.com/jobs/view/123456789`
@@ -44,7 +44,7 @@ Then wait for the user to provide the path before proceeding with profile extrac
 
 ## Profile Storage
 
-Your extracted profile is stored at `~/.claude-job-profile.json` for reuse across sessions. Run with `--reset-profile` to re-extract from resume.
+Your extracted profile is stored under `~/.job-apply/` for reuse across sessions. All persistent reads and writes go through `${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py` as defined by `/job-apply:answer-memory`. A first run non-destructively migrates an existing `~/.claude-job-profile.json`.
 
 ---
 
@@ -76,7 +76,7 @@ Use the fallback only for the blocked control, then return to the visible review
 
 ### Phase 1: Profile Setup
 
-If no profile exists at `~/.claude-job-profile.json`, or if the user requests a reset:
+If `profile-get` returns an empty object, or if the user requests a reset:
 
 1. **Read the resume file** using the Read tool
 2. **Extract structured data** into these categories:
@@ -89,21 +89,23 @@ If no profile exists at `~/.claude-job-profile.json`, or if the user requests a 
    - `skills[]`: array of skill strings
    - `resumePath`: absolute path to the resume file on disk
 3. **Present extracted data to user** for review and correction
-4. **Save confirmed profile** to `~/.claude-job-profile.json`
+4. **Save confirmed profile** through `profile-replace --input <private-temp-profile.json>`, then remove the temporary input
 
 ### Phase 2: Application Filling
 
-1. **Load profile** from `~/.claude-job-profile.json`
+1. **Initialize and load storage** through `/job-apply:answer-memory`; use `profile-get`, then check `session-list` for resumable work matching this application
 2. **Open the URL in Claude in Chrome** and identify the job site and application flow
 3. **Pause for user-only steps** if login, password, CAPTCHA, MFA, consent, or account creation appears
 4. **Open the application form**; if an Apply link opens an external portal, continue in that visible Chrome tab
-5. **Read the form** and fill only values supported by the confirmed profile
-6. **Ask before sensitive answers** such as salary, work authorization, visa status, demographic information, or disability disclosure
-7. **Upload the resume** through the visible file control and verify the selected filename
-8. **Handle inaccessible controls** using the optional fallback rules above, or leave the field for the user
-9. **Advance through non-final steps** only when the control is clearly Next, Continue, Save, or Review
-10. **Stop at final review** before any Submit, Send, or equivalent final-action button
-11. **Summarize every entered value**, identify anything incomplete or uncertain, and tell the user to inspect the page and submit manually
+5. **Read the form** and fill profile-backed fields; for recurring questions call `answer-find` with the exact visible question and relevant scope
+6. **Reuse only matching, non-sensitive `confirmed` answers**. Show and confirm `inferred` answers, ask for `missing` answers, and reconfirm every `sensitive` answer before entry
+7. **Separate fill consent from remember consent** for salary, work authorization, visa status, demographic information, disability disclosure, and similar answers. Use `--remember-sensitive` only after explicit field-specific permission to remember
+8. **Upload the resume** through the visible file control and verify the selected filename
+9. **Save resumable progress** through `session-save`; store answer keys and pending-field states, never answer values
+10. **Handle inaccessible controls** using the optional fallback rules above, or leave the field for the user
+11. **Advance through non-final steps** only when the control is clearly Next, Continue, Save, or Review
+12. **Stop at final review** before any Submit, Send, or equivalent final-action button
+13. **Record a minimal `reviewed` history event** with answer-key references, summarize every entered value, identify anything incomplete or uncertain, and tell the user to inspect the page and submit manually
 
 User confirmation never authorizes this skill to click Submit, Send, or any equivalent final-action button.
 
@@ -278,6 +280,8 @@ If Playwright is already configured and Chrome cannot reach a specific iframe or
 5. **Handle sensitive questions carefully** - Salary expectations, visa status, disability disclosure should be confirmed with user before filling
 6. **Use Claude in Chrome by default** - Playwright is only an already-configured fallback for a specific inaccessible control
 7. **Never store or pass login credentials between tools** - Authentication remains a user-only step in the visible Chrome session
+8. **Use answer memory only through the helper** - Never directly modify `~/.job-apply/`; history and sessions reference answer keys, not values
+9. **Remembering is separate consent** - Permission to use a sensitive answer now never authorizes storing it for later
 
 ---
 

--- a/skills/job-preferences/SKILL.md
+++ b/skills/job-preferences/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: job-preferences
 description: Set or update your job search preferences (titles, salary, remote, filters). Used by /job-apply:job-search and other skills.
-allowed-tools: Read, Write
+allowed-tools: Read, Write, Bash
 ---
 
 # Job Preferences
@@ -14,11 +14,11 @@ A Claude Code skill for managing persistent job search preferences. Set your tar
 
 ### Step 1: Load Profile
 
-Read `~/.claude-job-profile.json`. If the file doesn't exist yet, create it with an empty object `{}`.
+Follow `/job-apply:answer-memory`: run `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" init`, then load saved preferences with `preferences-get`. Never read or write persistent Job Apply files directly.
 
 ### Step 2: Check for Existing Preferences
 
-Look for the `preferences` key in the profile.
+Use the JSON object returned by `preferences-get`.
 
 **If preferences exist**, display them:
 
@@ -77,7 +77,7 @@ Use `AskUserQuestion` to collect all fields. Ask up to 4 questions at a time (th
 
 ### Step 4: Save Preferences
 
-Write the collected values into `~/.claude-job-profile.json` under the `preferences` key. Preserve all other existing keys in the file (like profile data used by `/job-apply:job-apply`).
+Write the collected values to a private temporary JSON object, then call `preferences-set --input <preferences.json>` through the bundled helper and remove the temporary file. The helper merges supplied keys while preserving the rest of the preferences and profile. Never patch `profile.json` directly.
 
 **Schema:**
 
@@ -97,7 +97,7 @@ Write the collected values into `~/.claude-job-profile.json` under the `preferen
 
 Display the saved preferences and confirm:
 
-> **Preferences saved to `~/.claude-job-profile.json`.**
+> **Preferences saved to your local Job Apply store at `~/.job-apply/profile.json`.**
 >
 > These will be used automatically by `/job-apply:job-search`. Run `/job-apply:job-preferences` again any time to update them.
 
@@ -111,6 +111,6 @@ When the user runs `/job-apply:job-preferences` and preferences already exist, s
 
 ## Safety Rules
 
-1. **Never overwrite non-preference data** — only read/write the `preferences` key in the profile JSON
-2. **Preserve existing profile** — `/job-apply:job-apply` stores resume data in the same file; never delete or modify those keys
+1. **Use only the helper** — initialize, read, and merge preferences through `/job-apply:answer-memory`; never directly edit files under `~/.job-apply/`
+2. **Preserve existing profile** — use `preferences-set` without `--replace` for selective updates
 3. **No defaults without user input** — always ask the user, never assume values

--- a/skills/job-search/SKILL.md
+++ b/skills/job-search/SKILL.md
@@ -14,7 +14,7 @@ A Claude Code skill for searching jobs across LinkedIn, Hacker News Who's Hiring
 
 ### Step 1: Load Profile
 
-Read `~/.claude-job-profile.json`. Check for the `preferences` key.
+Follow `/job-apply:answer-memory`: run `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" init`, load preferences with `preferences-get`, and load location or other profile facts with `profile-get`. Never read or write persistent Job Apply files directly.
 
 **If no preferences found**, say:
 

--- a/tests/test_answer_memory_integration.py
+++ b/tests/test_answer_memory_integration.py
@@ -1,0 +1,181 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "job-apply-store.py"
+
+
+class AnswerMemoryIntegrationTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.home = Path(self.temporary.name)
+        self.environment = dict(os.environ)
+        self.environment["HOME"] = str(self.home)
+        self.environment.pop("JOB_APPLY_STORE_DIR", None)
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def write_input(self, name, payload):
+        path = self.home / name
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        if os.name != "nt":
+            path.chmod(0o600)
+        return path
+
+    def run_store(self, *arguments, check=True):
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=self.environment,
+        )
+        if check and completed.returncode != 0:
+            self.fail(f"store command failed: {arguments}: {completed.stderr}")
+        return completed
+
+    def json_store(self, *arguments):
+        return json.loads(self.run_store(*arguments).stdout)
+
+    def test_clean_room_documented_lifecycle(self):
+        legacy = {
+            "firstName": "Synthetic",
+            "lastName": "Applicant",
+            "preferences": {"targetTitles": ["Engineer"]},
+            "unknownLegacyField": {"preserve": True},
+        }
+        (self.home / ".claude-job-profile.json").write_text(
+            json.dumps(legacy), encoding="utf-8"
+        )
+
+        initialized = self.json_store("init")
+        self.assertTrue(initialized["migratedLegacyProfile"])
+        self.assertEqual(self.json_store("profile-get"), legacy)
+
+        preferences = self.write_input(
+            "preferences-input.json", {"remotePreference": "remote only"}
+        )
+        updated_preferences = self.json_store(
+            "preferences-set", "--input", str(preferences)
+        )
+        self.assertEqual(updated_preferences["targetTitles"], ["Engineer"])
+        self.assertEqual(updated_preferences["remotePreference"], "remote only")
+        self.assertTrue(self.json_store("profile-get")["unknownLegacyField"]["preserve"])
+
+        confirmed = self.write_input(
+            "confirmed-answer.json",
+            {
+                "question": "Are you authorized to work in the United States?",
+                "aliases": ["US work authorization"],
+                "value": "Yes",
+                "state": "confirmed",
+                "source": "user",
+                "scope": {"country": "US"},
+                "sensitivity": "none",
+            },
+        )
+        saved_answer = self.json_store("answer-put", "--input", str(confirmed))
+        reused = self.json_store(
+            "answer-find",
+            "--question",
+            "US work authorization",
+            "--scope",
+            '{"country":"US"}',
+        )
+        self.assertEqual(reused["key"], saved_answer["key"])
+        self.assertEqual(reused["value"], "Yes")
+
+        sensitive_value = "synthetic-private-answer"
+        sensitive = self.write_input(
+            "sensitive-answer.json",
+            {
+                "question": "Disability disclosure?",
+                "value": sensitive_value,
+                "state": "sensitive",
+                "source": "user",
+                "scope": {},
+                "sensitivity": "high",
+            },
+        )
+        denied = self.run_store("answer-put", "--input", str(sensitive), check=False)
+        self.assertEqual(denied.returncode, 2)
+        self.assertNotIn(sensitive_value, denied.stderr)
+        answers_text = (self.home / ".job-apply" / "answers.json").read_text()
+        self.assertNotIn(sensitive_value, answers_text)
+
+        session_input = self.write_input(
+            "session.json",
+            {
+                "status": "active",
+                "ats": "greenhouse",
+                "company": "Example Corp",
+                "role": "Engineer",
+                "step": "questions",
+                "answerKeys": [saved_answer["key"]],
+                "pendingFields": [
+                    {
+                        "question": "Disability disclosure?",
+                        "state": "sensitive",
+                        "sensitive": True,
+                    }
+                ],
+            },
+        )
+        self.json_store(
+            "session-save", "--id", "example-engineer", "--input", str(session_input)
+        )
+        resumed = self.json_store("session-load", "--id", "example-engineer")
+        self.assertEqual(resumed["step"], "questions")
+        self.assertNotIn("value", json.dumps(resumed))
+
+        history_input = self.write_input(
+            "history.json",
+            {
+                "applicationId": "example-engineer",
+                "event": "reviewed",
+                "company": "Example Corp",
+                "role": "Engineer",
+                "ats": "greenhouse",
+                "answerKeys": [saved_answer["key"]],
+            },
+        )
+        self.json_store("history-append", "--input", str(history_input))
+        history = self.json_store("history-list")
+        self.assertEqual(history[0]["event"], "reviewed")
+        self.assertEqual(history[0]["answerKeys"], [saved_answer["key"]])
+        self.assertNotIn("Yes", (self.home / ".job-apply" / "applications.jsonl").read_text())
+
+        self.assertEqual(
+            json.loads((self.home / ".claude-job-profile.json").read_text()), legacy
+        )
+
+    def test_skills_share_one_helper_contract_and_manual_submit_boundary(self):
+        skills = {
+            path.parent.name: path.read_text(encoding="utf-8")
+            for path in (ROOT / "skills").glob("*/SKILL.md")
+        }
+        self.assertEqual(
+            set(skills), {"answer-memory", "job-apply", "job-preferences", "job-search"}
+        )
+        for name, content in skills.items():
+            self.assertIn("job-apply-store.py", content, name)
+        for name in ("job-apply", "job-preferences", "job-search"):
+            self.assertNotIn("Read `~/.claude-job-profile.json`", skills[name])
+            self.assertNotIn("Write the collected values into `~/.claude-job-profile.json`", skills[name])
+        self.assertIn("--remember-sensitive", skills["answer-memory"])
+        self.assertIn("Permission to fill is not permission to remember", skills["answer-memory"])
+        self.assertIn(
+            "User confirmation never authorizes this skill to click Submit",
+            skills["job-apply"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -1,0 +1,309 @@
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "job-apply-store.py"
+SPEC = importlib.util.spec_from_file_location("job_apply_store", SCRIPT)
+STORE_MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(STORE_MODULE)
+
+
+class StoreTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.home = Path(self.temporary.name)
+        self.root = self.home / ".job-apply"
+        self.legacy = self.home / ".claude-job-profile.json"
+        self.store = STORE_MODULE.Store(self.root, self.legacy)
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_migrates_legacy_profile_once_and_preserves_unknown_fields(self):
+        legacy = {
+            "firstName": "Ada",
+            "preferences": {"remotePreference": "remote only"},
+            "futureCustomField": {"keep": True},
+        }
+        self.legacy.write_text(json.dumps(legacy), encoding="utf-8")
+
+        first = self.store.initialize()
+        self.assertTrue(first["migratedLegacyProfile"])
+        self.assertEqual(self.store.get_profile(), legacy)
+
+        self.legacy.write_text(json.dumps({"firstName": "Changed"}), encoding="utf-8")
+        second = self.store.initialize()
+        self.assertFalse(second["migratedLegacyProfile"])
+        self.assertEqual(self.store.get_profile(), legacy)
+
+    def test_preferences_merge_preserves_profile_and_existing_preferences(self):
+        self.store.initialize()
+        self.store.replace_profile(
+            {
+                "firstName": "Ada",
+                "preferences": {"targetTitles": ["Engineer"], "salary": "200K"},
+            }
+        )
+        updated = self.store.set_preferences({"salary": "250K"})
+        self.assertEqual(
+            updated, {"targetTitles": ["Engineer"], "salary": "250K"}
+        )
+        self.assertEqual(self.store.get_profile()["firstName"], "Ada")
+
+    def test_atomic_write_failure_keeps_previous_document_and_cleans_temp(self):
+        self.store.initialize()
+        before = self.store.profile_path.read_text(encoding="utf-8")
+        with mock.patch.object(STORE_MODULE.os, "replace", side_effect=OSError("boom")):
+            with self.assertRaises(OSError):
+                self.store.replace_profile({"firstName": "Grace"})
+        self.assertEqual(self.store.profile_path.read_text(encoding="utf-8"), before)
+        self.assertEqual(list(self.root.glob(".profile.json.*.tmp")), [])
+
+    @unittest.skipIf(os.name == "nt", "POSIX permissions only")
+    def test_private_permissions(self):
+        self.store.initialize()
+        self.assertEqual(stat.S_IMODE(self.root.stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE(self.store.sessions_path.stat().st_mode), 0o700)
+        for path in (
+            self.store.profile_path,
+            self.store.answers_path,
+            self.store.history_path,
+        ):
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+
+    def test_corrupt_and_future_documents_fail_closed(self):
+        self.root.mkdir(parents=True)
+        self.store.profile_path.write_text("not json", encoding="utf-8")
+        with self.assertRaises(STORE_MODULE.StoreError):
+            self.store.initialize()
+        self.assertEqual(self.store.profile_path.read_text(encoding="utf-8"), "not json")
+
+        self.store.profile_path.write_text(
+            json.dumps(
+                {"schemaVersion": 99, "profile": {}, "metadata": {}}
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaises(STORE_MODULE.StoreError):
+            self.store.initialize()
+        self.assertEqual(json.loads(self.store.profile_path.read_text())["schemaVersion"], 99)
+
+    def test_answer_key_normalization_alias_lookup_and_confirmed_reuse(self):
+        first = STORE_MODULE.answer_key(
+            "Are you AUTHORIZED to work in the U.S.?", {"country": "US"}
+        )
+        second = STORE_MODULE.answer_key(
+            "  are you authorized—to work in the u.s.  ", {"country": "US"}
+        )
+        self.assertEqual(first, second)
+        answer = self.store.put_answer(
+            {
+                "question": "Are you authorized to work in the U.S.?",
+                "aliases": ["US work authorization"],
+                "value": "Yes",
+                "state": "confirmed",
+                "source": "user",
+                "scope": {"country": "US"},
+                "sensitivity": "none",
+            }
+        )
+        self.assertEqual(answer["state"], "confirmed")
+        found = self.store.find_answer(
+            "US work authorization", {"country": "US"}
+        )
+        self.assertEqual(found["value"], "Yes")
+        self.assertIsNotNone(found["confirmedAt"])
+
+    def test_all_answer_states_and_sensitive_consent(self):
+        self.store.put_answer(
+            {"question": "Preferred start date?", "state": "inferred", "value": "June"}
+        )
+        self.store.put_answer(
+            {"question": "Security clearance?", "state": "missing", "value": None}
+        )
+        placeholder = self.store.put_answer(
+            {"question": "Disability disclosure?", "state": "sensitive", "value": None}
+        )
+        self.assertIsNone(placeholder["value"])
+        with self.assertRaises(STORE_MODULE.StoreError):
+            self.store.put_answer(
+                {
+                    "question": "Disability disclosure?",
+                    "state": "sensitive",
+                    "value": "Prefer not to answer",
+                }
+            )
+        remembered = self.store.put_answer(
+            {
+                "question": "Disability disclosure?",
+                "state": "sensitive",
+                "value": "Prefer not to answer",
+            },
+            remember_sensitive=True,
+        )
+        self.assertIn("rememberedWithConsentAt", remembered)
+
+    def test_tampered_sensitive_answer_without_consent_fails_closed(self):
+        self.store.initialize()
+        document = json.loads(self.store.answers_path.read_text(encoding="utf-8"))
+        document["answers"]["sensitive.example"] = {
+            "key": "sensitive.example",
+            "question": "Sensitive question?",
+            "aliases": [],
+            "value": "private",
+            "state": "sensitive",
+            "source": "user",
+            "scope": {},
+            "sensitivity": "high",
+            "confirmedAt": None,
+            "updatedAt": "2026-07-18T00:00:00Z",
+        }
+        self.store.answers_path.write_text(json.dumps(document), encoding="utf-8")
+        with self.assertRaises(STORE_MODULE.StoreError):
+            self.store.get_answer("sensitive.example")
+
+    def test_history_is_minimal_parseable_and_rejects_answer_values(self):
+        event = self.store.append_history(
+            {
+                "applicationId": "acme-role-1",
+                "event": "started",
+                "company": "Acme",
+                "role": "Engineer",
+                "answerKeys": ["work_authorization.us"],
+            }
+        )
+        self.assertEqual(event["answerKeys"], ["work_authorization.us"])
+        parsed = self.store.read_history()
+        self.assertEqual(len(parsed), 1)
+        self.assertNotIn("value", parsed[0])
+        with self.assertRaises(STORE_MODULE.StoreError):
+            self.store.append_history(
+                {
+                    "applicationId": "acme-role-1",
+                    "event": "progressed",
+                    "answerValue": "secret",
+                }
+            )
+        with self.assertRaises(STORE_MODULE.StoreError):
+            self.store.append_history(
+                {
+                    "applicationId": "acme-role-1",
+                    "event": "progressed",
+                    "company": {"answerValue": "private"},
+                }
+            )
+
+    def test_tampered_history_fails_closed(self):
+        self.store.initialize()
+        self.store.history_path.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "eventId": "event-1",
+                    "applicationId": "acme-role-1",
+                    "event": "started",
+                    "answerKeys": [],
+                    "company": {"value": "private"},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        with self.assertRaises(STORE_MODULE.StoreError):
+            self.store.read_history()
+
+    def test_session_round_trip_rejects_values_and_path_traversal(self):
+        session = self.store.save_session(
+            "acme-role-1",
+            {
+                "status": "active",
+                "ats": "greenhouse",
+                "step": "questions",
+                "answerKeys": ["work_authorization.us"],
+                "pendingFields": [
+                    {
+                        "question": "Salary expectation?",
+                        "state": "sensitive",
+                        "answerKey": "salary.expectation",
+                        "sensitive": True,
+                    }
+                ],
+            },
+        )
+        loaded = self.store.load_session("acme-role-1")
+        self.assertEqual(loaded["updatedAt"], session["updatedAt"])
+        with self.assertRaises(STORE_MODULE.StoreError):
+            self.store.save_session(
+                "acme-role-2",
+                {
+                    "pendingFields": [
+                        {"question": "Salary?", "state": "sensitive", "value": "250K"}
+                    ]
+                },
+            )
+        with self.assertRaises(STORE_MODULE.StoreError):
+            self.store.load_session("../profile")
+
+    def test_tampered_session_fails_closed(self):
+        self.store.initialize()
+        path = self.store.sessions_path / "acme-role-1.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "applicationId": "acme-role-1",
+                    "status": "active",
+                    "answerKeys": [],
+                    "pendingFields": [],
+                    "company": {"value": "private"},
+                    "createdAt": "2026-07-18T00:00:00Z",
+                    "updatedAt": "2026-07-18T00:00:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaises(STORE_MODULE.StoreError):
+            self.store.load_session("acme-role-1")
+
+    def test_cli_uses_machine_readable_json_and_store_override(self):
+        environment = dict(os.environ)
+        environment["HOME"] = str(self.home)
+        environment[STORE_MODULE.STORE_ENV] = str(self.root)
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "init"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+        result = json.loads(completed.stdout)
+        self.assertTrue(result["initialized"])
+        self.assertEqual(result["root"], str(self.root))
+
+    def test_cli_filesystem_failure_is_terse(self):
+        blocker = self.home / "not-a-directory"
+        blocker.write_text("Ada private data", encoding="utf-8")
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(blocker), "init"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 2)
+        self.assertNotIn("Traceback", completed.stderr)
+        self.assertNotIn("Ada private data", completed.stderr)
+        self.assertIn("storage operation failed", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a versioned, standard-library local storage helper for profiles, reusable answers, application history, and resumable sessions
- add the fourth `answer-memory` skill and route `job-apply`, `job-preferences`, and `job-search` through the shared helper
- distinguish confirmed, inferred, missing, and sensitive answers, with separate consent required before remembering sensitive values
- migrate an existing `~/.claude-job-profile.json` non-destructively into `~/.job-apply/`
- update the README, landing page, plugin smoke inventory, and privacy guidance

## Why

The plugin previously kept resume data and search preferences in one directly edited plaintext JSON file. That provided basic reuse, but it did not offer a stable mutation boundary, answer provenance, uncertainty states, application recovery, or a way to separate using a sensitive answer from remembering it.

This change gives the plugin a focused last-mile capability: reuse answers that are actually confirmed, return uncertain or sensitive fields to the user, preserve progress, and keep the user in control of final submission.

## User and developer impact

- first initialization copies the complete legacy profile into the new versioned store and leaves the legacy file untouched
- canonical JSON writes are atomic and use user-only permissions where supported
- corrupt and future-version files fail closed
- history and sessions reference answer keys instead of duplicating answer values
- only matching non-sensitive confirmed answers may be reused without asking
- sensitive answers require separate field-specific remember consent and are still reconfirmed before future use
- the hard stop-before-Submit/Send contract is unchanged
- no database, cloud service, telemetry, authentication, or third-party Python dependency is added

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py'` — 16 tests pass
- `bash scripts/smoke-plugin.sh` — plugin validation and isolated install pass; exactly four skills are registered
- `bash scripts/check-links.sh` — local and remote link checks pass
- `git diff --check HEAD^ HEAD` — passes
