### PR TITLE
Add ready job agent handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Invoke skills with `$job-apply:...` in Codex or `/job-apply:...` in Claude Code.
 - **Smart field mapping**: Automatically matches your profile to form fields
 - **Confidence-aware answer reuse**: Reuses confirmed non-sensitive answers and flags inferred, missing, or sensitive answers for review
 - **Resumable progress**: Saves application step metadata and answer references without copying answer values
+- **Ready-job handoff**: Selects a canonical ready job, exclusively claims it with a recoverable lease, uses its assigned/default resume, and atomically hands it to needs-info or final review
 - **Manual submission**: Stops at final review so only you can click Submit or Send
 - **Resume storage**: Profile saved locally for reuse across applications
 
@@ -166,6 +167,8 @@ Job Apply stores data as **plaintext local files** under `~/.job-apply/`:
   jobs.json
   resumes.json
   applications.jsonl
+  coordinator.json
+  coordinator-journal.json
   sessions/
     <application-id>.json
 ```
@@ -177,7 +180,11 @@ Job Apply stores data as **plaintext local files** under `~/.job-apply/`:
 | `jobs.json` | Canonical job records, application status, revisions, and recoverable trash state |
 | `resumes.json` | Versioned local resume references, labels, defaults, and file observations |
 | `applications.jsonl` | Minimal append-only application lifecycle events |
+| `coordinator.json` | One global, recoverable 300-second application-agent claim |
+| `coordinator-journal.json` | Value-free idempotent roll-forward record for lifecycle handoffs |
 | `sessions/*.json` | Resumable workflow metadata and answer-key references |
+
+The coordinator files are created only when the ready-job claim workflow is first used; direct-URL applications keep the legacy store shape.
 
 These files can include sensitive personal information such as:
 
@@ -193,7 +200,7 @@ Protect the directory like a resume. Do not attach its files to issues or share 
 
 ```bash
 chmod 700 ~/.job-apply
-chmod 600 ~/.job-apply/profile.json ~/.job-apply/answers.json ~/.job-apply/jobs.json ~/.job-apply/resumes.json ~/.job-apply/applications.jsonl
+chmod 600 ~/.job-apply/profile.json ~/.job-apply/answers.json ~/.job-apply/jobs.json ~/.job-apply/resumes.json ~/.job-apply/applications.jsonl ~/.job-apply/coordinator.json ~/.job-apply/coordinator-journal.json
 ```
 
 On first use, an existing `~/.claude-job-profile.json` is copied into the new versioned profile without modifying or deleting the legacy file. Once `~/.job-apply/profile.json` exists it is authoritative; later legacy-file changes are not re-imported. Verify the new profile before deciding whether to archive or remove the old file.

--- a/docs/goals/ready-job-agent-handoff/goal.md
+++ b/docs/goals/ready-job-agent-handoff/goal.md
@@ -1,0 +1,80 @@
+# Ready Job Agent Handoff
+
+## Objective
+
+Connect canonical jobs marked `ready` to the existing visible-browser application workflow through one shared, durable, concurrency-safe handoff that advances job status without weakening the human final-submit boundary.
+
+## Original Request
+
+Continue with the Ready Job Agent Handoff slice after canonical job ingestion was merged into staging.
+
+## Intake Summary
+
+- Input shape: `existing_plan`
+- Audience: Job Apply users coordinating with Codex or Claude Code agents
+- Authority: `approved`
+- Proof type: `test`
+- Completion proof: An integration test and documented CLI walkthrough prove that an agent can select a ready job, acquire exclusive application ownership, load its assigned durable data, record value-free blockers or progress, reach awaiting review, and release ownership safely.
+- Goal oracle: The normal job-application skill completes the shared ready-job lifecycle against an isolated durable store while concurrency, stale-claim recovery, privacy, optimistic revision, and manual-submit tests remain green.
+- Likely misfire: Building a second agent-state or queue system that can drift from the canonical job status, or adding orchestration primitives without wiring the real application skill to use them.
+- Blind spots considered: stale/crashed agents, concurrent CLI and future UX clients, assigned versus default resume selection, sensitive-answer consent, value-free pending questions, resumable sessions, compatibility with direct-URL application, and status recovery after partial failure.
+- Existing plan facts: Durable storage precedes UX; canonical job ingestion is merged into `staging`; next is Ready Job Agent Handoff; the companion UI remains out of scope for this tranche.
+
+## Goal Oracle
+
+The oracle for this goal is:
+
+`A tested end-to-end helper and skill walkthrough moves one canonical job through ready -> in_progress -> needs_info or awaiting_review under one exclusive recoverable runtime claim, uses the assigned/default resume and existing profile/answer/session contracts, records no answer values in claim/history/session metadata, releases the claim, and never activates the final action.`
+
+The PM must keep comparing task receipts to this oracle. Planning, discovery, isolated helper tests, or documentation alone are not enough. The goal finishes only when a final Judge/PM audit maps receipts and verification back to this oracle and records `full_outcome_complete: true`.
+
+## Goal Kind
+
+`existing_plan`
+
+## Current Tranche
+
+Deliver the complete Ready Job Agent Handoff vertical slice: validate the merged contract and current application workflow, implement the smallest coherent claim and pending-question/status integration required by the oracle, wire the Job Apply skill to consume ready jobs while retaining direct-URL compatibility, and verify the real lifecycle. Do not begin the companion UX or legacy Markdown migration in this tranche.
+
+## Non-Negotiable Constraints
+
+- The canonical job record remains the only durable application status; do not create a second agent-status model.
+- Exactly one live application runtime claim may exist across CLI and future UX clients.
+- Claim acquisition and the `ready` to `in_progress` transition must be atomic or fail without partial mutation.
+- Stale claim recovery must be explicit, bounded, deterministic, and tested.
+- Human-authored job fields and optimistic revisions remain authoritative.
+- Assigned resume wins; otherwise use the active default resume. Missing or changed files fail readiness safely.
+- Pending-question and progress metadata remain value-free and refer to answer keys where applicable.
+- Sensitive current-use consent remains separate from remember consent.
+- The visible-browser workflow and hard stop before Submit, Send, Apply, or equivalent final action remain unchanged.
+- Existing direct-URL application behavior and version-1 durable stores remain compatible.
+- The local companion UX, Markdown queue migration, answer merging, and resume extraction proposal UI are out of scope.
+
+## Stop Rule
+
+Stop only when a final audit proves the full original outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if a safe Worker task can be activated. Do not stop after isolated storage primitives if the job-application skill and integration oracle are not complete.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny. Prefer one coherent storage-and-skill vertical slice over separate micro-tasks for each helper command.
+
+## Board Health
+
+Machine truth lives in `state.yaml`. Use the bundled GoalBuddy checker when board state is changed or before completion.
+
+## Canonical Board
+
+`docs/goals/ready-job-agent-handoff/state.yaml`
+
+## Run Command
+
+```text
+Codex: /goal Follow docs/goals/ready-job-agent-handoff/goal.md.
+Claude Code: /goalbuddy Follow docs/goals/ready-job-agent-handoff/goal.md.
+```
+
+## PM Loop
+
+On every execution continuation, read this charter, the GoalBuddy execution contract, and `state.yaml`; work only the active task; persist a compact receipt; keep advancing safe work; and run the stop checker before declaring completion.

--- a/docs/goals/ready-job-agent-handoff/state.yaml
+++ b/docs/goals/ready-job-agent-handoff/state.yaml
@@ -1,0 +1,536 @@
+# GoalBuddy v2 state.yaml
+# Initial live-board seed. The full task sequence is populated after the board starts.
+
+version: 2
+
+goal:
+  title: "Ready Job Agent Handoff"
+  slug: "ready-job-agent-handoff"
+  kind: existing_plan
+  tranche: "Deliver the complete ready-job-to-visible-browser-agent handoff without starting the companion UX."
+  status: done
+  oracle:
+    signal: "A tested end-to-end lifecycle moves one canonical job through ready to in_progress to needs_info or awaiting_review under one exclusive recoverable claim, using durable assigned data and preserving the manual final-action boundary."
+    cadence: "after each Worker package and at final audit"
+    final_proof: "Integration receipt plus focused and full-suite verification mapped to every lifecycle, concurrency, privacy, compatibility, and manual-submit constraint."
+  intake:
+    original_request: "Continue with the Ready Job Agent Handoff slice after canonical job ingestion was merged."
+    interpreted_outcome: "Make ready jobs actionable by the current application agent through one shared durable and concurrency-safe workflow."
+    input_shape: existing_plan
+    audience: "Job Apply users coordinating with Codex or Claude Code agents"
+    authority: approved
+    proof_type: test
+    completion_proof: "The real application skill and helper pass an isolated ready-job lifecycle walkthrough and all regression suites."
+    likely_misfire: "Add disconnected claim helpers or a second agent-state model without wiring the application skill to the canonical job lifecycle."
+    blind_spots_considered:
+      - "Stale or crashed application agents"
+      - "Concurrent CLI and future UX clients"
+      - "Assigned versus default resume selection"
+      - "Sensitive-answer consent and value-free pending metadata"
+      - "Direct-URL backward compatibility"
+      - "Partial failure between claim, transition, session, and history writes"
+    existing_plan_facts:
+      - "Canonical job ingestion is merged into staging."
+      - "Durable storage and CLI integration precede the companion UX."
+      - "Ready Job Agent Handoff is the next agreed slice."
+      - "The job record remains the only durable application status."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  exact_human_approval_can_terminal_wait: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  goal_pressure_requires_oracle: true
+  no_completion_on_weak_proof: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/ready-job-agent-handoff/"
+    command: "node /Users/neonwatty/.codex/plugins/cache/goalbuddy/goalbuddy/0.4.3/skills/goal-prep/surfaces/local-goal-board/scripts/local-goal-board.mjs --goal docs/goals/ready-job-agent-handoff"
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: low
+    objective: "Map the merged durable job lifecycle and the current application skill seams required for the ready-job handoff."
+    inputs:
+      - "docs/superpowers/specs/2026-08-24-shared-job-workspace-design.md"
+      - "scripts/job-apply-store.py"
+      - "skills/job-apply/SKILL.md"
+      - "skills/answer-memory/SKILL.md"
+      - "tests/test_job_apply_store.py"
+      - "tests/test_answer_memory_integration.py"
+    constraints:
+      - "Read-only."
+      - "Do not edit implementation files."
+      - "Distinguish existing behavior from missing contract and wiring."
+    expected_output:
+      - "Lifecycle and data-flow map"
+      - "Exact missing seams"
+      - "Relevant files and verification commands"
+      - "Risks and candidate vertical slice boundaries"
+    receipt:
+      result: done
+      summary: "Canonical jobs, resumes, readiness preflight, optimistic revisions, guarded transitions, value-free sessions/history, and manual applied confirmation already exist. The ready-job handoff does not: there is no runtime claim, heartbeat/recovery, atomic claim-plus-in_progress operation, or transition-plus-history consistency. The job-apply skill still requires a supplied URL and independently writes sessions/history, so it never lists/selects ready jobs, loads the durable assigned/default resume, or drives canonical status through needs_info/awaiting_review. A safe vertical slice should add one recoverable global claim/coordinator operation, wire the real skill while preserving direct-URL behavior, and prove concurrency, stale recovery, privacy, and manual final action end to end."
+      evidence:
+        - file: scripts/job-apply-store.py
+          lines: "35-84,1361-1432,1833-1891"
+          detail: "Defines the complete status graph, ready-job filtering via job-list, readiness preflight, optimistic revisions, and guarded transitions including explicit confirmation for applied."
+        - file: scripts/job-apply-store.py
+          lines: "1833-1891,2212-2415"
+          detail: "job-transition writes only jobs.json; history append and session save are separate operations. No atomic lifecycle coordinator spans job, history, and session state."
+        - file: scripts/job-apply-store.py
+          lines: 2458-2593
+          detail: "CLI exposes job/resume/history/session commands but no claim, heartbeat, release, stale recovery, pending-question, or ready-job acquisition command."
+        - file: skills/job-apply/SKILL.md
+          lines: "8-61,93-116"
+          detail: "Startup asks for a supplied URL; Phase 2 opens that URL and uses profile/session/answer/history operations, but does not list ready jobs or acquire ownership."
+        - file: skills/job-apply/SKILL.md
+          lines: 99-116
+          detail: "The application workflow saves progress and appends reviewed history but never transitions the canonical job to in_progress, needs_info, or awaiting_review."
+        - file: skills/job-apply/SKILL.md
+          lines: "35-61,105-116"
+          detail: "Resume upload uses the profile resume path; no durable assigned resumeId/default resume lookup is specified."
+        - file: skills/answer-memory/SKILL.md
+          lines: 236-278
+          detail: "Documents canonical job and session commands, preflight, revision checks, applied confirmation, and value-free progress, but no ownership/coordinator contract."
+        - file: tests/test_job_apply_store.py
+          lines: "792-849,1036-1215"
+          detail: "Covers status flow, readiness failure, explicit applied confirmation, value-free history/session, and replay ordering; it does not cover ready-job claims or atomic job/history/session lifecycle."
+        - file: tests/test_answer_memory_integration.py
+          lines: 47-209
+          detail: "Integration tests cover legacy profile/answers/session/history, skill text boundaries, and isolated replay, but not one canonical ready job consumed by the real skill contract."
+        - command: "PYTHONPATH=tests python3 -m unittest -v test_job_apply_store test_answer_memory_integration"
+          detail: "Baseline verification passed: 50 tests, 0 failures."
+      facts:
+        - kind: existing
+          detail: "jobs.json is the sole durable application-status model; jobs begin saved and support needs_info, ready, in_progress, awaiting_review, applied, and closed."
+        - kind: existing
+          detail: "job-list --status ready provides deterministic priority-first selection data, and job-preflight resolves assigned resumeId or the active default without mutating observations."
+        - kind: existing
+          detail: "Job and resume mutations use a global store lock plus optimistic revisions; ready fails without profile/resume, and applied requires --user-confirmed."
+        - kind: existing
+          detail: "Session pendingFields allow only question, state, answerKey, and sensitive; history/session schemas reject arbitrary values."
+        - kind: missing
+          detail: "No exclusive recoverable runtime claim exists: no durable owner token, lease/heartbeat, release, expiry, or stale takeover semantics."
+        - kind: missing
+          detail: "No single helper operation atomically acquires the claim and moves ready to in_progress, or couples later status transitions with required lifecycle history."
+        - kind: missing
+          detail: "The real job-apply skill lacks ready-job discovery/selection, claim lifecycle, durable assigned/default resume loading, canonical job identity for sessions/history, and needs_info/awaiting_review transitions."
+        - kind: candidate_vertical_slice
+          detail: "Add claim/coordinator storage plus CLI; wire job-apply startup to accept either direct URL or selected ready job; load job/profile/resume/answers; persist value-free pending/session data; transition to needs_info or awaiting_review; release claim; retain manual submit prohibition."
+        - kind: verification
+          detail: "Focused verification should include both named unittest modules; completion should also run unittest discovery, scripts/smoke-plugin.sh, and git diff --check as already specified by the board."
+      contradictions:
+        - detail: "The design requires status and required lifecycle history to remain consistent through one atomic helper operation, while current job-transition never appends history and history-append is independent."
+        - detail: "The design says ready selection atomically acquires one global claim and transitions to in_progress, while the helper has neither claim state nor a combined operation."
+        - detail: "The design says the agent loads the assigned resume, while the current job-apply skill treats profile.resumePath as required input and does not consult job.resumeId/default resume records."
+        - detail: "The tranche requires preserving direct-URL compatibility, but simply replacing the current URL-first startup with ready-job selection would regress existing behavior."
+      ambiguity_requiring_judge:
+        - detail: "Define exact claim persistence schema, lease duration, heartbeat cadence, owner/token visibility, stale threshold, and whether release is idempotent."
+        - detail: "Choose recoverability semantics after partial failure: transactional multi-file strategy, journal/reconciliation protocol, or a consolidated coordinator record, while keeping job status authoritative."
+        - detail: "Specify whether needs_info should retain or release the claim immediately and how resumption returns that job to in_progress without allowing concurrent work."
+        - detail: "Map canonical transitions to required history events and session states, especially ready→in_progress, in_progress→needs_info, and in_progress→awaiting_review."
+      commands:
+        - "git rev-parse --show-toplevel && rg --files \"$(git rev-parse --show-toplevel)\" -g 'AGENTS.md' -g 'AGENTS.override.md' && buffer context"
+        - "sed -n '1,240p' docs/goals/ready-job-agent-handoff/state.yaml; sed -n '1,280p' docs/superpowers/specs/2026-08-24-shared-job-workspace-design.md"
+        - "sed -n '280,620p' docs/superpowers/specs/2026-08-24-shared-job-workspace-design.md; rg -n \"^(def |class )|add_parser|job|claim|transition|ready|session|history|pending|resume\" scripts/job-apply-store.py"
+        - "sed -n '1,100p' scripts/job-apply-store.py; sed -n '1360,1440p' scripts/job-apply-store.py; sed -n '1740,1950p' scripts/job-apply-store.py; sed -n '1,300p' skills/job-apply/SKILL.md"
+        - "sed -n '1,320p' skills/answer-memory/SKILL.md; rg -n \"job|ready|claim|transition|preflight|resume|session|history|pending|value|helper\" skills/answer-memory/SKILL.md skills/answer-memory/references/storage-contract.md"
+        - "rg -n \"^    def test_|job|ready|transition|preflight|resume|history|session|pending|claim|concurr|stale|manual|submit|direct\" tests/test_job_apply_store.py tests/test_answer_memory_integration.py"
+        - "PYTHONPATH=tests python3 -m unittest -v test_job_apply_store test_answer_memory_integration"
+      note_needed: false
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate the Ready Job Agent Handoff contract and specify the largest safe vertical Worker package that proves the goal oracle."
+    inputs:
+      - "T001 receipt"
+      - "docs/goals/ready-job-agent-handoff/goal.md"
+      - "docs/superpowers/specs/2026-08-24-shared-job-workspace-design.md"
+    constraints:
+      - "Read-only; do not implement."
+      - "Keep canonical job status as the sole durable workflow status."
+      - "Reject a storage-only package that leaves the real job-apply skill disconnected."
+      - "Preserve direct-URL compatibility and the manual final-action boundary."
+      - "Select the largest safe useful vertical slice with exact allowed files, verification, and stop conditions."
+    expected_output:
+      - "Contract decision and lifecycle invariants"
+      - "Exact Worker objective"
+      - "Exact allowed_files"
+      - "Focused and full verify commands"
+      - "Stop conditions and deferred scope"
+    receipt:
+      result: done
+      decision: approved
+      full_outcome_complete: false
+      rationale: "Approve one vertical package spanning recoverable global ownership, atomic canonical lifecycle operations, and real Job Apply skill wiring. Storage-only work would fail the oracle. Use a 300-second lease with 60-second heartbeats, explicit same-job stale recovery, journaled idempotent roll-forward, assigned-resume precedence, value-free progress, and atomic needs_info or awaiting_review handoff plus claim release. Preserve unchanged direct-URL behavior and the human-only final action."
+      evidence:
+        - "T001 proves canonical jobs, readiness, revisions, sessions, history, and manual applied confirmation exist, while claims, atomic coordination, assigned-resume skill wiring, and ready-job consumption are missing."
+        - "goal.md requires ready -> in_progress -> needs_info or awaiting_review under one exclusive recoverable claim with value-free metadata and no final action."
+        - "The shared-workspace design makes canonical job status authoritative and requires status plus lifecycle history consistency through one atomic helper operation."
+        - "Claim schema: one version-1 runtime coordinator record containing at most one active {claimId, jobId, ownerLabel, tokenHash, acquiredAt, heartbeatAt, expiresAt}; expose no token hash and store no workflow status."
+        - "Acquisition must re-run preflight under the store lock, resolve assigned resume before active default, atomically create the claim, transition ready -> in_progress, and append an idempotent job-started event."
+        - "Expired claims require explicit same-job recovery while the job remains in_progress; recovery rotates the token, preserves session/status, records an idempotent claim-recovered event, and uses injectable time."
+        - "Blocked and review operations must atomically save value-free session metadata, append job-blocked or reviewed history, transition status, and release the claim. needs_info resumes only through readiness and fresh acquisition."
+        - "The real skill must support ready-job selection and claim-aware progress while retaining direct-URL mode and stopping before Submit, Send, Apply, or equivalent."
+      worker_package:
+        objective: "Implement and document one complete Ready Job Agent Handoff vertical slice: a versioned global recoverable claim and journaled coordinator operations; atomic ready acquisition and terminal needs_info/awaiting_review handoffs; claim-gated value-free progress; assigned/default resume resolution; explicit stale recovery; and real Job Apply skill consumption of selected ready jobs while preserving direct-URL behavior and the manual final-action boundary."
+        allowed_files:
+          - scripts/job-apply-store.py
+          - skills/job-apply/SKILL.md
+          - skills/answer-memory/SKILL.md
+          - skills/answer-memory/references/storage-contract.md
+          - tests/test_job_apply_store.py
+          - tests/test_answer_memory_integration.py
+          - README.md
+          - scripts/smoke-plugin.sh
+        verify:
+          - "PYTHONPATH=tests python3 -m unittest -v test_job_apply_store"
+          - "PYTHONPATH=tests python3 -m unittest -v test_answer_memory_integration"
+          - "python3 -m unittest discover -s tests -v"
+          - "bash scripts/smoke-plugin.sh"
+          - "git diff --check"
+        stop_if:
+          - "Crash-recoverable coordination requires an external service, second authoritative job-status field, or non-value-free recovery data."
+          - "The status graph cannot support needs_info -> ready preflight resumption without an owner decision."
+          - "Implementation would silently steal or clear a live claim."
+          - "Claim, journal, history, or session data would contain answer values, resume contents, credentials, CAPTCHA/MFA data, or browser state."
+          - "Implementation would regress direct-URL mode, optimistic revisions, human precedence, or the manual final-action boundary."
+          - "Implementation requires files outside allowed_files."
+          - "Focused verification fails twice for the same unresolved contract reason."
+        deferred_scope:
+          - "Companion UX and local server"
+          - "Markdown queue migration"
+          - "Answer merging"
+          - "Resume extraction proposal UI"
+          - "Multiple concurrent application agents"
+          - "Automatic submission or inferred applied status"
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks: []
+      missing_evidence:
+        - "Worker implementation receipt."
+        - "Claim concurrency, expiry, recovery, reconciliation, privacy, resume precedence, direct-URL, and manual-boundary tests."
+        - "Focused, full-suite, smoke, and diff verification."
+        - "Final Judge oracle audit."
+      required_board_updates:
+        - "Persist this receipt on T002 and mark T002 done."
+        - "Apply worker_package to T003 and activate T003 as the sole write task."
+        - "Keep T999 queued until implementation and verification evidence exist."
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Implement and document one complete Ready Job Agent Handoff vertical slice: a versioned global recoverable claim and journaled coordinator operations; atomic ready acquisition and terminal needs_info/awaiting_review handoffs; claim-gated value-free progress; assigned/default resume resolution; explicit stale recovery; and real Job Apply skill consumption of selected ready jobs while preserving direct-URL behavior and the manual final-action boundary."
+    allowed_files:
+      - "scripts/job-apply-store.py"
+      - "skills/job-apply/SKILL.md"
+      - "skills/answer-memory/SKILL.md"
+      - "skills/answer-memory/references/storage-contract.md"
+      - "tests/test_job_apply_store.py"
+      - "tests/test_answer_memory_integration.py"
+      - "README.md"
+      - "scripts/smoke-plugin.sh"
+    verify:
+      - "PYTHONPATH=tests python3 -m unittest -v test_job_apply_store"
+      - "PYTHONPATH=tests python3 -m unittest -v test_answer_memory_integration"
+      - "python3 -m unittest discover -s tests -v"
+      - "bash scripts/smoke-plugin.sh"
+      - "git diff --check"
+    stop_if:
+      - "Crash-recoverable coordination requires an external service, second authoritative job-status field, or non-value-free recovery data."
+      - "The status graph cannot support needs_info -> ready preflight resumption without an owner decision."
+      - "Implementation would silently steal or clear a live claim."
+      - "Claim, journal, history, or session data would contain answer values, resume contents, credentials, CAPTCHA/MFA data, or browser state."
+      - "Implementation would regress direct-URL mode, optimistic revisions, human precedence, or the manual final-action boundary."
+      - "Implementation requires files outside allowed_files."
+      - "Focused verification fails twice for the same unresolved contract reason."
+    constraints:
+      - "Defer companion UX and local server."
+      - "Defer Markdown queue migration, answer merging, and resume extraction proposal UI."
+      - "Defer multiple concurrent agents, automatic submission, and inferred applied status."
+    expected_output:
+      - "Working helper and skill lifecycle"
+      - "Concurrency and stale-recovery tests"
+      - "Value-free pending/progress evidence"
+      - "Direct-URL compatibility evidence"
+      - "Focused and full verification receipt"
+    receipt:
+      result: done
+      changed_files:
+        - README.md
+        - scripts/job-apply-store.py
+        - skills/answer-memory/SKILL.md
+        - skills/answer-memory/references/storage-contract.md
+        - skills/job-apply/SKILL.md
+        - tests/test_answer_memory_integration.py
+        - tests/test_job_apply_store.py
+      commands:
+        - cmd: "PYTHONPATH=tests python3 -m unittest -v test_job_apply_store"
+          status: pass
+        - cmd: "PYTHONPATH=tests python3 -m unittest -v test_answer_memory_integration"
+          status: pass
+        - cmd: "python3 -m unittest discover -s tests -v"
+          status: pass
+        - cmd: "bash scripts/smoke-plugin.sh"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Implemented the full ready-job vertical slice: lazy versioned global claim storage, 300-second leases and heartbeats, explicit same-job stale recovery, hashed token persistence, journaled idempotent roll-forward, atomic acquisition and needs_info/awaiting_review handoffs, claim-gated value-free progress, and assigned-resume precedence. Wired the real Job Apply skill while preserving direct-URL artifact shape and the manual final-action boundary. Added concurrency, privacy, recovery, reconciliation, resume precedence, CLI lifecycle, and compatibility coverage. All focused tests, 341 discovered tests, plugin smoke checks, and diff checks pass. Deviations: none."
+      remaining_blockers: []
+      verification_attempts: 2
+      stopped_because: null
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit the implemented Ready Job Agent Handoff against the full owner outcome and goal oracle."
+    inputs:
+      - "All completed task receipts"
+      - "Current implementation diff"
+      - "Focused and full verification results"
+      - "docs/goals/ready-job-agent-handoff/goal.md"
+    constraints:
+      - "Read-only; do not implement."
+      - "Reject completion if the real job-apply skill cannot consume a ready job end to end."
+      - "Reject completion if claim and status updates can diverge or concurrency/stale recovery are not proved."
+      - "Reject completion if pending metadata contains answer values or final-action policy is weakened."
+      - "Reject completion if required Worker work remains queued, active, or unverified."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Oracle-to-evidence mapping"
+      - "Missing evidence or exact next task"
+    receipt:
+      result: done
+      decision: not_complete
+      full_outcome_complete: false
+      rationale: "The happy-path vertical slice works and all 341 tests pass, but canonical status and claim state can still diverge. After acquisition, generic job-transition can move in_progress directly to needs_info, awaiting_review, or closed without session/history coordination or claim release; heartbeat then renews that claim without checking job status. A direct audit reproduced awaiting_review with a live claim, only job-started history, and no session. Acquisition and handoff also omit caller-supplied expected revisions, so stale selections and agent state do not fail optimistically. These violate atomicity, recoverability, concurrency, and revision non-negotiables."
+      evidence:
+        - requirement: "Real skill consumes ready jobs"
+          result: proven
+          detail: "skills/job-apply/SKILL.md specifies ready selection, acquisition, resolved resume use, claim progress, terminal handoff, and direct-URL preservation; integration tests prove the CLI happy path."
+        - requirement: "Exclusive recoverable claim"
+          result: partially_proven
+          detail: "Concurrent acquisition and same-job expiry recovery pass, but generic status mutation can strand a live or expired claim on a non-in_progress job."
+        - requirement: "Atomic canonical lifecycle"
+          result: contradicted
+          detail: "Generic transitions out of in_progress remain possible without coordinator history, session, or claim release."
+        - requirement: "Claim/status coherence"
+          result: contradicted
+          detail: "Heartbeat renews a matching token without verifying canonical job status remains in_progress."
+        - requirement: "Authoritative optimistic revisions"
+          result: contradicted
+          detail: "Acquisition and handoff accept no expected revision and silently use the latest stored revision."
+        - requirement: "Crash recovery"
+          result: partially_proven
+          detail: "Acquisition roll-forward is tested, but handoff failures across job, session, history, claim, and journal-clear boundaries are not."
+        - requirement: "Value-free metadata and manual final action"
+          result: proven
+          detail: "Validators reject pending values and the skill forbids final-action activation."
+        - requirement: "Assigned/default resume and compatibility"
+          result: partially_proven
+          detail: "Assigned precedence is tested; default resolution and direct-URL behavior lack complete behavioral proof."
+        - command: "PYTHONPATH=tests python3 -m unittest -v test_job_apply_store"
+          result: pass
+          detail: "51 tests passed."
+        - command: "PYTHONPATH=tests python3 -m unittest -v test_answer_memory_integration"
+          result: pass
+          detail: "5 tests passed."
+        - command: "python3 -m unittest discover -s tests -v"
+          result: pass
+          detail: "341 tests passed."
+        - command: "bash scripts/smoke-plugin.sh && git diff --check"
+          result: pass
+          detail: "Plugin smoke and diff validation passed."
+        - command: "isolated coordinator divergence audit"
+          result: fail
+          detail: "Acquired a ready job, used generic transition to awaiting_review, then successfully heartbeated; observed awaiting_review, a live claim, only job-started history, and no session."
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks: []
+      missing_evidence:
+        - "Guard generic transitions, trash, and deletion for claimed in_progress jobs."
+        - "Verify canonical in_progress status on heartbeat and every claim-gated mutation."
+        - "Require caller-supplied expected revisions on acquisition and terminal handoff."
+        - "Add divergence, lease-boundary, stale-revision, default-resume, failure-boundary, and direct-URL tests."
+        - "Re-run complete verification and final audit."
+      required_board_updates:
+        - "Persist this receipt and keep goal active."
+        - "Activate bounded remediation Worker T004."
+        - "Queue final re-audit T998."
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Close every claim/status divergence path, enforce caller-supplied optimistic revisions on acquisition and terminal handoff, and add deterministic failure-boundary and direct-URL compatibility regressions required by the first final audit."
+    allowed_files:
+      - "scripts/job-apply-store.py"
+      - "skills/job-apply/SKILL.md"
+      - "skills/answer-memory/SKILL.md"
+      - "skills/answer-memory/references/storage-contract.md"
+      - "tests/test_job_apply_store.py"
+      - "tests/test_answer_memory_integration.py"
+      - "README.md"
+      - "scripts/smoke-plugin.sh"
+    verify:
+      - "PYTHONPATH=tests python3 -m unittest -v test_job_apply_store"
+      - "PYTHONPATH=tests python3 -m unittest -v test_answer_memory_integration"
+      - "python3 -m unittest discover -s tests -v"
+      - "bash scripts/smoke-plugin.sh"
+      - "git diff --check"
+    stop_if:
+      - "A required guard cannot be implemented without a second authoritative status model or weakening recoverability."
+      - "Expected-revision enforcement cannot preserve both canonical ready-job mode and direct-URL compatibility."
+      - "Implementation requires files outside allowed_files."
+      - "Focused verification fails twice for the same unresolved contract reason."
+    expected_output:
+      - "Generic transition/trash/delete guards for claimed jobs"
+      - "Status validation on heartbeat and every claim-gated mutation"
+      - "Expected revision enforcement on acquire and handoff"
+      - "Failure-boundary, default-resume, lease-boundary, and direct-URL regressions"
+      - "Focused and full verification receipt"
+    receipt:
+      result: done
+      changed_files:
+        - scripts/job-apply-store.py
+        - skills/job-apply/SKILL.md
+        - skills/answer-memory/SKILL.md
+        - skills/answer-memory/references/storage-contract.md
+        - tests/test_job_apply_store.py
+        - tests/test_answer_memory_integration.py
+      commands:
+        - cmd: "PYTHONPATH=tests python3 -m unittest -v test_job_apply_store"
+          status: pass
+        - cmd: "PYTHONPATH=tests python3 -m unittest -v test_answer_memory_integration"
+          status: pass
+        - cmd: "python3 -m unittest discover -s tests -v"
+          status: pass
+        - cmd: "bash scripts/smoke-plugin.sh"
+          status: pass
+        - cmd: "git diff --check"
+          status: pass
+      summary: "Closed every first-audit finding. Claimed jobs now reject generic transition, trash, and deletion; heartbeat, progress, handoff, and recovery require canonical in_progress status. Acquisition and terminal handoff require caller-supplied expected revisions, with updated skill and storage documentation. Added deterministic coverage for divergence, exact lease expiry, stale revisions, default-resume resolution, all acquisition and handoff failure boundaries, and behavioral direct-URL compatibility without coordinator artifacts. Focused suites pass with 55 storage and 5 integration tests; all 345 discovered tests, plugin smoke checks, and diff validation pass. Deviations: none."
+      remaining_blockers: []
+      verification_attempts: 1
+      stopped_because: null
+  - id: T998
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Re-audit the remediated Ready Job Agent Handoff against every goal oracle and first-audit finding."
+    inputs:
+      - "T999 receipt"
+      - "T004 receipt"
+      - "Current implementation diff"
+      - "Fresh focused and full verification"
+    constraints:
+      - "Read-only; do not implement."
+      - "Reproduce or falsify every previously identified divergence path."
+      - "Require authoritative expected-revision, recovery-boundary, direct-URL, privacy, and manual-submit proof."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "First-audit finding disposition"
+      - "Oracle-to-evidence mapping"
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      rationale: "The remediation closes every first-audit finding and proves the full oracle. Independent reproduction confirms generic transition, trash, and delete cannot diverge claimed jobs; heartbeat and all claim operations reject status mismatch; stale acquisition and handoff revisions fail without mutation; exact expiry and same-job recovery work; default resume and direct-URL compatibility hold. Journal tests cover every acquisition and handoff write boundary. The real skill uses ready selection, assigned/default data, value-free progress, atomic terminal handoff, and manual final review. All 345 tests, smoke checks, and diff validation pass."
+      evidence:
+        - requirement: "Canonical status remains sole workflow state"
+          result: proven
+          detail: "coordinator.json stores only runtime ownership; jobs.json remains authoritative. Generic transition, trash, and delete reject any claimed job."
+        - requirement: "First-audit divergence paths"
+          result: resolved
+          detail: "Independent audit confirmed transition, trash, and delete are rejected; tampered non-in_progress status causes heartbeat rejection; focused tests cover the same paths."
+        - requirement: "Exclusive recoverable ownership"
+          result: proven
+          detail: "Concurrent acquisition has one winner; the lease expires exactly at expiresAt; live claims cannot be stolen; explicit same-job recovery rotates the token and preserves status/session."
+        - requirement: "Optimistic revisions"
+          result: proven
+          detail: "Acquisition and terminal handoff require caller expected revisions; stale operations fail without releasing the claim or advancing status."
+        - requirement: "Atomic lifecycle and crash recovery"
+          result: proven
+          detail: "Journaled idempotent roll-forward couples acquisition and terminal handoffs; deterministic tests cover every acquisition and handoff write boundary."
+        - requirement: "Ready-job skill integration"
+          result: proven
+          detail: "The real skill lists ready jobs, obtains selection, acquires with revision, uses canonical URL and assigned/default resume, heartbeats, saves progress, and reaches needs_info or awaiting_review."
+        - requirement: "Assigned/default durable data"
+          result: proven
+          detail: "Assigned precedence and active-default fallback pass focused tests and independent audit; readiness revalidates current data under lock."
+        - requirement: "Privacy and consent"
+          result: proven
+          detail: "Claim persistence stores only token hashes; value-bearing metadata is rejected; sensitive-use and remember-consent tests remain green."
+        - requirement: "Direct-URL version-1 compatibility"
+          result: proven
+          detail: "Clean-room direct-URL lifecycle creates no coordinator artifacts; skill avoids implicit canonical job or claim creation."
+        - requirement: "Manual final-action boundary"
+          result: proven
+          detail: "Ready mode stops at awaiting_review and releases ownership without final activation; applied still requires explicit user confirmation."
+        - command: "PYTHONPATH=tests python3 -m unittest -v test_job_apply_store"
+          result: pass
+          detail: "55 tests passed."
+        - command: "PYTHONPATH=tests python3 -m unittest -v test_answer_memory_integration"
+          result: pass
+          detail: "5 tests passed."
+        - command: "python3 -m unittest discover -s tests -v"
+          result: pass
+          detail: "345 tests passed."
+        - command: "bash scripts/smoke-plugin.sh && git diff --check"
+          result: pass
+          detail: "Plugin smoke and diff validation passed."
+        - scope: "Worker package"
+          result: proven
+          detail: "All changes remain within approved files; deferred scope was not introduced."
+      subgoal_contract: null
+      parallel_safety: null
+      blocked_tasks: []
+      missing_evidence: []
+      required_board_updates:
+        - "Persist this receipt and mark T998 done."
+        - "Mark the goal complete with full_outcome_complete: true."
+        - "Run the GoalBuddy stop checker and record the final clean verification state."
+checks:
+  dirty_fingerprint: "910564214ef919fcc4a6235385c6157c63639a4c43f1efa4e706392a4b9db1db"
+  last_verification:
+    result: pass
+    task: T998
+    commands:
+      - "PYTHONPATH=tests python3 -m unittest -v test_job_apply_store (55 passed)"
+      - "PYTHONPATH=tests python3 -m unittest -v test_answer_memory_integration (5 passed)"
+      - "python3 -m unittest discover -s tests -v (345 passed)"
+      - "bash scripts/smoke-plugin.sh"
+      - "git diff --check"

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -13,13 +13,14 @@ import hmac
 import json
 import os
 import re
+import secrets
 import stat
 import sys
 import tempfile
 import unicodedata
 import uuid
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
@@ -36,6 +37,9 @@ HISTORY_EVENTS = {
     "completed",
     "abandoned",
     "failed",
+    "job-started",
+    "claim-recovered",
+    "job-blocked",
 }
 SESSION_STATUSES = {"active", "review", "completed", "abandoned"}
 JOB_STATUSES = {
@@ -84,6 +88,8 @@ FACT_SOURCES = {"user", "resume", "agent", "migration"}
 REPLAY_TRANSITIONS = {"started", "reviewed"}
 REPLAY_ATS = {"ashby", "greenhouse", "lever", "linkedin-easy-apply"}
 SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+CLAIM_LEASE_SECONDS = 300
+CLAIM_HEARTBEAT_SECONDS = 60
 
 
 class StoreError(Exception):
@@ -520,6 +526,20 @@ def _validate_session_document(session: dict[str, Any]) -> None:
     )
 
 
+def _validate_claim_record(value: Any) -> dict[str, Any]:
+    claim = _require_object(value, "coordinator claim")
+    required = {
+        "claimId", "jobId", "ownerLabel", "tokenHash", "acquiredAt",
+        "heartbeatAt", "expiresAt",
+    }
+    if set(claim) != required or not all(
+        isinstance(claim.get(field), str) and claim[field] for field in required
+    ):
+        raise StoreError("coordinator claim is invalid")
+    _safe_session_id(claim["jobId"])
+    return claim
+
+
 def _validate_job_record(key: str, value: Any) -> dict[str, Any]:
     record = _require_object(value, "job record")
     allowed = {
@@ -677,7 +697,7 @@ def _read_input(path: str) -> dict[str, Any]:
 
 
 class Store:
-    def __init__(self, root: Path, legacy_profile: Path | None = None):
+    def __init__(self, root: Path, legacy_profile: Path | None = None, clock=None):
         self.root = root.expanduser()
         self.profile_path = self.root / "profile.json"
         self.answers_path = self.root / "answers.json"
@@ -685,6 +705,8 @@ class Store:
         self.resumes_path = self.root / "resumes.json"
         self.history_path = self.root / "applications.jsonl"
         self.sessions_path = self.root / "sessions"
+        self.coordinator_path = self.root / "coordinator.json"
+        self.coordinator_journal_path = self.root / "coordinator-journal.json"
         self.store_lock_path = self.root / ".store.lock"
         self.auto_submit_policy_path = self.root / "auto-submit"
         self.legacy_profile = (
@@ -692,6 +714,18 @@ class Store:
             if legacy_profile is not None
             else Path.home() / ".claude-job-profile.json"
         )
+        self.clock = clock or (lambda: datetime.now(timezone.utc))
+
+    def _now_datetime(self) -> datetime:
+        value = self.clock()
+        if not isinstance(value, datetime):
+            raise StoreError("coordinator clock returned an invalid value")
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    def _now(self) -> str:
+        return self._now_datetime().isoformat(timespec="seconds").replace("+00:00", "Z")
 
     def paths(self) -> dict[str, Any]:
         return {
@@ -703,6 +737,8 @@ class Store:
             "resumes": str(self.resumes_path),
             "history": str(self.history_path),
             "sessions": str(self.sessions_path),
+            "coordinator": str(self.coordinator_path),
+            "coordinatorJournal": str(self.coordinator_journal_path),
             "autoSubmitPolicy": str(self.auto_submit_policy_path),
             "legacyProfile": str(self.legacy_profile),
         }
@@ -718,8 +754,15 @@ class Store:
             self._load_jobs_document()
         if self.resumes_path.exists():
             self._load_resumes_document()
-        if self.history_path.exists():
+        coordinator_exists = (
+            self.coordinator_path.exists() or self.coordinator_journal_path.exists()
+        )
+        if self.history_path.exists() and not coordinator_exists:
             self.read_history()
+        if self.coordinator_path.exists():
+            self._load_coordinator_document()
+        if self.coordinator_journal_path.exists():
+            self._load_coordinator_journal()
 
         _ensure_private_dir(self.root)
         _ensure_private_dir(self.sessions_path)
@@ -787,7 +830,91 @@ class Store:
             os.close(descriptor)
         _set_private_mode(self.history_path, 0o600)
 
+        if coordinator_exists:
+            with exclusive_file_lock(self.store_lock_path):
+                self._ensure_coordinator_files_locked()
+                self._repair_pending_history_tail_locked()
+                self._roll_forward_locked()
+                self.read_history()
+
         return {"initialized": True, "migratedLegacyProfile": migrated, **self.paths()}
+
+    def _ensure_coordinator_files_locked(self) -> None:
+        if not self.coordinator_path.exists():
+            atomic_write_json(
+                self.coordinator_path,
+                {"schemaVersion": SCHEMA_VERSION, "claim": None},
+            )
+        if not self.coordinator_journal_path.exists():
+            atomic_write_json(
+                self.coordinator_journal_path,
+                {"schemaVersion": SCHEMA_VERSION, "operation": None},
+            )
+
+    def _ensure_coordinator_files(self) -> None:
+        with exclusive_file_lock(self.store_lock_path):
+            self._ensure_coordinator_files_locked()
+            self._roll_forward_locked()
+
+    def _load_coordinator_document(self) -> dict[str, Any]:
+        document = read_json_object(self.coordinator_path, "coordinator")
+        validate_version(document, "coordinator")
+        if set(document) != {"schemaVersion", "claim"}:
+            raise StoreError("coordinator contains unsupported fields")
+        claim = document["claim"]
+        if claim is not None:
+            _validate_claim_record(claim)
+        return document
+
+    def _load_coordinator_journal(self) -> dict[str, Any]:
+        document = read_json_object(self.coordinator_journal_path, "coordinator journal")
+        validate_version(document, "coordinator journal")
+        if set(document) != {"schemaVersion", "operation"}:
+            raise StoreError("coordinator journal contains unsupported fields")
+        operation = document["operation"]
+        if operation is not None:
+            operation = _require_object(operation, "coordinator journal operation")
+            kind = operation.get("kind")
+            common = {"kind", "operationId", "jobId", "at", "historyEvent", "resultClaim"}
+            transition = {"sourceStatus", "targetStatus", "expectedRevision"}
+            expected = common | (transition if kind == "acquire" else set())
+            if kind == "handoff":
+                expected = common | transition | {"session"}
+            if kind not in {"acquire", "recover", "handoff"} or set(operation) != expected:
+                raise StoreError("coordinator journal operation is invalid")
+            job_id = _safe_session_id(operation.get("jobId", ""))
+            if not all(
+                isinstance(operation.get(field), str) and operation[field]
+                for field in ("operationId", "at")
+            ):
+                raise StoreError("coordinator journal operation is invalid")
+            event = _require_object(operation.get("historyEvent"), "coordinator history event")
+            _validate_history_event(event)
+            if event.get("applicationId") != job_id:
+                raise StoreError("coordinator history identity does not match")
+            if kind in {"acquire", "handoff"}:
+                revision = operation.get("expectedRevision")
+                if not isinstance(revision, int) or isinstance(revision, bool) or revision < 1:
+                    raise StoreError("coordinator journal revision is invalid")
+            if kind == "acquire":
+                if operation.get("sourceStatus") != "ready" or operation.get("targetStatus") != "in_progress":
+                    raise StoreError("coordinator acquisition transition is invalid")
+            if kind == "handoff":
+                if operation.get("sourceStatus") != "in_progress" or operation.get("targetStatus") not in {"needs_info", "awaiting_review"}:
+                    raise StoreError("coordinator handoff transition is invalid")
+                session = _require_object(operation.get("session"), "coordinator session")
+                _validate_session_document(session)
+                if session.get("applicationId") != job_id:
+                    raise StoreError("coordinator session identity does not match")
+            result_claim = operation.get("resultClaim")
+            if kind == "handoff":
+                if result_claim is not None:
+                    raise StoreError("coordinator handoff must release its claim")
+            else:
+                claim = _validate_claim_record(result_claim)
+                if claim["jobId"] != job_id:
+                    raise StoreError("coordinator claim identity does not match")
+        return document
 
     def _load_profile_document(self) -> dict[str, Any]:
         document = read_json_object(self.profile_path, "profile")
@@ -856,7 +983,10 @@ class Store:
 
     def inspect_profile(self) -> dict[str, Any]:
         self.initialize()
-        document = self._load_profile_document()
+        return self._profile_inspection(self._load_profile_document())
+
+    @staticmethod
+    def _profile_inspection(document: dict[str, Any]) -> dict[str, Any]:
         metadata = document["metadata"]
         return {
             "profile": document["profile"],
@@ -899,7 +1029,7 @@ class Store:
                 raise StoreError("profile revision conflict")
             updated, changed = _merge_object_patch(document["profile"], incoming)
             if not changed:
-                return self.inspect_profile()
+                return self._profile_inspection(document)
             now = utc_now()
             provenance = dict(metadata.get("factProvenance", {}))
             for path in changed:
@@ -1243,7 +1373,7 @@ class Store:
                 raise StoreError("answer revision conflict")
             if current.get("deletedAt") is None:
                 raise StoreError("answer must be trashed before permanent deletion")
-            for session in self.list_sessions():
+            for session in self._list_sessions_uninitialized():
                 if key in session.get("answerKeys", []) or any(
                     field.get("answerKey") == key
                     for field in session.get("pendingFields", [])
@@ -1877,10 +2007,13 @@ class Store:
                 raise StoreError("job does not exist")
             if current["revision"] != expected_revision:
                 raise StoreError("job revision conflict")
+            self._require_job_unclaimed_locked(job_id)
             if status == current["status"]:
                 return current
             if status not in JOB_TRANSITIONS[current["status"]]:
                 raise StoreError("job status transition is unsupported")
+            if status == "in_progress":
+                raise StoreError("in_progress requires atomic job-acquire")
             if status == "applied" and not user_confirmed:
                 raise StoreError("applied status requires explicit user confirmation")
             if status == "ready" and not self._preflight_job_record(current)["ready"]:
@@ -1895,6 +2028,270 @@ class Store:
             document["metadata"]["updatedAt"] = updated["updatedAt"]
             atomic_write_json(self.jobs_path, document)
         return updated
+
+    @staticmethod
+    def _token_hash(token: str) -> str:
+        if not isinstance(token, str) or not token:
+            raise StoreError("claim token is required")
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    def _public_claim(self, claim: dict[str, Any] | None) -> dict[str, Any] | None:
+        if claim is None:
+            return None
+        public = {key: value for key, value in claim.items() if key != "tokenHash"}
+        public["expired"] = self._now_datetime() >= self._parse_time(claim["expiresAt"])
+        return public
+
+    @staticmethod
+    def _parse_time(value: str) -> datetime:
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except (AttributeError, ValueError) as error:
+            raise StoreError("coordinator timestamp is invalid") from error
+        if parsed.tzinfo is None:
+            raise StoreError("coordinator timestamp is invalid")
+        return parsed.astimezone(timezone.utc)
+
+    def claim_status(self) -> dict[str, Any]:
+        self.initialize()
+        self._ensure_coordinator_files()
+        claim = self._load_coordinator_document()["claim"]
+        return {
+            "claim": self._public_claim(claim),
+            "leaseSeconds": CLAIM_LEASE_SECONDS,
+            "heartbeatSeconds": CLAIM_HEARTBEAT_SECONDS,
+        }
+
+    def _require_claim_locked(
+        self, job_id: str, token: str, allow_expired: bool = False
+    ) -> dict[str, Any]:
+        claim = self._load_coordinator_document()["claim"]
+        if claim is None or claim["jobId"] != job_id:
+            raise StoreError("job is not held by this claim")
+        if not hmac.compare_digest(claim["tokenHash"], self._token_hash(token)):
+            raise StoreError("claim token is invalid")
+        job = self._load_jobs_document()["jobs"].get(job_id)
+        if job is None or job.get("deletedAt") is not None or job.get("status") != "in_progress":
+            raise StoreError("claimed job is not in progress")
+        if not allow_expired and self._now_datetime() >= self._parse_time(claim["expiresAt"]):
+            raise StoreError("claim has expired; use explicit recovery")
+        return claim
+
+    def _require_job_unclaimed_locked(self, job_id: str) -> None:
+        if not self.coordinator_path.exists():
+            return
+        claim = self._load_coordinator_document()["claim"]
+        if claim is not None and claim["jobId"] == job_id:
+            raise StoreError("claimed job requires a coordinator operation")
+
+    def _history_event_for_operation(
+        self, operation_id: str, job: dict[str, Any], event: str, status: str, at: str
+    ) -> dict[str, Any]:
+        record = {
+            "schemaVersion": SCHEMA_VERSION,
+            "eventId": f"coordinator-{operation_id}",
+            "applicationId": job["id"],
+            "event": event,
+            "status": status,
+            "answerKeys": [],
+            "at": at,
+        }
+        for field in ("company", "role", "ats"):
+            if isinstance(job.get(field), str):
+                record[field] = job[field]
+        _validate_history_event(record)
+        return record
+
+    def _append_history_event_idempotent_locked(self, event: dict[str, Any]) -> None:
+        existing = self.read_history()
+        if any(item.get("eventId") == event["eventId"] for item in existing):
+            return
+        _validate_history_event(event)
+        encoded = (json.dumps(event, sort_keys=True, ensure_ascii=False) + "\n").encode("utf-8")
+        descriptor = os.open(
+            self.history_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600
+        )
+        original_size = os.fstat(descriptor).st_size
+        try:
+            offset = 0
+            while offset < len(encoded):
+                written = os.write(descriptor, encoded[offset:])
+                if written <= 0:
+                    raise StoreError("history append was incomplete")
+                offset += written
+            os.fsync(descriptor)
+        except BaseException:
+            os.ftruncate(descriptor, original_size)
+            os.fsync(descriptor)
+            raise
+        finally:
+            os.close(descriptor)
+        _set_private_mode(self.history_path, 0o600)
+
+    def _repair_pending_history_tail_locked(self) -> None:
+        journal = self._load_coordinator_journal()
+        if journal["operation"] is None or not self.history_path.exists():
+            return
+        descriptor = os.open(self.history_path, os.O_RDWR)
+        try:
+            content = os.read(descriptor, os.fstat(descriptor).st_size)
+            if not content or content.endswith(b"\n"):
+                return
+            last_newline = content.rfind(b"\n")
+            os.ftruncate(descriptor, last_newline + 1)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def _roll_forward_locked(self) -> None:
+        journal = self._load_coordinator_journal()
+        operation = journal["operation"]
+        if operation is None:
+            return
+        job_id = _safe_session_id(operation.get("jobId", ""))
+        if "targetStatus" in operation:
+            jobs = self._load_jobs_document()
+            current = jobs["jobs"].get(job_id)
+            if current is None or current.get("deletedAt") is not None:
+                raise StoreError("coordinator journal references a missing job")
+            expected = operation["expectedRevision"]
+            if current["revision"] == expected:
+                if current["status"] != operation["sourceStatus"]:
+                    raise StoreError("coordinator journal source status drifted")
+                updated = dict(current)
+                updated["status"] = operation["targetStatus"]
+                updated["closedOutcome"] = None
+                updated["revision"] = expected + 1
+                updated["updatedAt"] = operation["at"]
+                _validate_job_record(job_id, updated)
+                jobs["jobs"][job_id] = updated
+                jobs["metadata"]["updatedAt"] = operation["at"]
+                atomic_write_json(self.jobs_path, jobs)
+            elif not (
+                current["revision"] == expected + 1
+                and current["status"] == operation["targetStatus"]
+            ):
+                raise StoreError("coordinator journal cannot be reconciled")
+        session = operation.get("session")
+        if session is not None:
+            _validate_session_document(session)
+            atomic_write_json(self._session_path(job_id), session)
+        event = operation.get("historyEvent")
+        if event is not None:
+            self._append_history_event_idempotent_locked(event)
+        atomic_write_json(
+            self.coordinator_path,
+            {"schemaVersion": SCHEMA_VERSION, "claim": operation.get("resultClaim")},
+        )
+        atomic_write_json(
+            self.coordinator_journal_path,
+            {"schemaVersion": SCHEMA_VERSION, "operation": None},
+        )
+
+    def _commit_coordinator_operation_locked(self, operation: dict[str, Any]) -> None:
+        atomic_write_json(
+            self.coordinator_journal_path,
+            {"schemaVersion": SCHEMA_VERSION, "operation": operation},
+        )
+        self._roll_forward_locked()
+
+    def acquire_ready_job(
+        self, job_id: str, owner_label: str, expected_revision: int
+    ) -> dict[str, Any]:
+        self.initialize()
+        self._ensure_coordinator_files()
+        _safe_session_id(job_id)
+        if not isinstance(owner_label, str) or not owner_label.strip():
+            raise StoreError("owner label must be a non-empty string")
+        with exclusive_file_lock(self.store_lock_path):
+            coordinator = self._load_coordinator_document()
+            current_claim = coordinator["claim"]
+            if current_claim is not None:
+                if self._now_datetime() >= self._parse_time(current_claim["expiresAt"]):
+                    raise StoreError("expired claim requires explicit same-job recovery")
+                raise StoreError("another live job claim already exists")
+            jobs = self._load_jobs_document()
+            job = jobs["jobs"].get(job_id)
+            if job is None or job.get("deletedAt") is not None:
+                raise StoreError("job does not exist")
+            if job["revision"] != expected_revision:
+                raise StoreError("job revision conflict")
+            if job["status"] != "ready":
+                raise StoreError("only a ready job can be acquired")
+            preflight = self._preflight_job_record(job)
+            if not preflight["ready"]:
+                raise StoreError("job is not ready")
+            now_dt = self._now_datetime()
+            now = now_dt.isoformat(timespec="seconds").replace("+00:00", "Z")
+            token = secrets.token_urlsafe(32)
+            claim = {
+                "claimId": str(uuid.uuid4()),
+                "jobId": job_id,
+                "ownerLabel": owner_label.strip(),
+                "tokenHash": self._token_hash(token),
+                "acquiredAt": now,
+                "heartbeatAt": now,
+                "expiresAt": (now_dt + timedelta(seconds=CLAIM_LEASE_SECONDS)).isoformat(timespec="seconds").replace("+00:00", "Z"),
+            }
+            operation_id = str(uuid.uuid4())
+            operation = {
+                "kind": "acquire", "operationId": operation_id, "jobId": job_id,
+                "sourceStatus": "ready", "targetStatus": "in_progress",
+                "expectedRevision": job["revision"], "at": now,
+                "historyEvent": self._history_event_for_operation(operation_id, job, "job-started", "in_progress", now),
+                "resultClaim": claim,
+            }
+            self._commit_coordinator_operation_locked(operation)
+            return {
+                "job": self._load_jobs_document()["jobs"][job_id],
+                "resume": self._load_resumes_document()["resumes"][preflight["resumeId"]],
+                "claim": self._public_claim(claim),
+                "token": token,
+            }
+
+    def heartbeat_claim(self, job_id: str, token: str) -> dict[str, Any]:
+        self.initialize()
+        self._ensure_coordinator_files()
+        with exclusive_file_lock(self.store_lock_path):
+            claim = dict(self._require_claim_locked(job_id, token))
+            now_dt = self._now_datetime()
+            claim["heartbeatAt"] = now_dt.isoformat(timespec="seconds").replace("+00:00", "Z")
+            claim["expiresAt"] = (now_dt + timedelta(seconds=CLAIM_LEASE_SECONDS)).isoformat(timespec="seconds").replace("+00:00", "Z")
+            atomic_write_json(self.coordinator_path, {"schemaVersion": SCHEMA_VERSION, "claim": claim})
+            return {"claim": self._public_claim(claim)}
+
+    def recover_claim(self, job_id: str, owner_label: str) -> dict[str, Any]:
+        self.initialize()
+        self._ensure_coordinator_files()
+        _safe_session_id(job_id)
+        if not isinstance(owner_label, str) or not owner_label.strip():
+            raise StoreError("owner label must be a non-empty string")
+        with exclusive_file_lock(self.store_lock_path):
+            old = self._load_coordinator_document()["claim"]
+            if old is None or old["jobId"] != job_id:
+                raise StoreError("explicit recovery must name the expired claimed job")
+            job = self._load_jobs_document()["jobs"].get(job_id)
+            if job is None or job.get("status") != "in_progress":
+                raise StoreError("expired claim job is not in progress")
+            if self._now_datetime() < self._parse_time(old["expiresAt"]):
+                raise StoreError("live claim cannot be recovered")
+            now_dt = self._now_datetime()
+            now = now_dt.isoformat(timespec="seconds").replace("+00:00", "Z")
+            token = secrets.token_urlsafe(32)
+            claim = {
+                "claimId": str(uuid.uuid4()), "jobId": job_id,
+                "ownerLabel": owner_label.strip(), "tokenHash": self._token_hash(token),
+                "acquiredAt": now, "heartbeatAt": now,
+                "expiresAt": (now_dt + timedelta(seconds=CLAIM_LEASE_SECONDS)).isoformat(timespec="seconds").replace("+00:00", "Z"),
+            }
+            operation_id = str(uuid.uuid4())
+            self._commit_coordinator_operation_locked({
+                "kind": "recover", "operationId": operation_id, "jobId": job_id,
+                "at": now,
+                "historyEvent": self._history_event_for_operation(operation_id, job, "claim-recovered", "in_progress", now),
+                "resultClaim": claim,
+            })
+            return {"job": job, "claim": self._public_claim(claim), "token": token}
 
     def trash_job(self, job_id: str, expected_revision: int) -> dict[str, Any]:
         return self._set_job_deleted(job_id, expected_revision, restore=False)
@@ -1914,6 +2311,7 @@ class Store:
                 raise StoreError("job does not exist")
             if current["revision"] != expected_revision:
                 raise StoreError("job revision conflict")
+            self._require_job_unclaimed_locked(job_id)
             is_trashed = current.get("deletedAt") is not None
             if restore == (not is_trashed):
                 return current
@@ -1951,6 +2349,7 @@ class Store:
                 return {"deleted": False, "id": job_id}
             if current["revision"] != expected_revision:
                 raise StoreError("job revision conflict")
+            self._require_job_unclaimed_locked(job_id)
             if current.get("deletedAt") is None:
                 raise StoreError("job must be trashed before permanent deletion")
             del document["jobs"][job_id]
@@ -2362,57 +2761,106 @@ class Store:
     def _session_path(self, application_id: str) -> Path:
         return self.sessions_path / f"{_safe_session_id(application_id)}.json"
 
-    def save_session(
-        self, application_id: str, incoming: dict[str, Any]
+    def _build_session(
+        self, application_id: str, incoming: dict[str, Any], now: str | None = None
     ) -> dict[str, Any]:
-        self.initialize()
         allowed = {
-            "applicationId",
-            "status",
-            "ats",
-            "company",
-            "role",
-            "url",
-            "step",
-            "answerKeys",
-            "pendingFields",
-            "createdAt",
-            "updatedAt",
+            "applicationId", "status", "ats", "company", "role", "url", "step",
+            "answerKeys", "pendingFields", "createdAt", "updatedAt",
         }
         if set(incoming) - allowed:
             raise StoreError("session contains unsupported fields")
         application_id = _safe_session_id(application_id)
-        supplied_id = incoming.get("applicationId", application_id)
-        if supplied_id != application_id:
+        if incoming.get("applicationId", application_id) != application_id:
             raise StoreError("session application id does not match path")
         status = incoming.get("status", "active")
         if status not in SESSION_STATUSES:
             raise StoreError("session status is unsupported")
         answer_keys = incoming.get("answerKeys", [])
-        if not isinstance(answer_keys, list) or not all(
-            isinstance(item, str) for item in answer_keys
-        ):
+        if not isinstance(answer_keys, list) or not all(isinstance(item, str) for item in answer_keys):
             raise StoreError("session answerKeys must be strings")
-        pending_fields = incoming.get("pendingFields", [])
-
         path = self._session_path(application_id)
         created_at = incoming.get("createdAt")
         if path.exists():
-            existing = self.load_session(application_id)
+            existing = read_json_object(path, "session")
+            _validate_session_document(existing)
             created_at = created_at or existing.get("createdAt")
+        timestamp = now or utc_now()
         session = {
-            "schemaVersion": SCHEMA_VERSION,
-            **incoming,
-            "applicationId": application_id,
-            "status": status,
+            "schemaVersion": SCHEMA_VERSION, **incoming,
+            "applicationId": application_id, "status": status,
             "answerKeys": answer_keys,
-            "pendingFields": pending_fields,
-            "createdAt": created_at or utc_now(),
-            "updatedAt": utc_now(),
+            "pendingFields": incoming.get("pendingFields", []),
+            "createdAt": created_at or timestamp, "updatedAt": timestamp,
         }
         _validate_session_document(session)
-        atomic_write_json(path, session)
         return session
+
+    def save_claim_progress(
+        self, job_id: str, token: str, incoming: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.initialize()
+        self._ensure_coordinator_files()
+        with exclusive_file_lock(self.store_lock_path):
+            self._require_claim_locked(job_id, token)
+            job = self._load_jobs_document()["jobs"].get(job_id)
+            if job is None or job.get("status") != "in_progress":
+                raise StoreError("claimed job is not in progress")
+            session = self._build_session(job_id, incoming, self._now())
+            if session["status"] != "active":
+                raise StoreError("claim progress session must remain active")
+            atomic_write_json(self._session_path(job_id), session)
+            return session
+
+    def handoff_claimed_job(
+        self,
+        job_id: str,
+        token: str,
+        status: str,
+        incoming: dict[str, Any],
+        expected_revision: int,
+    ) -> dict[str, Any]:
+        self.initialize()
+        self._ensure_coordinator_files()
+        if status not in {"needs_info", "awaiting_review"}:
+            raise StoreError("claimed handoff status is unsupported")
+        with exclusive_file_lock(self.store_lock_path):
+            self._require_claim_locked(job_id, token)
+            job = self._load_jobs_document()["jobs"].get(job_id)
+            if job is None or job.get("status") != "in_progress":
+                raise StoreError("claimed job is not in progress")
+            if job["revision"] != expected_revision:
+                raise StoreError("job revision conflict")
+            now = self._now()
+            session = self._build_session(job_id, incoming, now)
+            required_session_status = "active" if status == "needs_info" else "review"
+            if session["status"] != required_session_status:
+                raise StoreError("handoff session status does not match job status")
+            event_name = "job-blocked" if status == "needs_info" else "reviewed"
+            operation_id = str(uuid.uuid4())
+            self._commit_coordinator_operation_locked({
+                "kind": "handoff", "operationId": operation_id, "jobId": job_id,
+                "sourceStatus": "in_progress", "targetStatus": status,
+                "expectedRevision": job["revision"], "at": now, "session": session,
+                "historyEvent": self._history_event_for_operation(operation_id, job, event_name, status, now),
+                "resultClaim": None,
+            })
+            return {
+                "job": self._load_jobs_document()["jobs"][job_id],
+                "session": session,
+                "claim": None,
+            }
+
+    def save_session(
+        self, application_id: str, incoming: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.initialize()
+        with exclusive_file_lock(self.store_lock_path):
+            self._require_generic_session_mutation_allowed_locked(application_id)
+            session = self._build_session(application_id, incoming)
+            path = self._session_path(application_id)
+            atomic_write_json(path, session)
+            return session
 
     def load_session(self, application_id: str) -> dict[str, Any]:
         self.initialize()
@@ -2428,6 +2876,9 @@ class Store:
 
     def list_sessions(self) -> list[dict[str, Any]]:
         self.initialize()
+        return self._list_sessions_uninitialized()
+
+    def _list_sessions_uninitialized(self) -> list[dict[str, Any]]:
         sessions: list[dict[str, Any]] = []
         for path in sorted(self.sessions_path.glob("*.json")):
             session = read_json_object(path, "session")
@@ -2440,12 +2891,29 @@ class Store:
 
     def delete_session(self, application_id: str) -> dict[str, Any]:
         self.initialize()
-        path = self._session_path(application_id)
-        if not path.exists():
-            return {"deleted": False, "applicationId": application_id}
-        path.unlink()
-        _fsync_directory(self.sessions_path)
-        return {"deleted": True, "applicationId": application_id}
+        with exclusive_file_lock(self.store_lock_path):
+            self._require_generic_session_mutation_allowed_locked(
+                application_id, allow_terminal_delete=True
+            )
+            path = self._session_path(application_id)
+            if not path.exists():
+                return {"deleted": False, "applicationId": application_id}
+            path.unlink()
+            _fsync_directory(self.sessions_path)
+            return {"deleted": True, "applicationId": application_id}
+
+    def _require_generic_session_mutation_allowed_locked(
+        self, application_id: str, allow_terminal_delete: bool = False
+    ) -> None:
+        job = self._load_jobs_document()["jobs"].get(application_id)
+        if (
+            job is not None
+            and job.get("deletedAt") is None
+            and not (
+                allow_terminal_delete and job.get("status") in {"applied", "closed"}
+            )
+        ):
+            raise StoreError("canonical job sessions require a coordinator operation")
 
 
 def _scope(value: str) -> dict[str, Any]:
@@ -2538,6 +3006,27 @@ def build_parser() -> argparse.ArgumentParser:
     job_transition.add_argument("--closed-outcome")
     job_transition.add_argument("--expected-revision", required=True, type=int)
     job_transition.add_argument("--user-confirmed", action="store_true")
+    job_acquire = commands.add_parser("job-acquire")
+    job_acquire.add_argument("--id", required=True)
+    job_acquire.add_argument("--owner", required=True)
+    job_acquire.add_argument("--expected-revision", required=True, type=int)
+    commands.add_parser("claim-status")
+    claim_heartbeat = commands.add_parser("claim-heartbeat")
+    claim_heartbeat.add_argument("--id", required=True)
+    claim_heartbeat.add_argument("--token", required=True)
+    claim_recover = commands.add_parser("claim-recover")
+    claim_recover.add_argument("--id", required=True)
+    claim_recover.add_argument("--owner", required=True)
+    claim_progress = commands.add_parser("claim-progress")
+    claim_progress.add_argument("--id", required=True)
+    claim_progress.add_argument("--token", required=True)
+    claim_progress.add_argument("--input", required=True)
+    claim_handoff = commands.add_parser("claim-handoff")
+    claim_handoff.add_argument("--id", required=True)
+    claim_handoff.add_argument("--token", required=True)
+    claim_handoff.add_argument("--status", required=True)
+    claim_handoff.add_argument("--input", required=True)
+    claim_handoff.add_argument("--expected-revision", required=True, type=int)
     job_trash = commands.add_parser("job-trash")
     job_trash.add_argument("--id", required=True)
     job_trash.add_argument("--expected-revision", required=True, type=int)
@@ -2675,6 +3164,24 @@ def run(args: argparse.Namespace) -> Any:
             args.expected_revision,
             closed_outcome=args.closed_outcome,
             user_confirmed=args.user_confirmed,
+        )
+    if command == "job-acquire":
+        return store.acquire_ready_job(args.id, args.owner, args.expected_revision)
+    if command == "claim-status":
+        return store.claim_status()
+    if command == "claim-heartbeat":
+        return store.heartbeat_claim(args.id, args.token)
+    if command == "claim-recover":
+        return store.recover_claim(args.id, args.owner)
+    if command == "claim-progress":
+        return store.save_claim_progress(args.id, args.token, _read_input(args.input))
+    if command == "claim-handoff":
+        return store.handoff_claimed_job(
+            args.id,
+            args.token,
+            args.status,
+            _read_input(args.input),
+            args.expected_revision,
         )
     if command == "job-trash":
         return store.trash_job(args.id, args.expected_revision)

--- a/skills/answer-memory/SKILL.md
+++ b/skills/answer-memory/SKILL.md
@@ -277,6 +277,23 @@ python3 "<plugin-root>/scripts/job-apply-store.py" session-delete --id <applicat
 
 Delete a session after the user confirms submission or explicitly abandons it. History remains separate.
 
+## Ready-job agent handoff
+
+Canonical ready jobs are consumed through the coordinator, not by a standalone `ready -> in_progress` transition. The store permits at most one global claim, uses a 300-second lease and 60-second heartbeat cadence, and stores only a SHA-256 token hash. `job-acquire` and `claim-recover` return the raw bearer token in their machine-readable stdout; treat that output as ephemeral and never repeat the token in user-facing text or persist it in logs, sessions, or temporary files.
+
+```bash
+python3 "<plugin-root>/scripts/job-apply-store.py" job-list --status ready
+python3 "<plugin-root>/scripts/job-apply-store.py" job-acquire --id <job-id> --owner <owner-label> --expected-revision <revision>
+python3 "<plugin-root>/scripts/job-apply-store.py" claim-status
+python3 "<plugin-root>/scripts/job-apply-store.py" claim-heartbeat --id <job-id> --token <token>
+python3 "<plugin-root>/scripts/job-apply-store.py" claim-progress --id <job-id> --token <token> --input <session.json>
+python3 "<plugin-root>/scripts/job-apply-store.py" claim-handoff --id <job-id> --token <token> --status needs_info --expected-revision <revision> --input <session.json>
+python3 "<plugin-root>/scripts/job-apply-store.py" claim-handoff --id <job-id> --token <token> --status awaiting_review --expected-revision <revision> --input <session.json>
+python3 "<plugin-root>/scripts/job-apply-store.py" claim-recover --id <same-job-id> --owner <owner-label>
+```
+
+`job-acquire` requires the revision shown during selection, rechecks readiness under the global lock, and returns the resolved resume record, preferring the job's assigned resume over the active default. Terminal handoff likewise requires the post-acquisition or post-recovery revision retained by the caller; reloading just before handoff would mask a concurrent change. A stale revision fails without changing claim, job, history, or session state. A live claim is never stolen or silently released. Generic transition, trash, deletion, and session-mutation commands reject active canonical jobs. An expired claim can only be recovered explicitly for the same `in_progress` job; use `claim-status` to obtain that job ID. Recovery rotates the token and preserves its session and status. Heartbeat, progress, recovery, and both handoffs require canonical `in_progress` status. The session schema rejects explicit value fields, but allowed metadata strings cannot be classified semantically: callers must never encode answer values in `step`, question metadata, answer keys, or any other allowed string. The needs-info and review handoffs journal and roll forward job, history, session, and claim-release changes idempotently after a crash.
+
 ## Safety rules
 
 1. Never bypass the helper for persistent data mutations.

--- a/skills/answer-memory/references/storage-contract.md
+++ b/skills/answer-memory/references/storage-contract.md
@@ -43,6 +43,15 @@ or resume values. `ready` requires a non-empty valid profile and a current local
 file for the assigned or default active resume. Missing role or company and a
 resume file that changed since registration remain visible warnings.
 
+### Exclusive ready-job coordinator
+
+Use `job-acquire`, never a standalone transition to `in_progress`, when an agent consumes a ready job. One version-1 `coordinator.json` record holds at most one claim with a hashed token and a 300-second lease; `coordinator-journal.json` provides idempotent crash roll-forward. Neither file is a second workflow-status model: `jobs.json` remains authoritative.
+The coordinator files are created lazily by the first claim command, so direct-URL and replay workflows that never use canonical ready jobs retain their existing store shape.
+
+Acquisition requires the caller's selected job revision, re-runs preflight under the store lock, resolves an assigned resume before the default, transitions the job to `in_progress`, and records `job-started`. Terminal handoff requires the post-acquisition or post-recovery revision retained before browser work; callers must not refresh that revision immediately before handoff. Stale revisions fail without mutation. Heartbeat at least every 60 seconds. Heartbeat and all claim-gated mutations require the canonical job to remain `in_progress`; generic transition, trash, deletion, and session-mutation commands reject active canonical jobs. A live claim cannot be recovered, replaced, or silently cleared. After expiry, `claim-recover` must name the same still-`in_progress` job exposed by `claim-status` and rotates the token while recording `claim-recovered`.
+
+Use `claim-progress` for value-free checkpoints. Use `claim-handoff --status needs_info` for a blocked application and `claim-handoff --status awaiting_review` at final review. Each handoff atomically journals the status transition, session, lifecycle history, and claim release. The schema rejects explicit answer-value fields, while callers remain responsible for keeping every allowed metadata string value-free. A `needs_info` job returns through preflight to `ready` and then receives a fresh claim. Claims, journals, sessions, and history must never contain raw tokens, answer values, resume contents, credentials, CAPTCHA/MFA data, or browser state.
+
 ## Profile fact updates
 
 `profile-get` remains backward compatible and returns the raw profile.

--- a/skills/job-apply/SKILL.md
+++ b/skills/job-apply/SKILL.md
@@ -30,7 +30,16 @@ After evaluation, or if the QA replay is abandoned, run `python3 "<plugin-root>/
 
 Then wait for the user to provide the path before proceeding with profile extraction.
 
-**If the profile contains applicant data**, say:
+**If the profile contains applicant data**, first determine the application mode:
+
+- If the user supplied a job URL, keep the existing direct-URL workflow unchanged. Do not create a canonical job or claim implicitly.
+- If no URL was supplied, run `claim-status` before listing ready jobs. If it returns a live claim, identify the claimed job and do not start another one. If it returns an expired claim, identify the returned claimed job ID and ask whether to recover that exact job; after confirmation run `claim-recover --id <claimed-job-id> --owner <owner-label>`. If there is no claim, run `job-list --status ready`. If ready jobs exist, show their role, company, and URL and ask the user to select one (offer the first priority-sorted result). If none exist, use the existing URL prompt below.
+
+For a selected ready job, retain its displayed revision, create a short non-sensitive owner label for this agent run, and run `job-acquire --id <job-id> --owner <owner-label> --expected-revision <revision>`. This single operation rejects a stale selection, re-runs preflight, resolves the job's assigned resume before the active default, creates the exclusive 300-second claim, moves `ready` to `in_progress`, and records `job-started`. Retain the returned post-acquisition job revision for the eventual handoff. The machine-readable result returns the bearer token on stdout; treat it as ephemeral sensitive output, never repeat it in user-facing text, and never place it in logs, saved sessions, or temporary files. Use the returned job URL and returned resume path for the application; do not substitute `profile.resumePath`.
+
+If acquisition reports a claim, run `claim-status` because the global claim can belong to a different job. Do not work around a live claim. For an expired claim, use the claimed job ID returned by `claim-status`, ask whether to resume that exact job, and only then run `claim-recover --id <claimed-job-id> --owner <owner-label>`. Recovery never steals a live claim. Retain the recovered job revision for handoff. Run `claim-heartbeat --id <job-id> --token <token>` at least every 60 seconds while actively working.
+
+**If the profile contains applicant data and neither a supplied URL nor a selected ready job is available**, say:
 
 > Welcome back! Your local Job Apply profile and answer memory are ready.
 >
@@ -46,7 +55,7 @@ Then wait for the user to provide the path before proceeding with profile extrac
 ## Required Input
 
 - **Resume file path**: Path to your resume (PDF, DOCX, or TXT format)
-- **Job URL**: LinkedIn job posting or direct application link
+- **Application target**: Either a selected canonical `ready` job or a supplied job URL
 
 ## Profile Storage
 
@@ -110,7 +119,7 @@ If `profile-get` returns an empty object, or if the user requests a reset:
 
 ### Phase 2: Application Filling
 
-1. **Initialize and load storage** through the bundled `answer-memory` skill; use `profile-get`, then check `session-list` for resumable work matching this application
+1. **Initialize and load storage** through the bundled `answer-memory` skill; use `profile-get`, then check `session-list` for resumable work matching this application. In selected-ready mode, use the acquired canonical job ID as the application/session ID and the resume returned by `job-acquire`; in direct-URL mode preserve the existing URL-derived workflow.
 2. **Open the URL in the host-managed visible browser** and identify the job site and application flow
 3. **Pause for user-only steps** if login, password, CAPTCHA, MFA, consent, or account creation appears
 4. **Open the application form**; if an Apply link opens an external portal, continue in that visible host-managed tab
@@ -118,11 +127,13 @@ If `profile-get` returns an empty object, or if the user requests a reset:
 6. **Reuse only matching, non-sensitive `confirmed` answers**. Show and confirm `inferred` answers, ask for `missing` answers, and reconfirm every `sensitive` answer before entry
 7. **Separate fill consent from remember consent** for salary, work authorization, visa status, demographic information, disability disclosure, and similar answers. Use `--remember-sensitive` only after explicit field-specific permission to remember
 8. **Upload the resume** through the visible file control and verify the selected filename
-9. **Save resumable progress** through `session-save`; store answer keys and pending-field states, never answer values
+9. **Save resumable progress**. In selected-ready mode use claim-gated `claim-progress --id <job-id> --token <token> --input <session.json>`; in direct-URL mode continue to use `session-save`. Store answer keys and pending-field states, never answer values.
 10. **Handle inaccessible controls** using the optional fallback rules above, or leave the field for the user
 11. **Advance through non-final steps** only when the control is clearly Next, Continue, Save, or Review
 12. **Stop at final review** before any Submit, Send, or equivalent final-action button
-13. **Record a minimal `reviewed` history event** with answer-key references (or use the required coordinator `reviewed` command for approved local QA), summarize every entered value, identify anything incomplete or uncertain, and tell the user to inspect the page and submit manually
+13. **Complete the durable handoff**. In selected-ready mode, pass the post-acquisition (or post-recovery) job revision retained before browser work to `claim-handoff --id <job-id> --token <token> --status awaiting_review --expected-revision <retained-revision> --input <review-session.json>`. The session JSON must contain only value-free review metadata. This atomically saves the review session, records `reviewed`, moves the canonical job to `awaiting_review`, and releases the claim. A revision conflict means the user or another client changed the job; stop and re-evaluate instead of reloading and retrying with an unseen revision. In direct-URL mode retain the existing minimal `reviewed` history event (or the required coordinator `reviewed` command for approved local QA). Summarize every entered value, identify anything incomplete or uncertain, and tell the user to inspect the page and submit manually.
+
+If selected-ready work needs a user answer, first prepare a session containing only question/state/answer-key/sensitivity metadata, then use `claim-handoff --id <job-id> --token <token> --status needs_info --expected-revision <retained-revision> --input <needs-info-session.json>`. Do not reload the job revision first; a conflict must expose concurrent changes. This atomically moves the job to `needs_info`, records `job-blocked`, and releases the claim. After the user supplies the missing information, transition `needs_info` to `ready` with the current revision (preflight is enforced), then acquire a fresh claim. Never retain a claim while waiting for the user. If the process crashes, leave the record intact for explicit stale recovery; never delete or silently clear a claim.
 
 User confirmation never authorizes this skill to click Submit, Send, or any equivalent final-action button.
 

--- a/tests/test_answer_memory_integration.py
+++ b/tests/test_answer_memory_integration.py
@@ -117,6 +117,7 @@ class AnswerMemoryIntegrationTests(unittest.TestCase):
                 "ats": "greenhouse",
                 "company": "Example Corp",
                 "role": "Engineer",
+                "url": "https://example.com/direct-job",
                 "step": "questions",
                 "answerKeys": [saved_answer["key"]],
                 "pendingFields": [
@@ -133,6 +134,7 @@ class AnswerMemoryIntegrationTests(unittest.TestCase):
         )
         resumed = self.json_store("session-load", "--id", "example-engineer")
         self.assertEqual(resumed["step"], "questions")
+        self.assertEqual(resumed["url"], "https://example.com/direct-job")
         self.assertNotIn("value", json.dumps(resumed))
 
         history_input = self.write_input(
@@ -155,6 +157,8 @@ class AnswerMemoryIntegrationTests(unittest.TestCase):
         self.assertEqual(
             json.loads((self.home / ".claude-job-profile.json").read_text()), legacy
         )
+        self.assertFalse((self.home / ".job-apply" / "coordinator.json").exists())
+        self.assertFalse((self.home / ".job-apply" / "coordinator-journal.json").exists())
 
     def test_skills_share_one_helper_contract_and_manual_submit_boundary(self):
         skills = {
@@ -187,6 +191,106 @@ class AnswerMemoryIntegrationTests(unittest.TestCase):
         self.assertIn("Every live Submit", skills["job-apply"])
         self.assertIn("separately audited canary", skills["job-apply"])
         self.assertIn("Auto-submit policy", skills["answer-memory"])
+        self.assertIn("job-list --status ready", skills["job-apply"])
+        self.assertIn("job-acquire", skills["job-apply"])
+        self.assertIn("claim-handoff --id <job-id> --token <token>", skills["job-apply"])
+        self.assertIn("--status awaiting_review", skills["job-apply"])
+        self.assertIn("--input <review-session.json>", skills["job-apply"])
+        self.assertIn("If the user supplied a job URL", skills["job-apply"])
+        self.assertIn("User confirmation never authorizes this skill to click Submit", skills["job-apply"])
+
+    def test_ready_job_cli_lifecycle_reaches_review_and_releases_claim(self):
+        self.json_store("init")
+        profile = self.write_input("profile.json", {"firstName": "Synthetic"})
+        self.json_store("profile-replace", "--input", str(profile))
+        resume_path = self.home / "assigned-resume.pdf"
+        resume_path.write_bytes(b"synthetic resume")
+        resume = self.write_input("resume.json", {
+            "id": "assigned-resume", "label": "Assigned", "path": str(resume_path)
+        })
+        self.json_store("resume-create", "--input", str(resume))
+        job_input = self.write_input("job.json", {
+            "id": "canonical-ready-job", "url": "https://example.com/jobs/ready",
+            "company": "Example", "role": "Engineer", "resumeId": "assigned-resume",
+        })
+        job = self.json_store("job-create", "--input", str(job_input))
+        job = self.json_store(
+            "job-transition", "--id", job["id"], "--status", "ready",
+            "--expected-revision", str(job["revision"]),
+        )
+        acquired = self.json_store(
+            "job-acquire", "--id", job["id"], "--owner", "integration-agent",
+            "--expected-revision", str(job["revision"]),
+        )
+        self.assertEqual(acquired["job"]["status"], "in_progress")
+        self.assertEqual(acquired["resume"]["id"], "assigned-resume")
+        progress = self.write_input("progress.json", {
+            "status": "active", "step": "questions", "answerKeys": [],
+            "pendingFields": [],
+        })
+        self.json_store(
+            "claim-progress", "--id", job["id"], "--token", acquired["token"],
+            "--input", str(progress),
+        )
+        review = self.write_input("review.json", {
+            "status": "review", "step": "review", "answerKeys": [],
+            "pendingFields": [],
+        })
+        handed = self.json_store(
+            "claim-handoff", "--id", job["id"], "--token", acquired["token"],
+            "--status", "awaiting_review", "--input", str(review),
+            "--expected-revision", str(acquired["job"]["revision"]),
+        )
+        self.assertEqual(handed["job"]["status"], "awaiting_review")
+        self.assertIsNone(self.json_store("claim-status")["claim"])
+        self.assertEqual(
+            [item["event"] for item in self.json_store("history-list")],
+            ["job-started", "reviewed"],
+        )
+        serialized = "\n".join(
+            (self.home / ".job-apply" / name).read_text(encoding="utf-8")
+            for name in ("coordinator.json", "coordinator-journal.json", "applications.jsonl")
+        )
+        self.assertNotIn(acquired["token"], serialized)
+        self.assertNotIn("synthetic resume", serialized)
+
+    def test_concurrent_cli_acquisition_allows_only_one_global_claim(self):
+        self.json_store("init")
+        profile = self.write_input("concurrent-profile.json", {"firstName": "Synthetic"})
+        self.json_store("profile-replace", "--input", str(profile))
+        resume_path = self.home / "concurrent-resume.pdf"
+        resume_path.write_bytes(b"resume")
+        resume = self.write_input("concurrent-resume.json", {
+            "id": "concurrent-resume", "label": "Concurrent", "path": str(resume_path)
+        })
+        self.json_store("resume-create", "--input", str(resume))
+        for job_id in ("concurrent-a", "concurrent-b"):
+            source = self.write_input(f"{job_id}.json", {
+                "id": job_id, "url": f"https://example.com/jobs/{job_id}",
+                "resumeId": "concurrent-resume",
+            })
+            job = self.json_store("job-create", "--input", str(source))
+            self.json_store(
+                "job-transition", "--id", job_id, "--status", "ready",
+                "--expected-revision", str(job["revision"]),
+            )
+        processes = [
+            subprocess.Popen(
+                [sys.executable, str(SCRIPT), "job-acquire", "--id", job_id,
+                 "--owner", f"agent-{job_id}", "--expected-revision", "2"],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+                env=self.environment,
+            )
+            for job_id in ("concurrent-a", "concurrent-b")
+        ]
+        results = [process.communicate(timeout=10) + (process.returncode,) for process in processes]
+        self.assertEqual(sorted(result[2] for result in results), [0, 2])
+        self.assertIn("live job claim", "\n".join(result[1] for result in results))
+        jobs = {
+            job_id: self.json_store("job-get", "--id", job_id)["status"]
+            for job_id in ("concurrent-a", "concurrent-b")
+        }
+        self.assertEqual(sorted(jobs.values()), ["in_progress", "ready"])
 
     def test_lever_replay_lifecycle_uses_value_free_store_records(self):
         application_id = "qa-run-20260816-ab12cd34"

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
@@ -154,6 +155,7 @@ class StoreTests(unittest.TestCase):
     @unittest.skipIf(os.name == "nt", "POSIX permissions only")
     def test_private_permissions(self):
         self.store.initialize()
+        self.store.claim_status()
         self.assertEqual(stat.S_IMODE(self.root.stat().st_mode), 0o700)
         self.assertEqual(stat.S_IMODE(self.store.sessions_path.stat().st_mode), 0o700)
         for path in (
@@ -162,6 +164,8 @@ class StoreTests(unittest.TestCase):
             self.store.jobs_path,
             self.store.resumes_path,
             self.store.history_path,
+            self.store.coordinator_path,
+            self.store.coordinator_journal_path,
         ):
             self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
 
@@ -332,6 +336,23 @@ class StoreTests(unittest.TestCase):
             self.store.delete_answer(
                 answer["key"], expected_revision=trashed["revision"]
             )["deleted"]
+        )
+
+    def test_profile_noop_and_answer_delete_do_not_reenter_coordinator_lock(self):
+        self.store.replace_profile({"firstName": "Ada"})
+        self.store.claim_status()
+        before = self.store.inspect_profile()
+        unchanged = self.store.patch_profile(
+            {"firstName": "Ada"}, before["revision"], "user"
+        )
+        self.assertEqual(unchanged, before)
+
+        answer = self.store.put_answer(
+            {"question": "Portfolio?", "state": "confirmed", "value": "Yes"}
+        )
+        trashed = self.store.trash_answer(answer["key"], answer["revision"])
+        self.assertTrue(
+            self.store.delete_answer(answer["key"], trashed["revision"])["deleted"]
         )
 
     def test_tampered_sensitive_answer_without_consent_fails_closed(self):
@@ -806,12 +827,16 @@ class StoreTests(unittest.TestCase):
         job = self.store.transition_job(
             job["id"], "ready", expected_revision=job["revision"]
         )
-        job = self.store.transition_job(
-            job["id"], "in_progress", expected_revision=job["revision"]
+        acquired = self.store.acquire_ready_job(
+            job["id"], "unit-test-agent", job["revision"]
         )
-        job = self.store.transition_job(
-            job["id"], "awaiting_review", expected_revision=job["revision"]
+        job = acquired["job"]
+        handoff = self.store.handoff_claimed_job(
+            job["id"], acquired["token"], "awaiting_review",
+            {"status": "review", "step": "review", "pendingFields": []},
+            job["revision"],
         )
+        job = handoff["job"]
         with self.assertRaisesRegex(STORE_MODULE.StoreError, "user confirmation"):
             self.store.transition_job(
                 job["id"], "applied", expected_revision=job["revision"]
@@ -833,6 +858,326 @@ class StoreTests(unittest.TestCase):
             closed_outcome="rejected",
         )
         self.assertEqual((job["status"], job["closedOutcome"]), ("closed", "rejected"))
+
+    def _make_ready_job(self, job_id="ready-job", assigned=False):
+        self.store.replace_profile({"firstName": "Ada"})
+        default_path = self.home / "default.pdf"
+        default_path.write_bytes(b"default-resume")
+        self.store.create_resume(
+            {"id": "default-resume", "label": "Default", "path": str(default_path)}
+        )
+        resume_id = None
+        if assigned:
+            assigned_path = self.home / "assigned.pdf"
+            assigned_path.write_bytes(b"assigned-resume")
+            assigned_resume = self.store.create_resume(
+                {"id": "assigned-resume", "label": "Assigned", "path": str(assigned_path)}
+            )
+            resume_id = assigned_resume["id"]
+        job = self.store.create_job({
+            "id": job_id, "url": f"https://example.com/jobs/{job_id}",
+            "role": "Engineer", "company": "Acme", "resumeId": resume_id,
+        })
+        return self.store.transition_job(job_id, "ready", job["revision"])
+
+    def test_ready_acquisition_is_exclusive_and_uses_assigned_resume(self):
+        self._make_ready_job(assigned=True)
+        ready = self.store.get_job("ready-job")
+        acquired = self.store.acquire_ready_job("ready-job", "codex", ready["revision"])
+        self.assertEqual(acquired["job"]["status"], "in_progress")
+        self.assertEqual(acquired["resume"]["id"], "assigned-resume")
+        self.assertNotIn("tokenHash", acquired["claim"])
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "live job claim"):
+            self.store.acquire_ready_job("ready-job", "claude", ready["revision"])
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "claim token"):
+            self.store.save_claim_progress(
+                "ready-job", "wrong-token", {"status": "active", "step": "form"}
+            )
+        protected = self.store.save_claim_progress(
+            "ready-job", acquired["token"], {"status": "active", "step": "protected"}
+        )
+        for action in (
+            lambda: self.store.save_session(
+                "ready-job", {"status": "review", "step": "overwrite"}
+            ),
+            lambda: self.store.delete_session("ready-job"),
+        ):
+            with self.assertRaisesRegex(
+                STORE_MODULE.StoreError, "coordinator operation"
+            ):
+                action()
+        self.assertEqual(self.store.load_session("ready-job"), protected)
+        events = self.store.read_history()
+        self.assertEqual([event["event"] for event in events], ["job-started"])
+
+    def test_expired_claim_requires_explicit_same_job_recovery_and_rotates_token(self):
+        instant = [datetime(2026, 8, 24, tzinfo=timezone.utc)]
+        self.store = STORE_MODULE.Store(self.root, self.legacy, clock=lambda: instant[0])
+        self._make_ready_job()
+        ready = self.store.get_job("ready-job")
+        acquired = self.store.acquire_ready_job("ready-job", "codex", ready["revision"])
+        instant[0] += timedelta(seconds=301)
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "explicit same-job recovery"):
+            self.store.acquire_ready_job("ready-job", "claude", ready["revision"])
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "claimed job"):
+            self.store.recover_claim("different-job", "claude")
+        recovered = self.store.recover_claim("ready-job", "claude")
+        self.assertNotEqual(recovered["token"], acquired["token"])
+        self.assertEqual(
+            [event["event"] for event in self.store.read_history()],
+            ["job-started", "claim-recovered"],
+        )
+
+    def test_claim_handoffs_are_atomic_value_free_and_release_ownership(self):
+        self._make_ready_job()
+        ready = self.store.get_job("ready-job")
+        acquired = self.store.acquire_ready_job("ready-job", "codex", ready["revision"])
+        pending = {
+            "status": "active", "step": "questions", "answerKeys": ["question.safe"],
+            "pendingFields": [{"question": "Authorization?", "state": "missing", "answerKey": "question.safe", "sensitive": False}],
+        }
+        self.store.save_claim_progress("ready-job", acquired["token"], pending)
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "unsupported fields"):
+            self.store.save_claim_progress(
+                "ready-job", acquired["token"],
+                {"status": "active", "pendingFields": [{"question": "Salary?", "value": "250K"}]},
+            )
+        handoff = self.store.handoff_claimed_job(
+            "ready-job", acquired["token"], "needs_info", pending,
+            acquired["job"]["revision"],
+        )
+        self.assertEqual(handoff["job"]["status"], "needs_info")
+        self.assertIsNone(self.store.claim_status()["claim"])
+        stored = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in (self.store.coordinator_path, self.store.coordinator_journal_path,
+                         self.store.history_path, self.store._session_path("ready-job"))
+        )
+        self.assertNotIn(acquired["token"], stored)
+        self.assertNotIn("250K", stored)
+        self.assertEqual([event["event"] for event in self.store.read_history()], ["job-started", "job-blocked"])
+
+    def test_coordinator_journal_rolls_forward_after_partial_failure_without_duplicates(self):
+        self._make_ready_job()
+        original = STORE_MODULE.atomic_write_json
+        failed = {"done": False}
+
+        def fail_coordinator_once(path, payload):
+            if path == self.store.coordinator_path and payload.get("claim") is not None and not failed["done"]:
+                failed["done"] = True
+                raise OSError("simulated crash")
+            return original(path, payload)
+
+        with mock.patch.object(STORE_MODULE, "atomic_write_json", side_effect=fail_coordinator_once):
+            with self.assertRaises(OSError):
+                ready = self.store.get_job("ready-job")
+                self.store.acquire_ready_job(
+                    "ready-job", "codex", ready["revision"]
+                )
+        repaired = STORE_MODULE.Store(self.root, self.legacy)
+        status = repaired.claim_status()
+        self.assertIsNotNone(status["claim"])
+        self.assertEqual(repaired.get_job("ready-job")["status"], "in_progress")
+        self.assertEqual([event["event"] for event in repaired.read_history()], ["job-started"])
+        self.assertIsNone(repaired._load_coordinator_journal()["operation"])
+
+    def test_claimed_jobs_reject_generic_mutations_and_divergence_claim_actions(self):
+        ready = self._make_ready_job()
+        acquired = self.store.acquire_ready_job("ready-job", "codex", ready["revision"])
+        revision = acquired["job"]["revision"]
+        for action in (
+            lambda: self.store.transition_job("ready-job", "awaiting_review", revision),
+            lambda: self.store.trash_job("ready-job", revision),
+            lambda: self.store.delete_job("ready-job", revision),
+        ):
+            with self.assertRaisesRegex(STORE_MODULE.StoreError, "coordinator operation"):
+                action()
+
+        document = json.loads(self.store.jobs_path.read_text(encoding="utf-8"))
+        document["jobs"]["ready-job"]["status"] = "awaiting_review"
+        document["jobs"]["ready-job"]["revision"] += 1
+        self.store.jobs_path.write_text(json.dumps(document), encoding="utf-8")
+        for action in (
+            lambda: self.store.heartbeat_claim("ready-job", acquired["token"]),
+            lambda: self.store.save_claim_progress(
+                "ready-job", acquired["token"], {"status": "active", "step": "form"}
+            ),
+            lambda: self.store.handoff_claimed_job(
+                "ready-job", acquired["token"], "awaiting_review",
+                {"status": "review", "step": "review"}, revision + 1,
+            ),
+            lambda: self.store.recover_claim("ready-job", "recovery-agent"),
+        ):
+            with self.assertRaisesRegex(STORE_MODULE.StoreError, "not in progress"):
+                action()
+
+    def test_lease_boundary_expires_exactly_at_expires_at(self):
+        instant = [datetime(2026, 8, 24, tzinfo=timezone.utc)]
+        self.store = STORE_MODULE.Store(self.root, self.legacy, clock=lambda: instant[0])
+        ready = self._make_ready_job()
+        acquired = self.store.acquire_ready_job("ready-job", "codex", ready["revision"])
+        instant[0] += timedelta(seconds=STORE_MODULE.CLAIM_LEASE_SECONDS)
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "claim has expired"):
+            self.store.heartbeat_claim("ready-job", acquired["token"])
+        recovered = self.store.recover_claim("ready-job", "recovery-agent")
+        self.assertNotEqual(recovered["token"], acquired["token"])
+
+    def test_expected_revisions_and_default_resume_are_enforced(self):
+        ready = self._make_ready_job()
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "revision conflict"):
+            self.store.acquire_ready_job("ready-job", "codex", ready["revision"] - 1)
+        acquired = self.store.acquire_ready_job("ready-job", "codex", ready["revision"])
+        self.assertEqual(acquired["resume"]["id"], "default-resume")
+        updated = self.store.update_job(
+            "ready-job", {"notes": "human update"}, acquired["job"]["revision"]
+        )
+        review = {"status": "review", "step": "review", "pendingFields": []}
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "revision conflict"):
+            self.store.handoff_claimed_job(
+                "ready-job", acquired["token"], "awaiting_review", review,
+                acquired["job"]["revision"],
+            )
+        self.assertIsNotNone(self.store.claim_status()["claim"])
+        handed = self.store.handoff_claimed_job(
+            "ready-job", acquired["token"], "awaiting_review", review,
+            updated["revision"],
+        )
+        self.assertEqual(handed["job"]["status"], "awaiting_review")
+
+    def test_acquisition_and_handoff_roll_forward_at_each_failure_boundary(self):
+        original_write = STORE_MODULE.atomic_write_json
+
+        def ready_store(case):
+            root = self.home / "boundaries" / case
+            store = STORE_MODULE.Store(root, self.legacy)
+            store.replace_profile({"firstName": "Ada"})
+            resume_path = root / "resume.pdf"
+            resume_path.write_bytes(b"resume")
+            store.create_resume({"id": "resume", "label": "Resume", "path": str(resume_path)})
+            job = store.create_job({"id": "job", "url": f"https://example.com/{case}"})
+            ready = store.transition_job("job", "ready", job["revision"])
+            store.claim_status()
+            return store, ready
+
+        acquisition_boundaries = {
+            "journal-write": lambda store, path, payload: path == store.coordinator_journal_path and payload.get("operation") is not None,
+            "jobs": lambda store, path, payload: path == store.jobs_path,
+            "history": None,
+            "coordinator": lambda store, path, payload: path == store.coordinator_path and payload.get("claim") is not None,
+            "journal-clear": lambda store, path, payload: path == store.coordinator_journal_path and payload.get("operation") is None,
+        }
+        for name, predicate in acquisition_boundaries.items():
+            with self.subTest(operation="acquire", boundary=name):
+                store, ready = ready_store(f"acquire-{name}")
+                if name == "history":
+                    patcher = mock.patch.object(
+                        store, "_append_history_event_idempotent_locked",
+                        side_effect=OSError("simulated crash"),
+                    )
+                else:
+                    failed = {"done": False}
+                    def fail_once(path, payload, predicate=predicate, store=store):
+                        if predicate(store, path, payload) and not failed["done"]:
+                            failed["done"] = True
+                            raise OSError("simulated crash")
+                        return original_write(path, payload)
+                    patcher = mock.patch.object(STORE_MODULE, "atomic_write_json", side_effect=fail_once)
+                with patcher, self.assertRaises(OSError):
+                    store.acquire_ready_job("job", "agent", ready["revision"])
+                repaired = STORE_MODULE.Store(store.root, self.legacy)
+                if name == "journal-write":
+                    self.assertIsNone(repaired.claim_status()["claim"])
+                    self.assertEqual(repaired.get_job("job")["status"], "ready")
+                    self.assertEqual(repaired.read_history(), [])
+                    continue
+                self.assertIsNotNone(repaired.claim_status()["claim"])
+                self.assertEqual(repaired.get_job("job")["status"], "in_progress")
+                self.assertEqual([event["event"] for event in repaired.read_history()], ["job-started"])
+
+        handoff_boundaries = {
+            "journal-write": lambda store, path, payload: path == store.coordinator_journal_path and payload.get("operation") is not None,
+            "jobs": lambda store, path, payload: path == store.jobs_path,
+            "session": lambda store, path, payload: path == store._session_path("job"),
+            "history": None,
+            "coordinator": lambda store, path, payload: path == store.coordinator_path and payload.get("claim") is None,
+            "journal-clear": lambda store, path, payload: path == store.coordinator_journal_path and payload.get("operation") is None,
+        }
+        for name, predicate in handoff_boundaries.items():
+            with self.subTest(operation="handoff", boundary=name):
+                store, ready = ready_store(f"handoff-{name}")
+                acquired = store.acquire_ready_job("job", "agent", ready["revision"])
+                if name == "history":
+                    patcher = mock.patch.object(
+                        store, "_append_history_event_idempotent_locked",
+                        side_effect=OSError("simulated crash"),
+                    )
+                else:
+                    failed = {"done": False}
+                    def fail_once(path, payload, predicate=predicate, store=store):
+                        if predicate(store, path, payload) and not failed["done"]:
+                            failed["done"] = True
+                            raise OSError("simulated crash")
+                        return original_write(path, payload)
+                    patcher = mock.patch.object(STORE_MODULE, "atomic_write_json", side_effect=fail_once)
+                with patcher, self.assertRaises(OSError):
+                    store.handoff_claimed_job(
+                        "job", acquired["token"], "awaiting_review",
+                        {"status": "review", "step": "review"},
+                        acquired["job"]["revision"],
+                    )
+                repaired = STORE_MODULE.Store(store.root, self.legacy)
+                if name == "journal-write":
+                    self.assertIsNotNone(repaired.claim_status()["claim"])
+                    self.assertEqual(repaired.get_job("job")["status"], "in_progress")
+                    self.assertFalse(repaired._session_path("job").exists())
+                    self.assertEqual(
+                        [event["event"] for event in repaired.read_history()],
+                        ["job-started"],
+                    )
+                    continue
+                self.assertIsNone(repaired.claim_status()["claim"])
+                self.assertEqual(repaired.get_job("job")["status"], "awaiting_review")
+                self.assertEqual(repaired.load_session("job")["status"], "review")
+                self.assertEqual(
+                    [event["event"] for event in repaired.read_history()],
+                    ["job-started", "reviewed"],
+                )
+
+    def test_pending_coordinator_operation_repairs_partial_history_tail(self):
+        ready = self._make_ready_job()
+
+        def append_partial_then_crash(event):
+            encoded = (
+                json.dumps(event, sort_keys=True, ensure_ascii=False) + "\n"
+            ).encode("utf-8")
+            descriptor = os.open(
+                self.store.history_path,
+                os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+                0o600,
+            )
+            try:
+                os.write(descriptor, encoded[: len(encoded) // 2])
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+            raise OSError("simulated process crash after partial append")
+
+        with mock.patch.object(
+            self.store,
+            "_append_history_event_idempotent_locked",
+            side_effect=append_partial_then_crash,
+        ):
+            with self.assertRaisesRegex(OSError, "partial append"):
+                self.store.acquire_ready_job("ready-job", "codex", ready["revision"])
+
+        self.assertFalse(self.store.history_path.read_bytes().endswith(b"\n"))
+        repaired = STORE_MODULE.Store(self.root, self.legacy)
+        self.assertIsNotNone(repaired.claim_status()["claim"])
+        self.assertEqual(repaired.get_job("ready-job")["status"], "in_progress")
+        self.assertEqual(
+            [event["event"] for event in repaired.read_history()], ["job-started"]
+        )
+        self.assertIsNone(repaired._load_coordinator_journal()["operation"])
 
     def test_ready_transition_fails_closed_without_profile_or_resume(self):
         job = self.store.create_job(


### PR DESCRIPTION
## Summary

- add an exclusive, leased coordinator for canonical ready-job acquisition, heartbeat, progress, recovery, and terminal handoff
- atomically keep job status, value-free session metadata, lifecycle history, and claim release consistent across crashes
- resolve assigned/default resumes and wire the existing visible-browser application skill to the shared durable store while preserving direct-URL compatibility and manual submission
- add the completed GoalBuddy specification/state and regression coverage for concurrency, revision drift, crash boundaries, privacy, and CLI integration

## PR review fixes

- repair partial history tails before journal roll-forward and avoid coordinator lock re-entry deadlocks
- prevent generic session mutations from bypassing canonical job ownership
- make expired-claim discovery and recovery identify the actual claimed job
- pass complete handoff commands and retain the acquisition revision so concurrent edits fail visibly
- accurately document bearer-token transport and the caller responsibility for value-free metadata strings

## Verification

- `PYTHONPATH=tests python3 -m unittest -q test_job_apply_store test_answer_memory_integration` — 62 passed
- `python3 -m unittest discover -s tests -v` — 347 passed
- `bash scripts/smoke-plugin.sh` — passed
- `git diff --check` — passed

Base: `staging`. This PR intentionally does not target `main`.
