### PR TITLE
Restore platform-specific product copy

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "source": "github",
         "repo": "neonwatty/job-apply-plugin"
       },
-      "description": "Local-first job application assistant for Codex and Claude Code that fills supported ATS forms and stops before submission",
+      "description": "AI-powered job application assistant for Claude Code and Codex covering LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday",
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "job-apply",
-  "description": "Local-first job application assistant for Codex and Claude Code that fills supported ATS forms and stops before submission",
+  "description": "AI-powered job application assistant for Claude Code and Codex covering LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday",
   "author": {
     "name": "Jeremy Watt",
     "url": "https://github.com/neonwatty"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "job-apply",
   "version": "1.1.0",
-  "description": "Local-first job application assistant for Codex and Claude Code that fills supported ATS forms and stops before submission.",
+  "description": "AI-powered job application assistant for Claude Code and Codex covering LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.",
   "author": {
     "name": "Jeremy Watt",
     "url": "https://github.com/neonwatty"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.gg/7xsxU4ZG6A)
 
-Local-first job application assistant for Codex and Claude Code that fills supported ATS forms in a visible browser and stops before Submit or Send.
+AI-powered job application assistant for Claude Code and Codex that fills job applications on LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday using visible browser automation.
 
 ## Skills
 

--- a/site/index.html
+++ b/site/index.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Local-first job application assistant for Codex and Claude Code that fills supported ATS forms in a visible browser and stops before submission.">
+  <meta name="description" content="AI-powered job application assistant for Claude Code and Codex with guided workflows for LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.">
   <link rel="canonical" href="https://neonwatty.github.io/job-apply-plugin/">
   <meta property="og:title" content="Job Apply Plugin for Codex and Claude Code">
-  <meta property="og:description" content="Guided, local-first resume workflows for Codex and Claude Code across six ATS families.">
+  <meta property="og:description" content="Guided resume-based workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://neonwatty.github.io/job-apply-plugin/">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Job Apply Plugin for Codex and Claude Code">
-  <meta name="twitter:description" content="Guided, local-first resume workflows for Codex and Claude Code across six ATS families.">
+  <meta name="twitter:description" content="Guided resume-based workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
   <title>Job Apply Plugin for Codex and Claude Code</title>
   <link rel="stylesheet" href="styles.css">
 </head>
@@ -33,7 +33,7 @@
   <main id="main">
     <section class="hero">
       <div class="hero-copy">
-        <p class="eyebrow">Local-first job application assistant for Codex and Claude Code</p>
+        <p class="eyebrow">AI-powered job application assistant for Claude Code and Codex</p>
         <h1>Fill out job applications automatically using your resume.</h1>
         <p class="lede">
           Guided workflows cover LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday. Set up your profile once, then start a guided application with a single command.


### PR DESCRIPTION
## What changed

- restore the platform-specific product description in the README and landing-page metadata
- keep Claude Code and Codex named as the two supported hosts
- align the Claude and Codex plugin descriptions with the platform-listing copy

## Why

PR #11 replaced the established platform-specific wording with a broader generic ATS description. The repository should continue telling users exactly which application platforms Job Apply supports while adding dual-host compatibility without otherwise rewriting the About message.

The GitHub repository About description has already been restored to the original structure with Claude Code and Codex added.

## Verification

- Codex plugin validator
- Claude marketplace validator
- landing-page local and remote link checks
- `git diff --check`