### PR TITLE
Add shared Facts workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ AI-powered job application assistant for Claude Code and Codex that fills job ap
 | `job-apply:answer-memory` | Safely manage your local profile, reusable answers, application history, and resumable sessions |
 | `job-apply:job-search` | Search LinkedIn, Hacker News, and Twitter/X for jobs, then rank results against your preferences |
 | `job-apply:job-preferences` | Set the titles, salary, remote-work, and filtering preferences used by job search |
-| `job-apply:job-workspace` | Open the optional local Jobs workspace shared with Job Apply agents |
+| `job-apply:job-workspace` | Open the optional local Jobs and Facts workspace shared with Job Apply agents |
 
 Invoke skills with `$job-apply:...` in Codex or `/job-apply:...` in Claude Code.
 
@@ -146,7 +146,7 @@ Results are automatically saved to `~/.claude-job-searches/`. Both Codex and Cla
 
 ### Local Jobs Workspace
 
-The optional workspace gives you a keyboard-accessible browser view of the same canonical Jobs records used by the CLI skills. From the plugin directory, start it with one command:
+The optional workspace gives you keyboard-accessible Jobs and Facts views backed by the same canonical records used by the CLI skills. From the plugin directory, start it with one command:
 
 ```bash
 python3 scripts/job-apply-workspace.py
@@ -154,7 +154,7 @@ python3 scripts/job-apply-workspace.py
 
 The launcher binds only to `127.0.0.1`, chooses a free port, opens the complete authenticated URL in your default browser, and stops cleanly with Ctrl-C. It requires Python 3 but no Node runtime, account, cloud service, telemetry, or separate database.
 
-Use the workspace to capture one job or paste multiple URLs, filter and edit records, assign an existing resume, run readiness checks, mark valid jobs ready for agent handoff, and move a job to recoverable trash. CLI changes appear within four seconds or when you select **Refresh**. If a CLI or agent changes an open record, the workspace keeps your draft and shows a revision conflict before anything can be overwritten.
+Use **Jobs** to capture one job or paste multiple URLs, filter and edit records, assign an existing resume, run readiness checks, mark valid jobs ready for agent handoff, and move a job to recoverable trash. Use **Facts** to review provenance and selectively edit identity, contact, location, professional links, history, education, skills, search preferences, and existing forward-compatible facts. Conflicts preserve the draft: disjoint scalar edits safely rebase, while same-path and structured-value changes require an explicit latest-or-mine choice.
 
 The workspace never runs an application, reads arbitrary files, or activates Submit, Send, Apply, or another third-party final action. A ready job remains an explicit handoff to `$job-apply:job-apply`; you personally control submission.
 

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -86,6 +86,10 @@ JOB_TRANSITIONS = {
     "closed": {"saved"},
 }
 FACT_SOURCES = {"user", "resume", "agent", "migration"}
+PROFILE_NAMED_TOP_LEVEL = {
+    "firstName", "lastName", "email", "phone", "location", "linkedInUrl",
+    "portfolioUrl", "githubUrl", "workHistory", "education", "skills", "preferences",
+}
 REPLAY_TRANSITIONS = {"started", "reviewed"}
 REPLAY_ATS = {"ashby", "greenhouse", "lever", "linkedin-easy-apply"}
 SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
@@ -434,6 +438,133 @@ def _merge_object_patch(
             updated[key] = value
             changed.append(path)
     return updated, changed
+
+
+def _top_level_pointer_key(pointer: str) -> str:
+    if not isinstance(pointer, str) or not pointer.startswith("/") or "/" in pointer[1:]:
+        raise StoreError("atomic profile paths must identify one top-level fact")
+    encoded = pointer[1:]
+    if not encoded or re.search(r"~(?![01])", encoded):
+        raise StoreError("atomic profile path is invalid")
+    return encoded.replace("~1", "/").replace("~0", "~")
+
+
+def _apply_profile_patch(
+    target: dict[str, Any],
+    patch: dict[str, Any],
+    atomic_paths: list[str],
+    deleted_paths: list[str],
+) -> tuple[dict[str, Any], list[str]]:
+    """Apply merge-patch fields plus explicit atomic replacements/deletions."""
+
+    atomic_keys = {_top_level_pointer_key(path): path for path in atomic_paths}
+    deleted = set(deleted_paths)
+    if len(atomic_keys) != len(atomic_paths) or len(deleted) != len(deleted_paths):
+        raise StoreError("atomic profile paths must be unique")
+    if not deleted <= set(atomic_paths):
+        raise StoreError("deleted profile paths must also be atomic")
+    if any(key not in patch for key in atomic_keys):
+        raise StoreError("atomic profile paths must be present in the patch")
+
+    merge_patch = {key: value for key, value in patch.items() if key not in atomic_keys}
+    updated, changed = _merge_object_patch(target, merge_patch)
+    for key, path in atomic_keys.items():
+        if path in deleted:
+            if key in updated:
+                del updated[key]
+                changed.append(path)
+        elif key not in updated or updated[key] != patch[key]:
+            updated[key] = patch[key]
+            changed.append(path)
+    return updated, changed
+
+
+def _changed_json_pointer_paths(
+    current: Any, replacement: Any, prefix: str = ""
+) -> list[str]:
+    """Return narrow changed paths, treating non-objects as atomic values."""
+    if isinstance(current, dict) and isinstance(replacement, dict):
+        changed: list[str] = []
+        for key in sorted(set(current) | set(replacement)):
+            path = f"{prefix}/{_json_pointer_segment(key)}"
+            if key not in current or key not in replacement:
+                changed.append(path)
+            else:
+                changed.extend(
+                    _changed_json_pointer_paths(current[key], replacement[key], path)
+                )
+        return changed
+    return [prefix or "/"] if current != replacement else []
+
+
+def _protect_user_provenance(
+    provenance: dict[str, Any], changed: list[str], source: str
+) -> None:
+    """Reject lower-authority writes overlapping a human-authored fact path."""
+    if source == "user":
+        return
+    protected = [
+        path for path, record in provenance.items() if record.get("source") == "user"
+    ]
+    if any(
+        changed_path == protected_path
+        or changed_path.startswith(f"{protected_path}/")
+        or protected_path.startswith(f"{changed_path}/")
+        for changed_path in changed
+        for protected_path in protected
+    ):
+        raise StoreError("profile change conflicts with user-provenanced facts")
+
+
+def _json_pointer_value(document: Any, pointer: str) -> Any:
+    current = document
+    for encoded in pointer.split("/")[1:]:
+        key = encoded.replace("~1", "/").replace("~0", "~")
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def _fact_leaf_paths(value: Any, prefix: str) -> list[str]:
+    if isinstance(value, dict) and value:
+        return [
+            leaf
+            for key, child in value.items()
+            for leaf in _fact_leaf_paths(
+                child, f"{prefix}/{_json_pointer_segment(key)}"
+            )
+        ]
+    return [prefix]
+
+
+def _stamp_fact_provenance(
+    provenance: dict[str, Any],
+    changed: list[str],
+    source: str,
+    updated_at: str,
+    current_profile: dict[str, Any],
+) -> dict[str, Any]:
+    stamped = dict(provenance)
+    # Refining a parent marker to a changed child must not discard the
+    # authority of unchanged siblings. Materialize the parent's existing
+    # leaf provenance before replacing the changed branch marker.
+    for protected_path, record in list(provenance.items()):
+        if any(path.startswith(f"{protected_path}/") for path in changed):
+            for leaf in _fact_leaf_paths(
+                _json_pointer_value(current_profile, protected_path), protected_path
+            ):
+                stamped.setdefault(leaf, record)
+    for path in changed:
+        prefix = f"{path}/"
+        for stale in [
+            key
+            for key in stamped
+            if key.startswith(prefix) or path.startswith(f"{key}/")
+        ]:
+            stamped.pop(stale, None)
+        stamped[path] = {"source": source, "updatedAt": updated_at}
+    return stamped
 
 
 def _validate_answer_record(key: str, value: Any) -> dict[str, Any]:
@@ -817,23 +948,7 @@ class Store:
     def initialize(self) -> dict[str, Any]:
         """Validate existing documents, then create only missing store files."""
 
-        if self.profile_path.exists():
-            self._load_profile_document()
-        if self.answers_path.exists():
-            self._load_answers_document()
-        if self.jobs_path.exists():
-            self._load_jobs_document()
-        if self.resumes_path.exists():
-            self._load_resumes_document()
-        coordinator_exists = (
-            self.coordinator_path.exists() or self.coordinator_journal_path.exists()
-        )
-        if self.history_path.exists() and not coordinator_exists:
-            self.read_history()
-        if self.coordinator_path.exists():
-            self._load_coordinator_document()
-        if self.coordinator_journal_path.exists():
-            self._load_coordinator_journal()
+        self._validate_existing_documents()
 
         _ensure_private_dir(self.root)
         _ensure_private_dir(self.sessions_path)
@@ -901,6 +1016,9 @@ class Store:
             os.close(descriptor)
         _set_private_mode(self.history_path, 0o600)
 
+        coordinator_exists = (
+            self.coordinator_path.exists() or self.coordinator_journal_path.exists()
+        )
         if coordinator_exists:
             with exclusive_file_lock(self.store_lock_path):
                 self._ensure_coordinator_files_locked()
@@ -909,6 +1027,27 @@ class Store:
                 self.read_history()
 
         return {"initialized": True, "migratedLegacyProfile": migrated, **self.paths()}
+
+    def _validate_existing_documents(self) -> None:
+        """Validate existing store documents without creating or repairing files."""
+
+        if self.profile_path.exists():
+            self._load_profile_document()
+        if self.answers_path.exists():
+            self._load_answers_document()
+        if self.jobs_path.exists():
+            self._load_jobs_document()
+        if self.resumes_path.exists():
+            self._load_resumes_document()
+        coordinator_exists = (
+            self.coordinator_path.exists() or self.coordinator_journal_path.exists()
+        )
+        if self.history_path.exists() and not coordinator_exists:
+            self.read_history()
+        if self.coordinator_path.exists():
+            self._load_coordinator_document()
+        if self.coordinator_journal_path.exists():
+            self._load_coordinator_journal()
 
     def _ensure_coordinator_files_locked(self) -> None:
         if not self.coordinator_path.exists():
@@ -1066,25 +1205,88 @@ class Store:
             "updatedAt": metadata.get("updatedAt"),
         }
 
-    def replace_profile(self, profile: dict[str, Any]) -> dict[str, Any]:
-        self.initialize()
+    def replace_profile(
+        self, profile: dict[str, Any], expected_revision: int, source: str
+    ) -> dict[str, Any]:
         incoming = _require_object(profile, "profile")
+        if (
+            not isinstance(expected_revision, int)
+            or isinstance(expected_revision, bool)
+            or expected_revision < 0
+        ):
+            raise StoreError("profile expected revision must be a non-negative integer")
+        if source not in FACT_SOURCES:
+            raise StoreError("profile fact source is unsupported")
+        if self.profile_path.exists():
+            self.initialize()
+        result: dict[str, Any] | None = None
+        conflict_after_migration = False
         with exclusive_file_lock(self.store_lock_path):
-            document = self._load_profile_document()
-            document["profile"] = incoming
-            document["metadata"]["updatedAt"] = utc_now()
-            document["metadata"]["revision"] = (
-                document["metadata"].get("revision", 1) + 1
-            )
-            document["metadata"]["factProvenance"] = {}
-            atomic_write_json(self.profile_path, document)
-        return document["profile"]
+            if not self.profile_path.exists():
+                self._validate_existing_documents()
+                now = utc_now()
+                if self.legacy_profile.exists():
+                    migrated = read_json_object(self.legacy_profile, "legacy profile")
+                    atomic_write_json(self.profile_path, {
+                        "schemaVersion": SCHEMA_VERSION,
+                        "profile": migrated,
+                        "metadata": {
+                            "createdAt": now, "updatedAt": now, "revision": 1,
+                            "factProvenance": {},
+                            "migratedFrom": "~/.claude-job-profile.json", "migratedAt": now,
+                        },
+                    })
+                    conflict_after_migration = True
+                elif expected_revision == 0:
+                    changed = _changed_json_pointer_paths({}, incoming)
+                    document = {
+                        "schemaVersion": SCHEMA_VERSION,
+                        "profile": incoming,
+                        "metadata": {
+                            "createdAt": now, "updatedAt": now, "revision": 1,
+                            "factProvenance": _stamp_fact_provenance({}, changed, source, now, {}),
+                        },
+                    }
+                    atomic_write_json(self.profile_path, document)
+                    result = self._profile_inspection(document)
+                else:
+                    raise StoreError("profile revision conflict")
+
+            if result is None and not conflict_after_migration:
+                document = self._load_profile_document()
+                metadata = document["metadata"]
+                revision = metadata.get("revision", 1)
+                if expected_revision == 0 or revision != expected_revision:
+                    raise StoreError("profile revision conflict")
+                changed = _changed_json_pointer_paths(document["profile"], incoming)
+                if not changed:
+                    result = self._profile_inspection(document)
+                else:
+                    provenance = dict(metadata.get("factProvenance", {}))
+                    _protect_user_provenance(provenance, changed, source)
+                    now = utc_now()
+                    stamped_provenance = _stamp_fact_provenance(
+                        provenance, changed, source, now, document["profile"]
+                    )
+                    document["profile"] = incoming
+                    metadata["updatedAt"] = now
+                    metadata["revision"] = revision + 1
+                    metadata["factProvenance"] = stamped_provenance
+                    atomic_write_json(self.profile_path, document)
+                    result = self._profile_inspection(document)
+        self.initialize()
+        if conflict_after_migration:
+            raise StoreError("profile revision conflict")
+        assert result is not None
+        return result
 
     def patch_profile(
         self,
         patch: dict[str, Any],
         expected_revision: int,
         source: str,
+        atomic_paths: list[str] | None = None,
+        deleted_paths: list[str] | None = None,
     ) -> dict[str, Any]:
         self.initialize()
         incoming = _require_object(patch, "profile patch")
@@ -1092,26 +1294,29 @@ class Store:
             raise StoreError("profile patch must not be empty")
         if source not in FACT_SOURCES:
             raise StoreError("profile fact source is unsupported")
+        atomic = atomic_paths or []
+        deleted = deleted_paths or []
+        if not isinstance(atomic, list) or not all(isinstance(path, str) for path in atomic):
+            raise StoreError("atomic profile paths must be strings")
+        if not isinstance(deleted, list) or not all(isinstance(path, str) for path in deleted):
+            raise StoreError("deleted profile paths must be strings")
         with exclusive_file_lock(self.store_lock_path):
             document = self._load_profile_document()
             metadata = document["metadata"]
             revision = metadata.get("revision", 1)
             if revision != expected_revision:
                 raise StoreError("profile revision conflict")
-            updated, changed = _merge_object_patch(document["profile"], incoming)
+            updated, changed = _apply_profile_patch(
+                document["profile"], incoming, atomic, deleted
+            )
             if not changed:
                 return self._profile_inspection(document)
             now = utc_now()
             provenance = dict(metadata.get("factProvenance", {}))
-            for path in changed:
-                prefix = f"{path}/"
-                for stale in [
-                    key
-                    for key in provenance
-                    if key.startswith(prefix) or path.startswith(f"{key}/")
-                ]:
-                    provenance.pop(stale, None)
-                provenance[path] = {"source": source, "updatedAt": now}
+            _protect_user_provenance(provenance, changed, source)
+            provenance = _stamp_fact_provenance(
+                provenance, changed, source, now, document["profile"]
+            )
             document["profile"] = updated
             metadata["factProvenance"] = provenance
             metadata["revision"] = revision + 1
@@ -1129,26 +1334,44 @@ class Store:
         return _require_object(preferences, "profile.preferences")
 
     def set_preferences(
-        self, preferences: dict[str, Any], replace: bool = False
+        self,
+        preferences: dict[str, Any],
+        expected_revision: int,
+        source: str,
+        replace: bool = False,
     ) -> dict[str, Any]:
-        self.initialize()
         incoming = _require_object(preferences, "preferences")
+        if not replace:
+            return self.patch_profile(
+                {"preferences": incoming}, expected_revision, source
+            )
+
+        if source not in FACT_SOURCES:
+            raise StoreError("profile fact source is unsupported")
+        self.initialize()
         with exclusive_file_lock(self.store_lock_path):
             document = self._load_profile_document()
-            profile = document["profile"]
-            if replace:
-                updated = dict(incoming)
-            else:
-                current = profile.get("preferences", {})
-                updated = dict(_require_object(current, "profile.preferences"))
-                updated.update(incoming)
-            profile["preferences"] = updated
-            document["metadata"]["updatedAt"] = utc_now()
-            document["metadata"]["revision"] = (
-                document["metadata"].get("revision", 1) + 1
+            metadata = document["metadata"]
+            revision = metadata.get("revision", 1)
+            if revision != expected_revision:
+                raise StoreError("profile revision conflict")
+            updated = dict(document["profile"])
+            updated["preferences"] = incoming
+            changed = _changed_json_pointer_paths(document["profile"], updated)
+            if not changed:
+                return self._profile_inspection(document)
+            now = utc_now()
+            provenance = dict(metadata.get("factProvenance", {}))
+            _protect_user_provenance(provenance, changed, source)
+            provenance = _stamp_fact_provenance(
+                provenance, changed, source, now, document["profile"]
             )
+            document["profile"] = updated
+            metadata["factProvenance"] = provenance
+            metadata["revision"] = revision + 1
+            metadata["updatedAt"] = now
             atomic_write_json(self.profile_path, document)
-        return updated
+        return self._profile_inspection(document)
 
     @staticmethod
     def _answer_view(record: dict[str, Any]) -> dict[str, Any]:
@@ -3452,6 +3675,8 @@ def build_parser() -> argparse.ArgumentParser:
     commands.add_parser("profile-inspect")
     profile_replace = commands.add_parser("profile-replace")
     profile_replace.add_argument("--input", required=True)
+    profile_replace.add_argument("--expected-revision", required=True, type=int)
+    profile_replace.add_argument("--source", required=True, choices=sorted(FACT_SOURCES))
     profile_patch = commands.add_parser("profile-patch")
     profile_patch.add_argument("--input", required=True)
     profile_patch.add_argument("--expected-revision", required=True, type=int)
@@ -3459,6 +3684,8 @@ def build_parser() -> argparse.ArgumentParser:
     commands.add_parser("preferences-get")
     preferences_set = commands.add_parser("preferences-set")
     preferences_set.add_argument("--input", required=True)
+    preferences_set.add_argument("--expected-revision", required=True, type=int)
+    preferences_set.add_argument("--source", required=True, choices=sorted(FACT_SOURCES))
     preferences_set.add_argument("--replace", action="store_true")
 
     key = commands.add_parser("answer-key")
@@ -3621,7 +3848,9 @@ def run(args: argparse.Namespace) -> Any:
     if command == "profile-inspect":
         return store.inspect_profile()
     if command == "profile-replace":
-        return store.replace_profile(_read_input(args.input))
+        return store.replace_profile(
+            _read_input(args.input), args.expected_revision, args.source
+        )
     if command == "profile-patch":
         return store.patch_profile(
             _read_input(args.input), args.expected_revision, args.source
@@ -3629,7 +3858,9 @@ def run(args: argparse.Namespace) -> Any:
     if command == "preferences-get":
         return store.get_preferences()
     if command == "preferences-set":
-        return store.set_preferences(_read_input(args.input), args.replace)
+        return store.set_preferences(
+            _read_input(args.input), args.expected_revision, args.source, args.replace
+        )
     if command == "answer-key":
         return {"key": answer_key(args.question, _scope(args.scope))}
     if command == "answer-put":

--- a/scripts/job-apply-workspace.py
+++ b/scripts/job-apply-workspace.py
@@ -230,6 +230,9 @@ class WorkspaceHandler(BaseHTTPRequestHandler):
         self._send_bytes(HTTPStatus.OK, body, asset[1])
 
     def _get_api(self, path: str) -> None:
+        if path == "/api/profile":
+            self._store_call(self.server.store.inspect_profile)
+            return
         if path == "/api/state":
             self._store_call(lambda: {
                 "jobs": self.server.store.list_jobs(),
@@ -270,6 +273,53 @@ class WorkspaceHandler(BaseHTTPRequestHandler):
             return
         payload = self._read_json()
         if payload is None:
+            return
+        if method == "PATCH" and path == "/api/profile":
+            allowed = {"patch", "expectedRevision", "atomicPaths", "deletedPaths"}
+            atomic_paths = payload.get("atomicPaths", [])
+            deleted_paths = payload.get("deletedPaths", [])
+            if (
+                set(payload) - allowed
+                or not {"patch", "expectedRevision"} <= set(payload)
+                or not isinstance(payload.get("patch"), dict)
+                or not payload["patch"]
+                or not isinstance(atomic_paths, list)
+                or not all(isinstance(item, str) for item in atomic_paths)
+                or not isinstance(deleted_paths, list)
+                or not all(isinstance(item, str) for item in deleted_paths)
+            ):
+                self._error(
+                    HTTPStatus.BAD_REQUEST,
+                    "body requires a non-empty patch object, expectedRevision, and valid path lists",
+                )
+                return
+            try:
+                atomic_keys = {
+                    STORE_MODULE._top_level_pointer_key(item) for item in atomic_paths
+                }
+            except STORE_MODULE.StoreError as error:
+                self._error(HTTPStatus.BAD_REQUEST, str(error))
+                return
+            if (
+                len(set(atomic_paths)) != len(atomic_paths)
+                or len(set(deleted_paths)) != len(deleted_paths)
+                or not set(deleted_paths) <= set(atomic_paths)
+                or atomic_keys & STORE_MODULE.PROFILE_NAMED_TOP_LEVEL
+            ):
+                self._error(
+                    HTTPStatus.BAD_REQUEST,
+                    "atomic paths must uniquely identify Additional facts and include every deletion",
+                )
+                return
+            expected_revision = self._expected_revision(payload)
+            if expected_revision is None:
+                return
+            self._store_call(
+                lambda: self.server.store.patch_profile(
+                    payload["patch"], expected_revision, source="user",
+                    atomic_paths=atomic_paths, deleted_paths=deleted_paths,
+                )
+            )
             return
         if method == "POST" and path == "/api/jobs":
             job = payload.get("job")

--- a/scripts/qa-replay.py
+++ b/scripts/qa-replay.py
@@ -1397,6 +1397,18 @@ def _prepare(fixture_id: str, scenario_id: str) -> dict[str, Any]:
         prepared_profile = dict(profile)
         prepared_profile["resumePath"] = str(copied_resume.resolve())
         _run_store(store_root, ["init"])
+        profile_inspection = _run_store_json(store_root, ["profile-inspect"])
+        expected_revision = (
+            profile_inspection.get("revision")
+            if isinstance(profile_inspection, dict)
+            else None
+        )
+        if (
+            not isinstance(expected_revision, int)
+            or isinstance(expected_revision, bool)
+            or expected_revision < 1
+        ):
+            raise CoordinatorError("isolated store initialization failed")
         _verify_directory_binding(run_root, run_descriptor, "run directory changed")
         prepared_path = run_root / ".prepared-profile.json"
         _atomic_json_at(run_descriptor, ".prepared-profile.json", prepared_profile)
@@ -1406,6 +1418,10 @@ def _prepare(fixture_id: str, scenario_id: str) -> dict[str, Any]:
                 "profile-replace",
                 "--input",
                 str(prepared_path),
+                "--expected-revision",
+                str(expected_revision),
+                "--source",
+                "resume",
             ],
         )
         _verify_directory_binding(run_root, run_descriptor, "run directory changed")

--- a/scripts/smoke-plugin.sh
+++ b/scripts/smoke-plugin.sh
@@ -418,13 +418,19 @@ try:
     host = f"127.0.0.1:{details['port']}"
     connection.request("GET", "/", headers={"Host": host})
     response = connection.getresponse()
-    if response.status != 200 or b"Jobs Workspace" not in response.read():
-        raise SystemExit("packaged workspace did not serve its Jobs UI")
+    markup = response.read()
+    if response.status != 200 or b"Jobs Workspace" not in markup or b"Facts Workspace" not in markup:
+        raise SystemExit("packaged workspace did not serve its Jobs and Facts UI")
     connection.request("GET", "/api/state", headers={"Host": host, "Authorization": f"Bearer {token}"})
     response = connection.getresponse()
     state = json.loads(response.read())
     if response.status != 200 or state != {"jobs": [], "resumes": []}:
         raise SystemExit("packaged workspace did not read the canonical store")
+    connection.request("GET", "/api/profile", headers={"Host": host, "Authorization": f"Bearer {token}"})
+    response = connection.getresponse()
+    profile = json.loads(response.read())
+    if response.status != 200 or profile.get("profile") != {} or profile.get("revision") != 1:
+        raise SystemExit("packaged workspace did not inspect the canonical profile")
     connection.close()
     process.send_signal(signal.SIGINT)
     if process.wait(timeout=5) != 0:
@@ -433,7 +439,7 @@ finally:
     if process.poll() is None:
         process.terminate()
         process.wait(timeout=5)
-print("Packaged Jobs workspace launch passed")
+print("Packaged Jobs and Facts workspace launch passed")
 PY
 
 echo "Running Playwright and CLI walkthrough against packaged fixture"

--- a/skills/answer-memory/SKILL.md
+++ b/skills/answer-memory/SKILL.md
@@ -116,15 +116,23 @@ Do not place passwords, credentials, authentication tokens, CAPTCHA answers, pay
 ```bash
 python3 "<plugin-root>/scripts/job-apply-store.py" profile-get
 python3 "<plugin-root>/scripts/job-apply-store.py" profile-inspect
