### PR TITLE
feat: add Jobs companion workspace

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -65,3 +65,17 @@ jobs:
 
       - name: Check documentation links
         run: bash scripts/check-links.sh
+
+  windows-store-workspace:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Verify Windows workspace and canonical store lifecycle
+        run: python -m unittest -v tests.test_job_apply_workspace tests.test_job_apply_store

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, staging]
 
 jobs:
   validate:

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ AI-powered job application assistant for Claude Code and Codex that fills job ap
 
 | Skill | Description |
 |-------|-------------|
-| `job-apply:job-apply` | Fill out job applications automatically using your resume |
+| `job-apply:job-apply` | Prepare application fields from your resume and stop before final submission |
 | `job-apply:answer-memory` | Safely manage your local profile, reusable answers, application history, and resumable sessions |
 | `job-apply:job-search` | Search LinkedIn, Hacker News, and Twitter/X for jobs, then rank results against your preferences |
 | `job-apply:job-preferences` | Set the titles, salary, remote-work, and filtering preferences used by job search |
+| `job-apply:job-workspace` | Open the optional local Jobs workspace shared with Job Apply agents |
 
 Invoke skills with `$job-apply:...` in Codex or `/job-apply:...` in Claude Code.
 
@@ -110,7 +111,7 @@ Once your profile is set up:
 
 3. Watch as the agent fills the application from your reviewed local profile
 
-4. Inspect the final review page and the field summary, then click Submit or Send yourself if everything is correct
+4. Inspect the final review page and field summary. The assistant stops before final submission; only you may decide whether to complete it manually on the third-party site.
 
 ### Searching for Jobs
 
@@ -142,6 +143,20 @@ First run `$job-apply:job-preferences` to save your search preferences. Then use
    - Matching Hacker News and Twitter/X opportunities
 
 Results are automatically saved to `~/.claude-job-searches/`. Both Codex and Claude Code use this legacy-compatible path.
+
+### Local Jobs Workspace
+
+The optional workspace gives you a keyboard-accessible browser view of the same canonical Jobs records used by the CLI skills. From the plugin directory, start it with one command:
+
+```bash
+python3 scripts/job-apply-workspace.py
+```
+
+The launcher binds only to `127.0.0.1`, chooses a free port, opens the complete authenticated URL in your default browser, and stops cleanly with Ctrl-C. It requires Python 3 but no Node runtime, account, cloud service, telemetry, or separate database.
+
+Use the workspace to capture one job or paste multiple URLs, filter and edit records, assign an existing resume, run readiness checks, mark valid jobs ready for agent handoff, and move a job to recoverable trash. CLI changes appear within four seconds or when you select **Refresh**. If a CLI or agent changes an open record, the workspace keeps your draft and shows a revision conflict before anything can be overwritten.
+
+The workspace never runs an application, reads arbitrary files, or activates Submit, Send, Apply, or another third-party final action. A ready job remains an explicit handoff to `$job-apply:job-apply`; you personally control submission.
 
 ## Compatibility and Verification Status
 

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -2528,6 +2528,12 @@ class Store:
             raise StoreError("claim token is required")
         return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
+    @staticmethod
+    def _new_claim_token() -> str:
+        # Keep the full 32-byte random payload while ensuring argparse can
+        # always consume the bearer token as a separate option value.
+        return f"claim_{secrets.token_urlsafe(32)}"
+
     def _public_claim(self, claim: dict[str, Any] | None) -> dict[str, Any] | None:
         if claim is None:
             return None
@@ -2716,7 +2722,7 @@ class Store:
                 raise StoreError("job is not ready")
             now_dt = self._now_datetime()
             now = now_dt.isoformat(timespec="seconds").replace("+00:00", "Z")
-            token = secrets.token_urlsafe(32)
+            token = self._new_claim_token()
             claim = {
                 "claimId": str(uuid.uuid4()),
                 "jobId": job_id,
@@ -2770,7 +2776,7 @@ class Store:
                 raise StoreError("live claim cannot be recovered")
             now_dt = self._now_datetime()
             now = now_dt.isoformat(timespec="seconds").replace("+00:00", "Z")
-            token = secrets.token_urlsafe(32)
+            token = self._new_claim_token()
             claim = {
                 "claimId": str(uuid.uuid4()), "jobId": job_id,
                 "ownerLabel": owner_label.strip(), "tokenHash": self._token_hash(token),

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -2342,7 +2342,12 @@ class Store:
         return document, {"state": "missing"}
 
     @staticmethod
-    def _selected_legacy_items(discovery: dict[str, Any], selected: list[str]) -> list[dict[str, Any]]:
+    def _selected_legacy_items(
+        discovery: dict[str, Any],
+        selected: list[str],
+        *,
+        unknown_message: str = "legacy job selection contains an unknown item id",
+    ) -> list[dict[str, Any]]:
         if len(selected) != len(set(selected)):
             raise StoreError("legacy job selection contains duplicate item ids")
         indexed = {item["itemId"]: item for item in discovery["items"]}
@@ -2350,7 +2355,7 @@ class Store:
         for item_id in selected:
             item = indexed.get(item_id)
             if item is None:
-                raise StoreError("legacy job selection contains an unknown item id")
+                raise StoreError(unknown_message)
             if item["state"] != "valid":
                 raise StoreError("legacy job selection contains an invalid item")
             chosen.append(item)
@@ -2471,7 +2476,13 @@ class Store:
             raise StoreError("legacy job commit requires selection and a preview token")
         with exclusive_file_lock(self.store_lock_path):
             discovery = self._discover_legacy_jobs()
-            chosen = self._selected_legacy_items(discovery, selected)
+            chosen = self._selected_legacy_items(
+                discovery,
+                selected,
+                unknown_message=(
+                    "legacy job preview token rejected because the source, selection, input, or store drifted"
+                ),
+            )
             document, snapshot = self._migration_jobs_snapshot()
             expected = self._legacy_jobs_token(discovery, selected, chosen, snapshot)
             if not hmac.compare_digest(token, expected):

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -2347,6 +2347,7 @@ class Store:
         selected: list[str],
         *,
         unknown_message: str = "legacy job selection contains an unknown item id",
+        invalid_message: str = "legacy job selection contains an invalid item",
     ) -> list[dict[str, Any]]:
         if len(selected) != len(set(selected)):
             raise StoreError("legacy job selection contains duplicate item ids")
@@ -2357,7 +2358,7 @@ class Store:
             if item is None:
                 raise StoreError(unknown_message)
             if item["state"] != "valid":
-                raise StoreError("legacy job selection contains an invalid item")
+                raise StoreError(invalid_message)
             chosen.append(item)
         return chosen
 
@@ -2480,6 +2481,9 @@ class Store:
                 discovery,
                 selected,
                 unknown_message=(
+                    "legacy job preview token rejected because the source, selection, input, or store drifted"
+                ),
+                invalid_message=(
                     "legacy job preview token rejected because the source, selection, input, or store drifted"
                 ),
             )

--- a/scripts/job-apply-workspace.py
+++ b/scripts/job-apply-workspace.py
@@ -31,6 +31,12 @@ ASSETS = {
 }
 
 
+def loopback_authority(port: int) -> tuple[str, str]:
+    if port == 80:
+        return f"http://{LOOPBACK}", LOOPBACK
+    return f"http://{LOOPBACK}:{port}", f"{LOOPBACK}:{port}"
+
+
 def load_store_module() -> Any:
     path = Path(__file__).resolve().with_name("job-apply-store.py")
     spec = importlib.util.spec_from_file_location("job_apply_store", path)
@@ -53,8 +59,7 @@ class WorkspaceServer(ThreadingHTTPServer):
         self.store.initialize()
         self.token = token or secrets.token_urlsafe(32)
         super().__init__((LOOPBACK, port), WorkspaceHandler)
-        self.origin = f"http://{LOOPBACK}:{self.server_port}"
-        self.expected_host = f"{LOOPBACK}:{self.server_port}"
+        self.origin, self.expected_host = loopback_authority(self.server_port)
 
 
 class WorkspaceHandler(BaseHTTPRequestHandler):

--- a/scripts/job-apply-workspace.py
+++ b/scripts/job-apply-workspace.py
@@ -173,6 +173,20 @@ class WorkspaceHandler(BaseHTTPRequestHandler):
         else:
             self._json(HTTPStatus.OK, result)
 
+    def _expected_revision(self, payload: dict[str, Any]) -> int | None:
+        revision = payload.get("expectedRevision")
+        if (
+            not isinstance(revision, int)
+            or isinstance(revision, bool)
+            or revision < 1
+        ):
+            self._error(
+                HTTPStatus.BAD_REQUEST,
+                "expectedRevision must be a positive integer",
+            )
+            return None
+        return revision
+
     def do_HEAD(self) -> None:
         path = self._path()
         if path is None or not self._valid_host():
@@ -267,8 +281,11 @@ class WorkspaceHandler(BaseHTTPRequestHandler):
             if set(payload) != {"patch", "expectedRevision"} or not isinstance(payload.get("patch"), dict):
                 self._error(HTTPStatus.BAD_REQUEST, "body requires patch and expectedRevision")
                 return
+            expected_revision = self._expected_revision(payload)
+            if expected_revision is None:
+                return
             self._store_call(lambda: self.server.store.update_job(
-                parts[3], payload["patch"], payload["expectedRevision"], origin="human"
+                parts[3], payload["patch"], expected_revision, origin="human"
             ))
             return
         if len(parts) == 5 and parts[1:3] == ["api", "jobs"]:
@@ -278,10 +295,22 @@ class WorkspaceHandler(BaseHTTPRequestHandler):
                 if set(payload) - allowed or not {"status", "expectedRevision"} <= set(payload):
                     self._error(HTTPStatus.BAD_REQUEST, "transition body is invalid")
                     return
+                if not isinstance(payload["status"], str):
+                    self._error(HTTPStatus.BAD_REQUEST, "transition status must be a string")
+                    return
+                if "closedOutcome" in payload and payload["closedOutcome"] is not None and not isinstance(payload["closedOutcome"], str):
+                    self._error(HTTPStatus.BAD_REQUEST, "closedOutcome must be a string or null")
+                    return
+                if "userConfirmed" in payload and not isinstance(payload["userConfirmed"], bool):
+                    self._error(HTTPStatus.BAD_REQUEST, "userConfirmed must be a boolean")
+                    return
+                expected_revision = self._expected_revision(payload)
+                if expected_revision is None:
+                    return
                 self._store_call(lambda: self.server.store.transition_job(
                     job_id,
                     payload["status"],
-                    payload["expectedRevision"],
+                    expected_revision,
                     closed_outcome=payload.get("closedOutcome"),
                     user_confirmed=payload.get("userConfirmed") is True,
                 ))
@@ -290,7 +319,10 @@ class WorkspaceHandler(BaseHTTPRequestHandler):
                 if set(payload) != {"expectedRevision"}:
                     self._error(HTTPStatus.BAD_REQUEST, "trash body requires expectedRevision")
                     return
-                self._store_call(lambda: self.server.store.trash_job(job_id, payload["expectedRevision"]))
+                expected_revision = self._expected_revision(payload)
+                if expected_revision is None:
+                    return
+                self._store_call(lambda: self.server.store.trash_job(job_id, expected_revision))
                 return
         self._error(HTTPStatus.NOT_FOUND, "route not found", "not_found")
 
@@ -329,7 +361,10 @@ class WorkspaceHandler(BaseHTTPRequestHandler):
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Start the local Job Apply Jobs workspace")
-    parser.add_argument("--root", help="canonical store root (default: JOB_APPLY_STORE or ~/.job-apply)")
+    parser.add_argument(
+        "--root",
+        help=f"canonical store root (default: ${STORE_MODULE.STORE_ENV} or ~/.job-apply)",
+    )
     parser.add_argument("--port", type=int, default=0, help="loopback port (default: choose a free port)")
     parser.add_argument("--no-open", action="store_true", help="do not open the default browser")
     parser.add_argument("--json", action="store_true", help="print startup details as one JSON line")
@@ -341,7 +376,7 @@ def main() -> int:
     if not 0 <= args.port <= 65535:
         print("job-apply-workspace: port must be between 0 and 65535", file=sys.stderr)
         return 2
-    configured = args.root or os.environ.get("JOB_APPLY_STORE")
+    configured = args.root or os.environ.get(STORE_MODULE.STORE_ENV)
     store_root = Path(configured).expanduser() if configured else Path.home() / ".job-apply"
     try:
         server = WorkspaceServer(store_root, args.port)

