### PR TITLE
Keep local test resumes out of repository fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Thumbs.db
 
 # Test files
 *.test.md
+test_resumes/

--- a/scripts/smoke-plugin.sh
+++ b/scripts/smoke-plugin.sh
@@ -106,7 +106,7 @@ print("Static smoke assertions passed")
 PY
 
 echo "Creating isolated working-tree marketplace fixture"
-tar --exclude='./.git' --exclude='./docs/goals' -cf - -C "$REPO_ROOT" . \
+tar --exclude='./.git' --exclude='./docs/goals' --exclude='./test_resumes' -cf - -C "$REPO_ROOT" . \
   | tar -xf - -C "$SMOKE_FIXTURE_DIR"
 
 python3 - "$SMOKE_FIXTURE_DIR/.claude-plugin/marketplace.json" <<'PY'


### PR DESCRIPTION
## Summary

- ignore the local `test_resumes/` directory
- exclude test resumes from isolated plugin smoke-test fixtures
- keep private acceptance inputs out of commits and fixture copies

## Verification

- `python3 -m unittest discover -s tests -p 'test_*.py'`\n- `bash scripts/check-links.sh`\n- `bash scripts/smoke-plugin.sh`\n- `git diff --check`