### PR TITLE
Clarify Codex and Claude Code support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "source": "github",
         "repo": "neonwatty/job-apply-plugin"
       },
-      "description": "AI-powered job application assistant for LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday",
+      "description": "Local-first job application assistant for Codex and Claude Code that fills supported ATS forms and stops before submission",
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "job-apply",
-  "description": "AI-powered job application assistant for LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday",
+  "description": "Local-first job application assistant for Codex and Claude Code that fills supported ATS forms and stops before submission",
   "author": {
     "name": "Jeremy Watt",
     "url": "https://github.com/neonwatty"
@@ -8,6 +8,8 @@
   "license": "MIT",
   "keywords": [
     "job-application",
+    "codex",
+    "claude-code",
     "linkedin",
     "greenhouse",
     "workday",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "job-apply",
   "version": "1.1.0",
-  "description": "A local-first job application assistant for Codex and Claude Code that reuses confirmed answers and always stops before submission.",
+  "description": "Local-first job application assistant for Codex and Claude Code that fills supported ATS forms and stops before submission.",
   "author": {
     "name": "Jeremy Watt",
     "url": "https://github.com/neonwatty"

--- a/.github/ISSUE_TEMPLATE/ats-failure.yml
+++ b/.github/ISSUE_TEMPLATE/ats-failure.yml
@@ -34,8 +34,8 @@ body:
   - type: input
     id: environment
     attributes:
-      label: Claude Code, operating system, and browser versions
-      placeholder: "Example: Claude Code 2.x, macOS 15, Chrome 138"
+      label: Codex or Claude Code, operating system, and browser versions
+      placeholder: "Example: Codex 0.x, macOS 15, Chrome 138"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/setup-help.yml
+++ b/.github/ISSUE_TEMPLATE/setup-help.yml
@@ -16,12 +16,22 @@ body:
         - label: I removed credentials, passwords, resume content, full application URLs, and personal applicant data.
           required: true
 
-  - type: input
-    id: claude_version
+  - type: dropdown
+    id: host
     attributes:
-      label: Claude Code version
-      description: Run `claude --version` and share only the version number.
-      placeholder: "Example: 2.x.x"
+      label: Host
+      options:
+        - Codex
+        - Claude Code
+    validations:
+      required: true
+
+  - type: input
+    id: host_version
+    attributes:
+      label: Codex or Claude Code version
+      description: Run `codex --version` or `claude --version` and share only the version number.
+      placeholder: "Example: Codex 0.x or Claude Code 2.x"
     validations:
       required: true
 
@@ -41,6 +51,7 @@ body:
         - Marketplace add
         - Plugin install
         - Skill invocation
+        - Codex Browser connection
         - Claude in Chrome connection
         - Profile setup
         - Other setup step

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.gg/7xsxU4ZG6A)
 
-AI-powered job application assistant for Codex and Claude Code that fills job applications on LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday using visible browser automation.
+Local-first job application assistant for Codex and Claude Code that fills supported ATS forms in a visible browser and stops before Submit or Send.
 
 ## Skills
 
@@ -39,7 +39,7 @@ Invoke skills with `$job-apply:...` in Codex or `/job-apply:...` in Claude Code.
 - **Connection insights**: Finds jobs at companies where you have connections
 - **Hiring manager discovery**: Identifies jobs with hiring managers listed
 - **Multi-source discovery**: Searches LinkedIn, Hacker News Who's Hiring, and Twitter/X
-- **Results saved**: Full search results saved to `~/.claude-job-searches/` as Markdown
+- **Results saved**: Full search results saved to the shared `~/.claude-job-searches/` compatibility directory as Markdown
 
 ### Job Preferences (`job-apply:job-preferences`)
 - **Reusable search settings**: Save target titles, salary floor, remote preference, exclusion patterns, and time range
@@ -140,11 +140,11 @@ First run `$job-apply:job-preferences` to save your search preferences. Then use
    - Jobs with 1st-degree connections
    - Matching Hacker News and Twitter/X opportunities
 
-Results are automatically saved to `~/.claude-job-searches/`.
+Results are automatically saved to `~/.claude-job-searches/`. Both Codex and Claude Code use this legacy-compatible path.
 
 ## Compatibility and Verification Status
 
-The plugin includes guided workflows for six ATS families. Codex and Claude Code host instructions were reviewed on **2026-07-28**, but this PR does not claim live end-to-end validation of every current ATS form. Individual flows remain unverified and may drift as sites change.
+The plugin includes guided workflows for six ATS families. Codex and Claude Code host instructions were reviewed on **2026-07-28**. Live end-to-end ATS acceptance is tracked separately; individual flows remain unverified and may drift as sites change.
 
 | Platform | URL Pattern | Default browser path | Verification status |
 |----------|-------------|----------------------|---------------------|
@@ -203,11 +203,11 @@ To replace the stored profile from a new resume:
 $job-apply:job-apply reset profile
 ```
 
-To remove Job Apply data, close Codex or Claude Code and first move the directory to a private backup so recovery remains possible, for example `mv ~/.job-apply ~/.job-apply.backup`. Search-result Markdown files are separate under `~/.claude-job-searches/`; review them independently. The legacy `~/.claude-job-profile.json` is also separate and is never deleted automatically.
+To remove Job Apply data, close Codex or Claude Code and first move the directory to a private backup so recovery remains possible, for example `mv ~/.job-apply ~/.job-apply.backup`. Shared search-result Markdown files are separate under `~/.claude-job-searches/`; review them independently. The legacy `~/.claude-job-profile.json` is also separate and is never deleted automatically.
 
 ## Search Results Storage
 
-Job search results are saved to `~/.claude-job-searches/` with timestamped filenames:
+Job search results from both Codex and Claude Code are saved to the legacy-compatible `~/.claude-job-searches/` path with timestamped filenames:
 
 ```
 ~/.claude-job-searches/

--- a/site/index.html
+++ b/site/index.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="AI-powered job application assistant for Codex and Claude Code with guided workflows for LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.">
+  <meta name="description" content="Local-first job application assistant for Codex and Claude Code that fills supported ATS forms in a visible browser and stops before submission.">
   <link rel="canonical" href="https://neonwatty.github.io/job-apply-plugin/">
   <meta property="og:title" content="Job Apply Plugin for Codex and Claude Code">
-  <meta property="og:description" content="Guided resume-based workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
+  <meta property="og:description" content="Guided, local-first resume workflows for Codex and Claude Code across six ATS families.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://neonwatty.github.io/job-apply-plugin/">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Job Apply Plugin for Codex and Claude Code">
-  <meta name="twitter:description" content="Guided resume-based workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
+  <meta name="twitter:description" content="Guided, local-first resume workflows for Codex and Claude Code across six ATS families.">
   <title>Job Apply Plugin for Codex and Claude Code</title>
   <link rel="stylesheet" href="styles.css">
 </head>
@@ -33,7 +33,7 @@
   <main id="main">
     <section class="hero">
       <div class="hero-copy">
-        <p class="eyebrow">AI-powered job application assistant for Codex and Claude Code</p>
+        <p class="eyebrow">Local-first job application assistant for Codex and Claude Code</p>
         <h1>Fill out job applications automatically using your resume.</h1>
         <p class="lede">
           Guided workflows cover LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday. Set up your profile once, then start a guided application with a single command.
@@ -122,7 +122,7 @@
             <li>Finds jobs at companies where you have connections</li>
             <li>Identifies jobs with hiring managers listed</li>
             <li>Searches LinkedIn, Hacker News, and Twitter/X</li>
-            <li>Results saved to <code>~/.claude-job-searches/</code> as Markdown</li>
+            <li>Results saved to a shared compatibility directory as Markdown</li>
           </ul>
         </article>
         <article class="skill-card">
@@ -155,7 +155,7 @@
         <div class="platform-pill">Workday</div>
       </div>
       <p>
-        Codex and Claude Code host guidance was reviewed on July 28, 2026. This PR does not claim live end-to-end validation of every current ATS form; individual flows remain unverified and may drift as sites change.
+        Codex and Claude Code host guidance was reviewed on July 28, 2026. Live end-to-end ATS acceptance is tracked separately; individual flows remain unverified and may drift as sites change.
       </p>
     </section>
 


### PR DESCRIPTION
## What changed

- align the README, landing page metadata/copy, and both plugin manifests around one dual-host product description
- remove stale “this PR” language from the ATS verification disclaimer
- clarify that the legacy-named search-results directory is shared by Codex and Claude Code
- update setup and ATS issue forms to collect either Codex or Claude Code environment details

## GitHub metadata

The repository About description now names both Codex and Claude Code, and the `codex` discovery topic was added alongside the existing `claude-code` topic.

## Why

PR #10 made the plugin installable in both hosts, but a few public discovery and support surfaces still implied Claude-only usage or referred to the now-merged PR. This makes the dual-host support unambiguous without changing the still-unverified ATS status.

## Verification

- Codex plugin validator
- Claude marketplace validator
- isolated Codex and Claude Code marketplace installs
- 16 Python storage/integration tests
- GitHub issue-form YAML parsing
- local and remote landing-page link checks
- `git diff --check`