### PR TITLE
Fail fast when visible account QA dependencies are missing

### DIFF
--- a/scripts/qa-account.py
+++ b/scripts/qa-account.py
@@ -42,12 +42,37 @@ VISIBLE_BROWSER_APPROVAL_ERROR = (
     "visible browser verification is disabled; explicit current-turn owner approval "
     "and --owner-approved-visible-browser-tests are required"
 )
+VISIBLE_BROWSER_DEPENDENCY_ERROR = (
+    "visible browser verification dependencies are unavailable; run from a dependency-complete "
+    "exact candidate checkout"
+)
 
 
 def _require_visible_browser_approval(owner_approved: bool) -> None:
     """Refuse before compiling helpers, starting servers, or launching a browser."""
     if not owner_approved:
         raise ValueError(VISIBLE_BROWSER_APPROVAL_ERROR)
+
+
+def _require_browser_test_dependencies() -> None:
+    """Refuse before any helper, server, browser, Store, or native setup."""
+    try:
+        completed = subprocess.run(
+            [
+                "node", "--input-type=module", "--eval",
+                'import { chromium } from "playwright"; if (!chromium) process.exit(9)',
+            ],
+            cwd=ROOT,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        raise ValueError(VISIBLE_BROWSER_DEPENDENCY_ERROR) from None
+    if completed.returncode:
+        raise ValueError(VISIBLE_BROWSER_DEPENDENCY_ERROR)
 
 
 def _compile_native(binary: Path) -> None:
@@ -278,6 +303,7 @@ def verify_all(provider: str, *, owner_approved_visible_browser_tests: bool = Fa
     _require_visible_browser_approval(owner_approved_visible_browser_tests)
     if provider != "macos-keychain" or not sys.platform.startswith("darwin"):
         raise ValueError("synthetic provider selection is unsupported")
+    _require_browser_test_dependencies()
     with tempfile.TemporaryDirectory() as directory:
         server = None
         thread = None
@@ -370,6 +396,7 @@ def verify_oracle_email_only(provider: str, *, owner_approved_visible_browser_te
     _require_visible_browser_approval(owner_approved_visible_browser_tests)
     if provider != "macos-accessibility" or not sys.platform.startswith("darwin"):
         raise ValueError("Oracle email-only automation provider is unsupported")
+    _require_browser_test_dependencies()
     descriptor = "oracle-recruiting:v1:synthetic.fa.us2.oraclecloud.com:jobsearch"
     realm = __import__("hashlib").sha256(descriptor.encode()).hexdigest()
     controls = {

--- a/scripts/qa-account.py
+++ b/scripts/qa-account.py
@@ -117,9 +117,12 @@ def _focus_browser(cdp_url: str, url: str) -> None:
 import { chromium } from "playwright";
 const browser = await chromium.connectOverCDP(process.argv[2]);
 const context = browser.contexts()[0];
-const page = context.pages()[0] ?? await context.newPage();
+const page = await context.newPage();
 page.setDefaultTimeout(5000);
 await page.goto(process.argv[1], {waitUntil: "domcontentloaded", timeout: 10000});
+for (const existing of context.pages()) {
+    if (existing !== page) await existing.close();
+}
 await page.getByRole("button", {name: "Focus protected synthetic control"}).click();
 await page.locator("#job-apply-secure-control").evaluate((element) => element.focus());
 await page.bringToFront();
@@ -148,9 +151,12 @@ def _open_oracle_browser(cdp_url: str, url: str) -> None:
 import { chromium } from "playwright";
 const browser = await chromium.connectOverCDP(process.argv[2]);
 const context = browser.contexts()[0];
-const page = context.pages()[0] ?? await context.newPage();
+const page = await context.newPage();
 page.setDefaultTimeout(5000);
 await page.goto(process.argv[1], {waitUntil: "domcontentloaded", timeout: 10000});
+for (const existing of context.pages()) {
+    if (existing !== page) await existing.close();
+}
 await page.locator("#job-apply-email-control").waitFor();
 await page.locator("#job-apply-focus-decoy").focus();
 if (await page.evaluate(() => document.activeElement?.id) !== "job-apply-focus-decoy") process.exit(7);

--- a/tests/test_qa_account.py
+++ b/tests/test_qa_account.py
@@ -95,7 +95,9 @@ class SyntheticAccountQATests(unittest.TestCase):
         server = (ROOT / "qa/account_server.py").read_text(encoding="utf-8")
         self.assertEqual(source.count("timeout=12"), 2)
         self.assertEqual(source.count("for _ in range(3):"), 2)
-        self.assertIn("context.pages()[0] ?? await context.newPage()", source)
+        self.assertEqual(source.count("const page = await context.newPage();"), 2)
+        self.assertEqual(source.count("if (existing !== page) await existing.close();"), 2)
+        self.assertNotIn("context.pages()[0] ?? await context.newPage()", source)
         self.assertIn("listener.settimeout(45)", server)
         self.assertEqual(source.count("provider.provision_or_reuse_and_fill"), 0)
 

--- a/tests/test_qa_account.py
+++ b/tests/test_qa_account.py
@@ -12,6 +12,7 @@ import unittest
 import urllib.error
 import urllib.request
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -25,6 +26,37 @@ QA = load("qa_account_test", ROOT / "scripts/qa-account.py")
 
 
 class SyntheticAccountQATests(unittest.TestCase):
+    def test_workday_missing_playwright_refuses_before_external_setup(self):
+        missing = subprocess.CompletedProcess([], 1)
+        with mock.patch.object(QA.sys, "platform", "darwin"), \
+             mock.patch.object(QA.subprocess, "run", return_value=missing) as run, \
+             mock.patch.object(QA, "_compile_native") as compile_native, \
+             mock.patch.object(QA, "_start_browser") as start_browser:
+            with self.assertRaisesRegex(ValueError, "dependencies are unavailable"):
+                QA.verify_all(
+                    "macos-keychain", owner_approved_visible_browser_tests=True,
+                )
+        run.assert_called_once()
+        compile_native.assert_not_called()
+        start_browser.assert_not_called()
+
+    def test_oracle_missing_playwright_refuses_before_external_setup(self):
+        missing = subprocess.CompletedProcess([], 1)
+        with mock.patch.object(QA.sys, "platform", "darwin"), \
+             mock.patch.object(QA.subprocess, "run", return_value=missing) as run, \
+             mock.patch.object(QA, "_start_browser") as start_browser, \
+             mock.patch.object(
+                 QA.ACCOUNT_FLOWS_MACOS.NativeMacOSAccessibilityProvider,
+                 "from_reviewed_sources",
+             ) as build_native:
+            with self.assertRaisesRegex(ValueError, "dependencies are unavailable"):
+                QA.verify_oracle_email_only(
+                    "macos-accessibility", owner_approved_visible_browser_tests=True,
+                )
+        run.assert_called_once()
+        start_browser.assert_not_called()
+        build_native.assert_not_called()
+
     @unittest.skipUnless(hasattr(socket, "AF_UNIX"), "Unix-domain sockets required")
     def test_registration_retirement_is_owned_by_exact_generation(self):
         server = SERVER.SyntheticAccountServer(0)


### PR DESCRIPTION
## Summary
- preflight the development-only Playwright dependency before any visible account QA setup
- fail with a fixed value-free diagnostic before helper compilation, server startup, Chrome launch, Store setup, or native behavior
- cover both Workday and Oracle entry points with quiet no-side-effect regressions

## Verification
- python3 -m unittest -v tests.test_qa_account
- python3 -m unittest discover -s tests -p 'test_*.py' (565 passed, 2 visible-native tests skipped)
- git diff --check

## Safety
No visible browser/native walkthrough was run after this repair. This PR does not change production account behavior, packaging, Keychain behavior, or final-action policy.