### PR TITLE
Fix packaged Store forward compatibility

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "job-apply",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "AI-powered job application assistant for Claude Code and Codex covering LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.",
   "author": {
     "name": "Jeremy Watt",

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ codex plugin add job-apply@neonwatty-plugins
 
 Start a new Codex task after installation, then invoke `$job-apply:job-apply`.
 
+When testing an unreleased branch, first check out the exact commit in an isolated
+worktree and pass that worktree's absolute path to `codex plugin marketplace add`.
+After installing, confirm that `codex plugin list --json` selects the manifest's
+version directory and start a new Codex task. This keeps branch tests tied to one
+explicit candidate instead of a previously cached package with the same version.
+
 ### Claude Code
 
 ```bash

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -1652,12 +1652,18 @@ class Store:
         coordinator_journal = None
         if self.coordinator_journal_path.exists():
             coordinator_journal = self._load_coordinator_journal()
+        pending_operation = (
+            coordinator_journal["operation"]
+            if coordinator_journal is not None
+            else None
+        )
+        pending_history_write = (
+            pending_operation is not None
+            and pending_operation.get("historyEvent") is not None
+        )
         if (
             self.history_path.exists()
-            and (
-                coordinator_journal is None
-                or coordinator_journal["operation"] is None
-            )
+            and not pending_history_write
         ):
             self.read_history()
 

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -1003,14 +1003,18 @@ def _validate_history_event_record(event: dict[str, Any]) -> None:
         or not HISTORY_EVENT_IDENTIFIER.fullmatch(event_name)
     ):
         raise StoreError("history event type is invalid")
-    answer_keys = event.get("answerKeys", [])
+    if not isinstance(event.get("eventId"), str) or not event["eventId"]:
+        raise StoreError("history event id is invalid")
+    if not isinstance(event.get("at"), str) or not event["at"]:
+        raise StoreError("history event timestamp is invalid")
+    answer_keys = event.get("answerKeys")
     if not isinstance(answer_keys, list) or not all(
         isinstance(item, str) for item in answer_keys
     ):
-        raise StoreError("history answerKeys must be strings")
+        raise StoreError("history answerKeys list is invalid")
     _validate_optional_strings(
         event,
-        {"eventId", "company", "role", "ats", "status", "at"},
+        {"company", "role", "ats", "status"},
         "history event",
     )
 

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -44,6 +44,7 @@ HISTORY_EVENTS = {
     "claim-recovered",
     "job-blocked",
 }
+HISTORY_EVENT_IDENTIFIER = re.compile(r"^[a-z][a-z0-9-]{0,63}$", re.ASCII)
 SESSION_STATUSES = {"active", "review", "completed", "abandoned"}
 JOB_STATUSES = {
     "saved",
@@ -978,7 +979,9 @@ def _validate_answer_redirects(
     return records
 
 
-def _validate_history_event(event: dict[str, Any]) -> None:
+def _validate_history_event_record(event: dict[str, Any]) -> None:
+    """Validate the value-free history schema without assigning event semantics."""
+
     allowed = {
         "schemaVersion",
         "eventId",
@@ -994,8 +997,12 @@ def _validate_history_event(event: dict[str, Any]) -> None:
     if set(event) - allowed:
         raise StoreError("history event contains unsupported fields")
     _safe_session_id(event.get("applicationId", ""))
-    if event.get("event") not in HISTORY_EVENTS:
-        raise StoreError("history event type is unsupported")
+    event_name = event.get("event")
+    if (
+        not isinstance(event_name, str)
+        or not HISTORY_EVENT_IDENTIFIER.fullmatch(event_name)
+    ):
+        raise StoreError("history event type is invalid")
     answer_keys = event.get("answerKeys", [])
     if not isinstance(answer_keys, list) or not all(
         isinstance(item, str) for item in answer_keys
@@ -1006,6 +1013,16 @@ def _validate_history_event(event: dict[str, Any]) -> None:
         {"eventId", "company", "role", "ats", "status", "at"},
         "history event",
     )
+
+
+def _validate_history_event_for_write(event: dict[str, Any]) -> None:
+    """Apply this helper version's strict event-name write policy."""
+
+    _validate_history_event_record(event)
+    if not isinstance(event.get("eventId"), str) or not event["eventId"]:
+        raise StoreError("history event id is invalid")
+    if event["event"] not in HISTORY_EVENTS:
+        raise StoreError("history event type is unsupported")
 
 
 def _validate_session_document(session: dict[str, Any]) -> None:
@@ -1818,7 +1835,7 @@ class Store:
             ):
                 raise StoreError("coordinator journal operation is invalid")
             event = _require_object(operation.get("historyEvent"), "coordinator history event")
-            _validate_history_event(event)
+            _validate_history_event_for_write(event)
             if event.get("applicationId") != job_id:
                 raise StoreError("coordinator history identity does not match")
             if kind in {"acquire", "handoff"}:
@@ -5041,14 +5058,26 @@ class Store:
         for field in ("company", "role", "ats"):
             if isinstance(job.get(field), str):
                 record[field] = job[field]
-        _validate_history_event(record)
+        _validate_history_event_for_write(record)
         return record
 
+    def _history_event_is_idempotent_locked(self, event: dict[str, Any]) -> bool:
+        _validate_history_event_for_write(event)
+        matching = [
+            item
+            for item in self.read_history()
+            if item.get("eventId") == event["eventId"]
+        ]
+        if not matching:
+            return False
+        normalized = _canonical_json(event)
+        if all(_canonical_json(item) == normalized for item in matching):
+            return True
+        raise StoreError("history event id collision")
+
     def _append_history_event_idempotent_locked(self, event: dict[str, Any]) -> None:
-        existing = self.read_history()
-        if any(item.get("eventId") == event["eventId"] for item in existing):
+        if self._history_event_is_idempotent_locked(event):
             return
-        _validate_history_event(event)
         encoded = (json.dumps(event, sort_keys=True, ensure_ascii=False) + "\n").encode("utf-8")
         descriptor = os.open(
             self.history_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600
@@ -5107,6 +5136,9 @@ class Store:
                 {"schemaVersion": SCHEMA_VERSION, "operation": None},
             )
             return
+        event = operation.get("historyEvent")
+        if event is not None:
+            self._history_event_is_idempotent_locked(event)
         job_id = _safe_session_id(operation.get("jobId", ""))
         if "targetStatus" in operation:
             jobs = self._load_jobs_document()
@@ -5135,7 +5167,6 @@ class Store:
         if session is not None:
             _validate_session_document(session)
             atomic_write_json(self._session_path(job_id), session)
-        event = operation.get("historyEvent")
         if event is not None:
             self._append_history_event_idempotent_locked(event)
         atomic_write_json(
@@ -5148,6 +5179,9 @@ class Store:
         )
 
     def _commit_coordinator_operation_locked(self, operation: dict[str, Any]) -> None:
+        event = operation.get("historyEvent")
+        if event is not None:
+            self._history_event_is_idempotent_locked(event)
         atomic_write_json(
             self.coordinator_journal_path,
             {"schemaVersion": SCHEMA_VERSION, "operation": operation},
@@ -6137,7 +6171,7 @@ class Store:
                     event = json.loads(line)
                     _require_object(event, f"history line {number}")
                     validate_version(event, f"history line {number}")
-                    _validate_history_event(event)
+                    _validate_history_event_record(event)
                     events.append(event)
         except (OSError, UnicodeError, json.JSONDecodeError) as error:
             raise StoreError(f"cannot read valid history JSONL at {self.history_path}") from error
@@ -6171,7 +6205,7 @@ class Store:
             "event": event_name,
             "answerKeys": answer_keys,
         }
-        _validate_history_event(event)
+        _validate_history_event_for_write(event)
         with exclusive_file_lock(self.store_lock_path):
             answers = self._load_answers_document()
             for key in event["answerKeys"]:
@@ -6202,7 +6236,10 @@ class Store:
         self.initialize()
         history = self.read_history()
         application_events = [
-            event for event in history if event["applicationId"] == application_id
+            event
+            for event in history
+            if event["applicationId"] == application_id
+            and event["event"] in HISTORY_EVENTS
         ]
         if any(
             event.get("ats") not in {None, ats} for event in application_events

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -298,7 +298,7 @@ def read_json_object(path: Path, label: str) -> dict[str, Any]:
 
 def validate_version(document: dict[str, Any], label: str) -> None:
     version = document.get("schemaVersion")
-    if not isinstance(version, int):
+    if isinstance(version, bool) or not isinstance(version, int):
         raise StoreError(f"{label} has no valid schemaVersion")
     if version > SCHEMA_VERSION:
         raise StoreError(f"{label} uses unsupported future schemaVersion {version}")

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -1647,15 +1647,19 @@ class Store:
             self._load_extraction_journal()
         if self.sessions_path.exists():
             self._validate_existing_session_documents()
-        coordinator_exists = (
-            self.coordinator_path.exists() or self.coordinator_journal_path.exists()
-        )
-        if self.history_path.exists() and not coordinator_exists:
-            self.read_history()
         if self.coordinator_path.exists():
             self._load_coordinator_document()
+        coordinator_journal = None
         if self.coordinator_journal_path.exists():
-            self._load_coordinator_journal()
+            coordinator_journal = self._load_coordinator_journal()
+        if (
+            self.history_path.exists()
+            and (
+                coordinator_journal is None
+                or coordinator_journal["operation"] is None
+            )
+        ):
+            self.read_history()
 
     def _validate_existing_session_documents(self) -> None:
         """Validate canonical session files without following or changing identities."""

--- a/scripts/smoke-plugin.sh
+++ b/scripts/smoke-plugin.sh
@@ -5,14 +5,21 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SMOKE_TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/job-apply-smoke.XXXXXX")"
 SMOKE_CLAUDE_CONFIG_DIR="$SMOKE_TEMP_ROOT/claude-config"
 SMOKE_CODEX_HOME="$SMOKE_TEMP_ROOT/codex-home"
+SMOKE_CODEX_UPGRADE_HOME="$SMOKE_TEMP_ROOT/codex-upgrade-home"
 SMOKE_FIXTURE_DIR="$SMOKE_TEMP_ROOT/plugin-fixture"
+SMOKE_UPGRADE_FIXTURE_DIR="$SMOKE_TEMP_ROOT/plugin-upgrade-fixture"
 
 cleanup() {
   rm -rf -- "$SMOKE_TEMP_ROOT"
 }
 trap cleanup EXIT
 
-mkdir -p "$SMOKE_CLAUDE_CONFIG_DIR" "$SMOKE_CODEX_HOME" "$SMOKE_FIXTURE_DIR"
+mkdir -p \
+  "$SMOKE_CLAUDE_CONFIG_DIR" \
+  "$SMOKE_CODEX_HOME" \
+  "$SMOKE_CODEX_UPGRADE_HOME" \
+  "$SMOKE_FIXTURE_DIR" \
+  "$SMOKE_UPGRADE_FIXTURE_DIR"
 
 echo "Validating plugin manifest"
 claude plugin validate "$REPO_ROOT"
@@ -499,6 +506,120 @@ for generated in fixture.rglob("*"):
 print("Packaged fixture exclusions passed")
 PY
 
+echo "Creating isolated prior-version Codex upgrade fixture"
+cp -R "$SMOKE_FIXTURE_DIR/." "$SMOKE_UPGRADE_FIXTURE_DIR"
+python3 - "$SMOKE_UPGRADE_FIXTURE_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+fixture = Path(sys.argv[1])
+manifest_path = fixture / ".codex-plugin" / "plugin.json"
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+manifest["version"] = "1.1.0"
+manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+(fixture / "scripts" / "job-apply-store.py").write_text(
+    "# isolated-old-version-sentinel\n", encoding="utf-8"
+)
+PY
+
+CODEX_HOME="$SMOKE_CODEX_UPGRADE_HOME" codex plugin marketplace add \
+  "$SMOKE_UPGRADE_FIXTURE_DIR" --json \
+  > "$SMOKE_TEMP_ROOT/codex-upgrade-marketplace-add.json"
+CODEX_HOME="$SMOKE_CODEX_UPGRADE_HOME" codex plugin add \
+  job-apply@neonwatty-plugins --json \
+  > "$SMOKE_TEMP_ROOT/codex-upgrade-old-plugin-add.json"
+
+python3 - "$SMOKE_CODEX_UPGRADE_HOME" <<'PY'
+import sys
+from pathlib import Path
+
+cache = (
+    Path(sys.argv[1])
+    / "plugins" / "cache" / "neonwatty-plugins" / "job-apply" / "1.1.0"
+)
+if cache.name != "1.1.0" or not cache.is_dir():
+    raise SystemExit("isolated prior Codex version directory was not selected")
+if (cache / "scripts" / "job-apply-store.py").read_text(encoding="utf-8") != "# isolated-old-version-sentinel\n":
+    raise SystemExit("isolated prior Codex sentinel bytes were not installed")
+print("Isolated prior Codex package installed")
+PY
+
+python3 - "$SMOKE_FIXTURE_DIR" "$SMOKE_UPGRADE_FIXTURE_DIR" <<'PY'
+import shutil
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+target = Path(sys.argv[2])
+critical = (
+    ".codex-plugin/plugin.json",
+    "scripts/job-apply-store.py",
+    "scripts/job-apply-workspace.py",
+    "skills/answer-memory/SKILL.md",
+    "skills/job-apply/SKILL.md",
+    "workspace/app.js",
+)
+for relative in critical:
+    shutil.copy2(source / relative, target / relative)
+PY
+
+CODEX_HOME="$SMOKE_CODEX_UPGRADE_HOME" codex plugin add \
+  job-apply@neonwatty-plugins --json \
+  > "$SMOKE_TEMP_ROOT/codex-upgrade-new-plugin-add.json"
+CODEX_HOME="$SMOKE_CODEX_UPGRADE_HOME" codex plugin list --json \
+  > "$SMOKE_TEMP_ROOT/codex-upgrade-plugin-list.json"
+
+python3 - \
+  "$SMOKE_TEMP_ROOT/codex-upgrade-plugin-list.json" \
+  "$SMOKE_CODEX_UPGRADE_HOME" \
+  "$SMOKE_FIXTURE_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+plugins = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+match = next(
+    (
+        plugin
+        for plugin in plugins.get("installed", [])
+        if plugin.get("pluginId") == "job-apply@neonwatty-plugins"
+    ),
+    None,
+)
+if not match or not match.get("enabled"):
+    raise SystemExit("isolated upgraded Codex plugin is not selected")
+
+source = Path(sys.argv[3])
+version = json.loads(
+    (source / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
+)["version"]
+if match.get("version") != version:
+    raise SystemExit("isolated upgraded Codex selection does not match the manifest version")
+installed = (
+    Path(sys.argv[2])
+    / "plugins" / "cache" / "neonwatty-plugins" / "job-apply" / version
+)
+if installed.name != version or not installed.is_dir():
+    raise SystemExit("upgraded Codex version directory does not match the manifest")
+critical = (
+    ".codex-plugin/plugin.json",
+    "scripts/job-apply-store.py",
+    "scripts/job-apply-workspace.py",
+    "skills/answer-memory/SKILL.md",
+    "skills/job-apply/SKILL.md",
+    "workspace/app.js",
+)
+for relative in critical:
+    if (installed / relative).read_bytes() != (source / relative).read_bytes():
+        raise SystemExit(f"upgraded Codex bytes differ for {relative}")
+if b"isolated-old-version-sentinel" in (
+    installed / "scripts" / "job-apply-store.py"
+).read_bytes():
+    raise SystemExit("upgraded Codex package retained prior sentinel bytes")
+print("Isolated Codex old-to-new replacement and critical-byte parity passed")
+PY
+
 python3 - "$SMOKE_FIXTURE_DIR" "$SMOKE_TEMP_ROOT" <<'PY'
 import base64
 import http.client
@@ -752,7 +873,10 @@ CODEX_HOME="$SMOKE_CODEX_HOME" codex plugin add job-apply@neonwatty-plugins --js
 CODEX_HOME="$SMOKE_CODEX_HOME" codex plugin list --json \
   > "$SMOKE_TEMP_ROOT/codex-plugin-list.json"
 
-python3 - "$SMOKE_TEMP_ROOT/codex-plugin-list.json" "$SMOKE_CODEX_HOME" <<'PY'
+python3 - \
+  "$SMOKE_TEMP_ROOT/codex-plugin-list.json" \
+  "$SMOKE_CODEX_HOME" \
+  "$SMOKE_FIXTURE_DIR" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -770,6 +894,14 @@ cache_root = Path(sys.argv[2]) / "plugins" / "cache" / "neonwatty-plugins" / "jo
 versions = [path for path in cache_root.iterdir() if path.is_dir()]
 if len(versions) != 1:
     raise SystemExit(f"expected one isolated Codex plugin version, found {len(versions)}")
+source = Path(sys.argv[3])
+manifest_version = json.loads(
+    (source / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
+)["version"]
+if match.get("version") != manifest_version:
+    raise SystemExit("installed Codex selection does not match the manifest version")
+if versions[0].name != manifest_version:
+    raise SystemExit("installed Codex version directory does not match the manifest")
 
 expected = {"answer-memory", "job-apply", "job-search", "job-preferences", "job-workspace"}
 installed_skills = {
@@ -781,7 +913,18 @@ if installed_skills != expected:
         f"got {sorted(installed_skills)}"
     )
 
-print("Isolated Codex marketplace install passed")
+for relative in (
+    ".codex-plugin/plugin.json",
+    "scripts/job-apply-store.py",
+    "scripts/job-apply-workspace.py",
+    "skills/answer-memory/SKILL.md",
+    "skills/job-apply/SKILL.md",
+    "workspace/app.js",
+):
+    if (versions[0] / relative).read_bytes() != (source / relative).read_bytes():
+        raise SystemExit(f"installed Codex bytes differ for {relative}")
+
+print("Isolated Codex marketplace install and critical-byte parity passed")
 PY
 
 echo "Plugin smoke checks passed"

--- a/tests/test_answer_memory_integration.py
+++ b/tests/test_answer_memory_integration.py
@@ -537,6 +537,32 @@ class AnswerMemoryIntegrationTests(unittest.TestCase):
         }
         self.assertEqual(after, before)
 
+    def test_cli_history_rejects_future_events_without_complete_audit_envelope(self):
+        self.json_store("init")
+        history_path = self.home / ".job-apply" / "applications.jsonl"
+        valid = {
+            "schemaVersion": 1,
+            "eventId": "future-cli-event",
+            "applicationId": "future-cli-application",
+            "event": "future-safe-event",
+            "answerKeys": [],
+            "at": "2026-08-28T00:00:00Z",
+        }
+        invalid_events = (
+            {key: value for key, value in valid.items() if key != "eventId"},
+            {**valid, "eventId": ""},
+            {key: value for key, value in valid.items() if key != "at"},
+            {**valid, "at": ""},
+            {key: value for key, value in valid.items() if key != "answerKeys"},
+        )
+
+        for event in invalid_events:
+            with self.subTest(event=event):
+                history_path.write_text(json.dumps(event) + "\n", encoding="utf-8")
+                completed = self.run_store("history-list", check=False)
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertNotIn("future-cli-application", completed.stderr)
+
     def test_resume_proposal_cli_autofills_and_reviews_conflicts(self):
         self.json_store("init")
         profile_input = self.write_input("proposal-profile.json", {"firstName": "Human"})

--- a/tests/test_answer_memory_integration.py
+++ b/tests/test_answer_memory_integration.py
@@ -489,6 +489,54 @@ class AnswerMemoryIntegrationTests(unittest.TestCase):
         self.assertNotIn(acquired["token"], serialized)
         self.assertNotIn("synthetic resume", serialized)
 
+    def test_cli_commands_read_safe_future_history_without_rewriting_store(self):
+        self.json_store("init")
+        self.json_store("claim-status")
+        history_path = self.home / ".job-apply" / "applications.jsonl"
+        events = [
+            {
+                "schemaVersion": 1,
+                "eventId": f"coordinator-event-{index}",
+                "applicationId": "compatibility-job",
+                "event": event,
+                "status": status,
+                "answerKeys": [],
+                "at": f"2026-08-28T00:0{index}:00Z",
+            }
+            for index, (event, status) in enumerate(
+                (
+                    ("job-started", "in_progress"),
+                    ("claim-recovered", "in_progress"),
+                    ("job-blocked", "needs_info"),
+                    ("future-safe-event", "future-status"),
+                ),
+                1,
+            )
+        ]
+        history_path.write_text(
+            "".join(json.dumps(event) + "\n" for event in events),
+            encoding="utf-8",
+        )
+        store_root = self.home / ".job-apply"
+        before = {
+            path.relative_to(store_root): path.read_bytes()
+            for path in store_root.rglob("*")
+            if path.is_file()
+        }
+
+        self.json_store("init")
+        self.assertEqual(self.json_store("profile-get"), {})
+        self.assertEqual(self.json_store("job-list"), [])
+        self.assertIsNone(self.json_store("claim-status")["claim"])
+        self.assertEqual(self.json_store("history-list"), events)
+
+        after = {
+            path.relative_to(store_root): path.read_bytes()
+            for path in store_root.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(after, before)
+
     def test_resume_proposal_cli_autofills_and_reviews_conflicts(self):
         self.json_store("init")
         profile_input = self.write_input("proposal-profile.json", {"firstName": "Human"})

--- a/tests/test_answer_memory_integration.py
+++ b/tests/test_answer_memory_integration.py
@@ -549,6 +549,7 @@ class AnswerMemoryIntegrationTests(unittest.TestCase):
             "at": "2026-08-28T00:00:00Z",
         }
         invalid_events = (
+            {**valid, "schemaVersion": True},
             {key: value for key, value in valid.items() if key != "eventId"},
             {**valid, "eventId": ""},
             {key: value for key, value in valid.items() if key != "at"},

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -4370,6 +4370,7 @@ class StoreTests(unittest.TestCase):
             "at": "2026-08-28T00:00:00Z",
         }
         invalid_cases = {
+            "boolean schema": {**valid, "schemaVersion": True},
             "future schema": {**valid, "schemaVersion": 2},
             "extra credential": {**valid, "password": "private"},
             "nested private value": {**valid, "company": {"value": "private"}},

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -4150,6 +4150,242 @@ class StoreTests(unittest.TestCase):
         with self.assertRaises(STORE_MODULE.StoreError):
             self.store.read_history()
 
+    def test_future_value_free_history_reads_without_mutation_but_writes_stay_strict(self):
+        self.store.initialize()
+        self.store.claim_status()
+        future_event = {
+            "schemaVersion": 1,
+            "eventId": "future-event-1",
+            "applicationId": "future-application",
+            "event": "future-safe-event",
+            "company": "Example",
+            "role": "Engineer",
+            "ats": "future-ats",
+            "status": "future-status",
+            "answerKeys": [],
+            "at": "2026-08-28T00:00:00Z",
+        }
+        self.store.history_path.write_text(
+            json.dumps(future_event) + "\n", encoding="utf-8"
+        )
+        before = {
+            path.relative_to(self.root): path.read_bytes()
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+
+        reopened = STORE_MODULE.Store(self.root, self.legacy)
+        reopened.validate_workspace_startup()
+        reopened.initialize()
+        self.assertEqual(reopened.get_profile(), {})
+        self.assertEqual(reopened.list_jobs(), [])
+        self.assertIsNone(reopened.claim_status()["claim"])
+        self.assertEqual(reopened.read_history(), [future_event])
+        after = {
+            path.relative_to(self.root): path.read_bytes()
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(after, before)
+
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "type is unsupported"):
+            reopened.append_history(
+                {
+                    "applicationId": "future-application",
+                    "event": "future-safe-event",
+                    "answerKeys": [],
+                }
+            )
+
+    def test_unknown_history_event_is_inert_for_replay_semantics(self):
+        self.store.initialize()
+        future_event = {
+            "schemaVersion": 1,
+            "eventId": "future-event-2",
+            "applicationId": "qa-future-event",
+            "event": "future-terminal-looking-event",
+            "ats": "different-future-ats",
+            "status": "completed",
+            "answerKeys": [],
+            "at": "2026-08-28T00:00:00Z",
+        }
+        self.store.history_path.write_text(
+            json.dumps(future_event) + "\n", encoding="utf-8"
+        )
+
+        result = self.store.record_replay_transition(
+            "qa-future-event", "started", "greenhouse"
+        )
+
+        self.assertTrue(result["changed"])
+        self.assertEqual(
+            [event["event"] for event in self.store.read_history()],
+            ["future-terminal-looking-event", "started"],
+        )
+
+    def test_history_event_idempotence_requires_the_complete_exact_record(self):
+        self.store.initialize()
+        event = {
+            "schemaVersion": 1,
+            "eventId": "exact-known-event",
+            "applicationId": "exact-application",
+            "event": "reviewed",
+            "status": "review",
+            "answerKeys": [],
+            "at": "2026-08-28T00:00:00Z",
+        }
+        self.store.history_path.write_text(
+            json.dumps(event, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        before = self.store.history_path.read_bytes()
+
+        self.store._append_history_event_idempotent_locked(dict(event))
+        self.assertEqual(self.store.history_path.read_bytes(), before)
+
+        for different in (
+            {**event, "status": "completed"},
+            {**event, "event": "started"},
+        ):
+            with self.subTest(different=different):
+                with self.assertRaisesRegex(
+                    STORE_MODULE.StoreError, "history event id collision"
+                ):
+                    self.store._append_history_event_idempotent_locked(different)
+                self.assertEqual(self.store.history_path.read_bytes(), before)
+
+    def test_unknown_event_id_collision_blocks_acquisition_before_any_mutation(self):
+        ready = self._make_ready_job()
+        self.store.claim_status()
+        unknown = {
+            "schemaVersion": 1,
+            "eventId": "coordinator-operation-fixed",
+            "applicationId": ready["id"],
+            "event": "future-safe-event",
+            "status": "future-status",
+            "answerKeys": [],
+            "at": "2026-08-28T00:00:00Z",
+        }
+        self.store.history_path.write_text(
+            json.dumps(unknown) + "\n", encoding="utf-8"
+        )
+        before = {
+            path.relative_to(self.root): path.read_bytes()
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+
+        with mock.patch.object(
+            STORE_MODULE.uuid,
+            "uuid4",
+            side_effect=["claim-fixed", "operation-fixed"],
+        ):
+            with self.assertRaisesRegex(
+                STORE_MODULE.StoreError, "history event id collision"
+            ):
+                self.store.acquire_ready_job(
+                    ready["id"], "collision-agent", ready["revision"]
+                )
+
+        after = {
+            path.relative_to(self.root): path.read_bytes()
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(after, before)
+        self.assertEqual(self.store.get_job(ready["id"]), ready)
+        self.assertIsNone(self.store.claim_status()["claim"])
+
+    def test_pending_coordinator_collision_fails_before_roll_forward_mutation(self):
+        ready = self._make_ready_job()
+        self.store.claim_status()
+        self.store.save_session(
+            "unrelated-session", {"status": "active", "step": "application"}
+        )
+        now = "2026-08-28T00:00:00Z"
+        operation_id = "pending-collision"
+        operation = {
+            "kind": "acquire",
+            "operationId": operation_id,
+            "jobId": ready["id"],
+            "sourceStatus": "ready",
+            "targetStatus": "in_progress",
+            "expectedRevision": ready["revision"],
+            "at": now,
+            "historyEvent": self.store._history_event_for_operation(
+                operation_id, ready, "job-started", "in_progress", now
+            ),
+            "resultClaim": {
+                "claimId": "pending-claim",
+                "jobId": ready["id"],
+                "ownerLabel": "collision-agent",
+                "tokenHash": "a" * 64,
+                "acquiredAt": now,
+                "heartbeatAt": now,
+                "expiresAt": "2026-08-28T00:05:00Z",
+            },
+        }
+        unknown = {
+            "schemaVersion": 1,
+            "eventId": operation["historyEvent"]["eventId"],
+            "applicationId": ready["id"],
+            "event": "future-safe-event",
+            "status": "future-status",
+            "answerKeys": [],
+            "at": now,
+        }
+        self.store.history_path.write_text(
+            json.dumps(unknown) + "\n", encoding="utf-8"
+        )
+        STORE_MODULE.atomic_write_json(
+            self.store.coordinator_journal_path,
+            {"schemaVersion": 1, "operation": operation},
+        )
+        before = {
+            path.relative_to(self.root): path.read_bytes()
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+
+        reopened = STORE_MODULE.Store(self.root, self.legacy)
+        with self.assertRaisesRegex(
+            STORE_MODULE.StoreError, "history event id collision"
+        ):
+            reopened.initialize()
+
+        after = {
+            path.relative_to(self.root): path.read_bytes()
+            for path in self.root.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(after, before)
+
+    def test_unknown_history_events_still_reject_unsafe_or_private_shapes(self):
+        self.store.initialize()
+        valid = {
+            "schemaVersion": 1,
+            "eventId": "future-event-3",
+            "applicationId": "future-application",
+            "event": "future-safe-event",
+            "answerKeys": [],
+            "at": "2026-08-28T00:00:00Z",
+        }
+        invalid_cases = {
+            "future schema": {**valid, "schemaVersion": 2},
+            "extra credential": {**valid, "password": "private"},
+            "nested private value": {**valid, "company": {"value": "private"}},
+            "invalid answer references": {**valid, "answerKeys": [{"key": "private"}]},
+            "uppercase identifier": {**valid, "event": "Future-Event"},
+            "unicode identifier": {**valid, "event": "futuré-event"},
+            "overlong identifier": {**valid, "event": "f" * 65},
+        }
+        for label, event in invalid_cases.items():
+            with self.subTest(label=label):
+                self.store.history_path.write_text(
+                    json.dumps(event) + "\n", encoding="utf-8"
+                )
+                with self.assertRaises(STORE_MODULE.StoreError):
+                    self.store.read_history()
+
     def test_replay_transitions_are_ordered_idempotent_and_value_free(self):
         application_id = "qa-run-20260815-1234abcd"
         started = self.store.record_replay_transition(

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -4374,6 +4374,17 @@ class StoreTests(unittest.TestCase):
             "extra credential": {**valid, "password": "private"},
             "nested private value": {**valid, "company": {"value": "private"}},
             "invalid answer references": {**valid, "answerKeys": [{"key": "private"}]},
+            "missing event identity": {
+                key: value for key, value in valid.items() if key != "eventId"
+            },
+            "empty event identity": {**valid, "eventId": ""},
+            "missing audit timestamp": {
+                key: value for key, value in valid.items() if key != "at"
+            },
+            "empty audit timestamp": {**valid, "at": ""},
+            "missing answer references": {
+                key: value for key, value in valid.items() if key != "answerKeys"
+            },
             "uppercase identifier": {**valid, "event": "Future-Event"},
             "unicode identifier": {**valid, "event": "futuré-event"},
             "overlong identifier": {**valid, "event": "f" * 65},

--- a/tests/test_job_apply_workspace.py
+++ b/tests/test_job_apply_workspace.py
@@ -218,6 +218,43 @@ class WorkspaceServerTests(unittest.TestCase):
         finally:
             server.server_close()
 
+    def test_owner_beta_incomplete_future_history_enters_degraded_recovery_without_mutation(self):
+        valid = {
+            "schemaVersion": 1,
+            "eventId": "future-workspace-event",
+            "applicationId": "future-workspace-job",
+            "event": "future-safe-event",
+            "answerKeys": [],
+            "at": "2026-08-28T00:00:00Z",
+        }
+        invalid_events = (
+            {key: value for key, value in valid.items() if key != "eventId"},
+            {**valid, "eventId": ""},
+            {key: value for key, value in valid.items() if key != "at"},
+            {**valid, "at": ""},
+            {key: value for key, value in valid.items() if key != "answerKeys"},
+        )
+
+        for index, event in enumerate(invalid_events):
+            with self.subTest(event=event):
+                degraded_root = Path(self.temporary.name) / f"incomplete-history-{index}"
+                degraded_root.mkdir()
+                history_path = degraded_root / "applications.jsonl"
+                history_path.write_text(json.dumps(event) + "\n", encoding="utf-8")
+                before = history_path.read_bytes()
+
+                server = WORKSPACE.WorkspaceServer(
+                    degraded_root, 0, token=f"incomplete-history-token-{index}"
+                )
+                try:
+                    self.assertEqual(
+                        (server.boot_status["status"], server.boot_status["code"]),
+                        ("degraded", "corrupt_store"),
+                    )
+                    self.assertEqual(history_path.read_bytes(), before)
+                finally:
+                    server.server_close()
+
     def test_owner_beta_startup_rejects_semantically_invalid_claim_timestamps_without_mutation(self):
         base_claim = {
             "claimId": "claim-one",

--- a/tests/test_job_apply_workspace.py
+++ b/tests/test_job_apply_workspace.py
@@ -326,6 +326,69 @@ class WorkspaceServerTests(unittest.TestCase):
         finally:
             server.server_close()
 
+    def test_owner_beta_pending_answer_merge_with_malformed_history_degrades_without_mutation(self):
+        recovery_root = Path(self.temporary.name) / "pending-answer-merge"
+        store = WORKSPACE.STORE_MODULE.Store(recovery_root)
+        store.initialize()
+        store.claim_status()
+        winner = store.put_answer({
+            "question": "Canonical availability?",
+            "state": "confirmed",
+            "value": "Yes",
+        })
+        source = store.put_answer({
+            "question": "When can you start?",
+            "state": "missing",
+        })
+
+        real_atomic_write = WORKSPACE.STORE_MODULE.atomic_write_json
+
+        def interrupt_answer_write(path, payload):
+            if path == store.answers_path:
+                raise OSError("simulated interrupted answer merge")
+            return real_atomic_write(path, payload)
+
+        with mock.patch.object(
+            WORKSPACE.STORE_MODULE,
+            "atomic_write_json",
+            side_effect=interrupt_answer_write,
+        ):
+            with self.assertRaisesRegex(OSError, "interrupted answer merge"):
+                store.merge_answers(
+                    winner["key"],
+                    source["key"],
+                    winner["revision"],
+                    source["revision"],
+                )
+
+        self.assertEqual(
+            store._load_coordinator_journal()["operation"]["kind"],
+            "answer_merge",
+        )
+        store.history_path.write_text('{"schemaVersion":1\n', encoding="utf-8")
+        before = {
+            path.relative_to(recovery_root): path.read_bytes()
+            for path in recovery_root.rglob("*")
+            if path.is_file()
+        }
+
+        server = WORKSPACE.WorkspaceServer(
+            recovery_root, 0, token="pending-answer-merge-token"
+        )
+        try:
+            self.assertEqual(
+                (server.boot_status["status"], server.boot_status["code"]),
+                ("degraded", "corrupt_store"),
+            )
+            after = {
+                path.relative_to(recovery_root): path.read_bytes()
+                for path in recovery_root.rglob("*")
+                if path.is_file()
+            }
+            self.assertEqual(after, before)
+        finally:
+            server.server_close()
+
     def test_owner_beta_startup_rejects_semantically_invalid_claim_timestamps_without_mutation(self):
         base_claim = {
             "claimId": "claim-one",

--- a/tests/test_job_apply_workspace.py
+++ b/tests/test_job_apply_workspace.py
@@ -228,6 +228,7 @@ class WorkspaceServerTests(unittest.TestCase):
             "at": "2026-08-28T00:00:00Z",
         }
         invalid_events = (
+            {**valid, "schemaVersion": True},
             {key: value for key, value in valid.items() if key != "eventId"},
             {**valid, "eventId": ""},
             {key: value for key, value in valid.items() if key != "at"},

--- a/tests/test_job_apply_workspace.py
+++ b/tests/test_job_apply_workspace.py
@@ -238,10 +238,16 @@ class WorkspaceServerTests(unittest.TestCase):
         for index, event in enumerate(invalid_events):
             with self.subTest(event=event):
                 degraded_root = Path(self.temporary.name) / f"incomplete-history-{index}"
-                degraded_root.mkdir()
-                history_path = degraded_root / "applications.jsonl"
+                store = WORKSPACE.STORE_MODULE.Store(degraded_root)
+                store.initialize()
+                store.claim_status()
+                history_path = store.history_path
                 history_path.write_text(json.dumps(event) + "\n", encoding="utf-8")
-                before = history_path.read_bytes()
+                before = {
+                    path.relative_to(degraded_root): path.read_bytes()
+                    for path in degraded_root.rglob("*")
+                    if path.is_file()
+                }
 
                 server = WORKSPACE.WorkspaceServer(
                     degraded_root, 0, token=f"incomplete-history-token-{index}"
@@ -251,9 +257,74 @@ class WorkspaceServerTests(unittest.TestCase):
                         (server.boot_status["status"], server.boot_status["code"]),
                         ("degraded", "corrupt_store"),
                     )
-                    self.assertEqual(history_path.read_bytes(), before)
+                    after = {
+                        path.relative_to(degraded_root): path.read_bytes()
+                        for path in degraded_root.rglob("*")
+                        if path.is_file()
+                    }
+                    self.assertEqual(after, before)
                 finally:
                     server.server_close()
+
+    def test_owner_beta_pending_coordinator_history_repair_starts_ready(self):
+        recovery_root = Path(self.temporary.name) / "pending-history-recovery"
+        store = WORKSPACE.STORE_MODULE.Store(recovery_root)
+        store.initialize()
+        store.replace_profile(
+            {"firstName": "Ada"}, expected_revision=1, source="user"
+        )
+        resume_path = Path(self.temporary.name) / "recovery-resume.pdf"
+        resume_path.write_bytes(b"%PDF-1.7\nrecovery")
+        resume = store.create_resume(
+            {"id": "recovery", "label": "Recovery", "path": str(resume_path)}
+        )
+        job = store.create_job({
+            "id": "recovery-job",
+            "url": "https://example.com/jobs/recovery",
+            "resumeId": resume["id"],
+        })
+        ready = store.transition_job(job["id"], "ready", job["revision"])
+
+        def append_partial_then_crash(event):
+            encoded = (
+                json.dumps(event, sort_keys=True, ensure_ascii=False) + "\n"
+            ).encode("utf-8")
+            descriptor = os.open(
+                store.history_path,
+                os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+                0o600,
+            )
+            try:
+                os.write(descriptor, encoded[: len(encoded) // 2])
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+            raise OSError("simulated process crash after partial append")
+
+        with mock.patch.object(
+            store,
+            "_append_history_event_idempotent_locked",
+            side_effect=append_partial_then_crash,
+        ):
+            with self.assertRaisesRegex(OSError, "partial append"):
+                store.acquire_ready_job(job["id"], "codex", ready["revision"])
+
+        self.assertFalse(store.history_path.read_bytes().endswith(b"\n"))
+        server = WORKSPACE.WorkspaceServer(
+            recovery_root, 0, token="pending-history-recovery-token"
+        )
+        try:
+            self.assertEqual(server.boot_status, {"status": "ready", "code": "ready"})
+            self.assertEqual(server.store.get_job(job["id"])["status"], "in_progress")
+            self.assertEqual(
+                [event["event"] for event in server.store.read_history()],
+                ["job-started"],
+            )
+            self.assertIsNone(
+                server.store._load_coordinator_journal()["operation"]
+            )
+        finally:
+            server.server_close()
 
     def test_owner_beta_startup_rejects_semantically_invalid_claim_timestamps_without_mutation(self):
         base_claim = {

--- a/tests/test_job_apply_workspace.py
+++ b/tests/test_job_apply_workspace.py
@@ -180,6 +180,44 @@ class WorkspaceServerTests(unittest.TestCase):
         finally:
             server.server_close()
 
+    def test_owner_beta_safe_future_history_starts_ready_without_mutation(self):
+        compatibility_root = Path(self.temporary.name) / "future-history-store"
+        store = WORKSPACE.STORE_MODULE.Store(compatibility_root)
+        store.initialize()
+        store.claim_status()
+        future_event = {
+            "schemaVersion": 1,
+            "eventId": "future-workspace-event",
+            "applicationId": "future-workspace-job",
+            "event": "future-safe-event",
+            "status": "future-status",
+            "answerKeys": [],
+            "at": "2026-08-28T00:00:00Z",
+        }
+        store.history_path.write_text(
+            json.dumps(future_event) + "\n", encoding="utf-8"
+        )
+        before = {
+            path.relative_to(compatibility_root): path.read_bytes()
+            for path in compatibility_root.rglob("*")
+            if path.is_file()
+        }
+
+        server = WORKSPACE.WorkspaceServer(
+            compatibility_root, 0, token="future-history-token"
+        )
+        try:
+            self.assertEqual(server.boot_status, {"status": "ready", "code": "ready"})
+            self.assertEqual(server.store.read_history(), [future_event])
+            after = {
+                path.relative_to(compatibility_root): path.read_bytes()
+                for path in compatibility_root.rglob("*")
+                if path.is_file()
+            }
+            self.assertEqual(after, before)
+        finally:
+            server.server_close()
+
     def test_owner_beta_startup_rejects_semantically_invalid_claim_timestamps_without_mutation(self):
         base_claim = {
             "claimId": "claim-one",


### PR DESCRIPTION
## Summary
- bump the Codex package to 1.2.0 and prove isolated 1.1.0-to-1.2.0 replacement with critical-byte parity
- accept structurally valid unknown history event names on reads while keeping writes and current lifecycle semantics strict
- fail closed on event-ID collisions, malformed history envelopes, boolean schema versions, and unsafe coordinator startup recovery classes
- preserve no-mutation degraded recovery for malformed stores and repair-before-read for genuine history-writing operations

## Verification
- 204 focused Store, CLI, and Workspace tests
- 489 full Python tests
- packaged plugin smoke and isolated Codex/Claude install checks
- screening replay, auto-submit safety, and 79 browser tests
- link, diff, and exact staging ancestry checks
- PR Review Toolkit native and independent role reviews; all accepted findings repaired and reverified

This PR targets staging and is intentionally not authorized for merge yet.