### PR TITLE
Add guided legacy job migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,39 @@ Each file contains:
 - Connection and hiring manager information
 - Priority ranking
 
+### Guided legacy job migration
+
+The helper can selectively import the documented numbered job entries from
+regular `search-*.md` files directly under `~/.claude-job-searches/`. It does
+not read `application_queue.md`, arbitrary paths, nested directories, or
+symlinks. Undocumented Markdown variants are not imported, and the helper never
+modifies report files.
+
+Discover candidates without changing or creating the canonical store:
+
+```bash
+python3 scripts/job-apply-store.py legacy-jobs-preview
+```
+
+Invalid entries remain visible with a reason. Preview chosen valid `itemId`
+values by repeating `--select`, then commit only after reviewing that exact
+selected preview:
+
+```bash
+python3 scripts/job-apply-store.py legacy-jobs-preview \
+  --select <item-id> --select <item-id>
+```
+
+Use `legacy-jobs-commit` with the identical ordered selection and the selected
+preview's confirmation token; `legacy-jobs-commit --help` shows the token option.
+
+Commit fails closed if the selection, any discovered report, parsed payload, or
+canonical job store changed. Imported records carry value-free migration
+provenance. Migration can create jobs, fill empty fields, and refresh
+migration-authored fields; it never overwrites nonempty human- or agent-authored
+values. The canonical job store is authoritative after import; Markdown export,
+mutation, and two-way sync are not supported.
+
 ## Safety Features
 
 - **Never handles credentials** - Pauses for you to complete login, password, CAPTCHA, or MFA steps

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -59,6 +59,7 @@ JOB_CLOSED_OUTCOMES = {
     "not_interested",
 }
 JOB_ORIGINS = {"human", "agent"}
