### PR TITLE
Add Codex plugin support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "neonwatty-plugins",
+  "interface": {
+    "displayName": "Neonwatty Plugins"
+  },
+  "plugins": [
+    {
+      "name": "job-apply",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "neonwatty-plugins",
-  "description": "Claude Code plugins by Jeremy Watt",
+  "description": "Job Apply plugins for Codex and Claude Code by Jeremy Watt",
   "owner": {
     "name": "Jeremy Watt",
     "github": "neonwatty"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "job-apply",
+  "version": "1.1.0",
+  "description": "A local-first job application assistant for Codex and Claude Code that reuses confirmed answers and always stops before submission.",
+  "author": {
+    "name": "Jeremy Watt",
+    "url": "https://github.com/neonwatty"
+  },
+  "homepage": "https://neonwatty.github.io/job-apply-plugin/",
+  "repository": "https://github.com/neonwatty/job-apply-plugin",
+  "license": "MIT",
+  "keywords": [
+    "job-application",
+    "codex",
+    "claude-code",
+    "greenhouse",
+    "workday",
+    "browser-automation",
+    "resume"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Job Apply",
+    "shortDescription": "Fill applications without surrendering the final click",
+    "longDescription": "Extract a reusable local profile from a resume, fill supported ATS forms with confidence-aware answer memory, and stop before Submit or Send so the applicant stays in control.",
+    "developerName": "Jeremy Watt",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://neonwatty.github.io/job-apply-plugin/",
+    "defaultPrompt": [
+      "Fill this job application from my resume.",
+      "Review my saved application answers.",
+      "Set my job-search preferences."
+    ],
+    "brandColor": "#0891B2"
+  }
+}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
 
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
       - name: Validate plugin schema
         run: claude plugin validate .
 
@@ -30,6 +33,10 @@ jobs:
           python3 -m json.tool .claude-plugin/plugin.json > /dev/null
           echo "Validating marketplace.json..."
           python3 -m json.tool .claude-plugin/marketplace.json > /dev/null
+          echo "Validating Codex plugin.json..."
+          python3 -m json.tool .codex-plugin/plugin.json > /dev/null
+          echo "Validating Codex marketplace.json..."
+          python3 -m json.tool .agents/plugins/marketplace.json > /dev/null
           echo "All JSON files are valid"
 
       - name: Run isolated plugin smoke test

--- a/README.md
+++ b/README.md
@@ -1,70 +1,89 @@
-# Job Apply Plugin for Claude Code
+# Job Apply Plugin for Codex and Claude Code
 
 [![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.gg/7xsxU4ZG6A)
 
-AI-powered job application assistant that automatically fills out job applications on LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday using browser automation.
+AI-powered job application assistant for Codex and Claude Code that fills job applications on LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday using visible browser automation.
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| `/job-apply:job-apply` | Fill out job applications automatically using your resume |
-| `/job-apply:answer-memory` | Safely manage your local profile, reusable answers, application history, and resumable sessions |
-| `/job-apply:job-search` | Search LinkedIn, Hacker News, and Twitter/X for jobs, then rank results against your preferences |
-| `/job-apply:job-preferences` | Set the titles, salary, remote-work, and filtering preferences used by job search |
+| `job-apply:job-apply` | Fill out job applications automatically using your resume |
+| `job-apply:answer-memory` | Safely manage your local profile, reusable answers, application history, and resumable sessions |
+| `job-apply:job-search` | Search LinkedIn, Hacker News, and Twitter/X for jobs, then rank results against your preferences |
+| `job-apply:job-preferences` | Set the titles, salary, remote-work, and filtering preferences used by job search |
+
+Invoke skills with `$job-apply:...` in Codex or `/job-apply:...` in Claude Code.
 
 ## Features
 
-### Job Apply (`/job-apply:job-apply`)
+### Job Apply (`job-apply:job-apply`)
 - **One-time profile setup**: Extract your information from a resume (PDF, DOCX, or TXT)
 - **Guided ATS coverage**: Workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday, with current forms unverified
-- **Visible browser automation**: Claude in Chrome fills forms in the browser session you can see and control
+- **Visible browser automation**: Codex Browser/Chrome or Claude in Chrome fills forms in a session you can see and control
 - **Smart field mapping**: Automatically matches your profile to form fields
 - **Confidence-aware answer reuse**: Reuses confirmed non-sensitive answers and flags inferred, missing, or sensitive answers for review
 - **Resumable progress**: Saves application step metadata and answer references without copying answer values
 - **Manual submission**: Stops at final review so only you can click Submit or Send
 - **Resume storage**: Profile saved locally for reuse across applications
 
-### Answer Memory (`/job-apply:answer-memory`)
+### Answer Memory (`job-apply:answer-memory`)
 - **One local contract**: All Job Apply skills use the same bundled storage helper
 - **Reusable answers**: Records confirmed, inferred, missing, and sensitive states with provenance and scope
 - **Separate remember consent**: A sensitive answer is never retained merely because it was used in a form
 - **Minimal history**: Application events and sessions reference answer keys instead of duplicating values
 - **Non-destructive migration**: Imports an existing legacy profile once and leaves the original file untouched
 
-### Job Search (`/job-apply:job-search`)
+### Job Search (`job-apply:job-search`)
 - **Preference-based search**: Searches for the titles, salary range, remote options, and time range you saved
 - **Connection insights**: Finds jobs at companies where you have connections
 - **Hiring manager discovery**: Identifies jobs with hiring managers listed
 - **Multi-source discovery**: Searches LinkedIn, Hacker News Who's Hiring, and Twitter/X
 - **Results saved**: Full search results saved to `~/.claude-job-searches/` as Markdown
 
-### Job Preferences (`/job-apply:job-preferences`)
+### Job Preferences (`job-apply:job-preferences`)
 - **Reusable search settings**: Save target titles, salary floor, remote preference, exclusion patterns, and time range
 - **Shared profile**: Preferences are stored in `~/.job-apply/profile.json` without replacing resume profile data
 - **Selective updates**: Change individual preferences while preserving the rest
 
 ## Requirements
 
-- [Claude Code](https://claude.ai/code) CLI
-- [Claude in Chrome](https://chromewebstore.google.com/detail/claude-in-chrome) for visible browser navigation, authenticated sessions, form filling, and local file uploads
+Choose either supported host:
 
-Playwright is not required. If you already have a Playwright integration configured, the skill may use it as a fallback when Chrome cannot reach a site-specific iframe or control. Otherwise, it leaves that field for you to complete manually.
+- **Codex**: Codex CLI or the Codex desktop app, with the Browser plugin enabled for visible navigation, form filling, authenticated Chrome sessions when selected, and local file uploads
+- **Claude Code**: [Claude Code](https://claude.ai/code) with [Claude in Chrome](https://chromewebstore.google.com/detail/claude-in-chrome)
+
+Codex stays inside its selected Browser plugin surface. Claude Code does not require Playwright; an already-configured Playwright integration may be used only for one inaccessible iframe or custom control.
 
 ## Installation
+
+### Codex
+
+```bash
+codex plugin marketplace add neonwatty/job-apply-plugin
+codex plugin add job-apply@neonwatty-plugins
+```
+
+Start a new Codex task after installation, then invoke `$job-apply:job-apply`.
+
+### Claude Code
 
 ```bash
 claude plugin marketplace add neonwatty/job-apply-plugin
 claude plugin install job-apply@neonwatty-plugins
 ```
 
+Start a new Claude Code session after installation, then invoke `/job-apply:job-apply`.
+
 ## Usage
+
+The examples below use Codex syntax. In Claude Code, replace the leading `$` with `/`.
 
 ### First Time Setup
 
 1. Invoke the skill:
    ```
-   /job-apply:job-apply
+   $job-apply:job-apply
    ```
 
 2. Provide your resume path when prompted:
@@ -80,7 +99,7 @@ Once your profile is set up:
 
 1. Invoke the skill:
    ```
-   /job-apply:job-apply
+   $job-apply:job-apply
    ```
 
 2. Provide a job URL:
@@ -88,22 +107,22 @@ Once your profile is set up:
    https://www.linkedin.com/jobs/view/123456789
    ```
 
-3. Watch as Claude fills out the application
+3. Watch as the agent fills the application from your reviewed local profile
 
 4. Inspect the final review page and the field summary, then click Submit or Send yourself if everything is correct
 
 ### Searching for Jobs
 
-First run `/job-apply:job-preferences` to save your search preferences. Then use `/job-apply:job-search` to search LinkedIn, Hacker News, and Twitter/X and rank matching jobs:
+First run `$job-apply:job-preferences` to save your search preferences. Then use `$job-apply:job-search` to search LinkedIn, Hacker News, and Twitter/X and rank matching jobs:
 
 1. Set or update your preferences:
    ```
-   /job-apply:job-preferences
+   $job-apply:job-preferences
    ```
 
 2. Invoke the search skill:
    ```
-   /job-apply:job-search
+   $job-apply:job-search
    ```
 
 3. Review the active search configuration loaded from your preferences:
@@ -125,16 +144,16 @@ Results are automatically saved to `~/.claude-job-searches/`.
 
 ## Compatibility and Verification Status
 
-The plugin includes guided workflows for six ATS families. Repository instructions and Claude in Chrome guidance were reviewed on **2026-07-18**, but this pass did not submit live applications or verify every current ATS form. Individual flows remain unverified and may drift as sites change.
+The plugin includes guided workflows for six ATS families. Codex and Claude Code host instructions were reviewed on **2026-07-28**, but this PR does not claim live end-to-end validation of every current ATS form. Individual flows remain unverified and may drift as sites change.
 
 | Platform | URL Pattern | Default browser path | Verification status |
 |----------|-------------|----------------------|---------------------|
-| LinkedIn Easy Apply | `linkedin.com/jobs/view/*` | Claude in Chrome | Guided; current ATS flow unverified |
-| Greenhouse | `boards.greenhouse.io/*` | Claude in Chrome | Guided; current ATS flow unverified |
-| Ashby | `jobs.ashbyhq.com/*` | Claude in Chrome | Guided; current ATS flow unverified |
-| Lever | `jobs.lever.co/*` | Claude in Chrome | Guided; current ATS flow unverified |
-| Rippling | `*.rippling.com/*` | Claude in Chrome | Guided; current ATS flow unverified |
-| Workday | `*.myworkdayjobs.com/*` | Claude in Chrome | Guided; current ATS flow unverified |
+| LinkedIn Easy Apply | `linkedin.com/jobs/view/*` | Codex Browser or Claude in Chrome | Guided; current ATS flow unverified |
+| Greenhouse | `boards.greenhouse.io/*` | Codex Browser or Claude in Chrome | Guided; current ATS flow unverified |
+| Ashby | `jobs.ashbyhq.com/*` | Codex Browser or Claude in Chrome | Guided; current ATS flow unverified |
+| Lever | `jobs.lever.co/*` | Codex Browser or Claude in Chrome | Guided; current ATS flow unverified |
+| Rippling | `*.rippling.com/*` | Codex Browser or Claude in Chrome | Guided; current ATS flow unverified |
+| Workday | `*.myworkdayjobs.com/*` | Codex Browser or Claude in Chrome | Guided; current ATS flow unverified |
 
 ## Profile Storage
 
@@ -164,7 +183,7 @@ These files can include sensitive personal information such as:
 - Skills
 - Social links (LinkedIn, GitHub, portfolio)
 
-The repository contains no telemetry or analytics integration, and the store is not uploaded to a plugin service. It remains on your computer until you direct Claude to use values in browser forms or searches; those third-party sites receive the information you choose to enter there.
+The repository contains no telemetry or analytics integration, and the store is not uploaded to a plugin service. It remains on your computer until you direct Codex or Claude Code to use values in browser forms or searches; those third-party sites receive the information you choose to enter there.
 
 Protect the directory like a resume. Do not attach its files to issues or share them in logs. The helper creates user-only permissions on supported systems. On macOS or Linux, you can verify or restore them with:
 
@@ -181,10 +200,10 @@ Only matching, non-sensitive `confirmed` answers may be reused without asking. I
 
 To replace the stored profile from a new resume:
 ```
-/job-apply:job-apply reset profile
+$job-apply:job-apply reset profile
 ```
 
-To remove Job Apply data, close Claude Code and first move the directory to a private backup so recovery remains possible, for example `mv ~/.job-apply ~/.job-apply.backup`. Search-result Markdown files are separate under `~/.claude-job-searches/`; review them independently. The legacy `~/.claude-job-profile.json` is also separate and is never deleted automatically.
+To remove Job Apply data, close Codex or Claude Code and first move the directory to a private backup so recovery remains possible, for example `mv ~/.job-apply ~/.job-apply.backup`. Search-result Markdown files are separate under `~/.claude-job-searches/`; review them independently. The legacy `~/.claude-job-profile.json` is also separate and is never deleted automatically.
 
 ## Search Results Storage
 
@@ -215,12 +234,12 @@ Each file contains:
 
 Before applying:
 
-1. Open Chrome and confirm Claude in Chrome is installed, enabled, and connected to Claude Code.
-2. Sign in to the job site yourself in the Chrome tab you want Claude to use.
-3. Keep your resume at a readable local path, then run `/job-apply:job-apply` and provide a test or intended job URL.
-4. Confirm Claude can read the page before allowing it to fill any fields.
+1. In Codex, enable the Browser plugin and select its visible browser surface. In Claude Code, connect Claude in Chrome.
+2. Sign in to the job site yourself in the visible tab you want the agent to use.
+3. Keep your resume at a readable local path, then run `$job-apply:job-apply` in Codex or `/job-apply:job-apply` in Claude Code and provide a test or intended job URL.
+4. Confirm the agent can read the page before allowing it to fill any fields.
 
-If the skill cannot see the page, reconnect Claude in Chrome and refresh the tab. If login, CAPTCHA, MFA, or account creation appears, complete it yourself and then tell Claude to continue. ATS markup changes frequently; if Chrome cannot reach an iframe, upload widget, or custom control, use an already-configured Playwright integration as an optional fallback or complete the remaining field manually. The plugin does not bypass blocked controls or guarantee every form on a platform will work.
+If the skill cannot see the page, reconnect the active browser surface and refresh the tab. If login, CAPTCHA, MFA, or account creation appears, complete it yourself and then tell the agent to continue. ATS markup changes frequently; if the browser cannot reach an iframe, upload widget, or custom control, complete the remaining field manually. Claude Code may also use an already-configured Playwright integration for one blocked control. The plugin does not bypass blocked controls or guarantee every form on a platform will work.
 
 ## Get Help or Share Feedback
 
@@ -244,10 +263,11 @@ Before opening a PR, run the same deterministic checks used by CI:
 bash scripts/smoke-plugin.sh
 bash scripts/check-links.sh
 claude plugin validate .
+python3 /path/to/plugin-creator/scripts/validate_plugin.py .
 git diff --check
 ```
 
-The smoke test installs a temporary working-tree marketplace fixture under an isolated `CLAUDE_CONFIG_DIR` and removes it on exit. It does not alter your normal Claude configuration.
+The smoke test installs temporary working-tree fixtures under isolated Codex and Claude Code configuration directories and removes them on exit. It does not alter your normal host configuration.
 
 ## Author
 

--- a/scripts/smoke-plugin.sh
+++ b/scripts/smoke-plugin.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SMOKE_TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/job-apply-smoke.XXXXXX")"
-SMOKE_CONFIG_DIR="$SMOKE_TEMP_ROOT/claude-config"
+SMOKE_CLAUDE_CONFIG_DIR="$SMOKE_TEMP_ROOT/claude-config"
+SMOKE_CODEX_HOME="$SMOKE_TEMP_ROOT/codex-home"
 SMOKE_FIXTURE_DIR="$SMOKE_TEMP_ROOT/plugin-fixture"
 
 cleanup() {
@@ -11,7 +12,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$SMOKE_CONFIG_DIR" "$SMOKE_FIXTURE_DIR"
+mkdir -p "$SMOKE_CLAUDE_CONFIG_DIR" "$SMOKE_CODEX_HOME" "$SMOKE_FIXTURE_DIR"
 
 echo "Validating plugin manifest"
 claude plugin validate "$REPO_ROOT"
@@ -35,6 +36,23 @@ for relative in (".claude-plugin/plugin.json", ".claude-plugin/marketplace.json"
         if "version" in plugin:
             raise SystemExit(f"{relative} plugin entries must omit version")
 
+codex_manifest = json.loads((root / ".codex-plugin/plugin.json").read_text())
+if codex_manifest.get("name") != "job-apply":
+    raise SystemExit(".codex-plugin/plugin.json name must be job-apply")
+if not re.fullmatch(r"\d+\.\d+\.\d+", codex_manifest.get("version", "")):
+    raise SystemExit(".codex-plugin/plugin.json version must be strict SemVer")
+if codex_manifest.get("skills") != "./skills/":
+    raise SystemExit(".codex-plugin/plugin.json must expose ./skills/")
+if codex_manifest.get("interface", {}).get("displayName") != "Job Apply":
+    raise SystemExit(".codex-plugin/plugin.json is missing install-surface metadata")
+
+codex_marketplace = json.loads((root / ".agents/plugins/marketplace.json").read_text())
+codex_entries = codex_marketplace.get("plugins", [])
+if len(codex_entries) != 1 or codex_entries[0].get("name") != "job-apply":
+    raise SystemExit("Codex marketplace must expose exactly the job-apply plugin")
+if codex_entries[0].get("source") != {"source": "local", "path": "./"}:
+    raise SystemExit("Codex marketplace must point at the repository-root plugin")
+
 skill_dirs = {path.name for path in (root / "skills").iterdir() if path.is_dir()}
 if skill_dirs != expected:
     raise SystemExit(f"skill directories differ: expected {sorted(expected)}, got {sorted(skill_dirs)}")
@@ -45,7 +63,7 @@ for skill in expected:
     if not match or match.group(1) != skill:
         raise SystemExit(f"skills/{skill}/SKILL.md frontmatter name is missing or incorrect")
 
-invocation_pattern = re.compile(r"/job-apply:(answer-memory|job-apply|job-search|job-preferences)")
+invocation_pattern = re.compile(r"(?:\$|/)?job-apply:(answer-memory|job-apply|job-search|job-preferences)")
 for relative in ("README.md", "site/index.html"):
     found = set(invocation_pattern.findall((root / relative).read_text()))
     if found != expected:
@@ -53,13 +71,17 @@ for relative in ("README.md", "site/index.html"):
 
 application_skill = (root / "skills/job-apply/SKILL.md").read_text()
 answer_memory_skill = (root / "skills/answer-memory/SKILL.md").read_text()
-helper_reference = 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py"'
 for skill in expected:
     content = (root / "skills" / skill / "SKILL.md").read_text()
     if "job-apply-store.py" not in content:
         raise SystemExit(f"skills/{skill}/SKILL.md does not use the shared storage helper")
-if helper_reference not in answer_memory_skill:
-    raise SystemExit("answer-memory skill does not use the plugin-root helper path")
+for required_root_contract in (
+    "<plugin-root>/scripts/job-apply-store.py",
+    "PLUGIN_ROOT",
+    "CLAUDE_PLUGIN_ROOT",
+):
+    if required_root_contract not in answer_memory_skill:
+        raise SystemExit(f"answer-memory skill is missing cross-host root contract: {required_root_contract}")
 if "--remember-sensitive" not in answer_memory_skill:
     raise SystemExit("answer-memory skill is missing explicit sensitive remember consent")
 if "Permission to fill is not permission to remember" not in answer_memory_skill:
@@ -98,10 +120,10 @@ data["plugins"][0]["source"] = "./"
 manifest.write_text(json.dumps(data, indent=2) + "\n")
 PY
 
-echo "Installing fixture with isolated CLAUDE_CONFIG_DIR=$SMOKE_CONFIG_DIR"
-CLAUDE_CONFIG_DIR="$SMOKE_CONFIG_DIR" claude plugin marketplace add "$SMOKE_FIXTURE_DIR"
-CLAUDE_CONFIG_DIR="$SMOKE_CONFIG_DIR" claude plugin install job-apply@neonwatty-plugins
-CLAUDE_CONFIG_DIR="$SMOKE_CONFIG_DIR" claude plugin details job-apply@neonwatty-plugins \
+echo "Installing fixture with isolated CLAUDE_CONFIG_DIR=$SMOKE_CLAUDE_CONFIG_DIR"
+CLAUDE_CONFIG_DIR="$SMOKE_CLAUDE_CONFIG_DIR" claude plugin marketplace add "$SMOKE_FIXTURE_DIR"
+CLAUDE_CONFIG_DIR="$SMOKE_CLAUDE_CONFIG_DIR" claude plugin install job-apply@neonwatty-plugins
+CLAUDE_CONFIG_DIR="$SMOKE_CLAUDE_CONFIG_DIR" claude plugin details job-apply@neonwatty-plugins \
   | tee "$SMOKE_TEMP_ROOT/plugin-details.txt"
 
 for skill in answer-memory job-apply job-search job-preferences; do
@@ -111,7 +133,7 @@ for skill in answer-memory job-apply job-search job-preferences; do
   fi
 done
 
-CLAUDE_CONFIG_DIR="$SMOKE_CONFIG_DIR" claude plugin list --json \
+CLAUDE_CONFIG_DIR="$SMOKE_CLAUDE_CONFIG_DIR" claude plugin list --json \
   > "$SMOKE_TEMP_ROOT/plugin-list.json"
 python3 - "$SMOKE_TEMP_ROOT/plugin-list.json" <<'PY'
 import json
@@ -121,7 +143,47 @@ plugins = json.load(open(sys.argv[1]))
 serialized = json.dumps(plugins)
 if "job-apply@neonwatty-plugins" not in serialized:
     raise SystemExit("isolated plugin list does not contain job-apply@neonwatty-plugins")
-print("Isolated local marketplace install passed")
+print("Isolated Claude Code marketplace install passed")
+PY
+
+echo "Installing fixture with isolated CODEX_HOME=$SMOKE_CODEX_HOME"
+CODEX_HOME="$SMOKE_CODEX_HOME" codex plugin marketplace add "$SMOKE_FIXTURE_DIR" --json \
+  > "$SMOKE_TEMP_ROOT/codex-marketplace-add.json"
+CODEX_HOME="$SMOKE_CODEX_HOME" codex plugin add job-apply@neonwatty-plugins --json \
+  > "$SMOKE_TEMP_ROOT/codex-plugin-add.json"
+CODEX_HOME="$SMOKE_CODEX_HOME" codex plugin list --json \
+  > "$SMOKE_TEMP_ROOT/codex-plugin-list.json"
+
+python3 - "$SMOKE_TEMP_ROOT/codex-plugin-list.json" "$SMOKE_CODEX_HOME" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+plugins = json.load(open(sys.argv[1]))
+installed = plugins.get("installed", [])
+match = next(
+    (plugin for plugin in installed if plugin.get("pluginId") == "job-apply@neonwatty-plugins"),
+    None,
+)
+if not match or not match.get("enabled"):
+    raise SystemExit("isolated Codex plugin list does not contain an enabled job-apply plugin")
+
+cache_root = Path(sys.argv[2]) / "plugins" / "cache" / "neonwatty-plugins" / "job-apply"
+versions = [path for path in cache_root.iterdir() if path.is_dir()]
+if len(versions) != 1:
+    raise SystemExit(f"expected one isolated Codex plugin version, found {len(versions)}")
+
+expected = {"answer-memory", "job-apply", "job-search", "job-preferences"}
+installed_skills = {
+    path.name for path in (versions[0] / "skills").iterdir() if path.is_dir()
+}
+if installed_skills != expected:
+    raise SystemExit(
+        f"installed Codex skill inventory differs: expected {sorted(expected)}, "
+        f"got {sorted(installed_skills)}"
+    )
+
+print("Isolated Codex marketplace install passed")
 PY
 
 echo "Plugin smoke checks passed"

--- a/site/index.html
+++ b/site/index.html
@@ -3,16 +3,16 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="AI-powered job application assistant for Claude Code with guided workflows for LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.">
+  <meta name="description" content="AI-powered job application assistant for Codex and Claude Code with guided workflows for LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.">
   <link rel="canonical" href="https://neonwatty.github.io/job-apply-plugin/">
-  <meta property="og:title" content="Job Apply Plugin - AI-powered job application assistant for Claude Code">
+  <meta property="og:title" content="Job Apply Plugin for Codex and Claude Code">
   <meta property="og:description" content="Guided resume-based workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://neonwatty.github.io/job-apply-plugin/">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Job Apply Plugin - AI-powered job application assistant for Claude Code">
+  <meta name="twitter:title" content="Job Apply Plugin for Codex and Claude Code">
   <meta name="twitter:description" content="Guided resume-based workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
-  <title>Job Apply Plugin - AI-powered job application assistant for Claude Code</title>
+  <title>Job Apply Plugin for Codex and Claude Code</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -33,7 +33,7 @@
   <main id="main">
     <section class="hero">
       <div class="hero-copy">
-        <p class="eyebrow">AI-powered job application assistant for Claude Code</p>
+        <p class="eyebrow">AI-powered job application assistant for Codex and Claude Code</p>
         <h1>Fill out job applications automatically using your resume.</h1>
         <p class="lede">
           Guided workflows cover LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday. Set up your profile once, then start a guided application with a single command.
@@ -51,8 +51,8 @@
           <span class="mac-dot green"></span>
         </div>
         <div class="terminal">
-          <div class="terminal-title">Claude Code</div>
-          <div class="prompt">$ /job-apply:job-apply</div>
+          <div class="terminal-title">Codex / Claude Code</div>
+          <div class="prompt">$job-apply:job-apply</div>
           <div class="output output-dim">Paste the job URL you'd like to apply to:</div>
           <div class="prompt">https://linkedin.com/jobs/view/4019283746</div>
           <div class="output">
@@ -76,7 +76,7 @@
 
     <section class="section intro">
       <p>
-        Job Apply Plugin turns Claude Code into a job application assistant. Extract your profile once, reuse confirmed answers, and let uncertain or sensitive fields come back to you for review before you submit manually.
+        Job Apply turns Codex or Claude Code into a job application assistant. Extract your profile once, reuse confirmed answers, and let uncertain or sensitive fields come back to you for review before you submit manually.
       </p>
     </section>
 
@@ -88,20 +88,20 @@
       <div class="skills-grid">
         <article class="skill-card">
           <div class="skill-header">
-            <span class="skill-badge">/job-apply:job-apply</span>
+            <span class="skill-badge">job-apply:job-apply</span>
           </div>
           <h3>Fill out applications automatically</h3>
           <ul class="feature-bullets">
             <li>One-time profile setup from your resume (PDF, DOCX, or TXT)</li>
             <li>Multi-platform: LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, Workday</li>
             <li>Smart field mapping from your profile to form fields</li>
-            <li>Visible automation in your Claude in Chrome session</li>
+            <li>Visible automation with Codex Browser or Claude in Chrome</li>
             <li>Stops at final review so only you can submit</li>
           </ul>
         </article>
         <article class="skill-card">
           <div class="skill-header">
-            <span class="skill-badge">/job-apply:answer-memory</span>
+            <span class="skill-badge">job-apply:answer-memory</span>
           </div>
           <h3>Reuse answers without losing control</h3>
           <ul class="feature-bullets">
@@ -114,7 +114,7 @@
         </article>
         <article class="skill-card">
           <div class="skill-header">
-            <span class="skill-badge">/job-apply:job-search</span>
+            <span class="skill-badge">job-apply:job-search</span>
           </div>
           <h3>Find jobs where you have an advantage</h3>
           <ul class="feature-bullets">
@@ -127,7 +127,7 @@
         </article>
         <article class="skill-card">
           <div class="skill-header">
-            <span class="skill-badge">/job-apply:job-preferences</span>
+            <span class="skill-badge">job-apply:job-preferences</span>
           </div>
           <h3>Save reusable search preferences</h3>
           <ul class="feature-bullets">
@@ -155,27 +155,27 @@
         <div class="platform-pill">Workday</div>
       </div>
       <p>
-        Repository and browser guidance was reviewed on July 18, 2026. This pass did not submit live applications or verify every current ATS form; individual flows remain unverified and may drift as sites change.
+        Codex and Claude Code host guidance was reviewed on July 28, 2026. This PR does not claim live end-to-end validation of every current ATS form; individual flows remain unverified and may drift as sites change.
       </p>
     </section>
 
     <section id="requirements" class="section split">
       <div class="section-heading">
         <p class="eyebrow">Requirements</p>
-        <h2>One browser integration required.</h2>
+        <h2>Choose your agent and a visible browser.</h2>
       </div>
       <div class="feature-list">
         <article>
+          <h3>Codex</h3>
+          <p>Use the Codex CLI or desktop app with the Browser plugin for visible navigation, form filling, and file uploads.</p>
+        </article>
+        <article>
           <h3>Claude Code</h3>
-          <p>The CLI that runs the plugin and orchestrates the entire workflow.</p>
+          <p>Use Claude Code with Claude in Chrome for the same visible, supervised workflow.</p>
         </article>
         <article>
-          <h3>Claude in Chrome</h3>
-          <p>The visible default for browser navigation, authenticated sessions, form filling, and local file uploads.</p>
-        </article>
-        <article>
-          <h3>Optional fallback</h3>
-          <p>If already configured, Playwright may help with a site-specific iframe or control Chrome cannot reach. It is not required.</p>
+          <h3>Your existing session</h3>
+          <p>Sign in yourself. The plugin never asks for, stores, or enters credentials, passwords, CAPTCHA responses, or MFA codes.</p>
         </article>
       </div>
     </section>
@@ -185,14 +185,18 @@
         <p class="eyebrow">Install</p>
         <h2>Add the plugin and start applying.</h2>
         <p>
-          Install from the Claude Code plugin marketplace, then invoke <code>/job-apply:job-apply</code> with a job URL. Your profile and explicitly confirmed answers are stored locally and reused when their scope still matches.
+          Install for Codex or Claude Code, then invoke the application skill with a job URL. Your profile and explicitly confirmed answers are stored locally and reused only when their scope still matches.
         </p>
       </div>
       <div class="code-card">
-        <pre><code>claude plugin marketplace add neonwatty/job-apply-plugin
-claude plugin install job-apply@neonwatty-plugins
+        <pre><code># Codex
+codex plugin marketplace add neonwatty/job-apply-plugin
+codex plugin add job-apply@neonwatty-plugins
+$job-apply:job-apply
 
-# Then in Claude Code:
+# Claude Code
+claude plugin marketplace add neonwatty/job-apply-plugin
+claude plugin install job-apply@neonwatty-plugins
 /job-apply:job-apply</code></pre>
       </div>
     </section>
@@ -221,7 +225,7 @@ claude plugin install job-apply@neonwatty-plugins
         </article>
         <article>
           <h3>Changing ATS controls</h3>
-          <p>If Chrome cannot reach a site-specific field, the plugin reports it and leaves it for you unless an optional fallback is already configured.</p>
+          <p>If the visible browser cannot reach a site-specific field, the plugin reports it and leaves it for you.</p>
         </article>
       </div>
     </section>
@@ -238,7 +242,7 @@ claude plugin install job-apply@neonwatty-plugins
         </article>
         <article>
           <h3>No plugin telemetry</h3>
-          <p>The repository defines no telemetry service. Information is shared with third-party sites only when you direct Claude to use it in browser or search workflows.</p>
+          <p>The repository defines no telemetry service. Information is shared with third-party sites only when you direct Codex or Claude Code to use it in browser or search workflows.</p>
         </article>
         <article>
           <h3>Friendly, redacted support</h3>

--- a/skills/answer-memory/SKILL.md
+++ b/skills/answer-memory/SKILL.md
@@ -10,10 +10,16 @@ Use this skill as the storage contract for every Job Apply workflow. It manages 
 
 ## Non-negotiable interface
 
-Run the helper from the installed plugin root:
+Resolve `<plugin-root>` once before the first helper call:
+
+1. In Codex, use the installed skill path shown in the skill catalog and walk up from `skills/answer-memory/SKILL.md` to the plugin root. If Codex exposes `PLUGIN_ROOT`, it may be used after confirming it contains `scripts/job-apply-store.py`.
+2. In Claude Code, use `CLAUDE_PLUGIN_ROOT` after confirming it contains the helper.
+3. Never assume the current working directory is the plugin root, and never search unrelated user directories for it.
+
+Run the helper from that resolved root:
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" <command>
+python3 "<plugin-root>/scripts/job-apply-store.py" <command>
 ```
 
 Do not directly create, parse, patch, append to, or replace files under `~/.job-apply/`. Do not recreate question normalization, answer keys, migration logic, permissions, or atomic writes in the agent. Use only helper commands described here and in [the storage contract](references/storage-contract.md).
@@ -25,13 +31,13 @@ Successful data commands return JSON on stdout. If the helper returns nonzero, s
 Start every workflow that needs persistent state with:
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" init
+python3 "<plugin-root>/scripts/job-apply-store.py" init
 ```
 
 This creates the local store if needed and non-destructively migrates an existing `~/.claude-job-profile.json`. The legacy file is never deleted or rewritten. To inspect resolved locations:
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" paths
+python3 "<plugin-root>/scripts/job-apply-store.py" paths
 ```
 
 The default layout is:
@@ -54,10 +60,10 @@ Do not place passwords, credentials, authentication tokens, CAPTCHA answers, pay
 ## Profile and preferences
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" profile-get
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" profile-replace --input <profile.json>
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" preferences-get
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" preferences-set --input <preferences.json>
+python3 "<plugin-root>/scripts/job-apply-store.py" profile-get
+python3 "<plugin-root>/scripts/job-apply-store.py" profile-replace --input <profile.json>
+python3 "<plugin-root>/scripts/job-apply-store.py" preferences-get
+python3 "<plugin-root>/scripts/job-apply-store.py" preferences-set --input <preferences.json>
 ```
 
 `preferences-set` merges supplied keys and preserves all other profile and preference fields. Use `--replace` only after the user explicitly chooses to replace the full preferences object.
@@ -76,7 +82,7 @@ Answer states have distinct behavior:
 Look up the exact question and relevant scope before filling:
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" answer-find \
+python3 "<plugin-root>/scripts/job-apply-store.py" answer-find \
   --question "Are you authorized to work in the United States?" \
   --scope '{"country":"US"}'
 ```
@@ -95,7 +101,7 @@ Permission to fill is not permission to remember. If the user approves current u
 Persist a non-null sensitive value only after explicit field-specific remember consent in the current interaction:
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" answer-put \
+python3 "<plugin-root>/scripts/job-apply-store.py" answer-put \
   --input <sensitive-answer.json> \
   --remember-sensitive
 ```
@@ -109,7 +115,7 @@ Append minimal lifecycle events using `history-append --input <event.json>`. His
 Use `reviewed` when Job Apply reaches final review. Do not record `completed` unless the user later confirms that they personally submitted the application.
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" history-list
+python3 "<plugin-root>/scripts/job-apply-store.py" history-list
 ```
 
 ## Resumable sessions
@@ -117,9 +123,9 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" history-list
 Use `session-save --id <application-id> --input <session.json>` after meaningful non-final progress. Sessions may contain ATS/role/step metadata, `answerKeys`, and pending-field descriptions; they must not contain answer values.
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" session-list
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" session-load --id <application-id>
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" session-delete --id <application-id>
+python3 "<plugin-root>/scripts/job-apply-store.py" session-list
+python3 "<plugin-root>/scripts/job-apply-store.py" session-load --id <application-id>
+python3 "<plugin-root>/scripts/job-apply-store.py" session-delete --id <application-id>
 ```
 
 Delete a session after the user confirms submission or explicitly abandons it. History remains separate.

--- a/skills/answer-memory/references/storage-contract.md
+++ b/skills/answer-memory/references/storage-contract.md
@@ -3,7 +3,7 @@
 The bundled helper is the sole supported mutation interface:
 
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" --help
+python3 "<plugin-root>/scripts/job-apply-store.py" --help
 ```
 
 ## Files

--- a/skills/job-apply/SKILL.md
+++ b/skills/job-apply/SKILL.md
@@ -6,11 +6,11 @@ allowed-tools: Read, Write, Bash, mcp__claude-in-chrome__*, mcp__plugin_playwrig
 
 # Job Application Assistant
 
-A Claude Code skill for filling job applications on LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday using browser automation.
+A Codex and Claude Code skill for filling job applications on LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday using visible browser automation.
 
 ## Initial Prompt
 
-When this skill is invoked, first follow `/job-apply:answer-memory`: run the bundled helper's `init` command, then load the profile with `profile-get`. Never read or write persistent Job Apply files directly.
+When this skill is invoked, first follow the bundled `answer-memory` skill (`$job-apply:answer-memory` in Codex; `/job-apply:answer-memory` in Claude Code): resolve `<plugin-root>`, run the bundled helper's `init` command, then load the profile with `profile-get`. Never read or write persistent Job Apply files directly.
 
 **If the returned profile object is empty**, say:
 
@@ -44,28 +44,31 @@ Then wait for the user to provide the path before proceeding with profile extrac
 
 ## Profile Storage
 
-Your extracted profile is stored under `~/.job-apply/` for reuse across sessions. All persistent reads and writes go through `${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py` as defined by `/job-apply:answer-memory`. A first run non-destructively migrates an existing `~/.claude-job-profile.json`.
+Your extracted profile is stored under `~/.job-apply/` for reuse across sessions. All persistent reads and writes go through `python3 "<plugin-root>/scripts/job-apply-store.py"` as defined by the bundled `answer-memory` skill. A first run non-destructively migrates an existing `~/.claude-job-profile.json`.
 
 ---
 
 ## Browser Routing
 
-Use **Claude in Chrome** as the default and only required browser integration. Work in the visible Chrome session so the user can see navigation, authenticated state, entered values, uploads, and the final review page.
+Use the active host's supported visible browser integration so the user can see navigation, authenticated state, entered values, uploads, and the final review page.
 
-### Chrome-First Rules
+- **Codex:** Use the installed Browser plugin and follow its complete browser-control instructions. When the job URL is known, let the Browser runtime select the appropriate in-app or Chrome surface for that URL. Reuse that browser binding and visible tab throughout the application. Do not substitute an unrelated browser automation server.
+- **Claude Code:** Use Claude in Chrome as the default and only required browser integration.
 
-- Use Claude in Chrome for LinkedIn and every external application portal.
+### Visible-Browser Rules
+
+- Use Codex Browser/Chrome or Claude in Chrome for LinkedIn and every external application portal, according to the active host.
 - Use the user's existing authenticated Chrome session, but never ask for, read, store, or enter credentials.
 - Pause for the user to handle login, password, CAPTCHA, MFA, consent prompts, or account creation.
 - Use Chrome's visible form controls and local file-upload support. Confirm the selected filename after an upload.
-- If an Apply link opens an external portal or a new tab, continue there in Claude in Chrome.
+- If an Apply link opens an external portal or a new tab, continue there in the same host-managed visible browser session.
 
-### Optional Playwright Fallback
+### Optional Browser Fallback
 
-Playwright is not required. Use it only when **all** of the following are true:
+In Codex, use only the interaction methods exposed by the selected Browser plugin; its Playwright API is part of that browser surface, not a separate integration. In Claude Code, a separate Playwright integration is not required and may be used only when **all** of the following are true:
 
-1. The user already has a Playwright integration configured.
-2. Chrome cannot reach a specific iframe, upload widget, or custom control after a reasonable visible attempt.
+1. The user already has a Playwright integration configured in Claude Code.
+2. Claude in Chrome cannot reach a specific iframe, upload widget, or custom control after a reasonable visible attempt.
 3. The fallback does not require transferring login state or credentials.
 
 Use the fallback only for the blocked control, then return to the visible review workflow. If these conditions are not met, explain which field is blocked and leave it for the user to complete manually.
@@ -93,10 +96,10 @@ If `profile-get` returns an empty object, or if the user requests a reset:
 
 ### Phase 2: Application Filling
 
-1. **Initialize and load storage** through `/job-apply:answer-memory`; use `profile-get`, then check `session-list` for resumable work matching this application
-2. **Open the URL in Claude in Chrome** and identify the job site and application flow
+1. **Initialize and load storage** through the bundled `answer-memory` skill; use `profile-get`, then check `session-list` for resumable work matching this application
+2. **Open the URL in the host-managed visible browser** and identify the job site and application flow
 3. **Pause for user-only steps** if login, password, CAPTCHA, MFA, consent, or account creation appears
-4. **Open the application form**; if an Apply link opens an external portal, continue in that visible Chrome tab
+4. **Open the application form**; if an Apply link opens an external portal, continue in that visible host-managed tab
 5. **Read the form** and fill profile-backed fields; for recurring questions call `answer-find` with the exact visible question and relevant scope
 6. **Reuse only matching, non-sensitive `confirmed` answers**. Show and confirm `inferred` answers, ask for `missing` answers, and reconfirm every `sensitive` answer before entry
 7. **Separate fill consent from remember consent** for salary, work authorization, visa status, demographic information, disability disclosure, and similar answers. Use `--remember-sensitive` only after explicit field-specific permission to remember
@@ -125,7 +128,7 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
 2. Use `read_page` on each step to identify fields
 3. Common fields:
    - Phone number (often pre-filled from LinkedIn)
-   - Resume upload (use `upload_image` tool with resume path)
+   - Resume upload (use the host browser's supported file-chooser flow with the resume path)
    - Work authorization questions (dropdowns)
    - Custom screening questions (varies by employer)
 4. Click "Next" to advance, "Review" on final step
@@ -145,8 +148,8 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
 - Often has "Add another" for work history/education
 - May be embedded in an iframe on a company career site
 
-**Approach (Chrome first):**
-1. Navigate to the application URL in Claude in Chrome
+**Approach (visible browser first):**
+1. Navigate to the application URL in the host-managed visible browser
 2. Read the visible form; if an embedded form is inaccessible, follow the optional fallback rules or leave it for the user
 3. Fill from top to bottom
 4. **Phone country code**: Click the country code toggle → select "United States: +1" from the listbox → the phone field auto-formats with +1 prefix
@@ -170,8 +173,8 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
 - Fields: name, phone, email, location (combobox), LinkedIn URL, resume upload
 - Has both a resume upload field and a separate autofill file input — use the resume field, not the autofill one
 
-**Approach (Chrome first):**
-1. Navigate to the URL in Claude in Chrome
+**Approach (visible browser first):**
+1. Navigate to the URL in the host-managed visible browser
 2. Read the visible form structure
 3. Fill text fields (name, phone, email, LinkedIn URL)
 4. **Location combobox**: Type the location to trigger suggestions, then click the matching option
@@ -187,8 +190,8 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
 - Text fields for name, email, phone, LinkedIn, etc.
 - Radio buttons for screening questions — often use custom overlays that intercept clicks
 
-**Approach (Chrome first):**
-1. Navigate to the URL in Claude in Chrome
+**Approach (visible browser first):**
+1. Navigate to the URL in the host-managed visible browser
 2. Scroll down to find the application form (usually below job description)
 3. Read the visible form structure and fill text fields
 4. **Radio buttons**: If a custom overlay blocks a control, follow the optional fallback rules or leave it for the user
@@ -202,8 +205,8 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
 - Upload resume first, then verify/correct auto-filled data
 - Location uses a typeahead combobox
 
-**Approach (Chrome first):**
-1. Navigate to the URL in Claude in Chrome
+**Approach (visible browser first):**
+1. Navigate to the URL in the host-managed visible browser
 2. **Upload resume first** — Rippling will auto-parse and fill fields
 3. Read the visible form to see what was auto-filled
 4. Correct any mis-parsed fields
@@ -218,7 +221,7 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
 - Non-standard UI components (custom dropdowns, date pickers)
 - Often requires account creation (pause so the user can decide and handle it)
 
-**Approach (Chrome first):**
+**Approach (visible browser first):**
 1. If login, CAPTCHA, MFA, or account creation is required, pause for the user; never handle credentials or create the account
 2. Navigate through "My Information" → "My Experience" → "Application Questions"
 3. Read the visible form structure on each page
@@ -257,7 +260,7 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
 
 ## Browser Tool Usage
 
-### Claude in Chrome (Default)
+### Codex Browser or Claude in Chrome (Default)
 
 1. Read the visible page and identify interactive fields.
 2. Fill standard fields and use visible controls for dropdowns, radio buttons, and checkboxes.
@@ -265,9 +268,9 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
 4. After each non-final Next, Continue, or Save action, read the new page before proceeding.
 5. When Review, Submit, Send, or an equivalent final action appears, stop and summarize the application for the user.
 
-### Playwright (Optional Fallback Only)
+### Separate Playwright Integration (Claude Code Optional Fallback Only)
 
-If Playwright is already configured and Chrome cannot reach a specific iframe or custom control, it may be used only for that blocked field. Do not require it, do not transfer authenticated state or credentials, and do not use it to activate Submit, Send, or any equivalent final action. If the fallback is unavailable or unsuccessful, leave the field for the user.
+In Codex, stay inside the selected Browser plugin surface. In Claude Code, if a separate Playwright integration is already configured and Claude in Chrome cannot reach a specific iframe or custom control, it may be used only for that blocked field. Do not require it, do not transfer authenticated state or credentials, and do not use it to activate Submit, Send, or any equivalent final action. If the fallback is unavailable or unsuccessful, leave the field for the user.
 
 ---
 
@@ -278,7 +281,7 @@ If Playwright is already configured and Chrome cannot reach a specific iframe or
 3. **Never submit applications** - Stop at final review; confirmation does not authorize clicking Submit, Send, or an equivalent final action
 4. **Never enter payment information** - Some applications have optional premium features
 5. **Handle sensitive questions carefully** - Salary expectations, visa status, disability disclosure should be confirmed with user before filling
-6. **Use Claude in Chrome by default** - Playwright is only an already-configured fallback for a specific inaccessible control
+6. **Use the host-managed visible browser by default** - Codex stays within its Browser plugin; Claude Code may use an already-configured Playwright fallback for one inaccessible control
 7. **Never store or pass login credentials between tools** - Authentication remains a user-only step in the visible Chrome session
 8. **Use answer memory only through the helper** - Never directly modify `~/.job-apply/`; history and sessions reference answer keys, not values
 9. **Remembering is separate consent** - Permission to use a sensitive answer now never authorizes storing it for later
@@ -288,5 +291,6 @@ If Playwright is already configured and Chrome cannot reach a specific iframe or
 ## Example Invocation
 
 ```
-User: /job-apply:job-apply https://www.linkedin.com/jobs/view/123456789
+Codex: $job-apply:job-apply https://www.linkedin.com/jobs/view/123456789
+Claude Code: /job-apply:job-apply https://www.linkedin.com/jobs/view/123456789
 ```

--- a/skills/job-preferences/SKILL.md
+++ b/skills/job-preferences/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: job-preferences
-description: Set or update your job search preferences (titles, salary, remote, filters). Used by /job-apply:job-search and other skills.
+description: Set or update job-search preferences such as titles, salary, remote work, and filters for the other Job Apply skills.
 allowed-tools: Read, Write, Bash
 ---
 
 # Job Preferences
 
-A Claude Code skill for managing persistent job search preferences. Set your target titles, salary floor, remote preference, and exclusion filters once — `/job-apply:job-search` and other skills reuse them automatically.
+A Codex and Claude Code skill for managing persistent job search preferences. Set your target titles, salary floor, remote preference, and exclusion filters once; the bundled `job-search` skill reuses them automatically.
 
 ---
 
@@ -14,7 +14,7 @@ A Claude Code skill for managing persistent job search preferences. Set your tar
 
 ### Step 1: Load Profile
 
-Follow `/job-apply:answer-memory`: run `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" init`, then load saved preferences with `preferences-get`. Never read or write persistent Job Apply files directly.
+Follow the bundled `answer-memory` skill (`$job-apply:answer-memory` in Codex; `/job-apply:answer-memory` in Claude Code). Resolve `<plugin-root>` as that skill directs, run `python3 "<plugin-root>/scripts/job-apply-store.py" init`, then load saved preferences with `preferences-get`. Never read or write persistent Job Apply files directly.
 
 ### Step 2: Check for Existing Preferences
 
@@ -32,13 +32,13 @@ Use the JSON object returned by `preferences-get`.
 >
 > Would you like to update any of these?
 
-Then wait for the user. If they say no, stop. If they want to update, ask only about the fields they want to change using `AskUserQuestion`.
+Then wait for the user. If they say no, stop. If they want to update, ask only about the fields they want to change using the host's structured question surface when available, or concise direct questions otherwise.
 
 **If no preferences exist**, run the full Q&A below.
 
 ### Step 3: Collect Preferences (full Q&A)
 
-Use `AskUserQuestion` to collect all fields. Ask up to 4 questions at a time (the tool's limit).
+Use the host's structured question surface when available; otherwise ask concise direct questions. Ask no more than 4 questions at a time.
 
 **Question batch 1:**
 
@@ -99,18 +99,18 @@ Display the saved preferences and confirm:
 
 > **Preferences saved to your local Job Apply store at `~/.job-apply/profile.json`.**
 >
-> These will be used automatically by `/job-apply:job-search`. Run `/job-apply:job-preferences` again any time to update them.
+> These will be used automatically by the bundled `job-search` skill. Invoke `job-preferences` again any time to update them.
 
 ---
 
 ## Updating Preferences
 
-When the user runs `/job-apply:job-preferences` and preferences already exist, show current values and let them update selectively. Only overwrite the fields they change — keep the rest intact.
+When the user invokes `job-preferences` and preferences already exist, show current values and let them update selectively. Only overwrite the fields they change — keep the rest intact.
 
 ---
 
 ## Safety Rules
 
-1. **Use only the helper** — initialize, read, and merge preferences through `/job-apply:answer-memory`; never directly edit files under `~/.job-apply/`
+1. **Use only the helper** — initialize, read, and merge preferences through the bundled `answer-memory` skill; never directly edit files under `~/.job-apply/`
 2. **Preserve existing profile** — use `preferences-set` without `--replace` for selective updates
 3. **No defaults without user input** — always ask the user, never assume values

--- a/skills/job-search/SKILL.md
+++ b/skills/job-search/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Write, Bash, WebSearch, WebFetch, mcp__claude-in-chrome__*
 
 # Multi-Source Job Search
 
-A Claude Code skill for searching jobs across LinkedIn, Hacker News Who's Hiring, and Twitter/X. Scores and ranks results against your saved preferences, highlights network advantages, and saves structured output.
+A Codex and Claude Code skill for searching jobs across LinkedIn, Hacker News Who's Hiring, and Twitter/X. Scores and ranks results against your saved preferences, highlights network advantages, and saves structured output.
 
 ---
 
@@ -14,11 +14,11 @@ A Claude Code skill for searching jobs across LinkedIn, Hacker News Who's Hiring
 
 ### Step 1: Load Profile
 
-Follow `/job-apply:answer-memory`: run `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/job-apply-store.py" init`, load preferences with `preferences-get`, and load location or other profile facts with `profile-get`. Never read or write persistent Job Apply files directly.
+Follow the bundled `answer-memory` skill (`$job-apply:answer-memory` in Codex; `/job-apply:answer-memory` in Claude Code). Resolve `<plugin-root>` as that skill directs, run `python3 "<plugin-root>/scripts/job-apply-store.py" init`, load preferences with `preferences-get`, and load location or other profile facts with `profile-get`. Never read or write persistent Job Apply files directly.
 
 **If no preferences found**, say:
 
-> No search preferences found. Run `/job-apply:job-preferences` first to set your target titles, salary range, and filters.
+> No search preferences found. Invoke the bundled `job-preferences` skill first to set your target titles, salary range, and filters.
 
 Then **STOP**. Do not prompt the user to set preferences inline.
 
@@ -54,14 +54,14 @@ Display the active search config before proceeding:
 
 ---
 
-## Phase 2a: LinkedIn Search (Chrome MCP)
+## Phase 2a: LinkedIn Search (visible host browser)
 
 ### Navigation
 
-1. Get browser context using `tabs_context_mcp`
-2. Create a new tab using `tabs_create_mcp`
+1. Use the host-managed visible browser (Codex Browser plugin or Claude in Chrome) and reuse an appropriate existing tab or create a new one
+2. Keep that browser/tab binding for the search instead of switching automation surfaces
 3. Navigate to `https://www.linkedin.com/jobs/`
-4. Verify user is logged in — use `read_page` to check for profile menu. If not logged in, say: "Please log into LinkedIn in this browser tab, then let me know when you're ready." and **wait**.
+4. Verify the user is logged in from visible page state. If not logged in, say: "Please log into LinkedIn in this browser tab, then let me know when you're ready." and **wait**.
 
 ### Build Search URL
 
@@ -92,12 +92,12 @@ Map time range:
 
 For each job card:
 
-1. Use `read_page` to read job cards from results list
-2. Click into job detail page using `computer` with left_click
+1. Read visible job cards from the results list with the host browser
+2. Click into a job detail page through the same visible browser surface
 3. Wait 2-3 seconds for detail page to load
 4. Extract: title, company, location, posted date, applicant count, work type, apply method
-5. Look for connection indicators — use `find` with query "connections work here" or "connections at"
-6. Look for hiring team — use `find` with query "Meet the hiring team" or "hiring manager"
+5. Look for visible connection indicators such as "connections work here" or "connections at"
+6. Look for "Meet the hiring team" or "hiring manager"
 7. If hiring manager found, extract name, title, profile URL
 8. Store result, navigate back to results list
 9. **2-3 second delay** between each job
@@ -105,18 +105,18 @@ For each job card:
 ### Scrolling for More Results
 
 LinkedIn uses infinite scroll:
-1. Use `computer` with action "scroll", scroll_direction "down"
+1. Scroll the results list through the host-managed browser
 2. Wait 2-3 seconds for new results
-3. Use `read_page` to see newly loaded cards
+3. Read the newly loaded visible cards
 4. Repeat until desired count or no more results
 
 ---
 
-## Phase 2b: Hacker News Who's Hiring (Bash + WebSearch)
+## Phase 2b: Hacker News Who's Hiring (shell + host web search)
 
 ### Find Current Thread
 
-1. Use `WebSearch` to search for: `"Ask HN: Who is hiring?" site:news.ycombinator.com {current_month} {current_year}`
+1. Use the host's supported web-search tool to search for: `"Ask HN: Who is hiring?" site:news.ycombinator.com {current_month} {current_year}`
 2. Extract the thread ID from the HN URL in the search results (e.g., `https://news.ycombinator.com/item?id=XXXXXXXX` → `XXXXXXXX`)
 
 If no thread found for the current month, try the previous month. If still nothing, skip HN and report it.
@@ -154,13 +154,13 @@ Skip comments that:
 
 ---
 
-## Phase 2c: Twitter/X Search (Chrome MCP)
+## Phase 2c: Twitter/X Search (visible host browser)
 
 ### Navigation
 
-1. Use existing browser context (or create new tab)
+1. Use the existing host-managed browser context (or create a new tab in that browser)
 2. Navigate to `https://x.com/search`
-3. Verify logged in — use `read_page` to check for profile avatar or compose button. If not logged in, **skip Twitter entirely** and continue with other sources. Report: "Skipped Twitter — not logged in."
+3. Verify login from visible page state by checking for a profile avatar or compose button. If not logged in, **skip Twitter entirely** and continue with other sources. Report: "Skipped Twitter — not logged in."
 
 ### Build Search Query
 
@@ -350,30 +350,30 @@ If confirmed, append to `application_queue.md` under a new "## Tier 3 — Auto-D
 
 **Standard search (all sources):**
 ```
-User: /job-apply:job-search
-Claude: [Loads preferences, searches LinkedIn + HN + Twitter, displays ranked results]
+User: $job-apply:job-search (Codex) or /job-apply:job-search (Claude Code)
+Agent: [Loads preferences, searches LinkedIn + HN + Twitter, displays ranked results]
 ```
 
 **With time range override:**
 ```
-User: /job-apply:job-search 2 weeks
-Claude: [Uses 2-week time range instead of default]
+User: Invoke job-search with "2 weeks"
+Agent: [Uses 2-week time range instead of default]
 ```
 
 **Single source:**
 ```
-User: /job-apply:job-search hn
-Claude: [Searches only Hacker News Who's Hiring]
+User: Invoke job-search with "hn"
+Agent: [Searches only Hacker News Who's Hiring]
 ```
 
 **Multiple source filter:**
 ```
-User: /job-apply:job-search linkedin hn
-Claude: [Searches LinkedIn and HN, skips Twitter]
+User: Invoke job-search with "linkedin hn"
+Agent: [Searches LinkedIn and HN, skips Twitter]
 ```
 
 **With extra keywords:**
 ```
-User: /job-apply:job-search agentic systems
-Claude: [Adds "agentic systems" to title-based keywords]
+User: Invoke job-search with "agentic systems"
+Agent: [Adds "agentic systems" to title-based keywords]
 ```


### PR DESCRIPTION
## What changed

- add Codex plugin and marketplace manifests
- make all four skills resolve the shared storage helper in either Codex or Claude Code
- route visible browser work through Codex Browser/Chrome or Claude in Chrome
- add Codex installation, invocation, requirements, and safety messaging to the README and landing page
- validate clean-room installation in both hosts through CI and the smoke script

## Why

Job Apply previously shipped only as a Claude Code plugin even though its local storage, trust boundary, and supervised browser workflow are host-neutral. This makes the same plugin installable and usable in Codex without weakening the manual Submit/Send boundary.

This PR deliberately keeps every ATS family marked as currently unverified. Live ATS acceptance evidence and any evidence-backed landing-page sharpening will follow in a separate QA PR.

## Verification

- Codex plugin validator
- all four skill validators
- `claude plugin validate .`
- isolated Claude Code marketplace install
- isolated Codex marketplace install
- 16 Python storage and integration tests
- local and remote link checks
- `git diff --check`