-python3 "<plugin-root>/scripts/job-apply-store.py" profile-replace --input <profile.json>
+python3 "<plugin-root>/scripts/job-apply-store.py" profile-replace \
+  --input <profile.json> --expected-revision <revision> \
+  --source <user|resume|agent|migration>
 python3 "<plugin-root>/scripts/job-apply-store.py" profile-patch \
   --input <patch.json> --expected-revision <revision> \
   --source <user|resume|agent|migration>
 python3 "<plugin-root>/scripts/job-apply-store.py" preferences-get
-python3 "<plugin-root>/scripts/job-apply-store.py" preferences-set --input <preferences.json>
+python3 "<plugin-root>/scripts/job-apply-store.py" preferences-set \
+  --input <preferences.json> --expected-revision <revision> \
+  --source <user|resume|agent|migration> [--replace]
 ```
 
-`preferences-set` merges supplied keys and preserves all other profile and preference fields. Use `--replace` only after the user explicitly chooses to replace the full preferences object.
+Inspect the profile immediately before either mutation and pass its current revision.
+`preferences-set` merges supplied keys and preserves all other profile and preference
+fields. Use `--replace` only after the user explicitly chooses to replace the full
+preferences object. A revision conflict means the profile changed concurrently;
+reload it and resolve the difference instead of retrying the stale write.
 
 `profile-get` keeps the legacy raw-profile response. Use `profile-inspect` before a
 selective edit to obtain the current revision and fact provenance, then pass that

--- a/skills/job-apply/SKILL.md
+++ b/skills/job-apply/SKILL.md
@@ -115,7 +115,7 @@ If `profile-get` returns an empty object, or if the user requests a reset:
    - `skills[]`: array of skill strings
    - `resumePath`: absolute path to the resume file on disk
 3. **Present extracted data to user** for review and correction
-4. **Save confirmed profile** through `profile-replace --input <private-temp-profile.json>`, then remove the temporary input
+4. **Inspect and save confirmed profile** by running `profile-inspect`, retaining its revision, then calling `profile-replace --input <private-temp-profile.json> --expected-revision <inspected-revision> --source user`. Remove the temporary input. If the revision conflicts, stop and review the newly inspected profile; never replace unseen changes.
 
 ### Phase 2: Application Filling
 

--- a/skills/job-preferences/SKILL.md
+++ b/skills/job-preferences/SKILL.md
@@ -12,13 +12,13 @@ A Codex and Claude Code skill for managing persistent job search preferences. Se
 
 ## Workflow
 
-### Step 1: Load Profile
+### Step 1: Inspect Profile
 
-Follow the bundled `answer-memory` skill (`$job-apply:answer-memory` in Codex; `/job-apply:answer-memory` in Claude Code). Resolve `<plugin-root>` as that skill directs, run `python3 "<plugin-root>/scripts/job-apply-store.py" init`, then load saved preferences with `preferences-get`. Never read or write persistent Job Apply files directly.
+Follow the bundled `answer-memory` skill (`$job-apply:answer-memory` in Codex; `/job-apply:answer-memory` in Claude Code). Resolve `<plugin-root>` as that skill directs, run `python3 "<plugin-root>/scripts/job-apply-store.py" init`, then run `profile-inspect`. Retain its `revision` and read the saved values from `profile.preferences`. Never read or write persistent Job Apply files directly.
 
 ### Step 2: Check for Existing Preferences
 
-Use the JSON object returned by `preferences-get`.
+Use the `profile.preferences` JSON object returned by `profile-inspect`.
 
 **If preferences exist**, display them:
 
@@ -77,19 +77,17 @@ Use the host's structured question surface when available; otherwise ask concise
 
 ### Step 4: Save Preferences
 
-Write the collected values to a private temporary JSON object, then call `preferences-set --input <preferences.json>` through the bundled helper and remove the temporary file. The helper merges supplied keys while preserving the rest of the preferences and profile. Never patch `profile.json` directly.
+Write only the changed preference keys to a private temporary JSON object, then call `preferences-set --input <preferences.json> --expected-revision <inspected-revision> --source user` through the bundled helper and remove the temporary file. The helper returns the machine-readable profile inspection and merges supplied keys while preserving the rest of the preferences and profile. If the revision conflicts, inspect again, show the current preferences, and ask before retrying. Never patch `profile.json` directly.
 
 **Schema:**
 
 ```json
 {
-  "preferences": {
-    "targetTitles": ["Staff AI Engineer", "Principal ML Engineer"],
-    "minBaseSalary": "$250K",
-    "remotePreference": "remote only",
-    "excludePatterns": ["junior", "associate", "intern", "entry level"],
-    "defaultTimeRange": "last week"
-  }
+  "targetTitles": ["Staff AI Engineer", "Principal ML Engineer"],
+  "minBaseSalary": "$250K",
+  "remotePreference": "remote only",
+  "excludePatterns": ["junior", "associate", "intern", "entry level"],
+  "defaultTimeRange": "last week"
 }
 ```
 
@@ -112,5 +110,5 @@ When the user invokes `job-preferences` and preferences already exist, show curr
 ## Safety Rules
 
 1. **Use only the helper** — initialize, read, and merge preferences through the bundled `answer-memory` skill; never directly edit files under `~/.job-apply/`
-2. **Preserve existing profile** — use `preferences-set` without `--replace` for selective updates
+2. **Preserve existing profile** — inspect first, then use `preferences-set` with the exact revision, `--source user`, and no `--replace` for selective updates
 3. **No defaults without user input** — always ask the user, never assume values

--- a/skills/job-workspace/SKILL.md
+++ b/skills/job-workspace/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: job-workspace
-description: Start the optional local Jobs workspace shared with Job Apply agents and the canonical store.
+description: Start the optional local Jobs and Facts workspace shared with Job Apply agents and the canonical store.
 allowed-tools: Bash
 ---
 
 # Job Workspace
 
-Start the packaged, local-only Jobs companion when the user asks to view, organize, edit, preflight, or prepare canonical jobs in a browser.
+Start the packaged, local-only companion when the user asks to review or edit canonical profile facts and preferences, or to view, organize, edit, preflight, or prepare canonical jobs in a browser.
 
 ## Launch
 
@@ -25,6 +25,6 @@ The launcher chooses a free port, binds only to `127.0.0.1`, opens the browser, 
 
 - Never copy the printed fragment token into chat, logs, or another URL. If the browser did not open, tell the user to open the complete URL printed locally by the launcher.
 - Never bind the workspace to another host or proxy it onto a network.
-- The UI can create, edit, organize, preflight, mark ready, and move Jobs records to recoverable trash. It does not restore or permanently delete records and does not provide standalone Facts, Answers, Resumes, or Trash management.
+- The Jobs surface can create, edit, organize, preflight, mark ready, and move Jobs records to recoverable trash. The Facts surface selectively edits the canonical profile and preferences with provenance and explicit conflict choices. It does not restore or permanently delete records and does not provide Answers, Resumes, or Trash management.
 - The UI does not run application agents or access arbitrary files. It must not submit applications or activate any third-party final action. A ready record is only a handoff for the existing Job Apply workflow.
 - All mutations go through the canonical Store contract with optimistic revisions. If a conflict appears, preserve the draft and let the user review or reapply it explicitly.

--- a/tests/test_answer_memory_integration.py
+++ b/tests/test_answer_memory_integration.py
@@ -63,10 +63,26 @@ class AnswerMemoryIntegrationTests(unittest.TestCase):
             "preferences-input.json", {"remotePreference": "remote only"}
         )
         updated_preferences = self.json_store(
-            "preferences-set", "--input", str(preferences)
+            "preferences-set",
+            "--input",
+            str(preferences),
+            "--expected-revision",
+            str(self.json_store("profile-inspect")["revision"]),
+            "--source",
+            "user",
         )
-        self.assertEqual(updated_preferences["targetTitles"], ["Engineer"])
-        self.assertEqual(updated_preferences["remotePreference"], "remote only")
+        self.assertEqual(
+            updated_preferences["profile"]["preferences"]["targetTitles"],
+            ["Engineer"],
+        )
+        self.assertEqual(
+            updated_preferences["profile"]["preferences"]["remotePreference"],
+            "remote only",
+        )
+        self.assertEqual(
+            updated_preferences["factProvenance"]["/preferences/remotePreference"]["source"],
+            "user",
+        )
         self.assertTrue(self.json_store("profile-get")["unknownLegacyField"]["preserve"])
 
         confirmed = self.write_input(
@@ -211,7 +227,15 @@ class AnswerMemoryIntegrationTests(unittest.TestCase):
     def test_ready_job_cli_lifecycle_reaches_review_and_releases_claim(self):
         self.json_store("init")
         profile = self.write_input("profile.json", {"firstName": "Synthetic"})
-        self.json_store("profile-replace", "--input", str(profile))
+        self.json_store(
+            "profile-replace",
+            "--input",
+            str(profile),
+            "--expected-revision",
+            str(self.json_store("profile-inspect")["revision"]),
+            "--source",
+            "user",
+        )
         resume_path = self.home / "assigned-resume.pdf"
         resume_path.write_bytes(b"synthetic resume")
         resume = self.write_input("resume.json", {
@@ -266,7 +290,15 @@ class AnswerMemoryIntegrationTests(unittest.TestCase):
     def test_concurrent_cli_acquisition_allows_only_one_global_claim(self):
         self.json_store("init")
         profile = self.write_input("concurrent-profile.json", {"firstName": "Synthetic"})
-        self.json_store("profile-replace", "--input", str(profile))
+        self.json_store(
+            "profile-replace",
+            "--input",
+            str(profile),
+            "--expected-revision",
+            str(self.json_store("profile-inspect")["revision"]),
+            "--source",
+            "user",
+        )
         resume_path = self.home / "concurrent-resume.pdf"
         resume_path.write_bytes(b"resume")
         resume = self.write_input("concurrent-resume.json", {

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -5,7 +5,9 @@ import stat
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
@@ -53,11 +55,16 @@ class StoreTests(unittest.TestCase):
             {
                 "firstName": "Ada",
                 "preferences": {"targetTitles": ["Engineer"], "salary": "200K"},
-            }
+            },
+            expected_revision=1,
+            source="resume",
         )
-        updated = self.store.set_preferences({"salary": "250K"})
+        updated = self.store.set_preferences(
+            {"salary": "250K"}, expected_revision=2, source="user"
+        )
         self.assertEqual(
-            updated, {"targetTitles": ["Engineer"], "salary": "250K"}
+            updated["profile"]["preferences"],
+            {"targetTitles": ["Engineer"], "salary": "250K"},
         )
         self.assertEqual(self.store.get_profile()["firstName"], "Ada")
 
@@ -69,7 +76,9 @@ class StoreTests(unittest.TestCase):
                 "location": {"city": "London", "country": "UK"},
                 "skills": ["Python"],
                 "portfolioUrl": "https://example.com",
-            }
+            },
+            expected_revision=1,
+            source="resume",
         )
         before = self.store.inspect_profile()
         updated = self.store.patch_profile(
@@ -87,13 +96,22 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(updated["revision"], before["revision"] + 1)
         self.assertEqual(
             set(updated["factProvenance"]),
-            {"/location/city", "/skills", "/portfolioUrl"},
+            {
+                "/firstName",
+                "/location/city",
+                "/location/country",
+                "/skills",
+                "/portfolioUrl",
+            },
         )
         self.assertTrue(
             all(
-                item["source"] == "user"
-                for item in updated["factProvenance"].values()
+                updated["factProvenance"][path]["source"] == "user"
+                for path in ("/location/city", "/skills", "/portfolioUrl")
             )
+        )
+        self.assertEqual(
+            updated["factProvenance"]["/location/country"]["source"], "resume"
         )
         with self.assertRaisesRegex(STORE_MODULE.StoreError, "revision conflict"):
             self.store.patch_profile(
@@ -101,6 +119,39 @@ class StoreTests(unittest.TestCase):
                 expected_revision=before["revision"],
                 source="user",
             )
+
+    def test_atomic_profile_patch_replaces_whole_value_and_distinguishes_null_from_delete(self):
+        seeded = self.store.patch_profile(
+            {"futureConfig": {"enabled": True, "nested": {"keep": True}}},
+            expected_revision=1,
+            source="resume",
+        )
+        replaced = self.store.patch_profile(
+            {"futureConfig": {"enabled": False}},
+            seeded["revision"],
+            "user",
+            atomic_paths=["/futureConfig"],
+        )
+        self.assertEqual(replaced["profile"]["futureConfig"], {"enabled": False})
+        self.assertEqual(replaced["factProvenance"]["/futureConfig"]["source"], "user")
+
+        stored_null = self.store.patch_profile(
+            {"futureConfig": None},
+            replaced["revision"],
+            "user",
+            atomic_paths=["/futureConfig"],
+        )
+        self.assertIn("futureConfig", stored_null["profile"])
+        self.assertIsNone(stored_null["profile"]["futureConfig"])
+
+        deleted = self.store.patch_profile(
+            {"futureConfig": None},
+            stored_null["revision"],
+            "user",
+            atomic_paths=["/futureConfig"],
+            deleted_paths=["/futureConfig"],
+        )
+        self.assertNotIn("futureConfig", deleted["profile"])
 
     def test_profile_patch_replaces_parent_provenance_with_specific_changes(self):
         self.store.initialize()
@@ -117,6 +168,40 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(second["factProvenance"]["/location/city"]["source"], "user")
         self.assertEqual(
             second["factProvenance"]["/location/country"]["source"], "resume"
+        )
+
+    def test_profile_patch_preserves_user_authority_on_unchanged_nested_siblings(self):
+        seeded = self.store.replace_profile(
+            {"location": {"city": "Phoenix", "country": "US"}}, 0, "user"
+        )
+        self.assertEqual(seeded["factProvenance"]["/location"]["source"], "user")
+
+        updated = self.store.patch_profile(
+            {"location": {"city": "Tempe"}}, seeded["revision"], "user"
+        )
+
+        self.assertEqual(updated["factProvenance"]["/location/city"]["source"], "user")
+        self.assertEqual(
+            updated["factProvenance"]["/location/country"]["source"], "user"
+        )
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "user-provenanced"):
+            self.store.patch_profile(
+                {"location": {"country": "CA"}}, updated["revision"], "agent"
+            )
+
+        replacement_store = STORE_MODULE.Store(
+            self.root / "replacement-store", self.root / "replacement-legacy.json"
+        )
+        replacement_seed = replacement_store.replace_profile(
+            {"location": {"city": "Phoenix", "country": "US"}}, 0, "user"
+        )
+        replacement = replacement_store.replace_profile(
+            {"location": {"city": "Tempe", "country": "US"}},
+            replacement_seed["revision"],
+            "user",
+        )
+        self.assertEqual(
+            replacement["factProvenance"]["/location/country"]["source"], "user"
         )
 
     def test_existing_v1_profile_without_revision_upgrades_on_first_patch(self):
@@ -143,12 +228,201 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(updated["revision"], 2)
         self.assertEqual(updated["profile"]["firstName"], "Grace")
 
+    def test_user_provenance_blocks_lower_authority_patch_and_replace(self):
+        initialized = self.store.replace_profile(
+            {"firstName": "Ada", "location": {"city": "Phoenix"}},
+            expected_revision=0,
+            source="resume",
+        )
+        human = self.store.patch_profile(
+            {"location": {"city": "Tempe"}}, initialized["revision"], "user"
+        )
+        for patch in ({"location": {"city": "Mesa"}}, {"location": None}):
+            with self.subTest(patch=patch):
+                with self.assertRaisesRegex(STORE_MODULE.StoreError, "user-provenanced"):
+                    self.store.patch_profile(patch, human["revision"], "agent")
+        allowed = self.store.patch_profile(
+            {"firstName": "Grace"}, human["revision"], "agent"
+        )
+        self.assertEqual(allowed["profile"]["location"]["city"], "Tempe")
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "user-provenanced"):
+            self.store.replace_profile(
+                {"firstName": "Grace", "location": {"city": "Mesa"}},
+                allowed["revision"],
+                "migration",
+            )
+
+    def test_profile_replace_is_revisioned_provenance_aware_and_initializes_at_zero(self):
+        first = self.store.replace_profile(
+            {"firstName": "Ada", "skills": ["Python"]}, 0, "resume"
+        )
+        self.assertEqual(first["revision"], 1)
+        self.assertEqual(first["factProvenance"]["/skills"]["source"], "resume")
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "revision conflict"):
+            self.store.replace_profile({"firstName": "Grace"}, 0, "user")
+        replaced = self.store.replace_profile(
+            {"firstName": "Grace", "skills": ["Python"]}, 1, "user"
+        )
+        self.assertEqual(replaced["revision"], 2)
+        self.assertEqual(replaced["factProvenance"]["/firstName"]["source"], "user")
+
+    def test_first_replacement_writes_only_its_final_revision_one_profile(self):
+        writes = []
+        original = STORE_MODULE.atomic_write_json
+
+        def recording_write(path, payload):
+            if path == self.store.profile_path:
+                writes.append(json.loads(json.dumps(payload)))
+            return original(path, payload)
+
+        with mock.patch.object(STORE_MODULE, "atomic_write_json", recording_write):
+            result = self.store.replace_profile({"firstName": "Ada"}, 0, "resume")
+
+        self.assertEqual(result["revision"], 1)
+        self.assertEqual(
+            [(item["metadata"]["revision"], item["profile"]) for item in writes],
+            [(1, {"firstName": "Ada"})],
+        )
+
+    def test_first_replacement_validates_existing_store_before_creating_profile(self):
+        sibling_paths = (
+            "answers.json",
+            "jobs.json",
+            "resumes.json",
+            "applications.jsonl",
+            "coordinator.json",
+            "coordinator-journal.json",
+        )
+        for index, filename in enumerate(sibling_paths):
+            with self.subTest(filename=filename):
+                root = self.home / f"invalid-sibling-{index}"
+                root.mkdir()
+                sibling = root / filename
+                sibling.write_text("not json\n", encoding="utf-8")
+                store = STORE_MODULE.Store(root, self.home / f"legacy-{index}.json")
+
+                with self.assertRaises(STORE_MODULE.StoreError):
+                    store.replace_profile({"firstName": "Ada"}, 0, "resume")
+
+                self.assertFalse(store.profile_path.exists())
+                self.assertEqual(sibling.read_text(encoding="utf-8"), "not json\n")
+
+        legacy = self.home / "invalid-legacy.json"
+        legacy.write_text("not json\n", encoding="utf-8")
+        legacy_store = STORE_MODULE.Store(self.home / "invalid-legacy-store", legacy)
+        with self.assertRaises(STORE_MODULE.StoreError):
+            legacy_store.replace_profile({"firstName": "Ada"}, 0, "resume")
+        self.assertFalse(legacy_store.profile_path.exists())
+        self.assertEqual(legacy.read_text(encoding="utf-8"), "not json\n")
+
+    def test_revision_zero_cannot_replace_migrated_legacy_profile(self):
+        self.legacy.write_text(json.dumps({"firstName": "Legacy"}), encoding="utf-8")
+
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "revision conflict"):
+            self.store.replace_profile({"firstName": "Replacement"}, 0, "resume")
+
+        inspected = self.store.inspect_profile()
+        self.assertEqual(inspected["revision"], 1)
+        self.assertEqual(inspected["profile"], {"firstName": "Legacy"})
+        replaced = self.store.replace_profile(
+            {"firstName": "Replacement"}, inspected["revision"], "resume"
+        )
+        self.assertEqual(replaced["revision"], 2)
+
+    def test_revision_zero_no_op_replacement_claims_initialization(self):
+        claimed = self.store.replace_profile({}, 0, "resume")
+        self.assertEqual(claimed["revision"], 1)
+        self.assertEqual(claimed["profile"], {})
+        self.assertEqual(claimed["factProvenance"], {})
+
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "revision conflict"):
+            self.store.replace_profile({"firstName": "Ada"}, 0, "resume")
+
+        updated = self.store.replace_profile(
+            {"firstName": "Ada"}, claimed["revision"], "resume"
+        )
+        self.assertEqual(updated["revision"], 2)
+
+    def test_only_one_concurrent_revision_zero_profile_replacement_succeeds(self):
+        stores = [
+            STORE_MODULE.Store(self.root, self.legacy),
+            STORE_MODULE.Store(self.root, self.legacy),
+        ]
+        def replace(store, profile):
+            try:
+                return store.replace_profile(profile, 0, "resume")
+            except STORE_MODULE.StoreError as error:
+                return error
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            outcomes = list(
+                executor.map(replace, stores, ({}, {"firstName": "Grace"}))
+            )
+
+        successes = [item for item in outcomes if isinstance(item, dict)]
+        conflicts = [item for item in outcomes if isinstance(item, STORE_MODULE.StoreError)]
+        self.assertEqual(len(successes), 1)
+        self.assertEqual(len(conflicts), 1)
+        self.assertRegex(str(conflicts[0]), "revision conflict")
+        self.assertEqual(self.store.inspect_profile()["profile"], successes[0]["profile"])
+
+    def test_preferences_set_is_selective_revisioned_and_stamps_source(self):
+        seeded = self.store.patch_profile(
+            {"preferences": {"targetTitles": ["Engineer"], "remotePreference": "remote"}},
+            1,
+            "resume",
+        )
+        updated = self.store.set_preferences(
+            {"remotePreference": "hybrid"}, seeded["revision"], "user"
+        )
+        self.assertEqual(updated["profile"]["preferences"]["targetTitles"], ["Engineer"])
+        self.assertEqual(
+            updated["factProvenance"]["/preferences/remotePreference"]["source"],
+            "user",
+        )
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "revision conflict"):
+            self.store.set_preferences({"defaultTimeRange": "week"}, seeded["revision"], "user")
+
+    def test_preferences_replace_replaces_nested_values_in_one_revision(self):
+        seeded = self.store.patch_profile(
+            {
+                "firstName": "Ada",
+                "preferences": {
+                    "filters": {"locations": ["Phoenix"], "seniority": "staff"},
+                    "remotePreference": "remote",
+                },
+            },
+            1,
+            "resume",
+        )
+        updated = self.store.set_preferences(
+            {"filters": {"locations": ["Tempe"]}},
+            seeded["revision"],
+            "user",
+            replace=True,
+        )
+
+        self.assertEqual(
+            updated["profile"],
+            {
+                "firstName": "Ada",
+                "preferences": {"filters": {"locations": ["Tempe"]}},
+            },
+        )
+        self.assertEqual(updated["revision"], seeded["revision"] + 1)
+        self.assertEqual(
+            updated["factProvenance"]["/preferences/filters/locations"]["source"],
+            "user",
+        )
+
     def test_atomic_write_failure_keeps_previous_document_and_cleans_temp(self):
         self.store.initialize()
         before = self.store.profile_path.read_text(encoding="utf-8")
         with mock.patch.object(STORE_MODULE.os, "replace", side_effect=OSError("boom")):
             with self.assertRaises(OSError):
-                self.store.replace_profile({"firstName": "Grace"})
+                self.store.replace_profile(
+                    {"firstName": "Grace"}, expected_revision=1, source="user"
+                )
         self.assertEqual(self.store.profile_path.read_text(encoding="utf-8"), before)
         self.assertEqual(list(self.root.glob(".profile.json.*.tmp")), [])
 
@@ -339,7 +613,9 @@ class StoreTests(unittest.TestCase):
         )
 
     def test_profile_noop_and_answer_delete_do_not_reenter_coordinator_lock(self):
-        self.store.replace_profile({"firstName": "Ada"})
+        self.store.replace_profile(
+            {"firstName": "Ada"}, expected_revision=0, source="user"
+        )
         self.store.claim_status()
         before = self.store.inspect_profile()
         unchanged = self.store.patch_profile(
@@ -1345,7 +1621,11 @@ class StoreTests(unittest.TestCase):
         self.assertTrue(json.loads(committed.stdout)["committed"])
 
     def test_job_transitions_require_supported_flow_and_user_submission(self):
-        self.store.replace_profile({"firstName": "Ada"})
+        self.store.replace_profile(
+            {"firstName": "Ada"},
+            expected_revision=self.store.inspect_profile()["revision"],
+            source="user",
+        )
         resume_path = self.home / "resume.pdf"
         resume_path.write_bytes(b"resume")
         self.store.create_resume(
@@ -1394,7 +1674,11 @@ class StoreTests(unittest.TestCase):
         self.assertEqual((job["status"], job["closedOutcome"]), ("closed", "rejected"))
 
     def _make_ready_job(self, job_id="ready-job", assigned=False):
-        self.store.replace_profile({"firstName": "Ada"})
+        self.store.replace_profile(
+            {"firstName": "Ada"},
+            expected_revision=self.store.inspect_profile()["revision"],
+            source="user",
+        )
         default_path = self.home / "default.pdf"
         default_path.write_bytes(b"default-resume")
         self.store.create_resume(
@@ -1635,7 +1919,11 @@ class StoreTests(unittest.TestCase):
         def ready_store(case):
             root = self.home / "boundaries" / case
             store = STORE_MODULE.Store(root, self.legacy)
-            store.replace_profile({"firstName": "Ada"})
+            store.replace_profile(
+                {"firstName": "Ada"},
+                expected_revision=store.inspect_profile()["revision"],
+                source="user",
+            )
             resume_path = root / "resume.pdf"
             resume_path.write_bytes(b"resume")
             store.create_resume({"id": "resume", "label": "Resume", "path": str(resume_path)})
@@ -2233,6 +2521,60 @@ class StoreTests(unittest.TestCase):
             text=True,
         )
         self.assertEqual(json.loads(patched.stdout)["revision"], 2)
+
+        preferences_input = self.home / "preferences.json"
+        preferences_input.write_text(
+            json.dumps({"remotePreference": "hybrid"}), encoding="utf-8"
+        )
+        preferences = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--root",
+                str(self.root),
+                "preferences-set",
+                "--input",
+                str(preferences_input),
+                "--expected-revision",
+                "2",
+                "--source",
+                "user",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        preference_result = json.loads(preferences.stdout)
+        self.assertEqual(preference_result["revision"], 3)
+        self.assertEqual(
+            preference_result["factProvenance"]["/preferences/remotePreference"]["source"],
+            "user",
+        )
+
+        replacement_input = self.home / "profile-replacement.json"
+        replacement_input.write_text(
+            json.dumps({"firstName": "Grace", "preferences": {"remotePreference": "hybrid"}}),
+            encoding="utf-8",
+        )
+        replaced = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--root",
+                str(self.root),
+                "profile-replace",
+                "--input",
+                str(replacement_input),
+                "--expected-revision",
+                "3",
+                "--source",
+                "user",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(json.loads(replaced.stdout)["revision"], 4)
 
         resume_file = self.home / "resume.pdf"
         resume_file.write_bytes(b"resume")

--- a/tests/test_job_apply_workspace.py
+++ b/tests/test_job_apply_workspace.py
@@ -154,6 +154,100 @@ class WorkspaceServerTests(unittest.TestCase):
         self.assertEqual(self.server.store.get_job(ui_job["id"])["notes"], "human note")
         self.assertEqual(updated["revision"], 2)
 
+    def test_profile_api_inspects_and_forces_browser_user_provenance(self):
+        seeded = self.server.store.patch_profile(
+            {
+                "firstName": "Ada",
+                "location": {"city": "Phoenix", "country": "US"},
+                "futureFact": {"enabled": True},
+            },
+            expected_revision=1,
+            source="resume",
+        )
+        status, _headers, inspected = self.request("GET", "/api/profile", origin=False)
+        self.assertEqual((status, inspected["revision"]), (200, seeded["revision"]))
+        status, _headers, updated = self.request(
+            "PATCH",
+            "/api/profile",
+            {
+                "patch": {"location": {"city": "Tempe"}},
+                "expectedRevision": inspected["revision"],
+            },
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(updated["profile"]["location"], {"city": "Tempe", "country": "US"})
+        self.assertEqual(updated["profile"]["futureFact"], {"enabled": True})
+        self.assertEqual(updated["factProvenance"]["/location/city"]["source"], "user")
+
+    def test_profile_api_atomically_replaces_additional_facts_and_separates_deletion(self):
+        seeded = self.server.store.patch_profile(
+            {"futureFact": {"enabled": True, "keep": "old"}}, 1, "resume"
+        )
+        status, _headers, replaced = self.request(
+            "PATCH",
+            "/api/profile",
+            {
+                "patch": {"futureFact": {"enabled": False}},
+                "expectedRevision": seeded["revision"],
+                "atomicPaths": ["/futureFact"],
+                "deletedPaths": [],
+            },
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(replaced["profile"]["futureFact"], {"enabled": False})
+
+        status, _headers, stored_null = self.request(
+            "PATCH",
+            "/api/profile",
+            {
+                "patch": {"futureFact": None},
+                "expectedRevision": replaced["revision"],
+                "atomicPaths": ["/futureFact"],
+                "deletedPaths": [],
+            },
+        )
+        self.assertEqual(status, 200)
+        self.assertIn("futureFact", stored_null["profile"])
+        self.assertIsNone(stored_null["profile"]["futureFact"])
+
+        status, _headers, deleted = self.request(
+            "PATCH",
+            "/api/profile",
+            {
+                "patch": {"futureFact": None},
+                "expectedRevision": stored_null["revision"],
+                "atomicPaths": ["/futureFact"],
+                "deletedPaths": ["/futureFact"],
+            },
+        )
+        self.assertEqual(status, 200)
+        self.assertNotIn("futureFact", deleted["profile"])
+
+    def test_profile_api_rejects_bad_shape_stale_revision_and_wrong_origin(self):
+        current = self.server.store.inspect_profile()
+        probes = (
+            ({"patch": {}, "expectedRevision": current["revision"]}, True, 400),
+            ({"patch": {"firstName": "Ada"}, "expectedRevision": True}, True, 400),
+            ({"patch": {"firstName": "Ada"}, "expectedRevision": current["revision"], "source": "agent"}, True, 400),
+            ({"patch": {"firstName": "Ada"}, "expectedRevision": current["revision"]}, False, 403),
+            ({"patch": {"firstName": "Ada"}, "expectedRevision": current["revision"], "atomicPaths": ["/firstName"]}, True, 400),
+            ({"patch": {"futureFact": None}, "expectedRevision": current["revision"], "deletedPaths": ["/futureFact"]}, True, 400),
+        )
+        for payload, origin, expected_status in probes:
+            with self.subTest(payload=set(payload), origin=origin):
+                status, _headers, _body = self.request("PATCH", "/api/profile", payload, origin=origin)
+                self.assertEqual(status, expected_status)
+        advanced = self.server.store.patch_profile(
+            {"firstName": "Grace"}, current["revision"], "agent"
+        )
+        status, _headers, body = self.request(
+            "PATCH",
+            "/api/profile",
+            {"patch": {"lastName": "Hopper"}, "expectedRevision": current["revision"]},
+        )
+        self.assertEqual((status, body["error"]["code"]), (409, "revision_conflict"))
+        self.assertEqual(self.server.store.inspect_profile()["revision"], advanced["revision"])
+
     def test_revision_conflict_is_409_and_never_overwrites_canonical_data(self):
         job = self.create_job(role="Original")
         cli = self.server.store.update_job(job["id"], {"role": "CLI edit"}, job["revision"])
@@ -187,7 +281,9 @@ class WorkspaceServerTests(unittest.TestCase):
         self.assertEqual(len(self.server.store.list_jobs()), 1)
 
     def test_preflight_resume_assignment_ready_handoff_and_guarded_applied(self):
-        self.server.store.replace_profile({"firstName": "Ada"})
+        self.server.store.replace_profile(
+            {"firstName": "Ada"}, expected_revision=1, source="user"
+        )
         resume_path = Path(self.temporary.name) / "resume.pdf"
         resume_path.write_bytes(b"resume")
         resume = self.server.store.create_resume({"id": "main", "label": "Main", "path": str(resume_path)})

--- a/tests/test_qa_replay_cli.py
+++ b/tests/test_qa_replay_cli.py
@@ -490,14 +490,17 @@ class ReplayCoordinatorTests(unittest.TestCase):
         code, route, stderr = self.invoke(["resolve", "--route-token", route_token])
         self.assertEqual((code, stderr), (0, ""))
         self.assertEqual(route, {"storeRoot": output["storeRoot"]})
-        stored_profile = json.loads(
-            (run_root / "store/profile.json").read_text()
-        )["profile"]
+        stored_document = json.loads((run_root / "store/profile.json").read_text())
+        stored_profile = stored_document["profile"]
         self.assertEqual(stored_profile["name"], self.profile["name"])
         self.assertEqual(stored_profile["email"], self.profile["email"])
         self.assertEqual(
             Path(stored_profile["resumePath"]),
             (run_root / "synthetic-resume.pdf").resolve(),
+        )
+        self.assertEqual(
+            stored_document["metadata"]["factProvenance"]["/resumePath"]["source"],
+            "resume",
         )
         self.assertEqual(
             json.loads((run_root / "profile.json").read_text()), self.profile

--- a/tests_js/workspace.test.mjs
+++ b/tests_js/workspace.test.mjs
@@ -14,12 +14,18 @@ const REPO_ROOT = process.env.JOB_WORKSPACE_TEST_ROOT
 const PYTHON = process.env.PYTHON || "python3";
 const {
   ApiError,
+  FACT_SAVE_REVISION_RETRIES,
   canMarkReadyFrom,
   createApi,
+  conflictingPaths,
   filterJobs,
   formPatch,
+  patchForPaths,
+  pointerValue,
   safeSessionStorage,
   sessionToken,
+  shouldRetryFactSave,
+  summarizeProvenance,
   tokenFromHash,
   transitionsFor,
 } = await import(pathToFileURL(join(REPO_ROOT, "workspace", "app.js")).href);
@@ -56,6 +62,17 @@ test("API client authenticates in memory and surfaces revision conflicts", async
   assert.equal(captured.path.includes("secret"), false);
 });
 
+test("Facts save retry policy is bounded and limited to revision conflicts", () => {
+  const revisionConflict = new ApiError(409, { error: { code: "revision_conflict", message: "changed" } });
+  const otherConflict = new ApiError(409, { error: { code: "protected_fact_conflict", message: "protected" } });
+  assert.equal(FACT_SAVE_REVISION_RETRIES, 2);
+  assert.equal(shouldRetryFactSave(revisionConflict, 0), true);
+  assert.equal(shouldRetryFactSave(revisionConflict, 1), true);
+  assert.equal(shouldRetryFactSave(revisionConflict, 2), false);
+  assert.equal(shouldRetryFactSave(otherConflict, 0), false);
+  assert.equal(shouldRetryFactSave(new ApiError(500, { error: { code: "revision_conflict" } }), 0), false);
+});
+
 test("jobs filter by status and human-visible fields", () => {
   const jobs = [
     { role: "Staff Engineer", company: "Acme", location: "Phoenix", status: "ready" },
@@ -78,6 +95,43 @@ test("form values become a supported Store patch", () => {
   assert.equal("status" in patch, false);
 });
 
+test("profile paths build selective patches and distinguish safe rebases from conflicts", () => {
+  const base = { location: { city: "Phoenix", country: "US" }, skills: ["Python"], firstName: "Ada" };
+  const latest = { location: { city: "Phoenix", country: "CA" }, skills: ["Python", "Rust"], firstName: "Grace" };
+  const drafts = new Map([["/location/city", "Tempe"], ["/skills", ["Go"]], ["/firstName", "Augusta"]]);
+  assert.equal(pointerValue(base, "/location/city"), "Phoenix");
+  assert.deepEqual(patchForPaths(drafts), { location: { city: "Tempe" }, skills: ["Go"], firstName: "Augusta" });
+  assert.deepEqual(conflictingPaths(base, latest, drafts, new Set(["/skills"])), ["/skills", "/firstName"]);
+  const draftBases = new Map([["/firstName", "Ada"]]);
+  assert.deepEqual(conflictingPaths(draftBases, latest, new Map([["/firstName", "Augusta"]])), ["/firstName"]);
+});
+
+test("profile pointer patches preserve forward-compatible prototype-shaped keys", () => {
+  const patch = patchForPaths(new Map([
+    ["/__proto__", { enabled: true }],
+    ["/constructor/prototype", "kept"],
+  ]));
+
+  assert.equal(Object.hasOwn(patch, "__proto__"), true);
+  assert.deepEqual(patch.__proto__, { enabled: true });
+  assert.equal(Object.hasOwn(patch, "constructor"), true);
+  assert.equal(patch.constructor.prototype, "kept");
+  assert.equal(pointerValue({}, "/__proto__"), undefined);
+  assert.deepEqual(pointerValue(JSON.parse('{"__proto__":{"enabled":true}}'), "/__proto__"), { enabled: true });
+  assert.equal({}.enabled, undefined);
+  assert.equal({}.kept, undefined);
+});
+
+test("atomic Additional provenance summarizes descendant sources", () => {
+  assert.deepEqual(
+    summarizeProvenance({
+      "/futureConfig/enabled": { source: "resume", updatedAt: "2026-01-01T00:00:00Z" },
+      "/futureConfig/note": { source: "user", updatedAt: "2026-01-02T00:00:00Z" },
+    }, "/futureConfig"),
+    { source: "mixed: resume, user", updatedAt: "2026-01-02T00:00:00Z" },
+  );
+});
+
 test("status actions preserve guarded ready, acquire, and applied boundaries", () => {
   assert.deepEqual(transitionsFor("saved"), ["needs_info", "closed"]);
   assert.equal(transitionsFor("ready").includes("in_progress"), false);
@@ -90,8 +144,16 @@ test("status actions preserve guarded ready, acquire, and applied boundaries", (
 
 test("workspace markup has semantic dialogs, labels, live regions, and no remote assets", async () => {
   const html = await readFile(join(REPO_ROOT, "workspace", "index.html"), "utf8");
-  assert.match(html, /<main>/);
+  assert.match(html, /<main(?:\s|>)/);
   assert.match(html, /<dialog id="job-dialog" aria-labelledby=/);
+  assert.match(html, /id="facts-workspace"/);
+  assert.match(html, /aria-label="Workspace sections"/);
+  for (const path of ["\/firstName", "\/location\/city", "\/workHistory", "\/education", "\/skills", "\/preferences\/targetTitles", "\/preferences\/minBaseSalary", "\/preferences\/remotePreference", "\/preferences\/excludePatterns", "\/preferences\/defaultTimeRange"]) {
+    assert.match(html, new RegExp(`data-path="${path}"`));
+  }
+  assert.match(html, /data-path="\/location\/zip"/);
+  assert.doesNotMatch(html, /data-path="\/location\/postalCode"/);
+  assert.match(html, /data-path="\/preferences\/minBaseSalary" type="text"/);
   assert.match(html, /role="alert"/);
   assert.match(html, /aria-live="polite"/);
   assert.match(html, /class="skip-link"/);
@@ -99,6 +161,12 @@ test("workspace markup has semantic dialogs, labels, live regions, and no remote
   for (const name of ["url", "role", "company", "location", "priority", "resumeId", "notes", "description"]) {
     assert.match(html, new RegExp(`<(?:input|select|textarea) name="${name}"`));
   }
+});
+
+test("answer-memory documents guarded profile and preference mutations", async () => {
+  const skill = await readFile(join(REPO_ROOT, "skills", "answer-memory", "SKILL.md"), "utf8");
+  assert.match(skill, /profile-replace[\s\\]+--input <profile\.json> --expected-revision <revision>[\s\\]+--source <user\|resume\|agent\|migration>/);
+  assert.match(skill, /preferences-set[\s\\]+--input <preferences\.json> --expected-revision <revision>[\s\\]+--source <user\|resume\|agent\|migration> \[--replace\]/);
 });
 
 test("styles include visible focus, reduced motion, contrast mode, and responsive behavior", async () => {
@@ -147,7 +215,18 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
   try {
     const resumePath = join(temporary, "resume.pdf");
     await writeFile(resumePath, "resume");
-    await cli("profile-replace", [], { firstName: "Ada" });
+    await cli("profile-replace", ["--expected-revision", "0", "--source", "resume"], {
+      firstName: "Ada", lastName: "Example", email: "ada@example.invalid",
+      location: { city: "Phoenix", country: "US", zip: "85001" }, skills: ["Python"],
+      workHistory: [{ company: "Example Co", title: "Engineer" }],
+      education: [{ school: "Example University", degree: "BS" }],
+      preferences: { targetTitles: ["Engineer"], minBaseSalary: "$150K", remotePreference: "remote", excludePatterns: ["intern"], defaultTimeRange: "week" },
+      customNote: "synthetic", futureConfig: { enabled: true, obsolete: "remove atomically" },
+    });
+    let seededProfile = await cli("profile-inspect");
+    await cli("profile-patch", ["--expected-revision", String(seededProfile.revision), "--source", "resume"], {
+      descendantConfig: { enabled: true, mode: "safe" },
+    });
     await cli("resume-create", [], { id: "browser-resume", label: "Browser resume", path: resumePath });
     const cliJob = await cli("job-create", [], { url: "https://example.com/jobs/cli-browser", role: "CLI Engineer", company: "CLI Co" });
 
@@ -160,6 +239,130 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     await page.reload();
     await page.getByText("Canonical store connected").waitFor();
     const jobDialog = page.locator("#job-dialog");
+
+    await page.getByRole("button", { name: "Facts" }).click();
+    await page.getByLabel("First name").waitFor();
+    assert.equal(await page.getByLabel("First name").inputValue(), "Ada");
+    assert.equal(await page.getByLabel("Postal code").inputValue(), "85001");
+    assert.equal(await page.getByLabel("Minimum base salary").inputValue(), "$150K");
+    assert.match(await page.locator('[data-provenance="/firstName"]').innerText(), /resume/);
+    assert.match(await page.locator('.additional-fact').filter({ hasText: "descendantConfig" }).locator("small").innerText(), /resume/);
+    await page.getByLabel("Last name").fill("Browser");
+    await page.getByLabel("City").fill("Tempe");
+    await page.getByLabel("Postal code").fill("85281");
+    await page.getByLabel("Minimum base salary").fill("$175K");
+    await page.getByLabel("Remote preference").fill("hybrid");
+    await page.getByLabel("Title, item 1").fill("Staff Engineer");
+    await page.getByLabel("Degree, item 1").fill("BSc");
+    await page.getByLabel("Skills (one per line)").fill("Python\nRust");
+    await page.locator('.additional-fact').filter({ hasText: "customNote" }).getByLabel("JSON value").fill('"browser synthetic"');
+    await page.locator('.additional-fact').filter({ hasText: "futureConfig" }).getByLabel("JSON value").fill('{"enabled":false}');
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await page.getByText("Profile is synchronized with the canonical store.").waitFor();
+    let profile = await cli("profile-inspect");
+    assert.equal(profile.profile.lastName, "Browser");
+    assert.equal(profile.profile.location.city, "Tempe");
+    assert.equal(profile.profile.location.zip, "85281");
+    assert.equal(profile.profile.preferences.minBaseSalary, "$175K");
+    assert.equal(profile.profile.preferences.remotePreference, "hybrid");
+    assert.equal(profile.profile.workHistory[0].title, "Staff Engineer");
+    assert.equal(profile.profile.education[0].degree, "BSc");
+    assert.deepEqual(profile.profile.skills, ["Python", "Rust"]);
+    assert.equal(profile.profile.customNote, "browser synthetic");
+    assert.deepEqual(profile.profile.futureConfig, { enabled: false });
+    assert.equal(profile.factProvenance["/location/city"].source, "user");
+
+    let futureConfig = page.locator('.additional-fact').filter({ hasText: "futureConfig" });
+    await futureConfig.getByLabel("JSON value").fill("null");
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await page.getByText("Profile is synchronized with the canonical store.").waitFor();
+    profile = await cli("profile-inspect");
+    assert.equal(Object.hasOwn(profile.profile, "futureConfig"), true);
+    assert.equal(profile.profile.futureConfig, null);
+
+    futureConfig = page.locator('.additional-fact').filter({ hasText: "futureConfig" });
+    page.once("dialog", (prompt) => prompt.accept());
+    await futureConfig.getByRole("button", { name: "Delete" }).click();
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await page.getByText("Profile is synchronized with the canonical store.").waitFor();
+    profile = await cli("profile-inspect");
+    assert.equal("futureConfig" in profile.profile, false);
+
+    let customNote = page.locator('.additional-fact').filter({ hasText: "customNote" });
+    await customNote.getByLabel("JSON value").fill('"draft after delete"');
+    profile = await cli("profile-patch", ["--expected-revision", String(profile.revision), "--source", "user"], { customNote: null });
+    await page.locator("#facts-refresh").click();
+    customNote = page.locator('.additional-fact').filter({ hasText: "customNote" });
+    assert.equal(await customNote.getByLabel("JSON value").inputValue(), '"draft after delete"');
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await page.locator("#facts-conflict").waitFor();
+    await page.getByRole("button", { name: "Use my values for conflicts" }).click();
+    await page.getByText("Profile is synchronized with the canonical store.").waitFor();
+    profile = await cli("profile-inspect");
+    assert.equal(profile.profile.customNote, "draft after delete");
+
+    customNote = page.locator('.additional-fact').filter({ hasText: "customNote" });
+    await customNote.getByLabel("JSON value").fill('"discard after delete"');
+    profile = await cli("profile-patch", ["--expected-revision", String(profile.revision), "--source", "user"], { customNote: null });
+    await page.locator("#facts-refresh").click();
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await page.locator("#facts-conflict").waitFor();
+    await page.getByRole("button", { name: "Use latest for conflicts" }).click();
+    assert.equal(await page.locator('.additional-fact').filter({ hasText: "customNote" }).count(), 0);
+
+    await page.getByLabel("First name").fill("Disjoint draft");
+    profile = await cli("profile-patch", ["--expected-revision", String(profile.revision), "--source", "agent"], { location: { country: "CA" } });
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await page.getByText("Profile is synchronized with the canonical store.").waitFor();
+    profile = await cli("profile-inspect");
+    assert.equal(profile.profile.firstName, "Disjoint draft");
+    assert.equal(profile.profile.location.country, "CA");
+
+    await page.getByLabel("First name").fill("Refresh-protected draft");
+    profile = await cli("profile-patch", ["--expected-revision", String(profile.revision), "--source", "user"], { firstName: "Refresh canonical" });
+    await page.locator("#facts-refresh").click();
+    assert.equal(await page.getByLabel("First name").inputValue(), "Refresh-protected draft");
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await page.locator("#facts-conflict").waitFor();
+    await page.getByRole("button", { name: "Use latest for conflicts" }).click();
+    assert.equal(await page.getByLabel("First name").inputValue(), "Refresh canonical");
+
+    await page.getByLabel("First name").fill("Same path draft");
+    profile = await cli("profile-patch", ["--expected-revision", String(profile.revision), "--source", "user"], { firstName: "CLI canonical" });
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await page.locator("#facts-conflict").waitFor();
+    await page.getByRole("button", { name: "Use latest for conflicts" }).click();
+    assert.equal(await page.getByLabel("First name").inputValue(), "CLI canonical");
+
+    await page.getByLabel("Skills (one per line)").fill("Draft skill");
+    profile = await cli("profile-patch", ["--expected-revision", String(profile.revision), "--source", "user"], { skills: ["Canonical skill"] });
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await page.locator("#facts-conflict").waitFor();
+    await page.getByRole("button", { name: "Use my values for conflicts" }).click();
+    await page.getByText("Profile is synchronized with the canonical store.").waitFor();
+    profile = await cli("profile-inspect");
+    assert.deepEqual(profile.profile.skills, ["Draft skill"]);
+
+    let forcedRevisionConflicts = 0;
+    await page.route("**/api/profile", async (route, request) => {
+      if (request.method() !== "PATCH") { await route.continue(); return; }
+      forcedRevisionConflicts += 1;
+      await route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { code: "revision_conflict", message: "synthetic conflict" } }),
+      });
+    });
+    await page.getByLabel("First name").fill("Retry-preserved draft");
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await page.getByText(/profile changed repeatedly while saving/i).waitFor();
+    assert.equal(forcedRevisionConflicts, FACT_SAVE_REVISION_RETRIES + 1);
+    assert.equal(await page.getByLabel("First name").inputValue(), "Retry-preserved draft");
+    assert.equal(await page.getByRole("button", { name: "Save changes" }).isEnabled(), true);
+    await page.unroute("**/api/profile");
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await page.getByText("Profile is synchronized with the canonical store.").waitFor();
+    await page.getByRole("button", { name: "Jobs" }).click();
 
     const cliButton = page.getByRole("button", { name: /CLI Engineer/ });
     await cliButton.waitFor();

--- a/tests_js/workspace.test.mjs
+++ b/tests_js/workspace.test.mjs
@@ -384,11 +384,11 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     await jobDialog.getByLabel("Notes", { exact: true }).fill("Edited in the browser");
     await page.getByRole("button", { name: "Save job" }).click();
     await page.locator("#job-dialog").waitFor({ state: "hidden" });
+    await page.waitForFunction((id) => document.activeElement?.dataset?.id === id, cliJob.id);
     const browserEdited = await cli("job-get", ["--id", cliJob.id]);
     assert.equal(browserEdited.role, "Browser-edited CLI Engineer");
     assert.equal(browserEdited.notes, "Edited in the browser");
     assert.equal(browserEdited.revision, cliJob.revision + 1);
-    await page.waitForFunction((id) => document.activeElement?.dataset?.id === id, cliJob.id);
 
     await page.getByRole("button", { name: "New job" }).click();
     await jobDialog.getByLabel("Job URL", { exact: true }).fill("https://example.com/jobs/ui-browser");

--- a/tests_js/workspace.test.mjs
+++ b/tests_js/workspace.test.mjs
@@ -241,7 +241,7 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     const jobDialog = page.locator("#job-dialog");
 
     await page.getByRole("button", { name: "Facts" }).click();
-    await page.getByLabel("First name").waitFor();
+    await page.waitForFunction(() => document.querySelector('[data-path="/firstName"]')?.value === "Ada");
     assert.equal(await page.getByLabel("First name").inputValue(), "Ada");
     assert.equal(await page.getByLabel("Postal code").inputValue(), "85001");
     assert.equal(await page.getByLabel("Minimum base salary").inputValue(), "$150K");

--- a/tests_js/workspace.test.mjs
+++ b/tests_js/workspace.test.mjs
@@ -292,6 +292,7 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     await customNote.getByLabel("JSON value").fill('"draft after delete"');
     profile = await cli("profile-patch", ["--expected-revision", String(profile.revision), "--source", "user"], { customNote: null });
     await page.locator("#facts-refresh").click();
+    await page.waitForFunction((revision) => document.querySelector("#facts-revision")?.textContent === `Revision ${revision}`, profile.revision);
     customNote = page.locator('.additional-fact').filter({ hasText: "customNote" });
     assert.equal(await customNote.getByLabel("JSON value").inputValue(), '"draft after delete"');
     await page.getByRole("button", { name: "Save changes" }).click();
@@ -305,6 +306,7 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     await customNote.getByLabel("JSON value").fill('"discard after delete"');
     profile = await cli("profile-patch", ["--expected-revision", String(profile.revision), "--source", "user"], { customNote: null });
     await page.locator("#facts-refresh").click();
+    await page.waitForFunction((revision) => document.querySelector("#facts-revision")?.textContent === `Revision ${revision}`, profile.revision);
     await page.getByRole("button", { name: "Save changes" }).click();
     await page.locator("#facts-conflict").waitFor();
     await page.getByRole("button", { name: "Use latest for conflicts" }).click();
@@ -321,6 +323,7 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     await page.getByLabel("First name").fill("Refresh-protected draft");
     profile = await cli("profile-patch", ["--expected-revision", String(profile.revision), "--source", "user"], { firstName: "Refresh canonical" });
     await page.locator("#facts-refresh").click();
+    await page.waitForFunction((revision) => document.querySelector("#facts-revision")?.textContent === `Revision ${revision}`, profile.revision);
     assert.equal(await page.getByLabel("First name").inputValue(), "Refresh-protected draft");
     await page.getByRole("button", { name: "Save changes" }).click();
     await page.locator("#facts-conflict").waitFor();

--- a/workspace/app.js
+++ b/workspace/app.js
@@ -6,6 +6,15 @@ export class ApiError extends Error {
   }
 }
 
+export const FACT_SAVE_REVISION_RETRIES = 2;
+
+export function shouldRetryFactSave(error, retries, maxRetries = FACT_SAVE_REVISION_RETRIES) {
+  return error instanceof ApiError
+    && error.status === 409
+    && error.code === "revision_conflict"
+    && retries < maxRetries;
+}
+
 export function tokenFromHash(hash) {
   const params = new URLSearchParams(String(hash || "").replace(/^#/, ""));
   return params.get("token") || "";
@@ -69,6 +78,49 @@ export function createApi(token, fetchImpl = globalThis.fetch) {
   };
 }
 
+export function pointerValue(value, pointer) {
+  return pointer.split("/").slice(1).reduce((item, segment) => {
+    const key = segment.replaceAll("~1", "/").replaceAll("~0", "~");
+    return item != null && Object.hasOwn(Object(item), key) ? item[key] : undefined;
+  }, value);
+}
+
+export function patchForPaths(entries) {
+  const patch = {};
+  for (const [pointer, value] of entries) {
+    const parts = pointer.split("/").slice(1).map((part) => part.replaceAll("~1", "/").replaceAll("~0", "~"));
+    let target = patch;
+    parts.forEach((part, index) => {
+      if (index === parts.length - 1) Object.defineProperty(target, part, { value, enumerable: true, configurable: true, writable: true });
+      else {
+        if (!Object.hasOwn(target, part)) Object.defineProperty(target, part, { value: {}, enumerable: true, configurable: true, writable: true });
+        target = target[part];
+      }
+    });
+  }
+  return patch;
+}
+
+export function conflictingPaths(base, latest, drafts, atomicPaths = new Set()) {
+  return [...drafts].filter(([path, mine]) => {
+    const before = base instanceof Map ? base.get(path) : pointerValue(base, path);
+    const now = pointerValue(latest, path);
+    const structured = atomicPaths.has(path) || typeof mine === "object" || typeof before === "object" || typeof now === "object";
+    return JSON.stringify(before) !== JSON.stringify(now) && (structured || JSON.stringify(mine) !== JSON.stringify(now));
+  }).map(([path]) => path);
+}
+
+export function summarizeProvenance(records, path) {
+  const ancestors = Object.entries(records || {}).filter(([candidate]) => path === candidate || path.startsWith(`${candidate}/`));
+  ancestors.sort((left, right) => right[0].length - left[0].length);
+  if (ancestors.length) return ancestors[0][1];
+  const descendants = Object.entries(records || {}).filter(([candidate]) => candidate.startsWith(`${path}/`));
+  if (!descendants.length) return null;
+  const sources = [...new Set(descendants.map(([, record]) => record.source))].sort();
+  const updatedAt = descendants.map(([, record]) => record.updatedAt).filter(Boolean).sort().at(-1);
+  return { source: sources.length === 1 ? sources[0] : `mixed: ${sources.join(", ")}`, updatedAt };
+}
+
 const hasDom = typeof document !== "undefined";
 
 if (hasDom) {
@@ -76,6 +128,7 @@ if (hasDom) {
   if (location.hash) history.replaceState(null, "", location.pathname);
   const api = createApi(token);
   const state = { jobs: [], resumes: [], selected: null, latest: null, draft: null, dirty: false, dirtyFields: new Set(), polling: false, opener: null, openerJobId: null, focusAfterClose: null };
+  const profileState = { inspection: null, drafts: new Map(), draftBases: new Map(), atomic: new Set(), additionalAtomic: new Set(), deletions: new Set(), conflicts: [], latest: null, loaded: false };
   const $ = (selector) => document.querySelector(selector);
   const form = $("#job-form");
   const dialog = $("#job-dialog");
@@ -89,6 +142,221 @@ if (hasDom) {
 
   function setConnection(online, message = online ? "Canonical store connected" : "Connection lost") {
     $("#connection-dot").classList.toggle("online", online); $("#connection-label").textContent = message;
+  }
+
+  const namedTopLevel = new Set(["firstName", "lastName", "email", "phone", "location", "linkedInUrl", "portfolioUrl", "githubUrl", "workHistory", "education", "skills", "preferences"]);
+  const encodePointer = (value) => String(value).replaceAll("~", "~0").replaceAll("/", "~1");
+  const decodePointer = (value) => String(value).replaceAll("~1", "/").replaceAll("~0", "~");
+  const equalJson = (left, right) => JSON.stringify(left) === JSON.stringify(right);
+
+  function provenanceFor(path) {
+    return summarizeProvenance(profileState.inspection?.factProvenance, path);
+  }
+
+  function provenanceText(path) {
+    const record = provenanceFor(path);
+    if (!record) return "No recorded provenance";
+    const time = new Date(record.updatedAt);
+    return `${record.source} · ${Number.isNaN(time.valueOf()) ? record.updatedAt : time.toLocaleString()}`;
+  }
+
+  function controlValue(control) {
+    if (control.dataset.deleted === "true") return null;
+    if (control.dataset.repeater) {
+      return [...control.querySelectorAll(".repeater-item")].map((row) => {
+        const item = { ...(row._base || {}) };
+        for (const input of row.querySelectorAll("[data-item-field]")) item[input.dataset.itemField] = input.type === "checkbox" ? input.checked : input.value;
+        return item;
+      });
+    }
+    if (control.dataset.lines !== undefined) return control.value.split(/\r?\n/).map((item) => item.trim()).filter(Boolean);
+    if (control.dataset.json !== undefined) {
+      let parsed;
+      try { parsed = JSON.parse(control.value); } catch { throw new Error(`${control.dataset.label || "Structured fact"} must contain valid JSON.`); }
+      if (control.dataset.array === "true" && !Array.isArray(parsed)) throw new Error(`${control.dataset.label} must be a JSON array.`);
+      return parsed;
+    }
+    if (control.type === "number" && control.value !== "") return Number(control.value);
+    return control.value;
+  }
+
+  function setControlValue(control, value) {
+    control.dataset.deleted = "false";
+    if (control.dataset.repeater) renderRepeater(control, Array.isArray(value) ? value : []);
+    else if (control.dataset.lines !== undefined) control.value = Array.isArray(value) ? value.join("\n") : "";
+    else if (control.dataset.json !== undefined) control.value = JSON.stringify(value ?? (control.dataset.array === "true" ? [] : null), null, 2);
+    else control.value = value ?? "";
+  }
+
+  const repeaterSchemas = {
+    work: [["company", "Company"], ["title", "Title"], ["startDate", "Start date"], ["endDate", "End date"], ["current", "Current position", "checkbox"], ["description", "Description"]],
+    education: [["school", "School"], ["degree", "Degree"], ["field", "Field of study"], ["startDate", "Start date"], ["endDate", "End date"], ["gpa", "GPA"]],
+  };
+
+  function renderRepeater(container, items) {
+    container.replaceChildren();
+    items.forEach((item, index) => {
+      const row = document.createElement("div"); row.className = "repeater-item form-grid"; row._base = item && typeof item === "object" ? { ...item } : {};
+      for (const [field, text, type] of repeaterSchemas[container.dataset.repeater]) {
+        const label = document.createElement("label"); label.textContent = text;
+        const input = document.createElement(field === "description" ? "textarea" : "input"); input.dataset.itemField = field;
+        if (type === "checkbox") { input.type = "checkbox"; input.checked = item?.[field] === true; }
+        else input.value = item?.[field] ?? "";
+        input.setAttribute("aria-label", `${text}, item ${index + 1}`); label.append(input); row.append(label);
+      }
+      const remove = document.createElement("button"); remove.type = "button"; remove.className = "button danger"; remove.textContent = `Remove ${container.dataset.repeater === "work" ? "position" : "education"}`;
+      remove.addEventListener("click", () => { row.remove(); markFactDirty(container); }); row.append(remove); container.append(row);
+    });
+  }
+
+  function addRepeaterItem(path) {
+    const container = document.querySelector(`#facts-form [data-path="${CSS.escape(path)}"]`);
+    const values = controlValue(container); values.push({}); renderRepeater(container, values); markFactDirty(container);
+    container.querySelector(".repeater-item:last-child input")?.focus();
+  }
+
+  function renderAdditionalFacts(profile, preservedDrafts = null, preservedDeletions = new Set()) {
+    const holder = $("#additional-facts"); holder.replaceChildren();
+    const keys = new Set(Object.keys(profile).filter((item) => !namedTopLevel.has(item)));
+    for (const [path] of preservedDrafts || []) {
+      const encoded = path.startsWith("/") ? path.slice(1) : "";
+      if (encoded && !encoded.includes("/")) {
+        const key = decodePointer(encoded);
+        if (!namedTopLevel.has(key)) keys.add(key);
+      }
+    }
+    for (const key of [...keys].sort()) {
+      const path = `/${encodePointer(key)}`;
+      const row = document.createElement("div"); row.className = "additional-fact";
+      const name = document.createElement("code"); name.textContent = key;
+      const label = document.createElement("label"); label.textContent = "JSON value";
+      const editor = document.createElement("textarea"); editor.dataset.path = path; editor.dataset.json = ""; editor.dataset.label = key; editor.dataset.additionalAtomic = ""; editor.rows = 4;
+      profileState.atomic.add(path); profileState.additionalAtomic.add(path);
+      const canonicalExists = Object.hasOwn(profile, key);
+      setControlValue(editor, canonicalExists ? profile[key] : preservedDrafts?.get(path));
+      const provenance = document.createElement("small"); provenance.textContent = provenanceText(path); label.append(editor, provenance);
+      const remove = document.createElement("button"); remove.type = "button"; remove.className = "button danger"; remove.textContent = "Delete";
+      remove.addEventListener("click", () => {
+        if (!confirm(`Delete the additional fact “${key}”?`)) return;
+        editor.dataset.deleted = "true"; editor.disabled = true; remove.disabled = true;
+        if (!profileState.drafts.has(path)) profileState.draftBases.set(path, pointerValue(profileState.inspection.profile, path));
+        profileState.drafts.set(path, null); profileState.deletions.add(path); row.classList.add("pending-delete");
+      });
+      editor.addEventListener("input", () => { profileState.deletions.delete(path); markFactDirty(editor); });
+      if (preservedDeletions.has(path)) {
+        editor.dataset.deleted = "true"; editor.disabled = true; remove.disabled = true; row.classList.add("pending-delete");
+      }
+      row.append(name, label, remove); holder.append(row);
+    }
+  }
+
+  function renderProfile(inspection, preserveDrafts = null, preserveDraftBases = null, preserveDeletions = new Set()) {
+    profileState.inspection = inspection; profileState.loaded = true; profileState.drafts.clear(); profileState.draftBases.clear(); profileState.atomic.clear(); profileState.additionalAtomic.clear(); profileState.deletions.clear(); profileState.conflicts = []; profileState.latest = null;
+    for (const control of document.querySelectorAll("#facts-form [data-path]")) {
+      const path = control.dataset.path;
+      if (control.dataset.atomic !== undefined) profileState.atomic.add(path);
+      if (control.dataset.json !== undefined) control.dataset.array = "true";
+      setControlValue(control, pointerValue(inspection.profile, path));
+      const note = document.querySelector(`[data-provenance="${CSS.escape(path)}"]`); if (note) note.textContent = provenanceText(path);
+    }
+    renderAdditionalFacts(inspection.profile, preserveDrafts, preserveDeletions);
+    if (preserveDrafts) {
+      for (const [path, value] of preserveDrafts) {
+        const control = document.querySelector(`#facts-form [data-path="${CSS.escape(path)}"]`);
+        if (control) {
+          if (!preserveDeletions.has(path)) setControlValue(control, value);
+          profileState.drafts.set(path, value);
+          profileState.draftBases.set(path, preserveDraftBases?.get(path));
+          if (preserveDeletions.has(path)) profileState.deletions.add(path);
+        }
+      }
+    }
+    $("#facts-revision").textContent = `Revision ${inspection.revision}`;
+    $("#facts-status").textContent = profileState.drafts.size ? "Draft changes are preserved against the latest profile." : "Profile is synchronized with the canonical store.";
+    $("#facts-conflict").classList.add("hidden"); $("#facts-error").classList.add("hidden");
+  }
+
+  function markFactDirty(control) {
+    try {
+      const value = controlValue(control);
+      const path = control.dataset.path;
+      if (equalJson(value, pointerValue(profileState.inspection.profile, path))) {
+        profileState.drafts.delete(path); profileState.draftBases.delete(path);
+      } else {
+        if (!profileState.drafts.has(path)) profileState.draftBases.set(path, pointerValue(profileState.inspection.profile, path));
+        profileState.drafts.set(path, value);
+      }
+      $("#facts-error").classList.add("hidden");
+      $("#facts-status").textContent = profileState.drafts.size ? `${profileState.drafts.size} fact change${profileState.drafts.size === 1 ? "" : "s"} ready to save.` : "Profile is synchronized with the canonical store.";
+    } catch (error) { const node = $("#facts-error"); node.textContent = error.message; node.classList.remove("hidden"); }
+  }
+
+  async function refreshProfile({ preserve = true } = {}) {
+    try {
+      const drafts = preserve ? new Map(profileState.drafts) : null;
+      const draftBases = preserve ? new Map(profileState.draftBases) : null;
+      const deletions = preserve ? new Set(profileState.deletions) : new Set();
+      const inspection = await api("/api/profile"); renderProfile(inspection, drafts, draftBases, deletions); setConnection(true);
+    } catch (error) { setConnection(false, error.message); const node = $("#facts-error"); node.textContent = error.message; node.classList.remove("hidden"); }
+  }
+
+  function showFactConflicts(latest, conflicts) {
+    profileState.latest = latest; profileState.conflicts = conflicts;
+    const list = $("#facts-conflict-list"); list.replaceChildren();
+    for (const path of conflicts) { const item = document.createElement("li"); item.textContent = path; list.append(item); }
+    $("#facts-conflict").classList.remove("hidden"); $("#facts-conflict").focus();
+  }
+
+  async function saveFacts() {
+    $("#facts-save").disabled = true;
+    try {
+      for (const control of document.querySelectorAll("#facts-form [data-path]")) if (profileState.drafts.has(control.dataset.path)) profileState.drafts.set(control.dataset.path, controlValue(control));
+      if (!profileState.drafts.size) { toast("No fact changes to save"); return; }
+      let retries = 0;
+      while (true) {
+        try {
+          const latest = await api("/api/profile");
+          const conflicts = conflictingPaths(profileState.draftBases, latest.profile, profileState.drafts, profileState.atomic);
+          if (conflicts.length) { showFactConflicts(latest, conflicts); return; }
+          const atomicPaths = [...profileState.drafts.keys()].filter((path) => profileState.additionalAtomic.has(path));
+          const deletedPaths = atomicPaths.filter((path) => profileState.deletions.has(path));
+          const updated = await api("/api/profile", { method: "PATCH", body: JSON.stringify({ patch: patchForPaths(profileState.drafts), expectedRevision: latest.revision, atomicPaths, deletedPaths }) });
+          renderProfile(updated); toast("Facts saved to the canonical profile");
+          return;
+        } catch (error) {
+          if (shouldRetryFactSave(error, retries)) { retries += 1; continue; }
+          if (error instanceof ApiError && error.status === 409 && error.code === "revision_conflict") {
+            const node = $("#facts-error");
+            node.textContent = "The profile changed repeatedly while saving. Your draft is preserved. Retry Save or refresh the profile before trying again.";
+            node.classList.remove("hidden");
+            return;
+          }
+          throw error;
+        }
+      }
+    } catch (error) {
+      const node = $("#facts-error"); node.textContent = error.message; node.classList.remove("hidden");
+    } finally { $("#facts-save").disabled = false; }
+  }
+
+  function resolveFactConflicts(useMine) {
+    const drafts = new Map(profileState.drafts);
+    if (!useMine) for (const path of profileState.conflicts) drafts.delete(path);
+    const deletions = new Set([...profileState.deletions].filter((path) => drafts.has(path)));
+    const resolvedBases = new Map(
+      [...drafts].map(([path]) => [path, pointerValue(profileState.latest.profile, path)]),
+    );
+    renderProfile(profileState.latest, drafts, resolvedBases, deletions);
+    if (useMine) saveFacts(); else $("#facts-save").focus();
+  }
+
+  async function showWorkspace(name) {
+    const facts = name === "facts";
+    $("#jobs-workspace").classList.toggle("hidden", facts); $("#facts-workspace").classList.toggle("hidden", !facts);
+    $("#nav-jobs").classList.toggle("active", !facts); $("#nav-facts").classList.toggle("active", facts);
+    $("#nav-jobs").toggleAttribute("aria-current", !facts); $("#nav-facts").toggleAttribute("aria-current", facts);
+    document.title = `${facts ? "Facts" : "Jobs"} · Job Apply Workspace`;
+    if (facts && !profileState.loaded) await refreshProfile({ preserve: false });
   }
 
   function metrics() {
@@ -254,6 +522,11 @@ if (hasDom) {
   function firstListDestination() { return $(".job-card") || $("#new-job"); }
 
   form.addEventListener("submit", save); form.addEventListener("input", (event) => { if (state.selected && event.target.name) { state.dirty = true; state.dirtyFields.add(event.target.name); } });
+  $("#nav-jobs").addEventListener("click", () => showWorkspace("jobs")); $("#nav-facts").addEventListener("click", () => showWorkspace("facts"));
+  $("#facts-form").addEventListener("input", (event) => { const control = event.target.closest("[data-path]"); if (control) markFactDirty(control); });
+  $("#add-work").addEventListener("click", () => addRepeaterItem("/workHistory")); $("#add-education").addEventListener("click", () => addRepeaterItem("/education"));
+  $("#facts-save").addEventListener("click", saveFacts); $("#facts-refresh").addEventListener("click", () => refreshProfile());
+  $("#facts-use-latest").addEventListener("click", () => resolveFactConflicts(false)); $("#facts-use-mine").addEventListener("click", () => resolveFactConflicts(true));
   $("#new-job").addEventListener("click", openNew); $("#empty-create").addEventListener("click", openNew); $("#refresh").addEventListener("click", () => refresh());
   $("#search").addEventListener("input", render); $("#status-filter").addEventListener("change", render);
   $("#preflight-job").addEventListener("click", preflight); $("#mark-ready").addEventListener("click", async () => { const result = await preflight(); if (result?.ready) transition("ready"); });

--- a/workspace/index.html
+++ b/workspace/index.html
@@ -8,19 +8,24 @@
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-  <a class="skip-link" href="#jobs">Skip to jobs</a>
+  <a class="skip-link" href="#workspace-content">Skip to workspace</a>
   <header class="topbar">
     <div>
       <p class="eyebrow">LOCAL COMPANION</p>
       <h1>Job Apply</h1>
     </div>
+    <nav class="workspace-nav" aria-label="Workspace sections">
+      <button id="nav-jobs" class="nav-link active" type="button" aria-current="page">Jobs</button>
+      <button id="nav-facts" class="nav-link" type="button">Facts</button>
+    </nav>
     <div class="connection" aria-live="polite">
       <span id="connection-dot" class="dot"></span>
       <span id="connection-label">Connecting…</span>
     </div>
   </header>
 
-  <main>
+  <main id="workspace-content">
+    <div id="jobs-workspace">
     <section class="hero" aria-labelledby="workspace-title">
       <div>
         <p class="eyebrow">Jobs Workspace</p>
@@ -64,6 +69,52 @@
       </div>
       <div id="job-list" class="job-list hidden" role="list"></div>
     </section>
+    </div>
+
+    <div id="facts-workspace" class="hidden">
+      <section class="hero" aria-labelledby="facts-title">
+        <div><p class="eyebrow">Facts Workspace</p><h2 id="facts-title">Your canonical application facts.</h2><p>Review and selectively edit the same local profile used by Job Apply agents.</p></div>
+        <div class="hero-actions"><button id="facts-refresh" class="button secondary" type="button">Refresh</button><button id="facts-save" class="button primary" type="button">Save changes</button></div>
+      </section>
+      <p id="facts-status" class="notice" role="status">Open Facts to load the canonical profile.</p>
+      <section class="facts-panel" aria-labelledby="facts-form-title">
+        <div class="panel-heading"><div><p class="eyebrow">CANONICAL PROFILE</p><h2 id="facts-form-title">Applicant facts</h2></div><p id="facts-revision">Revision —</p></div>
+        <form id="facts-form">
+          <fieldset><legend>Identity and contact</legend><div class="form-grid">
+            <label>First name <input data-path="/firstName" autocomplete="given-name"><small data-provenance="/firstName"></small></label>
+            <label>Last name <input data-path="/lastName" autocomplete="family-name"><small data-provenance="/lastName"></small></label>
+            <label>Email <input data-path="/email" type="email" autocomplete="email"><small data-provenance="/email"></small></label>
+            <label>Phone <input data-path="/phone" type="tel" autocomplete="tel"><small data-provenance="/phone"></small></label>
+          </div></fieldset>
+          <fieldset><legend>Location</legend><div class="form-grid">
+            <label>City <input data-path="/location/city" autocomplete="address-level2"><small data-provenance="/location/city"></small></label>
+            <label>State or region <input data-path="/location/state" autocomplete="address-level1"><small data-provenance="/location/state"></small></label>
+            <label>Country <input data-path="/location/country" autocomplete="country-name"><small data-provenance="/location/country"></small></label>
+            <label>Postal code <input data-path="/location/zip" autocomplete="postal-code"><small data-provenance="/location/zip"></small></label>
+          </div></fieldset>
+          <fieldset><legend>Professional links</legend><div class="form-grid">
+            <label>LinkedIn URL <input data-path="/linkedInUrl" type="url"><small data-provenance="/linkedInUrl"></small></label>
+            <label>Portfolio URL <input data-path="/portfolioUrl" type="url"><small data-provenance="/portfolioUrl"></small></label>
+            <label>GitHub URL <input data-path="/githubUrl" type="url"><small data-provenance="/githubUrl"></small></label>
+          </div></fieldset>
+          <fieldset><legend>Experience and skills</legend><div class="form-grid">
+            <section class="repeater wide" aria-labelledby="work-history-heading"><div class="repeater-heading"><h3 id="work-history-heading">Work history</h3><button id="add-work" class="button secondary" type="button">Add position</button></div><div id="work-history" data-path="/workHistory" data-repeater="work" data-atomic></div><small data-provenance="/workHistory"></small></section>
+            <section class="repeater wide" aria-labelledby="education-heading"><div class="repeater-heading"><h3 id="education-heading">Education</h3><button id="add-education" class="button secondary" type="button">Add education</button></div><div id="education-list" data-path="/education" data-repeater="education" data-atomic></div><small data-provenance="/education"></small></section>
+            <label class="wide">Skills (one per line) <textarea data-path="/skills" data-lines data-atomic rows="4"></textarea><small data-provenance="/skills"></small></label>
+          </div></fieldset>
+          <fieldset><legend>Search preferences</legend><div class="form-grid">
+            <label class="wide">Target titles (one per line) <textarea data-path="/preferences/targetTitles" data-lines data-atomic rows="3"></textarea><small data-provenance="/preferences/targetTitles"></small></label>
+            <label>Minimum base salary <input data-path="/preferences/minBaseSalary" type="text" inputmode="numeric"><small data-provenance="/preferences/minBaseSalary"></small></label>
+            <label>Remote preference <input data-path="/preferences/remotePreference"><small data-provenance="/preferences/remotePreference"></small></label>
+            <label class="wide">Exclude patterns (one per line) <textarea data-path="/preferences/excludePatterns" data-lines data-atomic rows="3"></textarea><small data-provenance="/preferences/excludePatterns"></small></label>
+            <label>Default time range <input data-path="/preferences/defaultTimeRange"><small data-provenance="/preferences/defaultTimeRange"></small></label>
+          </div></fieldset>
+          <fieldset><legend>Additional facts</legend><p>Existing forward-compatible facts can be edited as JSON or explicitly deleted.</p><div id="additional-facts"></div></fieldset>
+        </form>
+        <div id="facts-conflict" class="conflict hidden" role="alert" tabindex="-1"><h3>Some facts changed elsewhere</h3><p>Choose whether conflicting fields keep the latest canonical value or replace it with your draft. Structured values are never reapplied automatically.</p><ul id="facts-conflict-list"></ul><div class="button-row"><button id="facts-use-latest" class="button secondary" type="button">Use latest for conflicts</button><button id="facts-use-mine" class="button primary" type="button">Use my values for conflicts</button></div></div>
+        <p id="facts-error" class="error hidden" role="alert"></p>
+      </section>
+    </div>
   </main>
 
   <dialog id="job-dialog" aria-labelledby="job-dialog-title">

--- a/workspace/styles.css
+++ b/workspace/styles.css
@@ -14,6 +14,9 @@ button { cursor: pointer; }
 .skip-link:focus { top: 1rem; }
 .topbar { min-height: 76px; padding: 1rem max(4vw, 1.25rem); display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid rgba(23,34,29,.12); }
 .topbar h1 { margin: 0; font-family: Georgia, serif; font-size: 1.45rem; }
+.workspace-nav { display: flex; gap: .35rem; margin-left: auto; margin-right: 1.5rem; }
+.nav-link { border: 0; border-radius: 999px; padding: .55rem .9rem; color: var(--muted); background: transparent; font-weight: 750; }
+.nav-link.active { color: white; background: var(--forest); }
 .eyebrow { margin: 0 0 .25rem; font-size: .68rem; letter-spacing: .16em; font-weight: 800; color: var(--forest); }
 .connection { display: flex; align-items: center; gap: .55rem; color: var(--muted); font-size: .88rem; }
 .dot { width: .55rem; height: .55rem; border-radius: 50%; background: var(--amber); box-shadow: 0 0 0 4px rgba(219,157,43,.15); }
@@ -32,6 +35,20 @@ main { width: min(1180px, 92vw); margin: 0 auto 5rem; }
 .metrics div { padding: 1.25rem 1.5rem; border-right: 1px solid rgba(255,255,255,.16); display: flex; align-items: baseline; gap: .75rem; }
 .metrics strong { font: 500 2rem Georgia, serif; }.metrics span { color: #c9ded5; font-size: .82rem; }
 .jobs-panel { background: var(--panel); min-height: 410px; padding: clamp(1.2rem, 3vw, 2rem); border-radius: 0 0 20px 20px; box-shadow: var(--shadow); }
+.facts-panel { background: var(--panel); padding: clamp(1.2rem, 3vw, 2rem); border-radius: 20px; box-shadow: var(--shadow); }
+.facts-panel fieldset { margin: 1.5rem 0 0; padding: 1.25rem; border: 1px solid var(--line); border-radius: 14px; }
+.facts-panel legend { padding: 0 .4rem; font: 600 1.15rem Georgia, serif; }
+.facts-panel small { min-height: 1.1em; color: var(--muted); font-weight: 500; }
+.repeater { display: grid; gap: .8rem; }
+.repeater-heading { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.repeater-heading h3 { margin: 0; font: 600 1rem Georgia, serif; }
+.repeater-item { padding: 1rem; border: 1px solid var(--line); border-radius: 10px; background: color-mix(in srgb, var(--panel) 88%, var(--mint)); }
+.repeater-item .button { margin-top: .8rem; }
+.additional-fact { display: grid; grid-template-columns: minmax(9rem,.6fr) 2fr auto; align-items: start; gap: .8rem; padding: .9rem 0; border-top: 1px solid var(--line); }
+.additional-fact:first-child { border-top: 0; }
+.additional-fact code { padding-top: .7rem; overflow-wrap: anywhere; }
+.additional-fact label { min-width: 0; }
+.additional-fact textarea { min-height: 5rem; }
 .panel-heading { display: flex; justify-content: space-between; align-items: end; gap: 1.25rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--line); }
 .panel-heading h2 { margin: 0; font: 500 2rem Georgia, serif; }.filters { display: flex; gap: .8rem; }
 label { display: grid; gap: .4rem; color: #4f5c54; font-size: .78rem; font-weight: 750; }
@@ -58,6 +75,6 @@ dialog::backdrop { background: rgba(14,28,22,.58); backdrop-filter: blur(4px); }
 .error { color: var(--danger); font-weight: 700; }.bulk-results { margin-top: 1rem; display: grid; gap: .4rem; }.bulk-result { padding: .55rem .7rem; border-radius: 7px; background: #e7f3ec; overflow-wrap: anywhere; }.bulk-result.bad { background: #f8e5e2; color: #792c25; }
 .toast { position: fixed; right: 1.5rem; bottom: 1.5rem; z-index: 30; max-width: 420px; padding: .9rem 1.15rem; border-radius: 10px; color: white; background: var(--forest-2); box-shadow: var(--shadow); }
 @keyframes spin { to { transform: rotate(360deg); } }
-@media (max-width: 760px) { .hero { align-items: start; flex-direction: column; }.metrics { grid-template-columns: 1fr; }.metrics div { border-right: 0; border-bottom: 1px solid rgba(255,255,255,.16); }.panel-heading, .filters { align-items: stretch; flex-direction: column; }.filters input { width: 100%; }.job-card { grid-template-columns: 1fr auto; }.job-card > :nth-child(2) { display: none; }.form-grid { grid-template-columns: 1fr; }.wide { grid-column: auto; }.dialog-footer { align-items: stretch; flex-direction: column-reverse; } }
+@media (max-width: 760px) { .topbar { flex-wrap: wrap; }.workspace-nav { order: 3; width: 100%; margin: .6rem 0 0; }.hero { align-items: start; flex-direction: column; }.metrics { grid-template-columns: 1fr; }.metrics div { border-right: 0; border-bottom: 1px solid rgba(255,255,255,.16); }.panel-heading, .filters { align-items: stretch; flex-direction: column; }.filters input { width: 100%; }.job-card { grid-template-columns: 1fr auto; }.job-card > :nth-child(2) { display: none; }.form-grid { grid-template-columns: 1fr; }.wide { grid-column: auto; }.additional-fact { grid-template-columns: 1fr; }.dialog-footer { align-items: stretch; flex-direction: column-reverse; } }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; transition-duration: .01ms !important; } }
-@media (prefers-color-scheme: dark) { :root { --ink:#edf5ef; --muted:#aebbb2; --paper:#111914; --panel:#19231d; --line:#344139; --forest:#87c9aa; --forest-2:#579c7c; --mint:#253f33; --amber:#efb94e; --danger:#ff9c92; } body { background: radial-gradient(circle at 90% 0,#20362b 0,transparent 30rem),var(--paper); } input,select,textarea { color:var(--ink);background:#111914;border-color:#4a594f; }.primary { color:#102119; }.secondary:hover,.job-card:hover { background:#263129; }.icon-button { background:#2c3931;color:var(--ink); }.status { background:#344139;color:#d9e4dc; }.conflict { background:#493b20; }.preflight,.status-actions { background:#22372d; } }
+@media (prefers-color-scheme: dark) { :root { --ink:#edf5ef; --muted:#aebbb2; --paper:#111914; --panel:#19231d; --line:#344139; --forest:#87c9aa; --forest-2:#579c7c; --mint:#253f33; --amber:#efb94e; --danger:#ff9c92; } body { background: radial-gradient(circle at 90% 0,#20362b 0,transparent 30rem),var(--paper); } input,select,textarea { color:var(--ink);background:#111914;border-color:#4a594f; }.primary,.nav-link.active { color:#102119; }.secondary:hover,.job-card:hover { background:#263129; }.icon-button { background:#2c3931;color:var(--ink); }.status { background:#344139;color:#d9e4dc; }.conflict { background:#493b20; }.preflight,.status-actions { background:#22372d; } }


### PR DESCRIPTION
## Summary
- add a local Facts workspace backed by the canonical durable profile store
- support selective human edits, provenance, atomic structured facts, and explicit conflict resolution shared with CLI agents
- harden profile and preference mutations with revisions, sources, human-authority protection, and fail-closed initialization

## Verification
- 392 Python tests passed
- 61 JavaScript/browser tests passed
- packaged smoke walkthrough and isolated Claude/Codex installs passed
- PR Review Toolkit completed with confirmed findings repaired and final focused review clean

Targets staging only; main is unchanged.