+JOB_PROVENANCE_ORIGINS = JOB_ORIGINS | {"migration"}
 JOB_INGEST_FIELDS = {
     "url",
     "source",
@@ -90,6 +91,11 @@ REPLAY_ATS = {"ashby", "greenhouse", "lever", "linkedin-easy-apply"}
 SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 CLAIM_LEASE_SECONDS = 300
 CLAIM_HEARTBEAT_SECONDS = 60
+LEGACY_SEARCH_ROOT = ".claude-job-searches"
+LEGACY_SEARCH_MAX_FILES = 100
+LEGACY_SEARCH_MAX_FILE_BYTES = 2 * 1024 * 1024
+LEGACY_SEARCH_MAX_TOTAL_BYTES = 20 * 1024 * 1024
+LEGACY_SEARCH_MAX_ENTRIES = 5_000
 
 
 class StoreError(Exception):
@@ -331,7 +337,7 @@ def _job_field_provenance(
     provenance: dict[str, Any], field: str
 ) -> dict[str, Any] | None:
     value = provenance.get(f"/{_json_pointer_segment(field)}")
-    if not isinstance(value, dict) or value.get("origin") not in JOB_ORIGINS:
+    if not isinstance(value, dict) or value.get("origin") not in JOB_PROVENANCE_ORIGINS:
         return None
     return value
 
@@ -343,6 +349,44 @@ def _agent_may_update_job_field(
     if authored is not None:
         return authored["origin"] == "agent"
     return not _nonempty_job_value(record.get(field))
+
+
+def _migration_may_update_job_field(
+    record: dict[str, Any], provenance: dict[str, Any], field: str
+) -> bool:
+    if not _nonempty_job_value(record.get(field)):
+        return True
+    authored = _job_field_provenance(provenance, field)
+    if authored is not None:
+        return authored["origin"] == "migration"
+    return False
+
+
+def _reject_supplied_migration_provenance(provenance: dict[str, Any]) -> None:
+    if any(
+        isinstance(value, dict) and value.get("origin") == "migration"
+        for value in provenance.values()
+    ):
+        raise StoreError("migration provenance is reserved for guided legacy imports")
+
+
+def _validate_migration_provenance_replacement(
+    current: dict[str, Any], replacement: dict[str, Any]
+) -> None:
+    protected_paths = {
+        path
+        for path in set(current) | set(replacement)
+        if (
+            isinstance(current.get(path), dict)
+            and current[path].get("origin") == "migration"
+        )
+        or (
+            isinstance(replacement.get(path), dict)
+            and replacement[path].get("origin") == "migration"
+        )
+    }
+    if any(current.get(path) != replacement.get(path) for path in protected_paths):
+        raise StoreError("migration provenance is reserved for guided legacy imports")
 
 
 def _stamp_job_provenance(
@@ -562,6 +606,7 @@ def _validate_job_record(key: str, value: Any) -> dict[str, Any]:
         "resumeId",
         "notes",
         "provenance",
+        "legacySources",
         "lastCheckedAt",
         "revision",
         "createdAt",
@@ -592,6 +637,32 @@ def _validate_job_record(key: str, value: Any) -> dict[str, Any]:
         raise StoreError("job revision must be a positive integer")
     provenance = record.get("provenance", {})
     _require_object(provenance, "job provenance")
+    legacy_sources = record.get("legacySources", [])
+    if not isinstance(legacy_sources, list):
+        raise StoreError("job legacySources must be an array")
+    for source in legacy_sources:
+        source = _require_object(source, "job legacy source")
+        if set(source) != {"sourceKind", "relativePath", "entryId", "sourceSha256"}:
+            raise StoreError("job legacy source contains unsupported fields")
+        if source.get("sourceKind") != "timestamped-search-report":
+            raise StoreError("job legacy source kind is unsupported")
+        relative_path = source.get("relativePath")
+        if (
+            not isinstance(relative_path, str)
+            or not relative_path
+            or Path(relative_path).name != relative_path
+            or not relative_path.startswith("search-")
+            or not relative_path.endswith(".md")
+        ):
+            raise StoreError("job legacy source path is invalid")
+        if not isinstance(source.get("entryId"), str) or not re.fullmatch(
+            r"legacy-entry-[0-9a-f]{24}", source["entryId"]
+        ):
+            raise StoreError("job legacy source entry id is invalid")
+        if not isinstance(source.get("sourceSha256"), str) or not re.fullmatch(
+            r"[0-9a-f]{64}", source["sourceSha256"]
+        ):
+            raise StoreError("job legacy source digest is invalid")
     _validate_optional_strings(
         record,
         {
@@ -1433,6 +1504,7 @@ class Store:
         incoming_provenance = _require_object(
             incoming.get("provenance", {}), "job provenance"
         )
+        _reject_supplied_migration_provenance(incoming_provenance)
         stamped_fields = {
             field
             for field in JOB_INGEST_FIELDS
@@ -1605,14 +1677,21 @@ class Store:
             provenance_changed = False
             if origin == "human" and "provenance" in patch:
                 provenance = _require_object(patch["provenance"], "job provenance")
+                _validate_migration_provenance_replacement(
+                    current_provenance, provenance
+                )
                 provenance_changed = provenance != current_provenance
             accepted: dict[str, Any] = {}
             for field, value in patch.items():
                 if field == "provenance":
                     continue
-                if origin == "agent" and not _nonempty_job_value(value):
+                if origin in {"agent", "migration"} and not _nonempty_job_value(value):
                     continue
                 if origin == "agent" and not _agent_may_update_job_field(
+                    current, current_provenance, field
+                ):
+                    continue
+                if origin == "migration" and not _migration_may_update_job_field(
                     current, current_provenance, field
                 ):
                     continue
@@ -1750,8 +1829,12 @@ class Store:
         payload: dict[str, Any],
         origin: str,
         now: str,
+        *,
+        _allow_migration: bool = False,
+        _target_ids: list[str | None] | None = None,
     ) -> tuple[dict[str, Any], list[dict[str, Any]], bool]:
-        origin = _job_origin(origin)
+        if not (_allow_migration and origin == "migration"):
+            origin = _job_origin(origin)
         raw_jobs = self._job_upsert_payload(payload)
         normalized: list[dict[str, Any] | None] = []
         errors: list[str | None] = []
@@ -1801,6 +1884,10 @@ class Store:
                 continue
 
             jobs = simulated["jobs"]
+            target_id = _target_ids[index] if _target_ids is not None else None
+            target_matches = (
+                [jobs[target_id]] if target_id is not None and target_id in jobs else []
+            )
             url_matches = [
                 record
                 for record in jobs.values()
@@ -1816,7 +1903,10 @@ class Store:
                 if source_identity is not None
                 else []
             )
-            matches = {record["id"]: record for record in url_matches + source_matches}
+            matches = {
+                record["id"]: record
+                for record in url_matches + source_matches + target_matches
+            }
             if (
                 len(url_matches) > 1
                 or len(source_matches) > 1
@@ -1834,26 +1924,48 @@ class Store:
 
             current = next(iter(matches.values()), None)
             if current is not None:
+                provenance = _require_object(
+                    current.get("provenance", {}), "job provenance"
+                )
                 current_source = self._source_identity(current)
+                source_changed = (
+                    _nonempty_job_value(current.get("source"))
+                    and _nonempty_job_value(item.get("source"))
+                    and _normalized_job_source(current.get("source"))
+                    != _normalized_job_source(item.get("source"))
+                )
+                source_id_changed = (
+                    _nonempty_job_value(current.get("sourceId"))
+                    and _nonempty_job_value(item.get("sourceId"))
+                    and current.get("sourceId", "").strip()
+                    != item.get("sourceId", "").strip()
+                )
+                migration_identity_refresh = origin == "migration" and (
+                    current.get("normalizedUrl") == item["normalizedUrl"]
+                    or target_id == current["id"]
+                )
+                migration_url_refresh = (
+                    origin == "migration"
+                    and target_id == current["id"]
+                    and _migration_may_update_job_field(
+                        current, provenance, "url"
+                    )
+                )
                 if (
-                    current.get("normalizedUrl") != item["normalizedUrl"]
-                    or (
-                        current_source is not None
-                        and source_identity is not None
-                        and current_source != source_identity
+                    (
+                        current.get("normalizedUrl") != item["normalizedUrl"]
+                        and not migration_url_refresh
                     )
                     or (
-                        _nonempty_job_value(current.get("source"))
-                        and _nonempty_job_value(item.get("source"))
-                        and _normalized_job_source(current.get("source"))
-                        != _normalized_job_source(item.get("source"))
+                        (
+                            current_source is not None
+                            and source_identity is not None
+                            and current_source != source_identity
+                        )
+                        or source_changed
+                        or source_id_changed
                     )
-                    or (
-                        _nonempty_job_value(current.get("sourceId"))
-                        and _nonempty_job_value(item.get("sourceId"))
-                        and current.get("sourceId", "").strip()
-                        != item.get("sourceId", "").strip()
-                    )
+                    and not migration_identity_refresh
                 ):
                     decisions.append(
                         {
@@ -1864,15 +1976,16 @@ class Store:
                         }
                     )
                     continue
-                provenance = _require_object(
-                    current.get("provenance", {}), "job provenance"
-                )
                 accepted: dict[str, Any] = {}
                 for field in JOB_INGEST_FIELDS:
-                    if field not in item or field == "url":
+                    if field not in item or (field == "url" and not migration_url_refresh):
                         continue
                     value = item[field]
                     if origin == "agent" and not _agent_may_update_job_field(
+                        current, provenance, field
+                    ):
+                        continue
+                    if origin == "migration" and not _migration_may_update_job_field(
                         current, provenance, field
                     ):
                         continue
@@ -1884,6 +1997,8 @@ class Store:
                     )
                     continue
                 updated = {**current, **accepted}
+                if "url" in accepted:
+                    updated["normalizedUrl"] = item["normalizedUrl"]
                 updated["provenance"] = _stamp_job_provenance(
                     provenance,
                     list(accepted),
@@ -1987,6 +2102,384 @@ class Store:
             if changed:
                 atomic_write_json(self.jobs_path, planned)
         return self._upsert_result(token, decisions, committed=changed)
+
+    @staticmethod
+    def _read_legacy_search_file(
+        root_descriptor: int | None,
+        root: Path,
+        name: str,
+        metadata: os.stat_result,
+    ) -> bytes:
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = (
+                os.open(root / name, flags)
+                if root_descriptor is None
+                else os.open(name, flags, dir_fd=root_descriptor)
+            )
+        except OSError as error:
+            raise StoreError("legacy search report cannot be opened safely") from error
+        try:
+            opened = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or opened.st_dev != metadata.st_dev
+                or opened.st_ino != metadata.st_ino
+                or opened.st_size != metadata.st_size
+            ):
+                raise StoreError("legacy search report changed during discovery")
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                chunk = os.read(descriptor, min(65536, LEGACY_SEARCH_MAX_FILE_BYTES + 1 - total))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                total += len(chunk)
+                if total > LEGACY_SEARCH_MAX_FILE_BYTES:
+                    raise StoreError("legacy search report exceeds the per-file byte limit")
+            closed = os.fstat(descriptor)
+            if closed.st_size != opened.st_size:
+                raise StoreError("legacy search report changed during discovery")
+            return b"".join(chunks)
+        finally:
+            os.close(descriptor)
+
+    @staticmethod
+    def _parse_legacy_search_report(
+        relative_path: str, source_sha256: str, text: str
+    ) -> list[dict[str, Any]]:
+        lines = text.splitlines()
+        starts = [index for index, line in enumerate(lines) if line.startswith("###")]
+        items: list[dict[str, Any]] = []
+        heading_identities = [
+            re.sub(r"^###\s+\d+\.\s*", "", lines[start]).strip()
+            for start in starts
+        ]
+        heading_totals = {
+            identity: heading_identities.count(identity)
+            for identity in set(heading_identities)
+        }
+        content_occurrences: dict[str, int] = {}
+        for ordinal, start in enumerate(starts, 1):
+            end = starts[ordinal] if ordinal < len(starts) else len(lines)
+            heading = lines[start]
+            heading_identity = heading_identities[ordinal - 1]
+            content_identity = heading_identity
+            if heading_totals[heading_identity] > 1:
+                content_identity = "\n".join(
+                    [heading_identity, *lines[start + 1 : end]]
+                ).strip()
+            content_occurrence = content_occurrences.get(content_identity, 0) + 1
+            content_occurrences[content_identity] = content_occurrence
+            entry_id = "legacy-entry-" + hashlib.sha256(
+                f"{relative_path}\0{content_identity}\0{content_occurrence}".encode("utf-8")
+            ).hexdigest()[:24]
+            item_id = "legacy-item-" + hashlib.sha256(
+                entry_id.encode("utf-8")
+            ).hexdigest()[:24]
+            locator = {
+                "sourceKind": "timestamped-search-report",
+                "relativePath": relative_path,
+                "entryId": entry_id,
+                "sourceSha256": source_sha256,
+            }
+
+            heading_match = re.fullmatch(r"###\s+\d+\.\s+(.+?)\s+—\s+(.+)", heading)
+            if heading_match is None:
+                items.append({"itemId": item_id, "state": "invalid", "reason": "unsupported_heading", "source": locator})
+                continue
+            role = heading_match.group(1).strip()
+            company = re.sub(r"\s+\(Score:\s*[^)]*\)\s*$", "", heading_match.group(2)).strip()
+            if not role or not company:
+                items.append({"itemId": item_id, "state": "invalid", "reason": "incomplete_heading", "source": locator})
+                continue
+
+            labels: dict[str, str] = {}
+            duplicate = False
+            for line in lines[start + 1 : end]:
+                field = re.fullmatch(r"- \*\*([^*]+)\*\*:\s*(.*)", line)
+                if field is None:
+                    continue
+                label = field.group(1).strip().lower()
+                if label in labels:
+                    duplicate = True
+                    break
+                labels[label] = field.group(2).strip()
+            if duplicate:
+                items.append({"itemId": item_id, "state": "invalid", "reason": "duplicate_field", "source": locator})
+                continue
+
+            url_candidates = []
+            for label in ("url", "apply"):
+                value = labels.get(label, "")
+                if re.fullmatch(r"https?://\S+", value):
+                    try:
+                        normalized = normalize_job_url(value)
+                    except StoreError:
+                        continue
+                    url_candidates.append((value, normalized))
+            unique_urls = {normalized for _value, normalized in url_candidates}
+            if not url_candidates:
+                items.append({"itemId": item_id, "state": "invalid", "reason": "missing_url", "source": locator})
+                continue
+            if len(unique_urls) != 1:
+                items.append({"itemId": item_id, "state": "invalid", "reason": "ambiguous_url", "source": locator})
+                continue
+
+            job: dict[str, Any] = {"url": url_candidates[0][0], "role": role, "company": company}
+            mappings = {
+                "source": "source",
+                "location": "location",
+                "salary": "compensation",
+                "description": "description",
+            }
+            for label, canonical in mappings.items():
+                if labels.get(label):
+                    job[canonical] = labels[label]
+            items.append({"itemId": item_id, "state": "valid", "source": locator, "job": job})
+        return items
+
+    def _discover_legacy_jobs(self) -> dict[str, Any]:
+        root = Path.home() / LEGACY_SEARCH_ROOT
+        try:
+            root_metadata = root.lstat()
+        except FileNotFoundError:
+            return {"root": f"~/{LEGACY_SEARCH_ROOT}", "manifest": [], "items": []}
+        except OSError as error:
+            raise StoreError("legacy search root cannot be inspected") from error
+        if not stat.S_ISDIR(root_metadata.st_mode) or stat.S_ISLNK(root_metadata.st_mode):
+            raise StoreError("legacy search root must be a regular directory")
+
+        root_descriptor: int | None = None
+        if os.name != "nt":
+            root_flags = (
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+            )
+            try:
+                root_descriptor = os.open(root, root_flags)
+            except OSError as error:
+                raise StoreError("legacy search root cannot be opened safely") from error
+        manifest: list[dict[str, Any]] = []
+        items: list[dict[str, Any]] = []
+        aggregate = 0
+        try:
+            opened_root = (
+                root.lstat()
+                if root_descriptor is None
+                else os.fstat(root_descriptor)
+            )
+            if (
+                not stat.S_ISDIR(opened_root.st_mode)
+                or opened_root.st_dev != root_metadata.st_dev
+                or opened_root.st_ino != root_metadata.st_ino
+            ):
+                raise StoreError("legacy search root changed during discovery")
+            paths = sorted(
+                name
+                for name in os.listdir(root if root_descriptor is None else root_descriptor)
+                if name.startswith("search-") and name.endswith(".md")
+            )
+            if len(paths) > LEGACY_SEARCH_MAX_FILES:
+                raise StoreError("legacy search discovery exceeds the file limit")
+            for name in paths:
+                try:
+                    metadata = (
+                        (root / name).lstat()
+                        if root_descriptor is None
+                        else os.stat(
+                            name, dir_fd=root_descriptor, follow_symlinks=False
+                        )
+                    )
+                except OSError as error:
+                    raise StoreError("legacy search report cannot be inspected") from error
+                if not stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+                    raise StoreError("legacy search reports must be regular files")
+                if metadata.st_size > LEGACY_SEARCH_MAX_FILE_BYTES:
+                    raise StoreError("legacy search report exceeds the per-file byte limit")
+                aggregate += metadata.st_size
+                if aggregate > LEGACY_SEARCH_MAX_TOTAL_BYTES:
+                    raise StoreError("legacy search discovery exceeds the aggregate byte limit")
+                raw = self._read_legacy_search_file(
+                    root_descriptor, root, name, metadata
+                )
+                try:
+                    decoded = raw.decode("utf-8")
+                except UnicodeDecodeError as error:
+                    raise StoreError("legacy search report is not valid UTF-8") from error
+                digest = hashlib.sha256(raw).hexdigest()
+                manifest.append({"relativePath": name, "sourceSha256": digest, "size": len(raw)})
+                items.extend(self._parse_legacy_search_report(name, digest, decoded))
+                if len(items) > LEGACY_SEARCH_MAX_ENTRIES:
+                    raise StoreError("legacy search discovery exceeds the entry limit")
+        finally:
+            if root_descriptor is not None:
+                os.close(root_descriptor)
+        if root_descriptor is None:
+            try:
+                closed_root = root.lstat()
+            except OSError as error:
+                raise StoreError("legacy search root changed during discovery") from error
+            if (
+                not stat.S_ISDIR(closed_root.st_mode)
+                or closed_root.st_dev != root_metadata.st_dev
+                or closed_root.st_ino != root_metadata.st_ino
+            ):
+                raise StoreError("legacy search root changed during discovery")
+        return {"root": f"~/{LEGACY_SEARCH_ROOT}", "manifest": manifest, "items": items}
+
+    def _migration_jobs_snapshot(self) -> tuple[dict[str, Any], Any]:
+        if self.jobs_path.exists():
+            document = self._load_jobs_document()
+            return document, document
+        document = {
+            "schemaVersion": SCHEMA_VERSION,
+            "jobs": {},
+            "metadata": {"createdAt": "1970-01-01T00:00:00Z", "updatedAt": "1970-01-01T00:00:00Z"},
+        }
+        return document, {"state": "missing"}
+
+    @staticmethod
+    def _selected_legacy_items(discovery: dict[str, Any], selected: list[str]) -> list[dict[str, Any]]:
+        if len(selected) != len(set(selected)):
+            raise StoreError("legacy job selection contains duplicate item ids")
+        indexed = {item["itemId"]: item for item in discovery["items"]}
+        chosen: list[dict[str, Any]] = []
+        for item_id in selected:
+            item = indexed.get(item_id)
+            if item is None:
+                raise StoreError("legacy job selection contains an unknown item id")
+            if item["state"] != "valid":
+                raise StoreError("legacy job selection contains an invalid item")
+            chosen.append(item)
+        return chosen
+
+    @staticmethod
+    def _legacy_jobs_token(
+        discovery: dict[str, Any], selected: list[str], chosen: list[dict[str, Any]], snapshot: Any
+    ) -> str:
+        bound = {
+            "version": 1,
+            "origin": "migration",
+            "selection": selected,
+            "payloads": [item["job"] for item in chosen],
+            "selectedLocators": [item["source"] for item in chosen],
+            "manifest": discovery["manifest"],
+            "jobsSnapshot": snapshot,
+        }
+        return "legacy-jobs-v1." + hashlib.sha256(_canonical_json(bound).encode("utf-8")).hexdigest()
+
+    def _plan_legacy_jobs(
+        self, document: dict[str, Any], chosen: list[dict[str, Any]], now: str
+    ) -> tuple[dict[str, Any], list[dict[str, Any]], bool]:
+        payload = {"jobs": [item["job"] for item in chosen]}
+        target_ids: list[str | None] = []
+        for item in chosen:
+            locator = item["source"]
+            identity = (
+                locator["sourceKind"],
+                locator["relativePath"],
+                locator["entryId"],
+            )
+            matches = [
+                record["id"]
+                for record in document["jobs"].values()
+                if any(
+                    (
+                        source["sourceKind"],
+                        source["relativePath"],
+                        source["entryId"],
+                    )
+                    == identity
+                    for source in record.get("legacySources", [])
+                )
+            ]
+            if len(matches) > 1:
+                raise StoreError("legacy source locator resolves to multiple jobs")
+            target_ids.append(matches[0] if matches else None)
+        planned, decisions, changed = self._plan_job_upsert(
+            document,
+            payload,
+            "migration",
+            now,
+            _allow_migration=True,
+            _target_ids=target_ids,
+        )
+        for item, decision in zip(chosen, decisions):
+            decision["itemId"] = item["itemId"]
+            if decision["action"] in {"conflict", "invalid"}:
+                continue
+            record = planned["jobs"][decision["id"]]
+            sources = list(record.get("legacySources", []))
+            locator = item["source"]
+            identity = (locator["sourceKind"], locator["relativePath"], locator["entryId"])
+            replaced = False
+            merged = []
+            for source in sources:
+                source_identity = (source["sourceKind"], source["relativePath"], source["entryId"])
+                if source_identity == identity:
+                    merged.append(locator)
+                    replaced = True
+                else:
+                    merged.append(source)
+            if not replaced:
+                merged.append(locator)
+            merged.sort(key=lambda source: (source["relativePath"], source["entryId"]))
+            if merged != sources:
+                record["legacySources"] = merged
+                if decision["action"] == "noop":
+                    record["revision"] += 1
+                    record["updatedAt"] = now
+                    decision["action"] = "update"
+                    decision["fields"] = ["legacySources"]
+                elif decision["action"] == "update":
+                    decision["fields"] = sorted(set(decision.get("fields", [])) | {"legacySources"})
+                changed = True
+                planned["metadata"]["updatedAt"] = now
+                _validate_job_record(record["id"], record)
+        if document["metadata"].get("createdAt") == "1970-01-01T00:00:00Z" and changed:
+            planned["metadata"]["createdAt"] = now
+        return planned, decisions, changed
+
+    @staticmethod
+    def _legacy_result(
+        discovery: dict[str, Any], selected: list[str], decisions: list[dict[str, Any]] | None = None,
+        token: str | None = None, committed: bool = False,
+    ) -> dict[str, Any]:
+        result = {"root": discovery["root"], "manifest": discovery["manifest"], "items": discovery["items"], "selected": selected, "committed": committed}
+        if decisions is not None:
+            counts = {action: 0 for action in ("create", "update", "noop", "conflict", "invalid")}
+            for decision in decisions:
+                counts[decision["action"]] += 1
+            result.update({"token": token, "summary": counts, "decisions": decisions})
+        return result
+
+    def preview_legacy_jobs(self, selected: list[str]) -> dict[str, Any]:
+        discovery = self._discover_legacy_jobs()
+        if not selected:
+            return self._legacy_result(discovery, [])
+        chosen = self._selected_legacy_items(discovery, selected)
+        document, snapshot = self._migration_jobs_snapshot()
+        token = self._legacy_jobs_token(discovery, selected, chosen, snapshot)
+        _planned, decisions, _changed = self._plan_legacy_jobs(document, chosen, utc_now())
+        return self._legacy_result(discovery, selected, decisions, token)
+
+    def commit_legacy_jobs(self, selected: list[str], token: str) -> dict[str, Any]:
+        if not selected or not isinstance(token, str) or not token:
+            raise StoreError("legacy job commit requires selection and a preview token")
+        with exclusive_file_lock(self.store_lock_path):
+            discovery = self._discover_legacy_jobs()
+            chosen = self._selected_legacy_items(discovery, selected)
+            document, snapshot = self._migration_jobs_snapshot()
+            expected = self._legacy_jobs_token(discovery, selected, chosen, snapshot)
+            if not hmac.compare_digest(token, expected):
+                raise StoreError("legacy job preview token rejected because the source, selection, input, or store drifted")
+            planned, decisions, changed = self._plan_legacy_jobs(document, chosen, utc_now())
+            if changed:
+                atomic_write_json(self.jobs_path, planned)
+        return self._legacy_result(discovery, selected, decisions, token, changed)
 
     def transition_job(
         self,
@@ -2987,6 +3480,11 @@ def build_parser() -> argparse.ArgumentParser:
     job_upsert_commit.add_argument("--input", required=True)
     job_upsert_commit.add_argument("--origin", choices=sorted(JOB_ORIGINS), required=True)
     job_upsert_commit.add_argument("--token", required=True)
+    legacy_jobs_preview = commands.add_parser("legacy-jobs-preview")
+    legacy_jobs_preview.add_argument("--select", action="append", default=[])
+    legacy_jobs_commit = commands.add_parser("legacy-jobs-commit")
+    legacy_jobs_commit.add_argument("--select", action="append", required=True)
+    legacy_jobs_commit.add_argument("--confirm", required=True)
     job_get = commands.add_parser("job-get")
     job_get.add_argument("--id", required=True)
     job_get.add_argument("--include-trashed", action="store_true")
@@ -3144,6 +3642,10 @@ def run(args: argparse.Namespace) -> Any:
         return store.commit_job_upsert(
             _read_input(args.input), args.origin, args.token
         )
+    if command == "legacy-jobs-preview":
+        return store.preview_legacy_jobs(args.select)
+    if command == "legacy-jobs-commit":
+        return store.commit_legacy_jobs(args.select, args.confirm)
     if command == "job-get":
         return store.get_job(args.id, include_trashed=args.include_trashed)
     if command == "job-list":

--- a/scripts/smoke-plugin.sh
+++ b/scripts/smoke-plugin.sh
@@ -19,9 +19,10 @@ claude plugin validate "$REPO_ROOT"
 
 python3 "$REPO_ROOT/scripts/job-apply-store.py" --help >/dev/null
 
-python3 - "$REPO_ROOT" <<'PY'
+python3 - "$REPO_ROOT" "$SMOKE_TEMP_ROOT" <<'PY'
 import json
 import hashlib
+import os
 import re
 import stat
 import subprocess
@@ -29,7 +30,46 @@ import sys
 from pathlib import Path
 
 root = Path(sys.argv[1])
+smoke_root = Path(sys.argv[2])
 sys.path.insert(0, str(root))
+
+legacy_home = smoke_root / "legacy-home"
+legacy_reports = legacy_home / ".claude-job-searches"
+legacy_reports.mkdir(parents=True)
+(legacy_reports / "search-smoke.md").write_text(
+    """# Job Search Results — 2026-08-24
+## Results (ranked by score)
+### 1. Smoke Engineer — Example Co (Score: 90)
+- **Source**: Example
+- **URL**: https://example.com/jobs/smoke
+""",
+    encoding="utf-8",
+)
+legacy_store = smoke_root / "legacy-store"
+legacy_environment = {**os.environ, "HOME": str(legacy_home)}
+legacy_base = [
+    sys.executable,
+    str(root / "scripts" / "job-apply-store.py"),
+    "--root",
+    str(legacy_store),
+]
+discovery = json.loads(subprocess.run(
+    [*legacy_base, "legacy-jobs-preview"], check=True, capture_output=True,
+    text=True, env=legacy_environment,
+).stdout)
+if legacy_store.exists() or len(discovery.get("items", [])) != 1 or "token" in discovery:
+    raise SystemExit("legacy migration discovery must be non-mutating and token-free")
+item_id = discovery["items"][0]["itemId"]
+preview = json.loads(subprocess.run(
+    [*legacy_base, "legacy-jobs-preview", "--select", item_id], check=True,
+    capture_output=True, text=True, env=legacy_environment,
+).stdout)
+commit = json.loads(subprocess.run(
+    [*legacy_base, "legacy-jobs-commit", "--select", item_id, "--confirm", preview["token"]],
+    check=True, capture_output=True, text=True, env=legacy_environment,
+).stdout)
+if not commit.get("committed") or commit.get("summary", {}).get("create") != 1:
+    raise SystemExit("legacy migration selected commit smoke failed")
 
 from qa.contracts import ContractError, validate_fixture
 from qa.privacy import PrivacyError, scan_tree

--- a/skills/answer-memory/references/storage-contract.md
+++ b/skills/answer-memory/references/storage-contract.md
@@ -77,6 +77,28 @@ deletion requires an already-trashed record and its current revision.
 
 On first initialization, if the new profile does not exist and `~/.claude-job-profile.json` does, the helper copies the complete legacy object into `profile.json`. It preserves unknown keys and leaves the legacy file untouched. Once the new profile exists it is authoritative, so later changes to the legacy file are not re-imported.
 
+Timestamped job-report migration is separately explicit and selective. A
+discovery-only `legacy-jobs-preview` reads only regular, direct
+`~/.claude-job-searches/search-*.md` files in deterministic order and does not
+initialize the canonical store. Discovery is bounded to 100 files, 2 MiB per
+file, 20 MiB aggregate, and 5,000 candidate entries; excess, invalid UTF-8,
+symlinks, special files, and read-time type drift fail the whole operation.
+
+Selected preview and `legacy-jobs-commit` repeat the same ordered opaque item
+IDs. The confirmation token binds that selection, canonical payloads, selected
+locators, the complete report manifest and digests, migration origin, and the
+current jobs document or missing-store sentinel. Commit locks, rediscovers,
+reparses, and rejects drift before a canonical write. Reports are never modified.
+
+Imported jobs use `migration` field provenance and a closed `legacySources`
+array containing only source kind, root-relative report filename, deterministic
+content-derived entry ID, and SHA-256 digest. Migration may create records, fill empty fields, and
+replace fields already authored by migration, but it cannot overwrite nonempty
+human- or agent-authored values. Identical reruns are byte-stable no-ops. The job
+store is authoritative afterward; arbitrary roots, recursion,
+`application_queue.md`, Markdown export, source mutation, and continuous
+synchronization are unsupported.
+
 ## Versions and corruption
 
 Current documents use `schemaVersion: 1`. A corrupt document, invalid shape, or future schema version causes the helper to fail non-destructively. Agents must not repair canonical files with text editing; preserve the file and explain the error.

--- a/skills/job-search/SKILL.md
+++ b/skills/job-search/SKILL.md
@@ -347,6 +347,23 @@ again. Never commit a stale or altered preview. Report conflicts and invalid
 items without attempting to invent a merge rule. Delete the temporary input when
 the interaction is finished.
 
+### Import existing timestamped reports
+
+When the user asks to migrate previously saved search reports, use the guided
+legacy commands instead of reconstructing JSON by hand. Run
+`legacy-jobs-preview` with no selection to discover supported `search-*.md`
+entries directly under `~/.claude-job-searches/`. Show valid and invalid items,
+ask which opaque item IDs to import, then run `legacy-jobs-preview` with the
+chosen IDs as repeatable `--select` options. Show its canonical decisions and
+ask for explicit confirmation of that exact selected preview. Commit with the
+same ordered `--select` options and `--confirm <preview-token>`.
+
+If commit reports drift, rediscover and preview again. Never import
+`application_queue.md`, accept a caller-selected source root, recurse, follow a
+symlink, edit a report, or infer another Markdown format. After commit, use the
+canonical job commands for all queue work; timestamped reports remain preserved
+compatibility artifacts rather than a synchronization source.
+
 ---
 
 ## Safety Rules

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -810,6 +810,536 @@ class StoreTests(unittest.TestCase):
         self.assertNotIn("company", record)
         self.assertEqual(record["provenance"]["/url"]["origin"], "agent")
 
+    def _write_legacy_search_report(self, name="search-2026-08-24T12-00-00.md"):
+        legacy_root = self.home / ".claude-job-searches"
+        legacy_root.mkdir(exist_ok=True)
+        path = legacy_root / name
+        path.write_text(
+            """# Job Search Results — 2026-08-24
+
+## Results (ranked by score)
+
+### 1. Staff Engineer — Acme Corp (Score: 92)
+- **Source**: LinkedIn
+- **Location**: Remote
+- **Salary**: $250K
+- **Description**: Build reliable systems.
+- **Apply**: Easy Apply
+- **URL**: https://example.com/jobs/staff#apply
+
+### 2. Missing Link — Example Co (Score: 75)
+- **Source**: Hacker News
+- **Apply**: Ask the poster
+""",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_legacy_job_discovery_preview_is_deterministic_and_non_mutating(self):
+        source = self._write_legacy_search_report()
+        source_before = source.read_bytes()
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            first = self.store.preview_legacy_jobs([])
+            second = self.store.preview_legacy_jobs([])
+        self.assertEqual(first, second)
+        self.assertFalse(self.root.exists())
+        self.assertNotIn("token", first)
+        self.assertEqual([item["state"] for item in first["items"]], ["valid", "invalid"])
+        self.assertEqual(first["items"][1]["reason"], "missing_url")
+        self.assertEqual(source.read_bytes(), source_before)
+
+    def test_legacy_job_selected_commit_absent_store_provenance_and_rerun(self):
+        source = self._write_legacy_search_report()
+        source_before = source.read_bytes()
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            discovery = self.store.preview_legacy_jobs([])
+            selected = [discovery["items"][0]["itemId"]]
+            preview = self.store.preview_legacy_jobs(selected)
+            self.assertFalse(self.root.exists())
+            self.assertEqual(preview["summary"]["create"], 1)
+            committed = self.store.commit_legacy_jobs(selected, preview["token"])
+            replay_preview = self.store.preview_legacy_jobs(selected)
+            before = self.store.jobs_path.read_bytes()
+            replay = self.store.commit_legacy_jobs(selected, replay_preview["token"])
+        self.assertTrue(committed["committed"])
+        self.assertFalse(replay["committed"])
+        self.assertEqual(self.store.jobs_path.read_bytes(), before)
+        self.assertEqual(source.read_bytes(), source_before)
+        job_id = committed["decisions"][0]["id"]
+        record = self.store.get_job(job_id)
+        self.assertEqual(record["role"], "Staff Engineer")
+        self.assertEqual(record["company"], "Acme Corp")
+        self.assertEqual(record["provenance"]["/role"]["origin"], "migration")
+        self.assertEqual(record["legacySources"][0]["relativePath"], source.name)
+        self.assertNotIn(str(self.home), json.dumps(record["legacySources"]))
+
+    def test_legacy_job_commit_rejects_source_selection_and_store_drift(self):
+        source = self._write_legacy_search_report()
+        self.store.initialize()
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            discovery = self.store.preview_legacy_jobs([])
+            selected = [discovery["items"][0]["itemId"]]
+            preview = self.store.preview_legacy_jobs(selected)
+            source.write_text(source.read_text() + "\n", encoding="utf-8")
+            with self.assertRaisesRegex(STORE_MODULE.StoreError, "drifted"):
+                self.store.commit_legacy_jobs(selected, preview["token"])
+
+            fresh_discovery = self.store.preview_legacy_jobs([])
+            fresh_selected = [fresh_discovery["items"][0]["itemId"]]
+            fresh = self.store.preview_legacy_jobs(fresh_selected)
+            self.store.create_job({"id": "drift", "url": "https://example.com/drift"})
+            with self.assertRaisesRegex(STORE_MODULE.StoreError, "drifted"):
+                self.store.commit_legacy_jobs(fresh_selected, fresh["token"])
+            with self.assertRaisesRegex(STORE_MODULE.StoreError, "unknown item"):
+                self.store.preview_legacy_jobs(["legacy-item-000000000000000000000000"])
+
+    def test_legacy_migration_never_overwrites_human_or_agent_fields(self):
+        self._write_legacy_search_report()
+        existing = self.store.create_job(
+            {"url": "https://example.com/jobs/staff", "role": "Human Role"},
+            origin="human",
+        )
+        agent = self.store.update_job(
+            existing["id"], {"company": "Agent Company"}, existing["revision"], origin="agent"
+        )
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            discovery = self.store.preview_legacy_jobs([])
+            selected = [discovery["items"][0]["itemId"]]
+            preview = self.store.preview_legacy_jobs(selected)
+            committed = self.store.commit_legacy_jobs(selected, preview["token"])
+        record = self.store.get_job(existing["id"])
+        self.assertEqual(record["role"], "Human Role")
+        self.assertEqual(record["company"], "Agent Company")
+        self.assertEqual(committed["decisions"][0]["fields"], ["compensation", "description", "legacySources", "location", "source"])
+        self.assertEqual(agent["revision"] + 1, record["revision"])
+
+    def test_legacy_migration_fills_a_human_cleared_field(self):
+        self._write_legacy_search_report()
+        existing = self.store.create_job(
+            {"url": "https://example.com/jobs/staff", "role": "Human Role"},
+            origin="human",
+        )
+        cleared = self.store.update_job(
+            existing["id"], {"role": ""}, existing["revision"], origin="human"
+        )
+        self.assertEqual(cleared["provenance"]["/role"]["origin"], "human")
+
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            discovery = self.store.preview_legacy_jobs([])
+            selected = [discovery["items"][0]["itemId"]]
+            preview = self.store.preview_legacy_jobs(selected)
+            committed = self.store.commit_legacy_jobs(selected, preview["token"])
+
+        record = self.store.get_job(existing["id"])
+        self.assertEqual(record["role"], "Staff Engineer")
+        self.assertEqual(record["provenance"]["/role"]["origin"], "migration")
+        self.assertIn("role", committed["decisions"][0]["fields"])
+
+    def test_legacy_migration_refreshes_migration_authored_source(self):
+        source = self._write_legacy_search_report()
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            discovery = self.store.preview_legacy_jobs([])
+            selected = [discovery["items"][0]["itemId"]]
+            preview = self.store.preview_legacy_jobs(selected)
+            created = self.store.commit_legacy_jobs(selected, preview["token"])
+
+            original_digest = self.store.get_job(created["decisions"][0]["id"])[
+                "legacySources"
+            ][0]["sourceSha256"]
+            source.write_text(
+                source.read_text(encoding="utf-8").replace(
+                    "**Source**: LinkedIn", "**Source**: Company site"
+                ),
+                encoding="utf-8",
+            )
+            refreshed_discovery = self.store.preview_legacy_jobs([])
+            refreshed_selected = [refreshed_discovery["items"][0]["itemId"]]
+            refreshed_preview = self.store.preview_legacy_jobs(refreshed_selected)
+            refreshed = self.store.commit_legacy_jobs(
+                refreshed_selected, refreshed_preview["token"]
+            )
+
+        record = self.store.get_job(created["decisions"][0]["id"])
+        self.assertEqual(refreshed["decisions"][0]["action"], "update")
+        self.assertEqual(record["source"], "Company site")
+        self.assertEqual(record["provenance"]["/source"]["origin"], "migration")
+        self.assertNotEqual(record["legacySources"][0]["sourceSha256"], original_digest)
+
+    def test_legacy_migration_uses_stable_locator_to_refresh_url(self):
+        source = self._write_legacy_search_report()
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            discovery = self.store.preview_legacy_jobs([])
+            selected = [discovery["items"][0]["itemId"]]
+            preview = self.store.preview_legacy_jobs(selected)
+            created = self.store.commit_legacy_jobs(selected, preview["token"])
+            job_id = created["decisions"][0]["id"]
+
+            source.write_text(
+                source.read_text(encoding="utf-8").replace(
+                    "https://example.com/jobs/staff",
+                    "https://example.com/jobs/staff-corrected",
+                ),
+                encoding="utf-8",
+            )
+            refreshed_discovery = self.store.preview_legacy_jobs([])
+            refreshed_selected = [refreshed_discovery["items"][0]["itemId"]]
+            refreshed_preview = self.store.preview_legacy_jobs(refreshed_selected)
+            refreshed = self.store.commit_legacy_jobs(
+                refreshed_selected, refreshed_preview["token"]
+            )
+
+        jobs = self.store.list_jobs()
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs[0]["id"], job_id)
+        self.assertEqual(
+            jobs[0]["url"], "https://example.com/jobs/staff-corrected#apply"
+        )
+        self.assertEqual(
+            jobs[0]["normalizedUrl"], "https://example.com/jobs/staff-corrected"
+        )
+        self.assertEqual(jobs[0]["provenance"]["/url"]["origin"], "migration")
+        self.assertEqual(refreshed["decisions"][0]["action"], "update")
+        self.assertIn("url", refreshed["decisions"][0]["fields"])
+
+    def test_legacy_entry_locator_survives_report_reordering(self):
+        source = self._write_legacy_search_report()
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            discovery = self.store.preview_legacy_jobs([])
+            original_item = discovery["items"][0]
+            selected = [original_item["itemId"]]
+            preview = self.store.preview_legacy_jobs(selected)
+            created = self.store.commit_legacy_jobs(selected, preview["token"])
+            job_id = created["decisions"][0]["id"]
+
+            original = source.read_text(encoding="utf-8")
+            reordered = original.replace(
+                "### 1. Staff Engineer — Acme Corp (Score: 92)",
+                "### 2. Staff Engineer — Acme Corp (Score: 92)",
+            ).replace(
+                "### 2. Missing Link — Example Co (Score: 75)",
+                "### 3. Missing Link — Example Co (Score: 75)",
+            )
+            inserted = (
+                "### 1. New Role — New Co (Score: 99)\n"
+                "- **URL**: https://example.com/jobs/new\n\n"
+            )
+            source.write_text(
+                reordered.replace("## Results (ranked by score)\n", "## Results (ranked by score)\n\n" + inserted),
+                encoding="utf-8",
+            )
+
+            moved_discovery = self.store.preview_legacy_jobs([])
+            moved_item = next(
+                item
+                for item in moved_discovery["items"]
+                if item.get("job", {}).get("url")
+                == "https://example.com/jobs/staff#apply"
+            )
+            self.assertEqual(moved_item["itemId"], original_item["itemId"])
+            moved_preview = self.store.preview_legacy_jobs([moved_item["itemId"]])
+            moved = self.store.commit_legacy_jobs(
+                [moved_item["itemId"]], moved_preview["token"]
+            )
+
+        jobs = self.store.list_jobs()
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs[0]["id"], job_id)
+        self.assertEqual(jobs[0]["role"], "Staff Engineer")
+        self.assertEqual(moved["decisions"][0]["id"], job_id)
+
+    def test_duplicate_legacy_headings_keep_content_bound_locators(self):
+        reports = self.home / ".claude-job-searches"
+        reports.mkdir(parents=True)
+        source = reports / "search-duplicate-headings.md"
+
+        def report(first_url, second_url):
+            return (
+                "## Results (ranked by score)\n\n"
+                "### 1. Engineer — Acme (Score: 90)\n"
+                f"- **URL**: {first_url}\n\n"
+                "### 2. Engineer — Acme (Score: 90)\n"
+                f"- **URL**: {second_url}\n"
+            )
+
+        first_url = "https://example.com/jobs/duplicate-a"
+        second_url = "https://example.com/jobs/duplicate-b"
+        source.write_text(report(first_url, second_url), encoding="utf-8")
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            discovery = self.store.preview_legacy_jobs([])
+            first_item = next(
+                item for item in discovery["items"] if item["job"]["url"] == first_url
+            )
+            preview = self.store.preview_legacy_jobs([first_item["itemId"]])
+            created = self.store.commit_legacy_jobs(
+                [first_item["itemId"]], preview["token"]
+            )
+            job_id = created["decisions"][0]["id"]
+
+            source.write_text(report(second_url, first_url), encoding="utf-8")
+            reordered = self.store.preview_legacy_jobs([])
+            moved_first = next(
+                item for item in reordered["items"] if item["job"]["url"] == first_url
+            )
+            self.assertEqual(moved_first["itemId"], first_item["itemId"])
+            moved_preview = self.store.preview_legacy_jobs([moved_first["itemId"]])
+            moved = self.store.commit_legacy_jobs(
+                [moved_first["itemId"]], moved_preview["token"]
+            )
+
+        jobs = self.store.list_jobs()
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs[0]["id"], job_id)
+        self.assertEqual(jobs[0]["url"], first_url)
+        self.assertEqual(moved["decisions"][0]["id"], job_id)
+
+    def test_legacy_discovery_uses_path_fallback_on_windows(self):
+        self._write_legacy_search_report()
+        with (
+            mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home),
+            mock.patch.object(STORE_MODULE.os, "name", "nt"),
+        ):
+            discovery = self.store.preview_legacy_jobs([])
+        self.assertEqual(discovery["items"][0]["state"], "valid")
+        self.assertFalse(self.root.exists())
+
+    def test_legacy_migration_skips_protected_source_and_fills_empty_fields(self):
+        self._write_legacy_search_report()
+        existing = self.store.create_job(
+            {
+                "url": "https://example.com/jobs/staff#apply",
+                "source": "Company site",
+            },
+            origin="human",
+        )
+
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            discovery = self.store.preview_legacy_jobs([])
+            selected = [discovery["items"][0]["itemId"]]
+            preview = self.store.preview_legacy_jobs(selected)
+            committed = self.store.commit_legacy_jobs(selected, preview["token"])
+
+        record = self.store.get_job(existing["id"])
+        self.assertEqual(record["source"], "Company site")
+        self.assertEqual(record["provenance"]["/source"]["origin"], "human")
+        self.assertEqual(record["role"], "Staff Engineer")
+        self.assertEqual(record["company"], "Acme Corp")
+        self.assertNotIn("source", committed["decisions"][0]["fields"])
+
+    def test_migration_origin_is_private_to_guided_legacy_methods(self):
+        self.store.initialize()
+        existing = self.store.create_job(
+            {"id": "authority-boundary", "url": "https://example.com/authority"}
+        )
+        payload = {"jobs": [{"url": "https://example.com/forged"}]}
+
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "human or agent"):
+            self.store.create_job(payload["jobs"][0], origin="migration")
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "human or agent"):
+            self.store.update_job(
+                existing["id"],
+                {"role": "Forged"},
+                existing["revision"],
+                origin="migration",
+            )
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "human or agent"):
+            self.store.preview_job_upsert(payload, "migration")
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "human or agent"):
+            self.store.commit_job_upsert(payload, "migration", "forged-token")
+        self.assertIsNone(
+            next(
+                (
+                    record
+                    for record in self.store.list_jobs()
+                    if record["normalizedUrl"] == "https://example.com/forged"
+                ),
+                None,
+            )
+        )
+
+    def test_generic_job_cli_rejects_migration_origin(self):
+        self.store.initialize()
+        input_path = self.home / "forged-migration.json"
+        input_path.write_text(
+            json.dumps({"jobs": [{"url": "https://example.com/forged-cli"}]}),
+            encoding="utf-8",
+        )
+        base = [sys.executable, str(SCRIPT), "--root", str(self.root)]
+        commands = (
+            ["job-create", "--input", str(input_path), "--origin", "migration"],
+            ["job-upsert-preview", "--input", str(input_path), "--origin", "migration"],
+            [
+                "job-upsert-commit",
+                "--input",
+                str(input_path),
+                "--origin",
+                "migration",
+                "--token",
+                "forged-token",
+            ],
+            [
+                "job-update",
+                "--id",
+                "missing",
+                "--input",
+                str(input_path),
+                "--expected-revision",
+                "1",
+                "--origin",
+                "migration",
+            ],
+        )
+        for arguments in commands:
+            completed = subprocess.run(
+                [*base, *arguments], capture_output=True, text=True
+            )
+            self.assertEqual(completed.returncode, 2)
+            self.assertIn("invalid choice", completed.stderr)
+            self.assertNotIn("migration-authored", completed.stdout)
+
+    def test_generic_methods_reject_forged_migration_provenance(self):
+        forged = {
+            "/forged": {
+                "origin": "migration",
+                "observationSource": "legacy",
+                "updatedAt": "2026-08-24T00:00:00Z",
+            }
+        }
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "reserved"):
+            self.store.create_job(
+                {
+                    "url": "https://example.com/forged-create",
+                    "provenance": forged,
+                }
+            )
+
+        ordinary = self.store.create_job(
+            {"id": "ordinary-provenance", "url": "https://example.com/ordinary"}
+        )
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "reserved"):
+            self.store.update_job(
+                ordinary["id"],
+                {"provenance": forged},
+                ordinary["revision"],
+            )
+
+    def test_human_edits_preserve_but_cannot_alter_guided_migration_provenance(self):
+        self._write_legacy_search_report()
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            discovery = self.store.preview_legacy_jobs([])
+            selected = [discovery["items"][0]["itemId"]]
+            preview = self.store.preview_legacy_jobs(selected)
+            committed = self.store.commit_legacy_jobs(selected, preview["token"])
+        job_id = committed["decisions"][0]["id"]
+        guided = self.store.get_job(job_id)
+        original_company = guided["provenance"]["/company"]
+
+        altered = json.loads(json.dumps(guided["provenance"]))
+        altered["/company"]["updatedAt"] = "2000-01-01T00:00:00Z"
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "reserved"):
+            self.store.update_job(
+                job_id,
+                {"provenance": altered},
+                guided["revision"],
+            )
+
+        removed = json.loads(json.dumps(guided["provenance"]))
+        del removed["/company"]
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "reserved"):
+            self.store.update_job(
+                job_id,
+                {"provenance": removed},
+                guided["revision"],
+            )
+
+        corrected = self.store.update_job(
+            job_id,
+            {"role": "Human Corrected Role", "provenance": guided["provenance"]},
+            guided["revision"],
+        )
+        self.assertEqual(corrected["role"], "Human Corrected Role")
+        self.assertEqual(corrected["provenance"]["/role"]["origin"], "human")
+        self.assertEqual(corrected["provenance"]["/company"], original_company)
+
+    def test_generic_cli_rejects_forged_migration_provenance(self):
+        self.store.initialize()
+        ordinary = self.store.create_job(
+            {"id": "cli-provenance", "url": "https://example.com/cli-provenance"}
+        )
+        forged = {
+            "/forged": {
+                "origin": "migration",
+                "observationSource": "legacy",
+                "updatedAt": "2026-08-24T00:00:00Z",
+            }
+        }
+        create_input = self.home / "forged-create.json"
+        create_input.write_text(
+            json.dumps(
+                {
+                    "url": "https://example.com/forged-cli-provenance",
+                    "provenance": forged,
+                }
+            ),
+            encoding="utf-8",
+        )
+        update_input = self.home / "forged-update.json"
+        update_input.write_text(json.dumps({"provenance": forged}), encoding="utf-8")
+        base = [sys.executable, str(SCRIPT), "--root", str(self.root)]
+        commands = (
+            ["job-create", "--input", str(create_input)],
+            [
+                "job-update",
+                "--id",
+                ordinary["id"],
+                "--input",
+                str(update_input),
+                "--expected-revision",
+                str(ordinary["revision"]),
+            ],
+        )
+        for arguments in commands:
+            completed = subprocess.run(
+                [*base, *arguments], capture_output=True, text=True
+            )
+            self.assertEqual(completed.returncode, 2)
+            self.assertIn("reserved for guided legacy imports", completed.stderr)
+            self.assertEqual(completed.stdout, "")
+
+    @unittest.skipIf(os.name == "nt", "symlink behavior is platform-specific")
+    def test_legacy_discovery_rejects_symlinks_and_limits(self):
+        legacy_root = self.home / ".claude-job-searches"
+        legacy_root.mkdir()
+        target = self.home / "outside.md"
+        target.write_text("outside", encoding="utf-8")
+        (legacy_root / "search-link.md").symlink_to(target)
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            with self.assertRaisesRegex(STORE_MODULE.StoreError, "regular files"):
+                self.store.preview_legacy_jobs([])
+        (legacy_root / "search-link.md").unlink()
+        (legacy_root / "search-large.md").write_bytes(b"x" * (STORE_MODULE.LEGACY_SEARCH_MAX_FILE_BYTES + 1))
+        with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
+            with self.assertRaisesRegex(STORE_MODULE.StoreError, "per-file"):
+                self.store.preview_legacy_jobs([])
+
+    def test_legacy_job_cli_walkthrough_uses_fixed_home_root(self):
+        self._write_legacy_search_report()
+        environment = {**os.environ, "HOME": str(self.home)}
+        base = [sys.executable, str(SCRIPT), "--root", str(self.root)]
+        discovered = subprocess.run(
+            [*base, "legacy-jobs-preview"], check=True, capture_output=True, text=True, env=environment
+        )
+        item_id = json.loads(discovered.stdout)["items"][0]["itemId"]
+        preview = subprocess.run(
+            [*base, "legacy-jobs-preview", "--select", item_id], check=True,
+            capture_output=True, text=True, env=environment,
+        )
+        token = json.loads(preview.stdout)["token"]
+        committed = subprocess.run(
+            [*base, "legacy-jobs-commit", "--select", item_id, "--confirm", token],
+            check=True, capture_output=True, text=True, env=environment,
+        )
+        self.assertTrue(json.loads(committed.stdout)["committed"])
+
     def test_job_transitions_require_supported_flow_and_user_submission(self):
         self.store.replace_profile({"firstName": "Ada"})
         resume_path = self.home / "resume.pdf"


### PR DESCRIPTION
## Summary

- add guided discovery, selected preview, and exact-confirm commit for documented `~/.claude-job-searches/search-*.md` reports
- preserve legacy Markdown bytes while importing canonical jobs with bounded, value-free migration provenance
- enforce source/store drift rejection, duplicate handling, lower-trust field authority, deterministic content-bound locators, idempotent reruns, and Windows-compatible safe discovery
- document the canonical-store handoff and add packaged-plugin smoke coverage

`application_queue.md`, Markdown export/synchronization, and the companion UX remain intentionally out of scope because the legacy queue format has no reliable contract yet.

## Review

The PR review toolkit ran correctness, tests, silent-failure, contracts/types, and documentation passes with fresh validation of every candidate. Accepted findings were fixed, including empty-field precedence, migration-authored source refresh, stable locator URL refresh, reordered/duplicate-heading locator safety, protected source enrichment, Windows discovery compatibility, and precise read-scope documentation.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tests python3 -m unittest -q test_job_apply_store` — 75 passed
- `python3 -m unittest discover -s tests -q` — 365 passed
- `bash scripts/smoke-plugin.sh` — passed, including isolated Claude Code and Codex installs
- `git diff --check` — passed