--- a/scripts/job-apply-workspace.py
+++ b/scripts/job-apply-workspace.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Secure loopback companion workspace for canonical Job Apply records."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import secrets
+import signal
+import sys
+import threading
+import webbrowser
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import unquote, urlsplit
+
+LOOPBACK = "127.0.0.1"
+MAX_BODY_BYTES = 64 * 1024
+MAX_BULK_URLS = 50
+ROOT = Path(__file__).resolve().parent.parent
+ASSET_ROOT = ROOT / "workspace"
+ASSETS = {
+    "/": ("index.html", "text/html; charset=utf-8"),
+    "/index.html": ("index.html", "text/html; charset=utf-8"),
+    "/app.js": ("app.js", "text/javascript; charset=utf-8"),
+    "/styles.css": ("styles.css", "text/css; charset=utf-8"),
+}
+
+
+def load_store_module() -> Any:
+    path = Path(__file__).resolve().with_name("job-apply-store.py")
+    spec = importlib.util.spec_from_file_location("job_apply_store", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load the canonical Job Apply store")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+STORE_MODULE = load_store_module()
+
+
+class WorkspaceServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = False
+
+    def __init__(self, root: Path, port: int, token: str | None = None):
+        self.store = STORE_MODULE.Store(root)
+        self.store.initialize()
+        self.token = token or secrets.token_urlsafe(32)
+        super().__init__((LOOPBACK, port), WorkspaceHandler)
+        self.origin = f"http://{LOOPBACK}:{self.server_port}"
+        self.expected_host = f"{LOOPBACK}:{self.server_port}"
+
+
+class WorkspaceHandler(BaseHTTPRequestHandler):
+    server: WorkspaceServer
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        # Never log request fragments/tokens. The token is never sent in a URL.
+        sys.stderr.write("workspace: " + fmt % args + "\n")
+
+    def end_headers(self) -> None:
+        if self.close_connection:
+            self.send_header("Connection", "close")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'self'; script-src 'self'; style-src 'self'; "
+            "img-src 'self' data:; connect-src 'self'; base-uri 'none'; "
+            "form-action 'self'; frame-ancestors 'none'",
+        )
+        super().end_headers()
+
+    def _send_bytes(self, status: int, body: bytes, content_type: str) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def _json(self, status: int, payload: Any) -> None:
+        body = (json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n").encode()
+        self._send_bytes(status, body, "application/json; charset=utf-8")
+
+    def _error(self, status: int, message: str, code: str = "request_error") -> None:
+        # Error paths may reject before reading a request body. Never let unread,
+        # attacker-controlled bytes become another HTTP/1.1 request.
+        self.close_connection = True
+        self._json(status, {"error": {"code": code, "message": message}})
+
+    def _valid_host(self) -> bool:
+        if self.headers.get("Host") != self.server.expected_host:
+            self._error(HTTPStatus.FORBIDDEN, "request host is not the workspace", "host_rejected")
+            return False
+        return True
+
+    def _authorized_api(self, mutation: bool = False) -> bool:
+        if not self._valid_host():
+            return False
+        authorization = self.headers.get("Authorization", "")
+        expected = f"Bearer {self.server.token}"
+        if not secrets.compare_digest(authorization, expected):
+            self._error(HTTPStatus.UNAUTHORIZED, "workspace token is missing or invalid", "token_rejected")
+            return False
+        if mutation and self.headers.get("Origin") != self.server.origin:
+            self._error(HTTPStatus.FORBIDDEN, "request origin is not the workspace", "origin_rejected")
+            return False
+        return True
+
+    def _path(self) -> str | None:
+        parsed = urlsplit(self.path)
+        if parsed.query or parsed.fragment:
+            self._error(HTTPStatus.NOT_FOUND, "route not found", "not_found")
+            return None
+        try:
+            decoded = unquote(parsed.path, errors="strict")
+        except UnicodeError:
+            self._error(HTTPStatus.BAD_REQUEST, "request path is invalid")
+            return None
+        if decoded != parsed.path or "\\" in decoded or ".." in decoded:
+            self._error(HTTPStatus.NOT_FOUND, "route not found", "not_found")
+            return None
+        return decoded
+
+    def _read_json(self) -> dict[str, Any] | None:
+        if self.headers.get("Content-Type") != "application/json":
+            self._error(HTTPStatus.UNSUPPORTED_MEDIA_TYPE, "Content-Type must be application/json")
+            return None
+        raw_length = self.headers.get("Content-Length")
+        try:
+            length = int(raw_length) if raw_length is not None else -1
+        except ValueError:
+            length = -1
+        if length < 0:
+            self._error(HTTPStatus.LENGTH_REQUIRED, "a valid Content-Length is required")
+            return None
+        if length > MAX_BODY_BYTES:
+            self._error(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "request body is too large")
+            return None
+        try:
+            payload = json.loads(self.rfile.read(length))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            self._error(HTTPStatus.BAD_REQUEST, "request body must be valid JSON")
+            return None
+        if not isinstance(payload, dict):
+            self._error(HTTPStatus.BAD_REQUEST, "request body must be a JSON object")
+            return None
+        return payload
+
+    def _store_call(self, callback: Callable[[], Any]) -> None:
+        try:
+            result = callback()
+        except STORE_MODULE.StoreError as error:
+            message = str(error)
+            if "revision conflict" in message:
+                self._error(HTTPStatus.CONFLICT, message, "revision_conflict")
+            elif "does not exist" in message:
+                self._error(HTTPStatus.NOT_FOUND, message, "not_found")
+            else:
+                self._error(HTTPStatus.BAD_REQUEST, message, "store_rejected")
+        except OSError:
+            self._error(HTTPStatus.INTERNAL_SERVER_ERROR, "storage operation failed", "storage_error")
+        else:
+            self._json(HTTPStatus.OK, result)
+
+    def do_HEAD(self) -> None:
+        path = self._path()
+        if path is None or not self._valid_host():
+            return
+        asset = ASSETS.get(path)
+        if asset is None:
+            self._error(HTTPStatus.NOT_FOUND, "route not found", "not_found")
+            return
+        try:
+            body = (ASSET_ROOT / asset[0]).read_bytes()
+        except OSError:
+            self._error(HTTPStatus.INTERNAL_SERVER_ERROR, "workspace asset is unavailable")
+            return
+        self._send_bytes(HTTPStatus.OK, body, asset[1])
+
+    def do_GET(self) -> None:
+        path = self._path()
+        if path is None:
+            return
+        if path.startswith("/api/"):
+            if not self._authorized_api():
+                return
+            self._get_api(path)
+            return
+        if not self._valid_host():
+            return
+        asset = ASSETS.get(path)
+        if asset is None:
+            self._error(HTTPStatus.NOT_FOUND, "route not found", "not_found")
+            return
+        try:
+            body = (ASSET_ROOT / asset[0]).read_bytes()
+        except OSError:
+            self._error(HTTPStatus.INTERNAL_SERVER_ERROR, "workspace asset is unavailable")
+            return
+        self._send_bytes(HTTPStatus.OK, body, asset[1])
+
+    def _get_api(self, path: str) -> None:
+        if path == "/api/state":
+            self._store_call(lambda: {
+                "jobs": self.server.store.list_jobs(),
+                "resumes": self.server.store.list_resumes(),
+            })
+            return
+        if path == "/api/jobs":
+            self._store_call(lambda: {"jobs": self.server.store.list_jobs()})
+            return
+        if path == "/api/resumes":
+            self._store_call(lambda: {"resumes": self.server.store.list_resumes()})
+            return
+        parts = path.split("/")
+        if len(parts) == 4 and parts[1:3] == ["api", "jobs"]:
+            job_id = parts[3]
+            self._store_call(lambda: self._require_job(job_id))
+            return
+        if len(parts) == 5 and parts[1:3] == ["api", "jobs"] and parts[4] == "preflight":
+            self._store_call(lambda: self.server.store.preflight_job(parts[3]))
+            return
+        self._error(HTTPStatus.NOT_FOUND, "route not found", "not_found")
+
+    def _require_job(self, job_id: str) -> dict[str, Any]:
+        job = self.server.store.get_job(job_id)
+        if job is None:
+            raise STORE_MODULE.StoreError("job does not exist")
+        return job
+
+    def do_POST(self) -> None:
+        self._mutate("POST")
+
+    def do_PATCH(self) -> None:
+        self._mutate("PATCH")
+
+    def _mutate(self, method: str) -> None:
+        path = self._path()
+        if path is None or not self._authorized_api(mutation=True):
+            return
+        payload = self._read_json()
+        if payload is None:
+            return
+        if method == "POST" and path == "/api/jobs":
+            job = payload.get("job")
+            if not isinstance(job, dict) or set(payload) != {"job"}:
+                self._error(HTTPStatus.BAD_REQUEST, "body must contain only a job object")
+                return
+            self._store_call(lambda: self.server.store.create_job(job, origin="human"))
+            return
+        if method == "POST" and path == "/api/jobs/bulk":
+            self._bulk_create(payload)
+            return
+        parts = path.split("/")
+        if len(parts) == 4 and parts[1:3] == ["api", "jobs"] and method == "PATCH":
+            if set(payload) != {"patch", "expectedRevision"} or not isinstance(payload.get("patch"), dict):
+                self._error(HTTPStatus.BAD_REQUEST, "body requires patch and expectedRevision")
+                return
+            self._store_call(lambda: self.server.store.update_job(
+                parts[3], payload["patch"], payload["expectedRevision"], origin="human"
+            ))
+            return
+        if len(parts) == 5 and parts[1:3] == ["api", "jobs"]:
+            job_id, action = parts[3], parts[4]
+            if action == "transition" and method == "POST":
+                allowed = {"status", "expectedRevision", "closedOutcome", "userConfirmed"}
+                if set(payload) - allowed or not {"status", "expectedRevision"} <= set(payload):
+                    self._error(HTTPStatus.BAD_REQUEST, "transition body is invalid")
+                    return
+                self._store_call(lambda: self.server.store.transition_job(
+                    job_id,
+                    payload["status"],
+                    payload["expectedRevision"],
+                    closed_outcome=payload.get("closedOutcome"),
+                    user_confirmed=payload.get("userConfirmed") is True,
+                ))
+                return
+            if action == "trash" and method == "POST":
+                if set(payload) != {"expectedRevision"}:
+                    self._error(HTTPStatus.BAD_REQUEST, "trash body requires expectedRevision")
+                    return
+                self._store_call(lambda: self.server.store.trash_job(job_id, payload["expectedRevision"]))
+                return
+        self._error(HTTPStatus.NOT_FOUND, "route not found", "not_found")
+
+    def _bulk_create(self, payload: dict[str, Any]) -> None:
+        urls = payload.get("urls")
+        if set(payload) != {"urls"} or not isinstance(urls, list) or not urls or len(urls) > MAX_BULK_URLS:
+            self._error(HTTPStatus.BAD_REQUEST, f"urls must contain 1 to {MAX_BULK_URLS} items")
+            return
+        results = []
+        for index, url in enumerate(urls):
+            try:
+                if not isinstance(url, str):
+                    raise STORE_MODULE.StoreError("job URL must be a string")
+                job = self.server.store.create_job({"url": url}, origin="human")
+                results.append({"index": index, "url": url, "ok": True, "job": job})
+            except (STORE_MODULE.StoreError, OSError) as error:
+                results.append({"index": index, "url": url, "ok": False, "error": str(error)})
+        self._json(HTTPStatus.OK, {"results": results})
+
+    def do_OPTIONS(self) -> None:
+        if not self._valid_host():
+            return
+        self._error(HTTPStatus.METHOD_NOT_ALLOWED, "cross-origin preflight is not supported", "method_rejected")
+
+    def do_PUT(self) -> None:
+        self._method_rejected()
+
+    def do_DELETE(self) -> None:
+        self._method_rejected()
+
+    def _method_rejected(self) -> None:
+        if not self._valid_host():
+            return
+        self._error(HTTPStatus.METHOD_NOT_ALLOWED, "method not allowed", "method_rejected")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Start the local Job Apply Jobs workspace")
+    parser.add_argument("--root", help="canonical store root (default: JOB_APPLY_STORE or ~/.job-apply)")
+    parser.add_argument("--port", type=int, default=0, help="loopback port (default: choose a free port)")
+    parser.add_argument("--no-open", action="store_true", help="do not open the default browser")
+    parser.add_argument("--json", action="store_true", help="print startup details as one JSON line")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if not 0 <= args.port <= 65535:
+        print("job-apply-workspace: port must be between 0 and 65535", file=sys.stderr)
+        return 2
+    configured = args.root or os.environ.get("JOB_APPLY_STORE")
+    store_root = Path(configured).expanduser() if configured else Path.home() / ".job-apply"
+    try:
+        server = WorkspaceServer(store_root, args.port)
+    except (OSError, STORE_MODULE.StoreError) as error:
+        print(f"job-apply-workspace: unable to start: {error}", file=sys.stderr)
+        return 2
+    url = f"{server.origin}/#token={server.token}"
+    details = {"url": url, "origin": server.origin, "host": LOOPBACK, "port": server.server_port}
+    if args.json:
+        print(json.dumps(details, separators=(",", ":")), flush=True)
+    else:
+        print(f"Job Apply workspace: {url}", flush=True)
+        print("Press Ctrl-C to stop. Data stays in the canonical local store.", flush=True)
+    if not args.no_open:
+        threading.Timer(0.15, lambda: webbrowser.open(url)).start()
+
+    stopping = threading.Event()
+
+    def stop(_signum: int | None = None, _frame: Any = None) -> None:
+        if not stopping.is_set():
+            stopping.set()
+            threading.Thread(target=server.shutdown, daemon=True).start()
+
+    for name in ("SIGINT", "SIGTERM", "SIGBREAK"):
+        sig = getattr(signal, name, None)
+        if sig is not None:
+            signal.signal(sig, stop)
+    try:
+        server.serve_forever(poll_interval=0.2)
+    except KeyboardInterrupt:
+        stop()
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke-plugin.sh
+++ b/scripts/smoke-plugin.sh
@@ -81,7 +81,7 @@ from qa.promote import (
     _validate_approval,
 )
 
-expected = {"answer-memory", "job-apply", "job-search", "job-preferences"}
+expected = {"answer-memory", "job-apply", "job-search", "job-preferences", "job-workspace"}
 
 launcher = root / "scripts" / "qa-chrome.py"
 try:
@@ -295,7 +295,9 @@ for skill in expected:
     if not match or match.group(1) != skill:
         raise SystemExit(f"skills/{skill}/SKILL.md frontmatter name is missing or incorrect")
 
-invocation_pattern = re.compile(r"(?:\$|/)?job-apply:(answer-memory|job-apply|job-search|job-preferences)")
+invocation_pattern = re.compile(
+    r"(?:\$|/)?job-apply:(answer-memory|job-apply|job-search|job-preferences|job-workspace)"
+)
 for relative in ("README.md", "site/index.html"):
     found = set(invocation_pattern.findall((root / relative).read_text()))
     if found != expected:
@@ -389,6 +391,57 @@ for generated in fixture.rglob("*"):
 print("Packaged fixture exclusions passed")
 PY
 
+python3 - "$SMOKE_FIXTURE_DIR" "$SMOKE_TEMP_ROOT" <<'PY'
+import http.client
+import json
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+fixture = Path(sys.argv[1])
+smoke_root = Path(sys.argv[2])
+launcher = fixture / "scripts" / "job-apply-workspace.py"
+assets = [fixture / "workspace" / name for name in ("index.html", "app.js", "styles.css")]
+if not launcher.is_file() or not all(asset.is_file() for asset in assets):
+    raise SystemExit("packaged fixture is missing the Jobs workspace launcher or assets")
+process = subprocess.Popen(
+    [sys.executable, str(launcher), "--root", str(smoke_root / "workspace-store"), "--port", "0", "--no-open", "--json"],
+    stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+)
+try:
+    details = json.loads(process.stdout.readline())
+    parsed = urlsplit(details["url"])
+    token = parsed.fragment.removeprefix("token=")
+    connection = http.client.HTTPConnection("127.0.0.1", details["port"], timeout=5)
+    host = f"127.0.0.1:{details['port']}"
+    connection.request("GET", "/", headers={"Host": host})
+    response = connection.getresponse()
+    if response.status != 200 or b"Jobs Workspace" not in response.read():
+        raise SystemExit("packaged workspace did not serve its Jobs UI")
+    connection.request("GET", "/api/state", headers={"Host": host, "Authorization": f"Bearer {token}"})
+    response = connection.getresponse()
+    state = json.loads(response.read())
+    if response.status != 200 or state != {"jobs": [], "resumes": []}:
+        raise SystemExit("packaged workspace did not read the canonical store")
+    connection.close()
+    process.send_signal(signal.SIGINT)
+    if process.wait(timeout=5) != 0:
+        raise SystemExit("packaged workspace did not shut down cleanly")
+finally:
+    if process.poll() is None:
+        process.terminate()
+        process.wait(timeout=5)
+print("Packaged Jobs workspace launch passed")
+PY
+
+echo "Running Playwright and CLI walkthrough against packaged fixture"
+JOB_WORKSPACE_TEST_ROOT="$SMOKE_FIXTURE_DIR" \
+  node --test --test-name-pattern='real browser and CLI share CRUD' \
+  "$REPO_ROOT/tests_js/workspace.test.mjs"
+echo "Packaged Playwright and CLI walkthrough passed"
+
 python3 - "$SMOKE_FIXTURE_DIR/.claude-plugin/marketplace.json" <<'PY'
 import json
 import sys
@@ -406,7 +459,7 @@ CLAUDE_CONFIG_DIR="$SMOKE_CLAUDE_CONFIG_DIR" claude plugin install job-apply@neo
 CLAUDE_CONFIG_DIR="$SMOKE_CLAUDE_CONFIG_DIR" claude plugin details job-apply@neonwatty-plugins \
   | tee "$SMOKE_TEMP_ROOT/plugin-details.txt"
 
-for skill in answer-memory job-apply job-search job-preferences; do
+for skill in answer-memory job-apply job-search job-preferences job-workspace; do
   if ! grep -Fq -- "$skill" "$SMOKE_TEMP_ROOT/plugin-details.txt"; then
     echo "Installed plugin details did not list $skill" >&2
     exit 1
@@ -453,7 +506,7 @@ versions = [path for path in cache_root.iterdir() if path.is_dir()]
 if len(versions) != 1:
     raise SystemExit(f"expected one isolated Codex plugin version, found {len(versions)}")
 
-expected = {"answer-memory", "job-apply", "job-search", "job-preferences"}
+expected = {"answer-memory", "job-apply", "job-search", "job-preferences", "job-workspace"}
 installed_skills = {
     path.name for path in (versions[0] / "skills").iterdir() if path.is_dir()
 }

--- a/site/index.html
+++ b/site/index.html
@@ -82,8 +82,8 @@
 
     <section id="skills" class="section">
       <div class="section-heading">
-        <p class="eyebrow">Four skills</p>
-        <h2>Remember trusted answers, set preferences, discover opportunities, and apply.</h2>
+        <p class="eyebrow">Five skills</p>
+        <h2>Remember trusted answers, set preferences, discover, organize, and apply.</h2>
       </div>
       <div class="skills-grid">
         <article class="skill-card">
@@ -136,6 +136,19 @@
             <li>Filters out unwanted titles and seniority levels</li>
             <li>Stores preferences with your local profile</li>
             <li>Updates selected settings without replacing the rest</li>
+          </ul>
+        </article>
+        <article class="skill-card">
+          <div class="skill-header">
+            <span class="skill-badge">job-apply:job-workspace</span>
+          </div>
+          <h3>Organize jobs in a local workspace</h3>
+          <ul class="feature-bullets">
+            <li>Opens an optional browser workspace on your device</li>
+            <li>Shares the same canonical Jobs records with CLI agents</li>
+            <li>Captures, filters, edits, and preflights opportunities</li>
+            <li>Preserves drafts when another client changes a record</li>
+            <li>Marks valid jobs ready for explicit agent handoff</li>
           </ul>
         </article>
       </div>

--- a/skills/job-workspace/SKILL.md
+++ b/skills/job-workspace/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: job-workspace
+description: Start the optional local Jobs workspace shared with Job Apply agents and the canonical store.
+allowed-tools: Bash
+---
+
+# Job Workspace
+
+Start the packaged, local-only Jobs companion when the user asks to view, organize, edit, preflight, or prepare canonical jobs in a browser.
+
+## Launch
+
+1. Resolve `<plugin-root>` safely. In Codex, use the installed skill path and walk up from `skills/job-workspace/SKILL.md`; use `PLUGIN_ROOT` only after confirming it contains both `scripts/job-apply-workspace.py` and `workspace/index.html`. In Claude Code, use `CLAUDE_PLUGIN_ROOT` after the same checks.
+2. Run exactly:
+
+   ```bash
+   python3 "<plugin-root>/scripts/job-apply-workspace.py"
+   ```
+
+3. Leave the process attached while the user works. Report that Ctrl-C stops it cleanly.
+
+The launcher chooses a free port, binds only to `127.0.0.1`, opens the browser, and imports the same canonical Store implementation bundled in `scripts/job-apply-store.py`. The browser never reads or writes store files directly. It needs no account, cloud service, telemetry, separate database, Node runtime, or frontend installation.
+
+## Boundaries
+
+- Never copy the printed fragment token into chat, logs, or another URL. If the browser did not open, tell the user to open the complete URL printed locally by the launcher.
+- Never bind the workspace to another host or proxy it onto a network.
+- The UI can create, edit, organize, preflight, mark ready, and move Jobs records to recoverable trash. It does not restore or permanently delete records and does not provide standalone Facts, Answers, Resumes, or Trash management.
+- The UI does not run application agents or access arbitrary files. It must not submit applications or activate any third-party final action. A ready record is only a handoff for the existing Job Apply workflow.
+- All mutations go through the canonical Store contract with optimistic revisions. If a conflict appears, preserve the draft and let the user review or reapply it explicitly.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Local test package."""

--- a/tests/test_answer_memory_integration.py
+++ b/tests/test_answer_memory_integration.py
@@ -166,10 +166,19 @@ class AnswerMemoryIntegrationTests(unittest.TestCase):
             for path in (ROOT / "skills").glob("*/SKILL.md")
         }
         self.assertEqual(
-            set(skills), {"answer-memory", "job-apply", "job-preferences", "job-search"}
+            set(skills),
+            {
+                "answer-memory",
+                "job-apply",
+                "job-preferences",
+                "job-search",
+                "job-workspace",
+            },
         )
-        for name, content in skills.items():
-            self.assertIn("job-apply-store.py", content, name)
+        for name in ("answer-memory", "job-apply", "job-preferences", "job-search"):
+            self.assertIn("job-apply-store.py", skills[name], name)
+        self.assertIn("job-apply-workspace.py", skills["job-workspace"])
+        self.assertIn("canonical Store contract", skills["job-workspace"])
         for name in ("job-apply", "job-preferences", "job-search"):
             self.assertNotIn("Read `~/.claude-job-profile.json`", skills[name])
             self.assertNotIn("Write the collected values into `~/.claude-job-profile.json`", skills[name])

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -1458,6 +1458,57 @@ class StoreTests(unittest.TestCase):
             ["job-started", "claim-recovered"],
         )
 
+    def test_acquire_and_recover_tokens_are_cli_safe_when_random_payload_leads_hyphen(self):
+        instant = [datetime(2026, 8, 24, tzinfo=timezone.utc)]
+        self.store = STORE_MODULE.Store(self.root, self.legacy, clock=lambda: instant[0])
+        ready = self._make_ready_job()
+
+        with mock.patch.object(
+            STORE_MODULE.secrets,
+            "token_urlsafe",
+            side_effect=["-acquire-payload", "-recovery-payload"],
+        ):
+            acquired = self.store.acquire_ready_job(
+                "ready-job", "codex", ready["revision"]
+            )
+            self.assertEqual(acquired["token"], "claim_-acquire-payload")
+            parsed = STORE_MODULE.build_parser().parse_args(
+                [
+                    "--root",
+                    str(self.root),
+                    "claim-heartbeat",
+                    "--id",
+                    "ready-job",
+                    "--token",
+                    acquired["token"],
+                ]
+            )
+            self.assertEqual(parsed.token, acquired["token"])
+            persisted = self.store.coordinator_path.read_text(encoding="utf-8")
+            self.assertNotIn(acquired["token"], persisted)
+            self.assertIn(self.store._token_hash(acquired["token"]), persisted)
+
+            instant[0] += timedelta(seconds=STORE_MODULE.CLAIM_LEASE_SECONDS + 1)
+            recovered = self.store.recover_claim("ready-job", "recovery-agent")
+            self.assertEqual(recovered["token"], "claim_-recovery-payload")
+            parsed = STORE_MODULE.build_parser().parse_args(
+                [
+                    "--root",
+                    str(self.root),
+                    "claim-progress",
+                    "--id",
+                    "ready-job",
+                    "--token",
+                    recovered["token"],
+                    "--input",
+                    "progress.json",
+                ]
+            )
+            self.assertEqual(parsed.token, recovered["token"])
+            persisted = self.store.coordinator_path.read_text(encoding="utf-8")
+            self.assertNotIn(recovered["token"], persisted)
+            self.assertIn(self.store._token_hash(recovered["token"]), persisted)
+
     def test_claim_handoffs_are_atomic_value_free_and_release_ownership(self):
         self._make_ready_job()
         ready = self.store.get_job("ready-job")

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -1323,7 +1323,11 @@ class StoreTests(unittest.TestCase):
 
     def test_legacy_job_cli_walkthrough_uses_fixed_home_root(self):
         self._write_legacy_search_report()
-        environment = {**os.environ, "HOME": str(self.home)}
+        environment = {
+            **os.environ,
+            "HOME": str(self.home),
+            "USERPROFILE": str(self.home),
+        }
         base = [sys.executable, str(SCRIPT), "--root", str(self.root)]
         discovered = subprocess.run(
             [*base, "legacy-jobs-preview"], check=True, capture_output=True, text=True, env=environment

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -880,7 +880,7 @@ class StoreTests(unittest.TestCase):
             discovery = self.store.preview_legacy_jobs([])
             selected = [discovery["items"][0]["itemId"]]
             preview = self.store.preview_legacy_jobs(selected)
-            source.write_text(source.read_text() + "\n", encoding="utf-8")
+            source.write_bytes(source.read_bytes() + b"\n")
             with self.assertRaisesRegex(STORE_MODULE.StoreError, "drifted"):
                 self.store.commit_legacy_jobs(selected, preview["token"])
 

--- a/tests/test_job_apply_workspace.py
+++ b/tests/test_job_apply_workspace.py
@@ -160,6 +160,23 @@ class WorkspaceServerTests(unittest.TestCase):
         self.assertEqual(self.server.store.get_job(job["id"])["role"], "CLI edit")
         self.assertEqual(self.server.store.get_job(job["id"])["revision"], cli["revision"])
 
+    def test_mutations_reject_invalid_revision_and_transition_types(self):
+        job = self.create_job(role="Original")
+        probes = (
+            ("PATCH", f"/api/jobs/{job['id']}", {"patch": {"role": "bad"}, "expectedRevision": True}),
+            ("POST", f"/api/jobs/{job['id']}/transition", {"status": [], "expectedRevision": 1}),
+            ("POST", f"/api/jobs/{job['id']}/transition", {"status": "closed", "expectedRevision": 1, "closedOutcome": []}),
+            ("POST", f"/api/jobs/{job['id']}/transition", {"status": "needs_info", "expectedRevision": 1.0}),
+            ("POST", f"/api/jobs/{job['id']}/trash", {"expectedRevision": 1.0}),
+        )
+        for method, path, payload in probes:
+            with self.subTest(method=method, path=path, payload=payload):
+                status, _headers, body = self.request(method, path, payload)
+                self.assertEqual(status, 400)
+                self.assertEqual(body["error"]["code"], "request_error")
+        canonical = self.server.store.get_job(job["id"])
+        self.assertEqual((canonical["role"], canonical["status"], canonical["revision"]), ("Original", "saved", 1))
+
     def test_bulk_capture_keeps_valid_items_and_reports_each_failure(self):
         urls = ["https://example.com/good", "not a url", "https://example.com/good"]
         status, _headers, body = self.request("POST", "/api/jobs/bulk", {"urls": urls})
@@ -183,6 +200,8 @@ class WorkspaceServerTests(unittest.TestCase):
         status, _headers, body = self.request("POST", f"/api/jobs/{job['id']}/transition", {"status": "applied", "expectedRevision": ready["revision"]})
         self.assertEqual(status, 400)
         self.assertIn("unsupported", body["error"]["message"])
+        status, _headers, closed = self.request("POST", f"/api/jobs/{job['id']}/transition", {"status": "closed", "closedOutcome": "withdrawn", "expectedRevision": ready["revision"]})
+        self.assertEqual((status, closed["status"], closed["closedOutcome"]), (200, "closed", "withdrawn"))
 
     def test_trash_is_guarded_and_no_restore_or_delete_routes_exist(self):
         job = self.create_job()
@@ -212,6 +231,35 @@ class WorkspaceProcessTests(unittest.TestCase):
                 connection.request("GET", "/", headers={"Host": f"127.0.0.1:{details['port']}"})
                 self.assertEqual(connection.getresponse().status, 200)
                 connection.close()
+                if os.name == "nt":
+                    process.send_signal(signal.CTRL_BREAK_EVENT)
+                else:
+                    process.send_signal(signal.SIGINT)
+                self.assertEqual(process.wait(timeout=5), 0)
+            finally:
+                if process.poll() is None:
+                    process.terminate()
+                    process.wait(timeout=5)
+
+    def test_launcher_uses_canonical_store_environment_variable(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            home = Path(temporary) / "home"
+            store = Path(temporary) / "configured-store"
+            home.mkdir()
+            environment = os.environ.copy()
+            environment["HOME"] = str(home)
+            environment[WORKSPACE.STORE_MODULE.STORE_ENV] = str(store)
+            environment.pop("JOB_APPLY_STORE", None)
+            process = subprocess.Popen(
+                [sys.executable, str(ROOT / "scripts" / "job-apply-workspace.py"), "--port", "0", "--no-open", "--json"],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=environment,
+                creationflags=(subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0),
+            )
+            try:
+                details = json.loads(process.stdout.readline())
+                self.assertEqual(details["host"], "127.0.0.1")
+                self.assertTrue((store / "jobs.json").is_file())
+                self.assertFalse((home / ".job-apply").exists())
                 if os.name == "nt":
                     process.send_signal(signal.CTRL_BREAK_EVENT)
                 else:

--- a/tests/test_job_apply_workspace.py
+++ b/tests/test_job_apply_workspace.py
@@ -71,6 +71,8 @@ class WorkspaceServerTests(unittest.TestCase):
 
     def test_binds_exact_ipv4_loopback_and_serves_allowlisted_assets(self):
         self.assertEqual(self.server.server_address[0], "127.0.0.1")
+        self.assertEqual(WORKSPACE.loopback_authority(80), ("http://127.0.0.1", "127.0.0.1"))
+        self.assertEqual(WORKSPACE.loopback_authority(8080), ("http://127.0.0.1:8080", "127.0.0.1:8080"))
         status, headers, body = self.request("GET", "/", token=False, origin=False)
         self.assertEqual(status, 200)
         self.assertIn(b"Jobs Workspace", body)

--- a/tests/test_job_apply_workspace.py
+++ b/tests/test_job_apply_workspace.py
@@ -1,0 +1,227 @@
+import http.client
+import importlib.util
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+WORKSPACE = load_module("job_apply_workspace_test", ROOT / "scripts" / "job-apply-workspace.py")
+
+
+class WorkspaceServerTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.store_root = Path(self.temporary.name) / "store"
+        self.server = WORKSPACE.WorkspaceServer(self.store_root, 0, token="test-workspace-token")
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        self.temporary.cleanup()
+
+    def request(self, method, path, payload=None, *, token=True, origin=True, host=None, content_type="application/json", raw=None):
+        connection = http.client.HTTPConnection(WORKSPACE.LOOPBACK, self.server.server_port, timeout=3)
+        headers = {"Host": host or self.server.expected_host}
+        if token:
+            headers["Authorization"] = f"Bearer {self.server.token}"
+        if origin:
+            headers["Origin"] = self.server.origin
+        body = raw
+        if payload is not None:
+            body = json.dumps(payload).encode()
+        if body is not None:
+            headers["Content-Type"] = content_type
+            headers["Content-Length"] = str(len(body))
+        connection.request(method, path, body=body, headers=headers)
+        response = connection.getresponse()
+        data = response.read()
+        connection.close()
+        try:
+            decoded = json.loads(data)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            decoded = data
+        return response.status, response.getheaders(), decoded
+
+    def create_job(self, url="https://example.com/jobs/one", **fields):
+        status, _headers, result = self.request("POST", "/api/jobs", {"job": {"url": url, **fields}})
+        self.assertEqual(status, 200, result)
+        return result
+
+    def test_binds_exact_ipv4_loopback_and_serves_allowlisted_assets(self):
+        self.assertEqual(self.server.server_address[0], "127.0.0.1")
+        status, headers, body = self.request("GET", "/", token=False, origin=False)
+        self.assertEqual(status, 200)
+        self.assertIn(b"Jobs Workspace", body)
+        header_map = dict(headers)
+        self.assertIn("default-src 'self'", header_map["Content-Security-Policy"])
+        self.assertEqual(header_map["Cache-Control"], "no-store")
+        for path in ("/../scripts/job-apply-store.py", "/%2e%2e/scripts/job-apply-store.py", "/api/files", "/api/command"):
+            status, _headers, _body = self.request("GET", path, token=path.startswith("/api/"), origin=False)
+            self.assertEqual(status, 404, path)
+
+    def test_all_apis_require_token_and_mutations_require_exact_origin(self):
+        status, _headers, body = self.request("GET", "/api/state", token=False, origin=False)
+        self.assertEqual((status, body["error"]["code"]), (401, "token_rejected"))
+        status, _headers, body = self.request("POST", "/api/jobs", {"job": {"url": "https://example.com/no-origin"}}, origin=False)
+        self.assertEqual((status, body["error"]["code"]), (403, "origin_rejected"))
+        status, _headers, body = self.request("POST", "/api/jobs", {"job": {"url": "https://example.com/bad-origin"}}, origin=False)
+        self.assertEqual(status, 403)
+        self.assertEqual(self.server.store.list_jobs(), [])
+
+    def test_rejects_host_options_content_type_malformed_and_oversized_requests(self):
+        status, _headers, body = self.request("GET", "/", token=False, origin=False, host=f"localhost:{self.server.server_port}")
+        self.assertEqual((status, body["error"]["code"]), (403, "host_rejected"))
+        status, _headers, _body = self.request("OPTIONS", "/api/jobs", token=False, origin=False)
+        self.assertEqual(status, 405)
+        status, _headers, _body = self.request("POST", "/api/jobs", raw=b"{}", content_type="text/plain")
+        self.assertEqual(status, 415)
+        status, _headers, _body = self.request("POST", "/api/jobs", raw=b"{")
+        self.assertEqual(status, 400)
+        oversized = b"x" * (WORKSPACE.MAX_BODY_BYTES + 1)
+        status, _headers, _body = self.request("POST", "/api/jobs", raw=oversized)
+        self.assertEqual(status, 413)
+        self.assertEqual(self.server.store.list_jobs(), [])
+
+    def test_pre_body_rejections_close_connection_without_reparsing_bytes(self):
+        host = self.server.expected_host
+        probes = (
+            (
+                b"POST /api/jobs HTTP/1.1\r\n"
+                + f"Host: {host}\r\n".encode()
+                + b"Origin: http://attacker.invalid\r\nContent-Type: application/json\r\n"
+                + b"Content-Length: 2\r\n\r\n{}"
+                + f"GET /api/state HTTP/1.1\r\nHost: {host}\r\n\r\n".encode(),
+                b"HTTP/1.1 401 ",
+            ),
+            (
+                b"POST /api/jobs HTTP/1.1\r\n"
+                + f"Host: {host}\r\nAuthorization: Bearer {self.server.token}\r\n".encode()
+                + f"Origin: {self.server.origin}\r\nContent-Type: application/json\r\n".encode()
+                + f"Content-Length: {WORKSPACE.MAX_BODY_BYTES + 1}\r\n\r\n".encode()
+                + b"GET /api/state HTTP/1.1\r\n\r\n",
+                b"HTTP/1.1 413 ",
+            ),
+        )
+        for request, expected_status in probes:
+            with self.subTest(status=expected_status):
+                with socket.create_connection((WORKSPACE.LOOPBACK, self.server.server_port), timeout=3) as connection:
+                    connection.sendall(request)
+                    response = bytearray()
+                    while True:
+                        chunk = connection.recv(8192)
+                        if not chunk:
+                            break
+                        response.extend(chunk)
+                self.assertIn(expected_status, response)
+                self.assertIn(b"Connection: close", response)
+                self.assertEqual(response.count(b"HTTP/1.1 "), 1)
+
+    def test_ui_and_store_share_bidirectional_crud(self):
+        cli_job = self.server.store.create_job({"url": "https://example.com/cli", "role": "CLI role"})
+        status, _headers, state = self.request("GET", "/api/state", origin=False)
+        self.assertEqual(status, 200)
+        self.assertEqual(state["jobs"][0]["id"], cli_job["id"])
+        ui_job = self.create_job("HTTPS://Example.com:443/ui#apply", role="UI role", company="Acme", priority=4)
+        canonical = self.server.store.get_job(ui_job["id"])
+        self.assertEqual(canonical["normalizedUrl"], "https://example.com/ui")
+        self.assertEqual((canonical["role"], canonical["company"], canonical["priority"]), ("UI role", "Acme", 4))
+        status, _headers, updated = self.request("PATCH", f"/api/jobs/{ui_job['id']}", {"patch": {"notes": "human note"}, "expectedRevision": ui_job["revision"]})
+        self.assertEqual(status, 200)
+        self.assertEqual(self.server.store.get_job(ui_job["id"])["notes"], "human note")
+        self.assertEqual(updated["revision"], 2)
+
+    def test_revision_conflict_is_409_and_never_overwrites_canonical_data(self):
+        job = self.create_job(role="Original")
+        cli = self.server.store.update_job(job["id"], {"role": "CLI edit"}, job["revision"])
+        status, _headers, body = self.request("PATCH", f"/api/jobs/{job['id']}", {"patch": {"role": "stale UI edit"}, "expectedRevision": job["revision"]})
+        self.assertEqual((status, body["error"]["code"]), (409, "revision_conflict"))
+        self.assertEqual(self.server.store.get_job(job["id"])["role"], "CLI edit")
+        self.assertEqual(self.server.store.get_job(job["id"])["revision"], cli["revision"])
+
+    def test_bulk_capture_keeps_valid_items_and_reports_each_failure(self):
+        urls = ["https://example.com/good", "not a url", "https://example.com/good"]
+        status, _headers, body = self.request("POST", "/api/jobs/bulk", {"urls": urls})
+        self.assertEqual(status, 200)
+        self.assertEqual([item["ok"] for item in body["results"]], [True, False, False])
+        self.assertEqual(len(self.server.store.list_jobs()), 1)
+
+    def test_preflight_resume_assignment_ready_handoff_and_guarded_applied(self):
+        self.server.store.replace_profile({"firstName": "Ada"})
+        resume_path = Path(self.temporary.name) / "resume.pdf"
+        resume_path.write_bytes(b"resume")
+        resume = self.server.store.create_resume({"id": "main", "label": "Main", "path": str(resume_path)})
+        job = self.create_job(resumeId=resume["id"], role="Engineer", company="Acme")
+        status, _headers, preflight = self.request("GET", f"/api/jobs/{job['id']}/preflight", origin=False)
+        self.assertEqual(status, 200)
+        self.assertTrue(preflight["ready"])
+        status, _headers, ready = self.request("POST", f"/api/jobs/{job['id']}/transition", {"status": "ready", "expectedRevision": job["revision"]})
+        self.assertEqual((status, ready["status"]), (200, "ready"))
+        self.assertEqual(self.server.store.list_jobs("ready")[0]["id"], job["id"])
+        # Applied is never reachable from ready and never accepted without explicit confirmation.
+        status, _headers, body = self.request("POST", f"/api/jobs/{job['id']}/transition", {"status": "applied", "expectedRevision": ready["revision"]})
+        self.assertEqual(status, 400)
+        self.assertIn("unsupported", body["error"]["message"])
+
+    def test_trash_is_guarded_and_no_restore_or_delete_routes_exist(self):
+        job = self.create_job()
+        status, _headers, trashed = self.request("POST", f"/api/jobs/{job['id']}/trash", {"expectedRevision": job["revision"]})
+        self.assertEqual(status, 200)
+        self.assertIsNotNone(trashed["deletedAt"])
+        self.assertIsNone(self.server.store.get_job(job["id"]))
+        for action in ("restore", "delete"):
+            status, _headers, _body = self.request("POST", f"/api/jobs/{job['id']}/{action}", {"expectedRevision": trashed["revision"]})
+            self.assertEqual(status, 404)
+
+
+class WorkspaceProcessTests(unittest.TestCase):
+    def test_launcher_reports_fragment_token_and_stops_cleanly(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            process = subprocess.Popen(
+                [sys.executable, str(ROOT / "scripts" / "job-apply-workspace.py"), "--root", str(Path(temporary) / "store"), "--port", "0", "--no-open", "--json"],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+                creationflags=(subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0),
+            )
+            try:
+                line = process.stdout.readline()
+                details = json.loads(line)
+                self.assertEqual(details["host"], "127.0.0.1")
+                self.assertIn("/#token=", details["url"])
+                connection = http.client.HTTPConnection("127.0.0.1", details["port"], timeout=3)
+                connection.request("GET", "/", headers={"Host": f"127.0.0.1:{details['port']}"})
+                self.assertEqual(connection.getresponse().status, 200)
+                connection.close()
+                if os.name == "nt":
+                    process.send_signal(signal.CTRL_BREAK_EVENT)
+                else:
+                    process.send_signal(signal.SIGINT)
+                self.assertEqual(process.wait(timeout=5), 0)
+            finally:
+                if process.poll() is None:
+                    process.terminate()
+                    process.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_js/workspace.test.mjs
+++ b/tests_js/workspace.test.mjs
@@ -18,6 +18,7 @@ const {
   createApi,
   filterJobs,
   formPatch,
+  safeSessionStorage,
   sessionToken,
   tokenFromHash,
   transitionsFor,
@@ -33,6 +34,10 @@ test("fragment token survives a same-tab reload without remaining in the URL", (
   const storage = { setItem(key, value) { values.set(key, value); }, getItem(key) { return values.get(key) || null; } };
   assert.equal(sessionToken("#token=session-secret", storage), "session-secret");
   assert.equal(sessionToken("", storage), "session-secret");
+  const denied = {};
+  Object.defineProperty(denied, "sessionStorage", { get() { throw new DOMException("denied", "SecurityError"); } });
+  assert.equal(safeSessionStorage(denied), null);
+  assert.equal(sessionToken("#token=fallback-secret", safeSessionStorage(denied)), "fallback-secret");
 });
 
 test("API client authenticates in memory and surfaces revision conflicts", async () => {
@@ -198,6 +203,7 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     await page.getByRole("button", { name: /UI Engineer/ }).press("Enter");
     await jobDialog.getByLabel("Role", { exact: true }).fill("My preserved draft");
     const cliUpdated = await cli("job-update", ["--id", uiJob.id, "--expected-revision", String(uiJob.revision), "--origin", "human"], { role: "CLI canonical edit", notes: "CLI concurrent note" });
+    await cli("job-transition", ["--id", uiJob.id, "--status", "needs_info", "--expected-revision", String(cliUpdated.revision)]);
     await page.getByRole("button", { name: "Save job" }).click();
     const conflict = page.locator("#conflict");
     await conflict.waitFor();
@@ -208,6 +214,8 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     await page.getByRole("button", { name: "Reapply my draft" }).click();
     assert.equal(await jobDialog.getByLabel("Role", { exact: true }).inputValue(), "My preserved draft");
     assert.equal(await jobDialog.getByLabel("Notes", { exact: true }).inputValue(), "CLI concurrent note");
+    assert.equal(await page.getByRole("button", { name: "Move to saved" }).isVisible(), true);
+    assert.equal(await page.getByRole("button", { name: "Move to needs info" }).count(), 0);
     await page.getByRole("button", { name: "Save job" }).click();
     await page.locator("#job-dialog").waitFor({ state: "hidden" });
     const safelyRebased = await cli("job-get", ["--id", uiJob.id]);

--- a/tests_js/workspace.test.mjs
+++ b/tests_js/workspace.test.mjs
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import test from "node:test";
+import { chromium } from "playwright";
+
+const SOURCE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const REPO_ROOT = process.env.JOB_WORKSPACE_TEST_ROOT
+  ? resolve(process.env.JOB_WORKSPACE_TEST_ROOT)
+  : SOURCE_ROOT;
+const PYTHON = process.env.PYTHON || "python3";
+const {
+  ApiError,
+  createApi,
+  filterJobs,
+  formPatch,
+  tokenFromHash,
+  transitionsFor,
+} = await import(pathToFileURL(join(REPO_ROOT, "workspace", "app.js")).href);
+
+test("fragment token is decoded without accepting unrelated URL data", () => {
+  assert.equal(tokenFromHash("#token=abc%20123"), "abc 123");
+  assert.equal(tokenFromHash("#other=value"), "");
+});
+
+test("API client authenticates in memory and surfaces revision conflicts", async () => {
+  let captured;
+  const fetchImpl = async (path, options) => {
+    captured = { path, options };
+    return { ok: false, status: 409, async json() { return { error: { code: "revision_conflict", message: "job revision conflict" } }; } };
+  };
+  const api = createApi("secret", fetchImpl);
+  await assert.rejects(
+    api("/api/jobs/job-1", { method: "PATCH", body: "{}" }),
+    (error) => error instanceof ApiError && error.status === 409 && error.code === "revision_conflict",
+  );
+  assert.equal(captured.options.headers.Authorization, "Bearer secret");
+  assert.equal(captured.options.headers["Content-Type"], "application/json");
+  assert.equal(captured.path.includes("secret"), false);
+});
+
+test("jobs filter by status and human-visible fields", () => {
+  const jobs = [
+    { role: "Staff Engineer", company: "Acme", location: "Phoenix", status: "ready" },
+    { role: "Designer", company: "Orbit", location: "Remote", status: "saved" },
+  ];
+  assert.deepEqual(filterJobs(jobs, "acme", ""), [jobs[0]]);
+  assert.deepEqual(filterJobs(jobs, "remote", "saved"), [jobs[1]]);
+  assert.deepEqual(filterJobs(jobs, "engineer", "saved"), []);
+});
+
+test("form values become a supported Store patch", () => {
+  const patch = formPatch({
+    url: "https://example.com/job", role: "Engineer", company: "Acme", location: "Remote",
+    workplaceType: "remote", employmentType: "full_time", compensation: "$150k", notes: "note",
+    description: "description", resumeId: "", priority: "4",
+  });
+  assert.equal(patch.priority, 4);
+  assert.equal(patch.resumeId, null);
+  assert.equal(patch.role, "Engineer");
+  assert.equal("status" in patch, false);
+});
+
+test("status actions preserve guarded ready, acquire, and applied boundaries", () => {
+  assert.deepEqual(transitionsFor("saved"), ["needs_info", "closed"]);
+  assert.equal(transitionsFor("ready").includes("in_progress"), false);
+  assert.deepEqual(transitionsFor("awaiting_review"), ["in_progress", "applied", "closed"]);
+});
+
+test("workspace markup has semantic dialogs, labels, live regions, and no remote assets", async () => {
+  const html = await readFile(join(REPO_ROOT, "workspace", "index.html"), "utf8");
+  assert.match(html, /<main>/);
+  assert.match(html, /<dialog id="job-dialog" aria-labelledby=/);
+  assert.match(html, /role="alert"/);
+  assert.match(html, /aria-live="polite"/);
+  assert.match(html, /class="skip-link"/);
+  assert.doesNotMatch(html, /(?:src|href)="https?:\/\//);
+  for (const name of ["url", "role", "company", "location", "priority", "resumeId", "notes", "description"]) {
+    assert.match(html, new RegExp(`<(?:input|select|textarea) name="${name}"`));
+  }
+});
+
+test("styles include visible focus, reduced motion, contrast mode, and responsive behavior", async () => {
+  const css = await readFile(join(REPO_ROOT, "workspace", "styles.css"), "utf8");
+  assert.match(css, /:focus-visible/);
+  assert.match(css, /prefers-reduced-motion/);
+  assert.match(css, /prefers-color-scheme: dark/);
+  assert.match(css, /@media \(max-width:/);
+});
+
+test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus, and shutdown", { timeout: 60_000 }, async () => {
+  const temporary = await mkdtemp(join(tmpdir(), "job-workspace-browser-"));
+  const storeRoot = join(temporary, "store");
+  const storeScript = join(REPO_ROOT, "scripts", "job-apply-store.py");
+  let inputCounter = 0;
+  const cli = async (command, args = [], payload) => {
+    const finalArgs = [storeScript, "--root", storeRoot, command, ...args];
+    if (payload !== undefined) {
+      const inputPath = join(temporary, `input-${inputCounter++}.json`);
+      await writeFile(inputPath, JSON.stringify(payload));
+      finalArgs.push("--input", inputPath);
+    }
+    const result = spawnSync(PYTHON, finalArgs, { cwd: REPO_ROOT, encoding: "utf8" });
+    assert.equal(result.status, 0, `${command}: ${result.stderr}`);
+    return JSON.parse(result.stdout);
+  };
+  const waitForStartup = (child) => new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => reject(new Error(`workspace startup timed out: ${stderr}`)), 10_000);
+    child.stdout.setEncoding("utf8"); child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      const newline = stdout.indexOf("\n");
+      if (newline >= 0) {
+        clearTimeout(timer);
+        try { resolve(JSON.parse(stdout.slice(0, newline))); } catch (error) { reject(error); }
+      }
+    });
+    child.once("exit", (code) => { clearTimeout(timer); reject(new Error(`workspace exited during startup (${code}): ${stderr}`)); });
+  });
+
+  let server;
+  let browser;
+  try {
+    const resumePath = join(temporary, "resume.pdf");
+    await writeFile(resumePath, "resume");
+    await cli("profile-replace", [], { firstName: "Ada" });
+    await cli("resume-create", [], { id: "browser-resume", label: "Browser resume", path: resumePath });
+    const cliJob = await cli("job-create", [], { url: "https://example.com/jobs/cli-browser", role: "CLI Engineer", company: "CLI Co" });
+
+    server = spawn(PYTHON, [join(REPO_ROOT, "scripts", "job-apply-workspace.py"), "--root", storeRoot, "--port", "0", "--no-open", "--json"], { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"] });
+    const startup = await waitForStartup(server);
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+    await page.goto(startup.url);
+    const jobDialog = page.locator("#job-dialog");
+
+    const cliButton = page.getByRole("button", { name: /CLI Engineer/ });
+    await cliButton.waitFor();
+    assert.equal(await page.getByRole("listitem").count(), 1);
+    assert.equal(await page.getByRole("listitem").locator("button").count(), 1);
+    assert.equal(await cliButton.getAttribute("role"), null);
+
+    await cliButton.focus();
+    await page.keyboard.press("Enter");
+    await page.locator("#job-dialog[open]").waitFor();
+    const closeDetails = page.getByRole("button", { name: "Close job details" });
+    await closeDetails.focus();
+    await page.keyboard.press("Enter");
+    await page.locator("#job-dialog").waitFor({ state: "hidden" });
+    await page.waitForFunction((id) => document.activeElement?.dataset?.id === id, cliJob.id);
+
+    await cliButton.press("Enter");
+    await jobDialog.getByLabel("Role", { exact: true }).fill("Browser-edited CLI Engineer");
+    await jobDialog.getByLabel("Notes", { exact: true }).fill("Edited in the browser");
+    await page.getByRole("button", { name: "Save job" }).click();
+    await page.locator("#job-dialog").waitFor({ state: "hidden" });
+    const browserEdited = await cli("job-get", ["--id", cliJob.id]);
+    assert.equal(browserEdited.role, "Browser-edited CLI Engineer");
+    assert.equal(browserEdited.notes, "Edited in the browser");
+    assert.equal(browserEdited.revision, cliJob.revision + 1);
+    await page.waitForFunction((id) => document.activeElement?.dataset?.id === id, cliJob.id);
+
+    await page.getByRole("button", { name: "New job" }).click();
+    await jobDialog.getByLabel("Job URL", { exact: true }).fill("https://example.com/jobs/ui-browser");
+    await jobDialog.getByLabel("Role", { exact: true }).fill("UI Engineer");
+    await jobDialog.getByLabel("Company", { exact: true }).fill("UI Co");
+    await jobDialog.getByLabel("Priority", { exact: true }).fill("4");
+    await jobDialog.getByLabel("Notes", { exact: true }).fill("Created in the browser");
+    await page.getByRole("button", { name: "Save job" }).click();
+    await page.locator("#job-dialog").waitFor({ state: "hidden" });
+    const listed = await cli("job-list");
+    const uiJob = listed.find((job) => job.role === "UI Engineer");
+    assert.ok(uiJob, "browser-created job must be visible to the CLI");
+    await page.waitForFunction((id) => document.activeElement?.dataset?.id === id, uiJob.id);
+
+    await page.getByRole("button", { name: /UI Engineer/ }).press("Enter");
+    await jobDialog.getByLabel("Role", { exact: true }).fill("My preserved draft");
+    const cliUpdated = await cli("job-update", ["--id", uiJob.id, "--expected-revision", String(uiJob.revision), "--origin", "human"], { role: "CLI canonical edit" });
+    await page.getByRole("button", { name: "Save job" }).click();
+    const conflict = page.locator("#conflict");
+    await conflict.waitFor();
+    assert.equal(await jobDialog.getByLabel("Role", { exact: true }).inputValue(), "My preserved draft");
+    assert.match(await conflict.innerText(), /CLI canonical edit/);
+    assert.equal(await page.evaluate(() => document.activeElement?.id), "conflict");
+
+    await page.getByRole("button", { name: "Load canonical values" }).click();
+    assert.equal(await jobDialog.getByLabel("Role", { exact: true }).inputValue(), "CLI canonical edit");
+    await page.getByRole("button", { name: "Run ready check" }).click();
+    await page.getByText("No blocking issues").waitFor();
+    await page.getByRole("button", { name: "Mark ready" }).click();
+    await page.locator("#job-dialog").waitFor({ state: "hidden" });
+    const ready = await cli("job-list", ["--status", "ready"]);
+    assert.equal(ready.some((job) => job.id === uiJob.id), true);
+    await page.waitForFunction((id) => document.activeElement?.dataset?.id === id, uiJob.id);
+
+    await page.getByRole("button", { name: /CLI Engineer/ }).click();
+    page.once("dialog", (prompt) => prompt.accept());
+    await page.getByRole("button", { name: "Move to trash" }).click();
+    await page.locator("#job-dialog").waitFor({ state: "hidden" });
+    await page.waitForFunction((id) => document.activeElement?.dataset?.id === id, uiJob.id);
+    assert.equal((await cli("job-get", ["--id", cliJob.id])), null);
+
+    await browser.close(); browser = null;
+    server.kill("SIGINT");
+    const exitCode = await new Promise((resolve) => server.once("exit", resolve));
+    assert.equal(exitCode, 0);
+    server = null;
+    assert.equal((await cli("job-list", ["--status", "ready"])).some((job) => job.id === uiJob.id), true);
+    assert.equal(cliUpdated.role, "CLI canonical edit");
+  } finally {
+    if (browser) await browser.close();
+    if (server && server.exitCode === null) {
+      server.kill("SIGINT");
+      await new Promise((resolve) => server.once("exit", resolve));
+    }
+    await rm(temporary, { recursive: true, force: true });
+  }
+});

--- a/tests_js/workspace.test.mjs
+++ b/tests_js/workspace.test.mjs
@@ -14,9 +14,11 @@ const REPO_ROOT = process.env.JOB_WORKSPACE_TEST_ROOT
 const PYTHON = process.env.PYTHON || "python3";
 const {
   ApiError,
+  canMarkReadyFrom,
   createApi,
   filterJobs,
   formPatch,
+  sessionToken,
   tokenFromHash,
   transitionsFor,
 } = await import(pathToFileURL(join(REPO_ROOT, "workspace", "app.js")).href);
@@ -24,6 +26,13 @@ const {
 test("fragment token is decoded without accepting unrelated URL data", () => {
   assert.equal(tokenFromHash("#token=abc%20123"), "abc 123");
   assert.equal(tokenFromHash("#other=value"), "");
+});
+
+test("fragment token survives a same-tab reload without remaining in the URL", () => {
+  const values = new Map();
+  const storage = { setItem(key, value) { values.set(key, value); }, getItem(key) { return values.get(key) || null; } };
+  assert.equal(sessionToken("#token=session-secret", storage), "session-secret");
+  assert.equal(sessionToken("", storage), "session-secret");
 });
 
 test("API client authenticates in memory and surfaces revision conflicts", async () => {
@@ -67,7 +76,11 @@ test("form values become a supported Store patch", () => {
 test("status actions preserve guarded ready, acquire, and applied boundaries", () => {
   assert.deepEqual(transitionsFor("saved"), ["needs_info", "closed"]);
   assert.equal(transitionsFor("ready").includes("in_progress"), false);
-  assert.deepEqual(transitionsFor("awaiting_review"), ["in_progress", "applied", "closed"]);
+  assert.deepEqual(transitionsFor("in_progress"), []);
+  assert.deepEqual(transitionsFor("awaiting_review"), ["applied", "closed"]);
+  assert.equal(canMarkReadyFrom("saved"), true);
+  assert.equal(canMarkReadyFrom("needs_info"), true);
+  assert.equal(canMarkReadyFrom("awaiting_review"), false);
 });
 
 test("workspace markup has semantic dialogs, labels, live regions, and no remote assets", async () => {
@@ -138,6 +151,9 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     browser = await chromium.launch({ headless: true });
     const page = await browser.newPage();
     await page.goto(startup.url);
+    await page.getByText("Canonical store connected").waitFor();
+    await page.reload();
+    await page.getByText("Canonical store connected").waitFor();
     const jobDialog = page.locator("#job-dialog");
 
     const cliButton = page.getByRole("button", { name: /CLI Engineer/ });
@@ -181,7 +197,7 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
 
     await page.getByRole("button", { name: /UI Engineer/ }).press("Enter");
     await jobDialog.getByLabel("Role", { exact: true }).fill("My preserved draft");
-    const cliUpdated = await cli("job-update", ["--id", uiJob.id, "--expected-revision", String(uiJob.revision), "--origin", "human"], { role: "CLI canonical edit" });
+    const cliUpdated = await cli("job-update", ["--id", uiJob.id, "--expected-revision", String(uiJob.revision), "--origin", "human"], { role: "CLI canonical edit", notes: "CLI concurrent note" });
     await page.getByRole("button", { name: "Save job" }).click();
     const conflict = page.locator("#conflict");
     await conflict.waitFor();
@@ -189,8 +205,29 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     assert.match(await conflict.innerText(), /CLI canonical edit/);
     assert.equal(await page.evaluate(() => document.activeElement?.id), "conflict");
 
+    await page.getByRole("button", { name: "Reapply my draft" }).click();
+    assert.equal(await jobDialog.getByLabel("Role", { exact: true }).inputValue(), "My preserved draft");
+    assert.equal(await jobDialog.getByLabel("Notes", { exact: true }).inputValue(), "CLI concurrent note");
+    await page.getByRole("button", { name: "Save job" }).click();
+    await page.locator("#job-dialog").waitFor({ state: "hidden" });
+    const safelyRebased = await cli("job-get", ["--id", uiJob.id]);
+    assert.equal(safelyRebased.role, "My preserved draft");
+    assert.equal(safelyRebased.notes, "CLI concurrent note");
+
+    await page.getByRole("button", { name: /My preserved draft/ }).click();
+    await jobDialog.getByLabel("Company", { exact: true }).fill("Offline draft company");
+    const newest = await cli("job-update", ["--id", uiJob.id, "--expected-revision", String(safelyRebased.revision), "--origin", "human"], { notes: "Newest canonical note" });
+    await page.route(`**/api/jobs/${uiJob.id}`, (route) => route.request().method() === "GET" ? route.abort() : route.continue());
+    await page.getByRole("button", { name: "Save job" }).click();
+    await conflict.waitFor();
+    assert.match(await conflict.innerText(), /could not be loaded/i);
+    assert.equal(await page.getByRole("button", { name: "Load canonical values" }).isDisabled(), true);
+    assert.equal(await page.getByRole("button", { name: "Reapply my draft" }).isDisabled(), true);
+    assert.equal(await jobDialog.getByLabel("Company", { exact: true }).inputValue(), "Offline draft company");
+    await page.unroute(`**/api/jobs/${uiJob.id}`);
+    await page.getByRole("button", { name: "Save job" }).click();
     await page.getByRole("button", { name: "Load canonical values" }).click();
-    assert.equal(await jobDialog.getByLabel("Role", { exact: true }).inputValue(), "CLI canonical edit");
+    assert.equal(await jobDialog.getByLabel("Notes", { exact: true }).inputValue(), "Newest canonical note");
     await page.getByRole("button", { name: "Run ready check" }).click();
     await page.getByText("No blocking issues").waitFor();
     await page.getByRole("button", { name: "Mark ready" }).click();
@@ -199,7 +236,15 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     assert.equal(ready.some((job) => job.id === uiJob.id), true);
     await page.waitForFunction((id) => document.activeElement?.dataset?.id === id, uiJob.id);
 
-    await page.getByRole("button", { name: /CLI Engineer/ }).click();
+    await page.getByRole("button", { name: /Browser-edited CLI Engineer/ }).click();
+    await page.getByLabel("Closed outcome").selectOption("withdrawn");
+    await page.getByRole("button", { name: "Close job", exact: true }).click();
+    await page.locator("#job-dialog").waitFor({ state: "hidden" });
+    const closed = await cli("job-get", ["--id", cliJob.id]);
+    assert.equal(closed.status, "closed");
+    assert.equal(closed.closedOutcome, "withdrawn");
+
+    await page.getByRole("button", { name: /Browser-edited CLI Engineer/ }).click();
     page.once("dialog", (prompt) => prompt.accept());
     await page.getByRole("button", { name: "Move to trash" }).click();
     await page.locator("#job-dialog").waitFor({ state: "hidden" });
@@ -213,6 +258,7 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     server = null;
     assert.equal((await cli("job-list", ["--status", "ready"])).some((job) => job.id === uiJob.id), true);
     assert.equal(cliUpdated.role, "CLI canonical edit");
+    assert.equal(newest.notes, "Newest canonical note");
   } finally {
     if (browser) await browser.close();
     if (server && server.exitCode === null) {

--- a/workspace/app.js
+++ b/workspace/app.js
@@ -11,6 +11,16 @@ export function tokenFromHash(hash) {
   return params.get("token") || "";
 }
 
+export function sessionToken(hash, storage) {
+  const token = tokenFromHash(hash);
+  try {
+    if (token) storage?.setItem("jobApplyWorkspaceToken", token);
+    return token || storage?.getItem("jobApplyWorkspaceToken") || "";
+  } catch {
+    return token;
+  }
+}
+
 export function filterJobs(jobs, query = "", status = "") {
   const needle = query.trim().toLocaleLowerCase();
   return jobs.filter((job) => {
@@ -34,9 +44,13 @@ export function formPatch(values) {
 export function transitionsFor(status) {
   return {
     saved: ["needs_info", "closed"], needs_info: ["saved", "closed"], ready: ["saved", "needs_info", "closed"],
-    in_progress: ["needs_info", "awaiting_review", "closed"], awaiting_review: ["in_progress", "applied", "closed"],
+    in_progress: [], awaiting_review: ["applied", "closed"],
     applied: ["closed"], closed: ["saved"],
   }[status] || [];
+}
+
+export function canMarkReadyFrom(status) {
+  return status === "saved" || status === "needs_info";
 }
 
 export function createApi(token, fetchImpl = globalThis.fetch) {
@@ -54,10 +68,10 @@ export function createApi(token, fetchImpl = globalThis.fetch) {
 const hasDom = typeof document !== "undefined";
 
 if (hasDom) {
-  const token = tokenFromHash(location.hash);
-  history.replaceState(null, "", location.pathname);
+  const token = sessionToken(location.hash, sessionStorage);
+  if (location.hash) history.replaceState(null, "", location.pathname);
   const api = createApi(token);
-  const state = { jobs: [], resumes: [], selected: null, latest: null, draft: null, dirty: false, polling: false, opener: null, openerJobId: null, focusAfterClose: null };
+  const state = { jobs: [], resumes: [], selected: null, latest: null, draft: null, dirty: false, dirtyFields: new Set(), polling: false, opener: null, openerJobId: null, focusAfterClose: null };
   const $ = (selector) => document.querySelector(selector);
   const form = $("#job-form");
   const dialog = $("#job-dialog");
@@ -124,12 +138,12 @@ if (hasDom) {
 
   function fillForm(job) {
     for (const field of ["url", "role", "company", "location", "workplaceType", "employmentType", "compensation", "notes", "description", "priority"]) form.elements[field].value = job?.[field] ?? (field === "priority" ? 0 : "");
-    fillResumeOptions(job?.resumeId); state.dirty = false; hideConflict(); $("#form-error").classList.add("hidden");
+    fillResumeOptions(job?.resumeId); state.dirty = false; state.dirtyFields.clear(); hideConflict(); $("#form-error").classList.add("hidden");
   }
 
   function openNew() {
     rememberOpener();
-    state.selected = null; state.latest = null; fillForm(null); $("#job-dialog-title").textContent = "Capture a job"; $("#dialog-kicker").textContent = "NEW CANONICAL RECORD";
+    state.selected = null; state.latest = null; state.draft = null; fillForm(null); $("#job-dialog-title").textContent = "Capture a job"; $("#dialog-kicker").textContent = "NEW CANONICAL RECORD";
     for (const id of ["trash-job", "preflight-job", "mark-ready", "status-actions"]) $("#" + id).classList.add("hidden");
     dialog.showModal(); setTimeout(() => form.elements.url.focus(), 0);
   }
@@ -137,19 +151,28 @@ if (hasDom) {
   function openExisting(id) {
     const job = state.jobs.find((item) => item.id === id); if (!job) return;
     rememberOpener(id);
-    state.selected = job; state.latest = null; fillForm(job); $("#job-dialog-title").textContent = job.role || "Job details"; $("#dialog-kicker").textContent = `${statusLabel(job.status).toUpperCase()} · REVISION ${job.revision}`;
-    $("#trash-job").classList.remove("hidden"); $("#preflight-job").classList.remove("hidden"); $("#mark-ready").classList.toggle("hidden", job.status === "ready"); renderStatusActions(job); dialog.showModal(); setTimeout(() => form.elements.role.focus(), 0);
+    state.selected = job; state.latest = null; state.draft = null; fillForm(job); $("#job-dialog-title").textContent = job.role || "Job details"; $("#dialog-kicker").textContent = `${statusLabel(job.status).toUpperCase()} · REVISION ${job.revision}`;
+    $("#trash-job").classList.toggle("hidden", job.status === "in_progress"); $("#preflight-job").classList.remove("hidden"); $("#mark-ready").classList.toggle("hidden", !canMarkReadyFrom(job.status)); renderStatusActions(job); dialog.showModal(); setTimeout(() => form.elements.role.focus(), 0);
   }
 
   function currentValues() { return Object.fromEntries(new FormData(form).entries()); }
   function showFormError(message) { const node = $("#form-error"); node.textContent = message; node.classList.remove("hidden"); }
-  function hideConflict() { $("#conflict").classList.add("hidden"); $("#conflict-latest").replaceChildren(); }
+  function hideConflict() { $("#conflict").classList.add("hidden"); $("#conflict-latest").replaceChildren(); $("#reload-latest").disabled = false; $("#rebase-draft").disabled = false; }
 
   async function showConflict() {
-    state.draft = currentValues();
-    try { state.latest = await api(`/api/jobs/${encodeURIComponent(state.selected.id)}`); } catch { state.latest = state.jobs.find((j) => j.id === state.selected.id); }
+    const values = currentValues();
+    state.draft = Object.fromEntries([...state.dirtyFields].map((field) => [field, values[field]]));
     const holder = $("#conflict-latest"); holder.replaceChildren();
-    for (const field of ["role", "company", "location", "status", "revision"]) { const span = document.createElement("span"); span.textContent = `${field}: ${state.latest?.[field] || "—"}`; holder.append(span); }
+    $("#reload-latest").disabled = false; $("#rebase-draft").disabled = false;
+    try {
+      state.latest = await api(`/api/jobs/${encodeURIComponent(state.selected.id)}`);
+    } catch (error) {
+      state.latest = null;
+      const message = document.createElement("p"); message.textContent = `Latest canonical values could not be loaded: ${error.message}. Your draft is still here; try Save again after the connection recovers.`; holder.append(message);
+      $("#reload-latest").disabled = true; $("#rebase-draft").disabled = true;
+      $("#conflict").classList.remove("hidden"); $("#conflict").focus(); return;
+    }
+    for (const field of ["url", "role", "company", "location", "workplaceType", "employmentType", "compensation", "notes", "description", "resumeId", "priority", "status", "revision"]) { const span = document.createElement("span"); span.textContent = `${field}: ${state.latest[field] ?? "—"}`; holder.append(span); }
     $("#conflict").classList.remove("hidden"); $("#conflict").focus();
   }
 
@@ -177,12 +200,14 @@ if (hasDom) {
     const panel = $("#preflight-panel"), body = $("#preflight-results"); body.replaceChildren();
     const summary = document.createElement("p"); summary.textContent = result.ready ? "No blocking issues. This job can be handed to a Job Apply agent." : "Resolve the blocking issues before marking this job ready."; body.append(summary);
     for (const [label, items] of [["Blocking", result.errors], ["Warnings", result.warnings]]) if (items.length) { const h = document.createElement("strong"); h.textContent = label; const ul = document.createElement("ul"); for (const code of items) { const li = document.createElement("li"); li.textContent = issueText[code] || code; ul.append(li); } body.append(h, ul); }
-    panel.classList.remove("hidden"); $("#mark-ready").classList.toggle("hidden", !result.ready || state.selected?.status === "ready");
+    panel.classList.remove("hidden"); $("#mark-ready").classList.toggle("hidden", !result.ready || !canMarkReadyFrom(state.selected?.status));
   }
 
-  async function transition(status, userConfirmed = false) {
+  async function transition(status, userConfirmed = false, closedOutcome = null) {
     try {
-      const updated = await api(`/api/jobs/${encodeURIComponent(state.selected.id)}/transition`, { method: "POST", body: JSON.stringify({ status, expectedRevision: state.selected.revision, userConfirmed }) });
+      const body = { status, expectedRevision: state.selected.revision, userConfirmed };
+      if (closedOutcome !== null) body.closedOutcome = closedOutcome;
+      const updated = await api(`/api/jobs/${encodeURIComponent(state.selected.id)}/transition`, { method: "POST", body: JSON.stringify(body) });
       state.selected = updated; await refresh({ quiet: true }); closeJobDialog(jobButton(updated.id)); toast(`Job moved to ${statusLabel(status)}`);
     } catch (error) { if (error.status === 409) await showConflict(); else showFormError(error.message); }
   }
@@ -192,6 +217,12 @@ if (hasDom) {
     for (const status of transitionsFor(job.status)) {
       if (status === "applied") {
         const button = document.createElement("button"); button.type = "button"; button.className = "button secondary"; button.textContent = "Mark applied…"; button.addEventListener("click", () => { if (confirm("Confirm that you personally submitted this application on the third-party site. This workspace does not submit it.")) transition("applied", true); }); holder.append(button);
+      } else if (status === "closed") {
+        const label = document.createElement("label"); label.className = "close-action"; label.append("Close as ");
+        const select = document.createElement("select"); select.setAttribute("aria-label", "Closed outcome");
+        for (const [value, text] of [["rejected", "Rejected"], ["withdrawn", "Withdrawn"], ["expired", "Expired"], ["duplicate", "Duplicate"], ["not_interested", "Not interested"]]) select.append(new Option(text, value));
+        const button = document.createElement("button"); button.type = "button"; button.className = "button secondary"; button.textContent = "Close job"; button.addEventListener("click", () => transition("closed", false, select.value));
+        label.append(select); holder.append(label, button);
       } else {
         const button = document.createElement("button"); button.type = "button"; button.className = "button secondary"; button.textContent = `Move to ${statusLabel(status)}`; button.addEventListener("click", () => transition(status)); holder.append(button);
       }
@@ -211,18 +242,18 @@ if (hasDom) {
   }
   function firstListDestination() { return $(".job-card") || $("#new-job"); }
 
-  form.addEventListener("submit", save); form.addEventListener("input", () => { if (state.selected) state.dirty = true; });
+  form.addEventListener("submit", save); form.addEventListener("input", (event) => { if (state.selected && event.target.name) { state.dirty = true; state.dirtyFields.add(event.target.name); } });
   $("#new-job").addEventListener("click", openNew); $("#empty-create").addEventListener("click", openNew); $("#refresh").addEventListener("click", () => refresh());
   $("#search").addEventListener("input", render); $("#status-filter").addEventListener("change", render);
   $("#preflight-job").addEventListener("click", preflight); $("#mark-ready").addEventListener("click", async () => { const result = await preflight(); if (result?.ready) transition("ready"); });
   $("#trash-job").addEventListener("click", async () => { if (!confirm("Move this job to trash? It will leave this Jobs workspace, but remains recoverable through the canonical store.")) return; try { const id = state.selected.id; await api(`/api/jobs/${encodeURIComponent(id)}/trash`, { method: "POST", body: JSON.stringify({ expectedRevision: state.selected.revision }) }); await refresh({ quiet: true }); closeJobDialog(firstListDestination()); toast("Job moved to trash"); } catch (error) { if (error.status === 409) await showConflict(); else showFormError(error.message); } });
-  $("#reload-latest").addEventListener("click", () => { if (!state.latest) return; state.selected = state.latest; fillForm(state.latest); $("#dialog-kicker").textContent = `CANONICAL · REVISION ${state.latest.revision}`; form.elements.role.focus(); toast("Loaded the latest canonical values"); });
-  $("#rebase-draft").addEventListener("click", () => { if (!state.latest || !state.draft) return; state.selected = state.latest; for (const [name, value] of Object.entries(state.draft)) if (form.elements[name]) form.elements[name].value = value; state.dirty = true; hideConflict(); $("#save-job").focus(); toast("Draft reapplied. Review it, then save against the latest revision."); });
+  $("#reload-latest").addEventListener("click", () => { if (!state.latest) return; state.selected = state.latest; state.draft = null; fillForm(state.latest); $("#dialog-kicker").textContent = `CANONICAL · REVISION ${state.latest.revision}`; form.elements.role.focus(); toast("Loaded the latest canonical values"); });
+  $("#rebase-draft").addEventListener("click", () => { if (!state.latest || !state.draft) return; const latest = state.latest; const draft = state.draft; state.selected = latest; fillForm(latest); for (const [name, value] of Object.entries(draft)) if (form.elements[name]) form.elements[name].value = value; state.dirtyFields = new Set(Object.keys(draft)); state.dirty = state.dirtyFields.size > 0; state.draft = null; hideConflict(); $("#save-job").focus(); toast("Your edited fields were reapplied to the latest canonical values. Review, then save."); });
   for (const button of document.querySelectorAll("[data-close]")) button.addEventListener("click", () => document.getElementById(button.dataset.close).close());
   $("#bulk-open").addEventListener("click", () => { $("#bulk-results").replaceChildren(); $("#bulk-dialog").showModal(); setTimeout(() => $("#bulk-form").elements.urls.focus(), 0); });
   $("#bulk-form").addEventListener("submit", async (event) => { event.preventDefault(); const urls = event.currentTarget.elements.urls.value.split(/\r?\n/).map((v) => v.trim()).filter(Boolean); try { const data = await api("/api/jobs/bulk", { method: "POST", body: JSON.stringify({ urls }) }); const holder = $("#bulk-results"); holder.replaceChildren(); for (const item of data.results) { const row = document.createElement("div"); row.className = `bulk-result${item.ok ? "" : " bad"}`; row.textContent = item.ok ? `Saved · ${item.url}` : `Not saved · ${item.url} · ${item.error}`; holder.append(row); } await refresh({ quiet: true }); } catch (error) { const row = document.createElement("div"); row.className = "bulk-result bad"; row.textContent = error.message; $("#bulk-results").replaceChildren(row); } });
   dialog.addEventListener("close", () => {
-    state.dirty = false; $("#sync-notice").classList.add("hidden");
+    state.dirty = false; state.dirtyFields.clear(); state.draft = null; $("#sync-notice").classList.add("hidden");
     const destination = state.focusAfterClose
       || (state.openerJobId ? jobButton(state.openerJobId) : null)
       || (state.opener?.isConnected ? state.opener : null)

--- a/workspace/app.js
+++ b/workspace/app.js
@@ -1,0 +1,236 @@
+export class ApiError extends Error {
+  constructor(status, payload) {
+    super(payload?.error?.message || `Workspace request failed (${status})`);
+    this.status = status;
+    this.code = payload?.error?.code || "request_error";
+  }
+}
+
+export function tokenFromHash(hash) {
+  const params = new URLSearchParams(String(hash || "").replace(/^#/, ""));
+  return params.get("token") || "";
+}
+
+export function filterJobs(jobs, query = "", status = "") {
+  const needle = query.trim().toLocaleLowerCase();
+  return jobs.filter((job) => {
+    if (status && job.status !== status) return false;
+    if (!needle) return true;
+    return [job.role, job.company, job.location, job.url]
+      .some((value) => String(value || "").toLocaleLowerCase().includes(needle));
+  });
+}
+
+export function formPatch(values) {
+  const patch = {};
+  for (const field of ["url", "role", "company", "location", "workplaceType", "employmentType", "compensation", "notes", "description", "resumeId"]) {
+    const value = values[field];
+    patch[field] = value === "" && field === "resumeId" ? null : value;
+  }
+  patch.priority = Number(values.priority || 0);
+  return patch;
+}
+
+export function transitionsFor(status) {
+  return {
+    saved: ["needs_info", "closed"], needs_info: ["saved", "closed"], ready: ["saved", "needs_info", "closed"],
+    in_progress: ["needs_info", "awaiting_review", "closed"], awaiting_review: ["in_progress", "applied", "closed"],
+    applied: ["closed"], closed: ["saved"],
+  }[status] || [];
+}
+
+export function createApi(token, fetchImpl = globalThis.fetch) {
+  return async function api(path, options = {}) {
+    const headers = { Authorization: `Bearer ${token}`, ...(options.headers || {}) };
+    if (options.body !== undefined) headers["Content-Type"] = "application/json";
+    const response = await fetchImpl(path, { ...options, headers });
+    let payload = null;
+    try { payload = await response.json(); } catch { /* handled below */ }
+    if (!response.ok) throw new ApiError(response.status, payload);
+    return payload;
+  };
+}
+
+const hasDom = typeof document !== "undefined";
+
+if (hasDom) {
+  const token = tokenFromHash(location.hash);
+  history.replaceState(null, "", location.pathname);
+  const api = createApi(token);
+  const state = { jobs: [], resumes: [], selected: null, latest: null, draft: null, dirty: false, polling: false, opener: null, openerJobId: null, focusAfterClose: null };
+  const $ = (selector) => document.querySelector(selector);
+  const form = $("#job-form");
+  const dialog = $("#job-dialog");
+  const statusLabel = (value) => String(value || "saved").replaceAll("_", " ");
+  const escapeText = (value) => String(value ?? "");
+
+  function toast(message) {
+    const node = $("#toast"); node.textContent = message; node.classList.remove("hidden");
+    clearTimeout(toast.timer); toast.timer = setTimeout(() => node.classList.add("hidden"), 3500);
+  }
+
+  function setConnection(online, message = online ? "Canonical store connected" : "Connection lost") {
+    $("#connection-dot").classList.toggle("online", online); $("#connection-label").textContent = message;
+  }
+
+  function metrics() {
+    $("#metric-active").textContent = state.jobs.length;
+    $("#metric-ready").textContent = state.jobs.filter((j) => j.status === "ready").length;
+    $("#metric-needs").textContent = state.jobs.filter((j) => j.status === "needs_info").length;
+  }
+
+  function render() {
+    metrics(); $("#loading").classList.add("hidden");
+    const jobs = filterJobs(state.jobs, $("#search").value, $("#status-filter").value);
+    $("#empty").classList.toggle("hidden", jobs.length !== 0);
+    $("#job-list").classList.toggle("hidden", jobs.length === 0);
+    const list = $("#job-list"); list.replaceChildren();
+    for (const job of jobs) {
+      const item = document.createElement("div"); item.className = "job-item"; item.setAttribute("role", "listitem");
+      const button = document.createElement("button"); button.type = "button"; button.className = "job-card";
+      button.dataset.id = job.id;
+      const title = document.createElement("div"); title.className = "job-title";
+      const mark = document.createElement("span"); mark.className = "company-mark"; mark.textContent = escapeText(job.company || job.role || "J").slice(0, 1).toUpperCase(); mark.setAttribute("aria-hidden", "true");
+      const names = document.createElement("div"); const heading = document.createElement("h3"); heading.textContent = job.role || "Untitled opportunity"; const company = document.createElement("p"); company.textContent = job.company || "Company not set"; names.append(heading, company); title.append(mark, names);
+      const location = document.createElement("p"); location.textContent = job.location || job.workplaceType || "Location not set";
+      const priority = document.createElement("span"); priority.className = "priority"; priority.textContent = job.priority ? "★".repeat(Math.min(job.priority, 5)) : "—"; priority.setAttribute("aria-label", `Priority ${job.priority || 0}`);
+      const status = document.createElement("span"); status.className = `status ${job.status}`; status.textContent = statusLabel(job.status);
+      button.append(title, location, priority, status); button.addEventListener("click", () => openExisting(job.id)); item.append(button); list.append(item);
+    }
+  }
+
+  async function refresh({ quiet = false } = {}) {
+    if (state.polling) return; state.polling = true;
+    try {
+      const data = await api("/api/state");
+      if (state.dirty && state.selected) {
+        const latest = data.jobs.find((job) => job.id === state.selected.id);
+        if (latest && latest.revision !== state.selected.revision) {
+          state.latest = latest; $("#sync-notice").textContent = "A canonical job changed while your draft is open. Your draft has not been replaced."; $("#sync-notice").classList.remove("hidden");
+        }
+      }
+      state.jobs = data.jobs; state.resumes = data.resumes; render(); setConnection(true);
+      if (!quiet) toast("Jobs refreshed from the canonical store");
+    } catch (error) {
+      setConnection(false, error.message); if (!quiet) showFormError(error.message);
+    } finally { state.polling = false; }
+  }
+
+  function fillResumeOptions(selected) {
+    const select = form.elements.resumeId; select.replaceChildren(new Option("Use default resume", ""));
+    for (const resume of state.resumes) select.append(new Option(`${resume.label || resume.id}${resume.default ? " · default" : ""}`, resume.id));
+    select.value = selected || "";
+  }
+
+  function fillForm(job) {
+    for (const field of ["url", "role", "company", "location", "workplaceType", "employmentType", "compensation", "notes", "description", "priority"]) form.elements[field].value = job?.[field] ?? (field === "priority" ? 0 : "");
+    fillResumeOptions(job?.resumeId); state.dirty = false; hideConflict(); $("#form-error").classList.add("hidden");
+  }
+
+  function openNew() {
+    rememberOpener();
+    state.selected = null; state.latest = null; fillForm(null); $("#job-dialog-title").textContent = "Capture a job"; $("#dialog-kicker").textContent = "NEW CANONICAL RECORD";
+    for (const id of ["trash-job", "preflight-job", "mark-ready", "status-actions"]) $("#" + id).classList.add("hidden");
+    dialog.showModal(); setTimeout(() => form.elements.url.focus(), 0);
+  }
+
+  function openExisting(id) {
+    const job = state.jobs.find((item) => item.id === id); if (!job) return;
+    rememberOpener(id);
+    state.selected = job; state.latest = null; fillForm(job); $("#job-dialog-title").textContent = job.role || "Job details"; $("#dialog-kicker").textContent = `${statusLabel(job.status).toUpperCase()} · REVISION ${job.revision}`;
+    $("#trash-job").classList.remove("hidden"); $("#preflight-job").classList.remove("hidden"); $("#mark-ready").classList.toggle("hidden", job.status === "ready"); renderStatusActions(job); dialog.showModal(); setTimeout(() => form.elements.role.focus(), 0);
+  }
+
+  function currentValues() { return Object.fromEntries(new FormData(form).entries()); }
+  function showFormError(message) { const node = $("#form-error"); node.textContent = message; node.classList.remove("hidden"); }
+  function hideConflict() { $("#conflict").classList.add("hidden"); $("#conflict-latest").replaceChildren(); }
+
+  async function showConflict() {
+    state.draft = currentValues();
+    try { state.latest = await api(`/api/jobs/${encodeURIComponent(state.selected.id)}`); } catch { state.latest = state.jobs.find((j) => j.id === state.selected.id); }
+    const holder = $("#conflict-latest"); holder.replaceChildren();
+    for (const field of ["role", "company", "location", "status", "revision"]) { const span = document.createElement("span"); span.textContent = `${field}: ${state.latest?.[field] || "—"}`; holder.append(span); }
+    $("#conflict").classList.remove("hidden"); $("#conflict").focus();
+  }
+
+  async function save(event) {
+    event.preventDefault(); $("#save-job").disabled = true; $("#form-error").classList.add("hidden");
+    try {
+      const patch = formPatch(currentValues());
+      const job = state.selected
+        ? await api(`/api/jobs/${encodeURIComponent(state.selected.id)}`, { method: "PATCH", body: JSON.stringify({ patch, expectedRevision: state.selected.revision }) })
+        : await api("/api/jobs", { method: "POST", body: JSON.stringify({ job: patch }) });
+      state.selected = job; state.dirty = false; await refresh({ quiet: true }); closeJobDialog(jobButton(job.id)); toast("Job saved to the canonical store");
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 409 && state.selected) await showConflict(); else showFormError(error.message);
+    } finally { $("#save-job").disabled = false; }
+  }
+
+  async function preflight() {
+    if (!state.selected) return; try {
+      const result = await api(`/api/jobs/${encodeURIComponent(state.selected.id)}/preflight`); renderPreflight(result); return result;
+    } catch (error) { showFormError(error.message); return null; }
+  }
+
+  const issueText = { profile_empty: "Complete your applicant profile", resume_missing: "Assign an active resume", resume_file_missing: "The resume file cannot be found", resume_file_changed: "The resume file changed since it was added", role_missing: "Add a role for clearer handoff", company_missing: "Add a company for clearer handoff" };
+  function renderPreflight(result) {
+    const panel = $("#preflight-panel"), body = $("#preflight-results"); body.replaceChildren();
+    const summary = document.createElement("p"); summary.textContent = result.ready ? "No blocking issues. This job can be handed to a Job Apply agent." : "Resolve the blocking issues before marking this job ready."; body.append(summary);
+    for (const [label, items] of [["Blocking", result.errors], ["Warnings", result.warnings]]) if (items.length) { const h = document.createElement("strong"); h.textContent = label; const ul = document.createElement("ul"); for (const code of items) { const li = document.createElement("li"); li.textContent = issueText[code] || code; ul.append(li); } body.append(h, ul); }
+    panel.classList.remove("hidden"); $("#mark-ready").classList.toggle("hidden", !result.ready || state.selected?.status === "ready");
+  }
+
+  async function transition(status, userConfirmed = false) {
+    try {
+      const updated = await api(`/api/jobs/${encodeURIComponent(state.selected.id)}/transition`, { method: "POST", body: JSON.stringify({ status, expectedRevision: state.selected.revision, userConfirmed }) });
+      state.selected = updated; await refresh({ quiet: true }); closeJobDialog(jobButton(updated.id)); toast(`Job moved to ${statusLabel(status)}`);
+    } catch (error) { if (error.status === 409) await showConflict(); else showFormError(error.message); }
+  }
+
+  function renderStatusActions(job) {
+    const holder = $("#status-buttons"); holder.replaceChildren();
+    for (const status of transitionsFor(job.status)) {
+      if (status === "applied") {
+        const button = document.createElement("button"); button.type = "button"; button.className = "button secondary"; button.textContent = "Mark applied…"; button.addEventListener("click", () => { if (confirm("Confirm that you personally submitted this application on the third-party site. This workspace does not submit it.")) transition("applied", true); }); holder.append(button);
+      } else {
+        const button = document.createElement("button"); button.type = "button"; button.className = "button secondary"; button.textContent = `Move to ${statusLabel(status)}`; button.addEventListener("click", () => transition(status)); holder.append(button);
+      }
+    }
+    $("#status-actions").classList.toggle("hidden", holder.children.length === 0);
+  }
+
+  function jobButton(id) { return document.querySelector(`[data-id="${CSS.escape(id)}"]`); }
+  function rememberOpener(jobId = null) {
+    state.opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    state.openerJobId = jobId;
+    state.focusAfterClose = null;
+  }
+  function closeJobDialog(destination = null) {
+    state.focusAfterClose = destination;
+    dialog.close();
+  }
+  function firstListDestination() { return $(".job-card") || $("#new-job"); }
+
+  form.addEventListener("submit", save); form.addEventListener("input", () => { if (state.selected) state.dirty = true; });
+  $("#new-job").addEventListener("click", openNew); $("#empty-create").addEventListener("click", openNew); $("#refresh").addEventListener("click", () => refresh());
+  $("#search").addEventListener("input", render); $("#status-filter").addEventListener("change", render);
+  $("#preflight-job").addEventListener("click", preflight); $("#mark-ready").addEventListener("click", async () => { const result = await preflight(); if (result?.ready) transition("ready"); });
+  $("#trash-job").addEventListener("click", async () => { if (!confirm("Move this job to trash? It will leave this Jobs workspace, but remains recoverable through the canonical store.")) return; try { const id = state.selected.id; await api(`/api/jobs/${encodeURIComponent(id)}/trash`, { method: "POST", body: JSON.stringify({ expectedRevision: state.selected.revision }) }); await refresh({ quiet: true }); closeJobDialog(firstListDestination()); toast("Job moved to trash"); } catch (error) { if (error.status === 409) await showConflict(); else showFormError(error.message); } });
+  $("#reload-latest").addEventListener("click", () => { if (!state.latest) return; state.selected = state.latest; fillForm(state.latest); $("#dialog-kicker").textContent = `CANONICAL · REVISION ${state.latest.revision}`; form.elements.role.focus(); toast("Loaded the latest canonical values"); });
+  $("#rebase-draft").addEventListener("click", () => { if (!state.latest || !state.draft) return; state.selected = state.latest; for (const [name, value] of Object.entries(state.draft)) if (form.elements[name]) form.elements[name].value = value; state.dirty = true; hideConflict(); $("#save-job").focus(); toast("Draft reapplied. Review it, then save against the latest revision."); });
+  for (const button of document.querySelectorAll("[data-close]")) button.addEventListener("click", () => document.getElementById(button.dataset.close).close());
+  $("#bulk-open").addEventListener("click", () => { $("#bulk-results").replaceChildren(); $("#bulk-dialog").showModal(); setTimeout(() => $("#bulk-form").elements.urls.focus(), 0); });
+  $("#bulk-form").addEventListener("submit", async (event) => { event.preventDefault(); const urls = event.currentTarget.elements.urls.value.split(/\r?\n/).map((v) => v.trim()).filter(Boolean); try { const data = await api("/api/jobs/bulk", { method: "POST", body: JSON.stringify({ urls }) }); const holder = $("#bulk-results"); holder.replaceChildren(); for (const item of data.results) { const row = document.createElement("div"); row.className = `bulk-result${item.ok ? "" : " bad"}`; row.textContent = item.ok ? `Saved · ${item.url}` : `Not saved · ${item.url} · ${item.error}`; holder.append(row); } await refresh({ quiet: true }); } catch (error) { const row = document.createElement("div"); row.className = "bulk-result bad"; row.textContent = error.message; $("#bulk-results").replaceChildren(row); } });
+  dialog.addEventListener("close", () => {
+    state.dirty = false; $("#sync-notice").classList.add("hidden");
+    const destination = state.focusAfterClose
+      || (state.openerJobId ? jobButton(state.openerJobId) : null)
+      || (state.opener?.isConnected ? state.opener : null)
+      || $("#new-job");
+    state.focusAfterClose = null; state.opener = null; state.openerJobId = null;
+    setTimeout(() => destination?.focus(), 0);
+  });
+
+  if (!token) { setConnection(false, "Workspace token missing — restart with the printed URL"); $("#loading").innerHTML = "<p>Open the complete URL printed by the workspace launcher.</p>"; }
+  else { refresh({ quiet: true }); setInterval(() => refresh({ quiet: true }), 4000); }
+}

--- a/workspace/app.js
+++ b/workspace/app.js
@@ -21,6 +21,10 @@ export function sessionToken(hash, storage) {
   }
 }
 
+export function safeSessionStorage(scope) {
+  try { return scope?.sessionStorage || null; } catch { return null; }
+}
+
 export function filterJobs(jobs, query = "", status = "") {
   const needle = query.trim().toLocaleLowerCase();
   return jobs.filter((job) => {
@@ -68,7 +72,7 @@ export function createApi(token, fetchImpl = globalThis.fetch) {
 const hasDom = typeof document !== "undefined";
 
 if (hasDom) {
-  const token = sessionToken(location.hash, sessionStorage);
+  const token = sessionToken(location.hash, safeSessionStorage(globalThis));
   if (location.hash) history.replaceState(null, "", location.pathname);
   const api = createApi(token);
   const state = { jobs: [], resumes: [], selected: null, latest: null, draft: null, dirty: false, dirtyFields: new Set(), polling: false, opener: null, openerJobId: null, focusAfterClose: null };
@@ -152,7 +156,7 @@ if (hasDom) {
     const job = state.jobs.find((item) => item.id === id); if (!job) return;
     rememberOpener(id);
     state.selected = job; state.latest = null; state.draft = null; fillForm(job); $("#job-dialog-title").textContent = job.role || "Job details"; $("#dialog-kicker").textContent = `${statusLabel(job.status).toUpperCase()} · REVISION ${job.revision}`;
-    $("#trash-job").classList.toggle("hidden", job.status === "in_progress"); $("#preflight-job").classList.remove("hidden"); $("#mark-ready").classList.toggle("hidden", !canMarkReadyFrom(job.status)); renderStatusActions(job); dialog.showModal(); setTimeout(() => form.elements.role.focus(), 0);
+    renderJobControls(job); dialog.showModal(); setTimeout(() => form.elements.role.focus(), 0);
   }
 
   function currentValues() { return Object.fromEntries(new FormData(form).entries()); }
@@ -230,6 +234,13 @@ if (hasDom) {
     $("#status-actions").classList.toggle("hidden", holder.children.length === 0);
   }
 
+  function renderJobControls(job) {
+    $("#trash-job").classList.toggle("hidden", job.status === "in_progress");
+    $("#preflight-job").classList.remove("hidden");
+    $("#mark-ready").classList.toggle("hidden", !canMarkReadyFrom(job.status));
+    renderStatusActions(job);
+  }
+
   function jobButton(id) { return document.querySelector(`[data-id="${CSS.escape(id)}"]`); }
   function rememberOpener(jobId = null) {
     state.opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
@@ -247,8 +258,8 @@ if (hasDom) {
   $("#search").addEventListener("input", render); $("#status-filter").addEventListener("change", render);
   $("#preflight-job").addEventListener("click", preflight); $("#mark-ready").addEventListener("click", async () => { const result = await preflight(); if (result?.ready) transition("ready"); });
   $("#trash-job").addEventListener("click", async () => { if (!confirm("Move this job to trash? It will leave this Jobs workspace, but remains recoverable through the canonical store.")) return; try { const id = state.selected.id; await api(`/api/jobs/${encodeURIComponent(id)}/trash`, { method: "POST", body: JSON.stringify({ expectedRevision: state.selected.revision }) }); await refresh({ quiet: true }); closeJobDialog(firstListDestination()); toast("Job moved to trash"); } catch (error) { if (error.status === 409) await showConflict(); else showFormError(error.message); } });
-  $("#reload-latest").addEventListener("click", () => { if (!state.latest) return; state.selected = state.latest; state.draft = null; fillForm(state.latest); $("#dialog-kicker").textContent = `CANONICAL · REVISION ${state.latest.revision}`; form.elements.role.focus(); toast("Loaded the latest canonical values"); });
-  $("#rebase-draft").addEventListener("click", () => { if (!state.latest || !state.draft) return; const latest = state.latest; const draft = state.draft; state.selected = latest; fillForm(latest); for (const [name, value] of Object.entries(draft)) if (form.elements[name]) form.elements[name].value = value; state.dirtyFields = new Set(Object.keys(draft)); state.dirty = state.dirtyFields.size > 0; state.draft = null; hideConflict(); $("#save-job").focus(); toast("Your edited fields were reapplied to the latest canonical values. Review, then save."); });
+  $("#reload-latest").addEventListener("click", () => { if (!state.latest) return; state.selected = state.latest; state.draft = null; fillForm(state.latest); renderJobControls(state.latest); $("#dialog-kicker").textContent = `CANONICAL · REVISION ${state.latest.revision}`; form.elements.role.focus(); toast("Loaded the latest canonical values"); });
+  $("#rebase-draft").addEventListener("click", () => { if (!state.latest || !state.draft) return; const latest = state.latest; const draft = state.draft; state.selected = latest; fillForm(latest); renderJobControls(latest); for (const [name, value] of Object.entries(draft)) if (form.elements[name]) form.elements[name].value = value; state.dirtyFields = new Set(Object.keys(draft)); state.dirty = state.dirtyFields.size > 0; state.draft = null; hideConflict(); $("#save-job").focus(); toast("Your edited fields were reapplied to the latest canonical values. Review, then save."); });
   for (const button of document.querySelectorAll("[data-close]")) button.addEventListener("click", () => document.getElementById(button.dataset.close).close());
   $("#bulk-open").addEventListener("click", () => { $("#bulk-results").replaceChildren(); $("#bulk-dialog").showModal(); setTimeout(() => $("#bulk-form").elements.urls.focus(), 0); });
   $("#bulk-form").addEventListener("submit", async (event) => { event.preventDefault(); const urls = event.currentTarget.elements.urls.value.split(/\r?\n/).map((v) => v.trim()).filter(Boolean); try { const data = await api("/api/jobs/bulk", { method: "POST", body: JSON.stringify({ urls }) }); const holder = $("#bulk-results"); holder.replaceChildren(); for (const item of data.results) { const row = document.createElement("div"); row.className = `bulk-result${item.ok ? "" : " bad"}`; row.textContent = item.ok ? `Saved · ${item.url}` : `Not saved · ${item.url} · ${item.error}`; holder.append(row); } await refresh({ quiet: true }); } catch (error) { const row = document.createElement("div"); row.className = "bulk-result bad"; row.textContent = error.message; $("#bulk-results").replaceChildren(row); } });

--- a/workspace/index.html
+++ b/workspace/index.html
@@ -74,7 +74,7 @@
       </div>
       <div id="conflict" class="conflict hidden" role="alert" tabindex="-1">
         <h3>This job changed elsewhere</h3>
-        <p>Your draft is safe. Review the latest canonical values, then choose how to continue.</p>
+        <p>Your draft is safe. Review every latest canonical value, then load it or reapply only the fields you edited.</p>
         <div id="conflict-latest" class="conflict-values"></div>
         <div class="button-row">
           <button id="reload-latest" class="button secondary" type="button">Load canonical values</button>

--- a/workspace/index.html
+++ b/workspace/index.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <title>Jobs · Job Apply Workspace</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <a class="skip-link" href="#jobs">Skip to jobs</a>
+  <header class="topbar">
+    <div>
+      <p class="eyebrow">LOCAL COMPANION</p>
+      <h1>Job Apply</h1>
+    </div>
+    <div class="connection" aria-live="polite">
+      <span id="connection-dot" class="dot"></span>
+      <span id="connection-label">Connecting…</span>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero" aria-labelledby="workspace-title">
+      <div>
+        <p class="eyebrow">Jobs Workspace</p>
+        <h2 id="workspace-title">Keep every opportunity moving.</h2>
+        <p>One canonical local queue shared with your Job Apply agents. Nothing leaves this device until you choose to use it on a job site.</p>
+      </div>
+      <div class="hero-actions">
+        <button id="refresh" class="button secondary" type="button">Refresh</button>
+        <button id="bulk-open" class="button secondary" type="button">Paste URLs</button>
+        <button id="new-job" class="button primary" type="button">New job</button>
+      </div>
+    </section>
+
+    <section class="metrics" aria-label="Job summary">
+      <div><strong id="metric-active">0</strong><span>Active jobs</span></div>
+      <div><strong id="metric-ready">0</strong><span>Ready for agent</span></div>
+      <div><strong id="metric-needs">0</strong><span>Need information</span></div>
+    </section>
+
+    <section id="jobs" class="jobs-panel" aria-labelledby="jobs-heading">
+      <div class="panel-heading">
+        <div><p class="eyebrow">PIPELINE</p><h2 id="jobs-heading">Jobs</h2></div>
+        <div class="filters">
+          <label>Search <input id="search" type="search" placeholder="Role, company, location"></label>
+          <label>Status
+            <select id="status-filter">
+              <option value="">All active</option><option value="saved">Saved</option>
+              <option value="needs_info">Needs info</option><option value="ready">Ready</option>
+              <option value="in_progress">In progress</option><option value="awaiting_review">Awaiting review</option>
+              <option value="applied">Applied</option><option value="closed">Closed</option>
+            </select>
+          </label>
+        </div>
+      </div>
+      <p id="sync-notice" class="notice hidden" role="status"></p>
+      <div id="loading" class="empty-state"><span class="spinner" aria-hidden="true"></span><p>Loading your canonical job queue…</p></div>
+      <div id="empty" class="empty-state hidden">
+        <span class="empty-icon" aria-hidden="true">◎</span><h3>No jobs here yet</h3>
+        <p>Capture one opportunity or paste a list of URLs to start your local pipeline.</p>
+        <button id="empty-create" class="button primary" type="button">Capture a job</button>
+      </div>
+      <div id="job-list" class="job-list hidden" role="list"></div>
+    </section>
+  </main>
+
+  <dialog id="job-dialog" aria-labelledby="job-dialog-title">
+    <form id="job-form" class="dialog-shell">
+      <div class="dialog-heading">
+        <div><p class="eyebrow" id="dialog-kicker">CANONICAL RECORD</p><h2 id="job-dialog-title">Job details</h2></div>
+        <button class="icon-button" type="button" data-close="job-dialog" aria-label="Close job details">×</button>
+      </div>
+      <div id="conflict" class="conflict hidden" role="alert" tabindex="-1">
+        <h3>This job changed elsewhere</h3>
+        <p>Your draft is safe. Review the latest canonical values, then choose how to continue.</p>
+        <div id="conflict-latest" class="conflict-values"></div>
+        <div class="button-row">
+          <button id="reload-latest" class="button secondary" type="button">Load canonical values</button>
+          <button id="rebase-draft" class="button primary" type="button">Reapply my draft</button>
+        </div>
+      </div>
+      <div class="form-grid">
+        <label class="wide">Job URL <input name="url" type="url" required placeholder="https://company.example/jobs/123"></label>
+        <label>Role <input name="role" autocomplete="off"></label>
+        <label>Company <input name="company" autocomplete="organization"></label>
+        <label>Location <input name="location" autocomplete="off"></label>
+        <label>Workplace
+          <select name="workplaceType"><option value="">Not set</option><option>remote</option><option>hybrid</option><option>onsite</option></select>
+        </label>
+        <label>Employment
+          <select name="employmentType"><option value="">Not set</option><option>full_time</option><option>part_time</option><option>contract</option><option>temporary</option><option>internship</option></select>
+        </label>
+        <label>Priority <input name="priority" type="number" min="0" max="5" value="0"></label>
+        <label>Resume <select name="resumeId"><option value="">Use default resume</option></select></label>
+        <label>Compensation <input name="compensation" autocomplete="off"></label>
+        <label class="wide">Notes <textarea name="notes" rows="3"></textarea></label>
+        <label class="wide">Description <textarea name="description" rows="5"></textarea></label>
+      </div>
+      <section id="preflight-panel" class="preflight hidden" aria-labelledby="preflight-heading">
+        <h3 id="preflight-heading">Ready check</h3><div id="preflight-results"></div>
+      </section>
+      <p id="form-error" class="error hidden" role="alert"></p>
+      <div class="dialog-footer">
+        <div class="danger-zone"><button id="trash-job" class="button danger hidden" type="button">Move to trash</button></div>
+        <div class="button-row">
+          <button id="preflight-job" class="button secondary hidden" type="button">Run ready check</button>
+          <button id="mark-ready" class="button accent hidden" type="button">Mark ready</button>
+          <button id="save-job" class="button primary" type="submit">Save job</button>
+        </div>
+      </div>
+      <section id="status-actions" class="status-actions hidden" aria-label="Status actions">
+        <h3>Controlled status</h3><p>Status updates never submit or activate an application on a third-party site.</p>
+        <div id="status-buttons" class="button-row"></div>
+      </section>
+    </form>
+  </dialog>
+
+  <dialog id="bulk-dialog" aria-labelledby="bulk-title">
+    <form id="bulk-form" class="dialog-shell compact">
+      <div class="dialog-heading"><div><p class="eyebrow">QUICK CAPTURE</p><h2 id="bulk-title">Paste job URLs</h2></div><button class="icon-button" type="button" data-close="bulk-dialog" aria-label="Close bulk capture">×</button></div>
+      <p>One URL per line. Valid jobs are saved even if another line is a duplicate or invalid.</p>
+      <label>Job URLs <textarea name="urls" rows="9" required placeholder="https://example.com/jobs/one&#10;https://example.com/jobs/two"></textarea></label>
+      <div id="bulk-results" class="bulk-results" aria-live="polite"></div>
+      <div class="dialog-footer"><span></span><button class="button primary" type="submit">Capture jobs</button></div>
+    </form>
+  </dialog>
+
+  <div id="toast" class="toast hidden" role="status" aria-live="polite"></div>
+  <script type="module" src="/app.js"></script>
+</body>
+</html>

--- a/workspace/styles.css
+++ b/workspace/styles.css
@@ -1,0 +1,62 @@
+:root {
+  --ink: #17221d; --muted: #647168; --paper: #f4f3ed; --panel: #fffef9;
+  --line: #d9ddd6; --forest: #174c3c; --forest-2: #0c382b; --mint: #d7eee4;
+  --amber: #db9d2b; --danger: #a53b32; --shadow: 0 20px 60px rgba(23,34,29,.12);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink); background: var(--paper); font-synthesis: none;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; background: radial-gradient(circle at 90% 0, #e2eee6 0, transparent 30rem), var(--paper); }
+button, input, select, textarea { font: inherit; }
+button { cursor: pointer; }
+:focus-visible { outline: 3px solid #4f8df7; outline-offset: 2px; }
+.skip-link { position: fixed; left: 1rem; top: -5rem; z-index: 20; background: var(--ink); color: white; padding: .75rem 1rem; }
+.skip-link:focus { top: 1rem; }
+.topbar { min-height: 76px; padding: 1rem max(4vw, 1.25rem); display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid rgba(23,34,29,.12); }
+.topbar h1 { margin: 0; font-family: Georgia, serif; font-size: 1.45rem; }
+.eyebrow { margin: 0 0 .25rem; font-size: .68rem; letter-spacing: .16em; font-weight: 800; color: var(--forest); }
+.connection { display: flex; align-items: center; gap: .55rem; color: var(--muted); font-size: .88rem; }
+.dot { width: .55rem; height: .55rem; border-radius: 50%; background: var(--amber); box-shadow: 0 0 0 4px rgba(219,157,43,.15); }
+.dot.online { background: #2a8b63; box-shadow: 0 0 0 4px rgba(42,139,99,.15); }
+main { width: min(1180px, 92vw); margin: 0 auto 5rem; }
+.hero { padding: clamp(2.5rem, 7vw, 6rem) 0 2.5rem; display: flex; justify-content: space-between; align-items: end; gap: 2rem; }
+.hero h2 { max-width: 730px; margin: .35rem 0 .7rem; font: 500 clamp(2.3rem, 6vw, 5rem)/.98 Georgia, serif; letter-spacing: -.04em; }
+.hero p:not(.eyebrow) { max-width: 650px; color: var(--muted); line-height: 1.65; }
+.hero-actions, .button-row { display: flex; flex-wrap: wrap; gap: .65rem; }
+.button { min-height: 42px; border: 1px solid transparent; border-radius: 999px; padding: .68rem 1.08rem; font-weight: 750; transition: transform .15s, background .15s; }
+.button:hover { transform: translateY(-1px); }
+.primary { background: var(--forest); color: white; }.primary:hover { background: var(--forest-2); }
+.secondary { background: transparent; border-color: #aeb8b0; color: var(--ink); }.secondary:hover { background: white; }
+.accent { background: var(--amber); color: #211706; }.danger { color: var(--danger); border-color: #d7aaa5; background: transparent; }
+.metrics { display: grid; grid-template-columns: repeat(3, 1fr); background: var(--forest); color: white; border-radius: 20px 20px 0 0; overflow: hidden; }
+.metrics div { padding: 1.25rem 1.5rem; border-right: 1px solid rgba(255,255,255,.16); display: flex; align-items: baseline; gap: .75rem; }
+.metrics strong { font: 500 2rem Georgia, serif; }.metrics span { color: #c9ded5; font-size: .82rem; }
+.jobs-panel { background: var(--panel); min-height: 410px; padding: clamp(1.2rem, 3vw, 2rem); border-radius: 0 0 20px 20px; box-shadow: var(--shadow); }
+.panel-heading { display: flex; justify-content: space-between; align-items: end; gap: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--line); }
+.panel-heading h2 { margin: 0; font: 500 2rem Georgia, serif; }.filters { display: flex; gap: .8rem; }
+label { display: grid; gap: .4rem; color: #4f5c54; font-size: .78rem; font-weight: 750; }
+input, select, textarea { width: 100%; color: var(--ink); background: white; border: 1px solid #cbd1cb; border-radius: 9px; padding: .68rem .75rem; }
+textarea { resize: vertical; line-height: 1.5; }.filters input { width: min(260px, 38vw); }
+.job-list { display: grid; }
+.job-item { display: block; }
+.job-card { width: 100%; display: grid; grid-template-columns: minmax(230px, 2fr) minmax(120px, 1fr) auto auto; align-items: center; gap: 1rem; text-align: left; border: 0; border-bottom: 1px solid var(--line); background: transparent; padding: 1.15rem .35rem; color: var(--ink); }
+.job-card:hover { background: #f7f8f3; }.job-card h3 { margin: 0 0 .3rem; font: 600 1.15rem Georgia, serif; }.job-card p { margin: 0; color: var(--muted); font-size: .84rem; }
+.company-mark { width: 42px; height: 42px; display: grid; place-items: center; border-radius: 12px; background: var(--mint); color: var(--forest); font: 700 1.1rem Georgia, serif; }
+.job-title { display: flex; align-items: center; gap: .8rem; }.priority { color: #b47b18; letter-spacing: .05em; }
+.status { display: inline-flex; width: max-content; padding: .35rem .6rem; border-radius: 999px; background: #e8ece8; color: #4a574f; font-size: .72rem; font-weight: 800; text-transform: capitalize; }
+.status.ready { background: var(--mint); color: var(--forest); }.status.needs_info { background: #fff0cf; color: #78500a; }.status.awaiting_review { background: #e8e1f4; color: #503879; }
+.empty-state { min-height: 300px; display: grid; place-items: center; align-content: center; text-align: center; color: var(--muted); }.empty-state h3 { margin: .7rem 0 0; color: var(--ink); }.empty-state p { max-width: 430px; }
+.empty-icon { font-size: 3rem; color: var(--forest); }.spinner { width: 2rem; height: 2rem; border: 3px solid var(--mint); border-top-color: var(--forest); border-radius: 50%; animation: spin .8s linear infinite; }
+.hidden { display: none !important; }.notice { background: #fff4d9; padding: .7rem 1rem; border-radius: 8px; }
+dialog { width: min(820px, 94vw); max-height: 92vh; border: 0; border-radius: 20px; padding: 0; color: var(--ink); background: var(--panel); box-shadow: var(--shadow); }
+dialog::backdrop { background: rgba(14,28,22,.58); backdrop-filter: blur(4px); }.dialog-shell { padding: clamp(1.25rem, 4vw, 2.3rem); overflow: auto; max-height: 92vh; }.dialog-shell.compact { width: min(620px, 94vw); }
+.dialog-heading, .dialog-footer { display: flex; justify-content: space-between; align-items: center; gap: 1rem; }.dialog-heading { margin-bottom: 1.5rem; }.dialog-heading h2 { margin: 0; font: 500 2rem Georgia, serif; }
+.icon-button { border: 0; border-radius: 50%; background: #edf0ec; color: var(--ink); width: 40px; height: 40px; font-size: 1.6rem; }
+.form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }.wide { grid-column: 1/-1; }.dialog-footer { margin-top: 1.5rem; padding-top: 1.25rem; border-top: 1px solid var(--line); }
+.preflight, .conflict, .status-actions { margin-top: 1.2rem; padding: 1rem; border-radius: 12px; background: #eef4f0; }.preflight h3, .conflict h3, .status-actions h3 { margin: 0 0 .5rem; }.preflight ul { margin: .4rem 0; }.conflict { background: #fff1d7; border: 1px solid #e2bb70; }.conflict-values { display: grid; grid-template-columns: repeat(2,1fr); gap: .4rem; margin: .8rem 0; font-size: .84rem; }.conflict-values span { background: rgba(255,255,255,.6); padding: .5rem; border-radius: 6px; }
+.error { color: var(--danger); font-weight: 700; }.bulk-results { margin-top: 1rem; display: grid; gap: .4rem; }.bulk-result { padding: .55rem .7rem; border-radius: 7px; background: #e7f3ec; overflow-wrap: anywhere; }.bulk-result.bad { background: #f8e5e2; color: #792c25; }
+.toast { position: fixed; right: 1.5rem; bottom: 1.5rem; z-index: 30; max-width: 420px; padding: .9rem 1.15rem; border-radius: 10px; color: white; background: var(--forest-2); box-shadow: var(--shadow); }
+@keyframes spin { to { transform: rotate(360deg); } }
+@media (max-width: 760px) { .hero { align-items: start; flex-direction: column; }.metrics { grid-template-columns: 1fr; }.metrics div { border-right: 0; border-bottom: 1px solid rgba(255,255,255,.16); }.panel-heading, .filters { align-items: stretch; flex-direction: column; }.filters input { width: 100%; }.job-card { grid-template-columns: 1fr auto; }.job-card > :nth-child(2) { display: none; }.form-grid { grid-template-columns: 1fr; }.wide { grid-column: auto; }.dialog-footer { align-items: stretch; flex-direction: column-reverse; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; transition-duration: .01ms !important; } }
+@media (prefers-color-scheme: dark) { :root { --ink:#edf5ef; --muted:#aebbb2; --paper:#111914; --panel:#19231d; --line:#344139; --forest:#87c9aa; --forest-2:#579c7c; --mint:#253f33; --amber:#efb94e; --danger:#ff9c92; } body { background: radial-gradient(circle at 90% 0,#20362b 0,transparent 30rem),var(--paper); } input,select,textarea { color:var(--ink);background:#111914;border-color:#4a594f; }.primary { color:#102119; }.secondary:hover,.job-card:hover { background:#263129; }.icon-button { background:#2c3931;color:var(--ink); }.status { background:#344139;color:#d9e4dc; }.conflict { background:#493b20; }.preflight,.status-actions { background:#22372d; } }

--- a/workspace/styles.css
+++ b/workspace/styles.css
@@ -54,6 +54,7 @@ dialog::backdrop { background: rgba(14,28,22,.58); backdrop-filter: blur(4px); }
 .icon-button { border: 0; border-radius: 50%; background: #edf0ec; color: var(--ink); width: 40px; height: 40px; font-size: 1.6rem; }
 .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }.wide { grid-column: 1/-1; }.dialog-footer { margin-top: 1.5rem; padding-top: 1.25rem; border-top: 1px solid var(--line); }
 .preflight, .conflict, .status-actions { margin-top: 1.2rem; padding: 1rem; border-radius: 12px; background: #eef4f0; }.preflight h3, .conflict h3, .status-actions h3 { margin: 0 0 .5rem; }.preflight ul { margin: .4rem 0; }.conflict { background: #fff1d7; border: 1px solid #e2bb70; }.conflict-values { display: grid; grid-template-columns: repeat(2,1fr); gap: .4rem; margin: .8rem 0; font-size: .84rem; }.conflict-values span { background: rgba(255,255,255,.6); padding: .5rem; border-radius: 6px; }
+.close-action { display: flex; align-items: center; gap: .5rem; }.close-action select { width: auto; min-width: 9rem; }
 .error { color: var(--danger); font-weight: 700; }.bulk-results { margin-top: 1rem; display: grid; gap: .4rem; }.bulk-result { padding: .55rem .7rem; border-radius: 7px; background: #e7f3ec; overflow-wrap: anywhere; }.bulk-result.bad { background: #f8e5e2; color: #792c25; }
 .toast { position: fixed; right: 1.5rem; bottom: 1.5rem; z-index: 30; max-width: 420px; padding: .9rem 1.15rem; border-radius: 10px; color: white; background: var(--forest-2); box-shadow: var(--shadow); }
 @keyframes spin { to { transform: rotate(360deg); } }


### PR DESCRIPTION
## Summary

- add a secure loopback-only Jobs workspace backed directly by the canonical Store
- support bidirectional browser and CLI job CRUD, resume assignment, readiness, status controls, conflict recovery, and recoverable trash
- package the workspace for Claude Code and Codex, document launch and safety boundaries, and add Windows validation
- harden claim-token CLI values, HTTP validation, authenticated reloads, lifecycle controls, and conflict-safe rebasing

## Verification

- 378 Python tests
- 57 browser tests
- isolated packaged Playwright and CLI walkthrough
- isolated Claude Code and Codex installs
- documentation policy, links, compilation, and diff checks

## Review

PR Review Toolkit completed against staging. All independently validated findings were fixed and the full verification matrix reran green.