### PR TITLE
Unify the application task spine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Job Apply Plugin for Codex and Claude Code
 
+Run the isolated cross-client task-spine oracle with `npm run qa:unified-task-spine`. It uses a temporary synthetic Store, the shipped CLIs, an authenticated loopback Companion server, and Playwright; its single JSON report is value-free and cleanup-closed, and it never enables a final application action.
+
 [![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.gg/7xsxU4ZG6A)
 
 AI-powered job application assistant for Claude Code and Codex that fills job applications on LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday using visible browser automation.
@@ -234,7 +236,7 @@ Job Apply stores data as **plaintext local files** under `~/.job-apply/`:
 | `coordinator-journal.json` | Value-free idempotent roll-forward record for lifecycle handoffs |
 | `sessions/*.json` | Resumable workflow metadata and answer-key references |
 
-The coordinator files are created only when the ready-job claim workflow is first used; direct-URL applications keep the legacy store shape.
+The coordinator files are created only when the ready-job claim workflow is first used. Ordinary URL applications are first ingested as canonical jobs and use the same canonical job ID for selection, claims, sessions, activity, and review handoff. Authenticated loopback QA replay is the only synthetic exception.
 
 These files can include sensitive personal information such as:
 
@@ -259,6 +261,12 @@ chmod 600 ~/.job-apply/resume-extractions.json ~/.job-apply/resume-extraction-jo
 On first use, an existing `~/.claude-job-profile.json` is copied into the new versioned profile without modifying or deleting the legacy file. Once `~/.job-apply/profile.json` exists it is authoritative; later legacy-file changes are not re-imported. Verify the new profile before deciding whether to archive or remove the old file.
 
 All plugin skills access this data through the bundled `scripts/job-apply-store.py` helper. Canonical JSON updates are atomic, corrupt or future-version files fail closed, and application history and sessions do not duplicate reusable answer values.
+
+The packaged `scripts/job-apply-task.py` helper is the ordinary agent-facing job protocol. `snapshot` returns one redacted Store-owned overview/jobs/attention view; `activity --id <job-id>` returns value-free activity for one exact canonical job. `intake --input <private-json>` atomically resolves or creates exactly one active job without returning its URL or the Store's upsert token. After the owner explicitly chooses a displayed job, `select --id <job-id> --expected-revision <revision> --owner-confirmed` rechecks preflight and marks it Ready, or returns a stable no-op when that exact revision is already Ready. All failures are stable machine-readable JSON; identity conflicts, trashed matches, stale revisions, unavailable jobs, and failed preflight stop before browser work.
+
+The packaged `scripts/job-apply-attempt.py` helper uses a detached broker scoped to one Store and exact selected attempt. A short `start` client launches the broker, acquires the exact job and revision, returns the redacted application inputs, and exits; no launcher, stdin stream, terminal, or conversational process stays attached. The broker retains claim authority only in memory, heartbeats automatically, and accepts later stateless `heartbeat`, value-free `progress`, and `handoff` clients through its OS-user-restricted Store socket. It cannot switch jobs, Stores, revisions, owners, or claims. Its argv, environment, JSON responses, diagnostics, and durable files never carry the raw claim authority. A successful `awaiting_review` or `needs_info` handoff saves the value-free session, releases the claim, and causes the broker to exit.
+
+When an exact managed attempt is blocked by a referenced non-sensitive question, send a value-free `needs_info` handoff so the broker releases the claim and exits, then inspect `activity --id <job-id>`. Edit and accept the answer in Companion's canonical Answers library and explicitly resolve that pending reference against the exact job, session, and answer revisions shown there. The Store rechecks all three revisions under its lock, removes only that pending reference, and never copies the answer value into the session, journal result, history, activity, or diagnostics. The job stays in Needs Attention while another blocker remains; with no blockers it becomes Ready only after preflight. Use the returned exact Ready revision with a fresh `start` client, which creates a fresh broker acquisition for the same canonical job; the assigned/default managed resume binding and resumable session continue through the next `job-started` and `reviewed` handoff. Missing, inferred, declined, sensitive, or stale answers fail closed without retry. Refresh and review canonical state; browser drafts are not overwritten. This flow opens no portal and performs no final action.
 
 New resume records import a private managed copy rather than retaining the source
 path. Imports accept PDF, DOCX, and UTF-8 TXT files up to 10 MiB, reject duplicate

--- a/native/macos/job_apply_account_flow_helper.swift
+++ b/native/macos/job_apply_account_flow_helper.swift
@@ -667,14 +667,22 @@ private final class OracleEmailOnlyEffect {
         guard AXUIElementSetAttributeValue(
             exactControl, kAXValueAttribute as CFString, email as CFString
         ) == .success else { throw AccountFlowHelperError.emailEffect }
-        let reattestedForm = try exactAccountForm(page)
-        let reattestedEmail = binding.isSynthetic
-            ? try exact(elements(reattestedForm), id: "job-apply-email-control")
-            : try reviewedControls(reattestedForm).email
-        guard CFEqual(reattestedEmail, exactControl),
-              binding.isSynthetic || reviewedFingerprint(reattestedEmail) == binding.emailControlFingerprint,
-              string(reattestedEmail, kAXValueAttribute as CFString) == email
-        else { throw AccountFlowHelperError.emailEffect }
+        // Chromium can acknowledge the single native write before its AX tree
+        // publishes the new value. Reobserve only; never repeat the effect.
+        for _ in 0..<20 {
+            if let reattestedForm = try? exactAccountForm(page),
+               let reattestedEmail = try? (binding.isSynthetic
+                    ? exact(elements(reattestedForm), id: "job-apply-email-control")
+                    : reviewedControls(reattestedForm).email),
+               CFEqual(reattestedEmail, exactControl),
+               (binding.isSynthetic
+                    || reviewedFingerprint(reattestedEmail) == binding.emailControlFingerprint),
+               string(reattestedEmail, kAXValueAttribute as CFString) == email {
+                return
+            }
+            usleep(50_000)
+        }
+        throw AccountFlowHelperError.emailEffect
     }
 
     func perform(email: String) throws {

--- a/native/macos/job_apply_account_flow_helper.swift
+++ b/native/macos/job_apply_account_flow_helper.swift
@@ -440,7 +440,7 @@ private final class OracleEmailOnlyEffect {
         // A freshly launched signed browser can briefly exist before AppKit and
         // Security.framework expose a consistent running/active view. Poll only
         // this pre-effect proof; no form control is read or mutated here.
-        for _ in 0..<20 {
+        for _ in 0..<100 {
             if kill(binding.browserProcessIdentifier, 0) == 0,
                AXIsProcessTrusted(), signedBrowser(),
                let running = NSRunningApplication(

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "test:qa-browser": "node --test --test-concurrency=1 tests_js/*.test.mjs",
+    "qa:unified-task-spine": "node qa/unified_task_spine_oracle.mjs --json",
     "test:auto-submit": "python3 scripts/qa-replay.py verify-auto-submit --fixture qa/fixtures/linkedin-easy-apply-screening-2026-08-v1/fixture.json --json",
     "test:qa-screening": "PYTHONPATH=tests python3 -m unittest -v test_qa_replay_cli.CommittedScenarioTests.test_linkedin_screening_scenario_is_closed_and_synthetic test_qa_replay_cli.CommittedScenarioTests.test_linkedin_screening_fresh_prepare_evaluate_cleanup_lifecycle test_qa_server_oracle.SemanticOracleTests.test_committed_linkedin_screening_fixture_passes_with_closed_identity && node --test --test-name-pattern='committed LinkedIn screening' tests_js/renderer.test.mjs",
     "qa:record": "node qa/recorder.mjs"

--- a/qa/unified_task_spine_oracle.mjs
+++ b/qa/unified_task_spine_oracle.mjs
@@ -1,0 +1,384 @@
+#!/usr/bin/env node
+
+import { strict as assert } from "node:assert";
+import { spawn, spawnSync } from "node:child_process";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const PYTHON = process.env.PYTHON || "python3";
+const PASS_REPORT = Object.freeze({
+  schemaVersion: 1,
+  oracle: "unified_task_spine",
+  result: "pass",
+  closed: true,
+  proof: {
+    isolatedStore: true,
+    uxFirstIntake: true,
+    agentFirstCanonicalIntake: true,
+    duplicateConvergence: true,
+    sharedComparisonSnapshot: true,
+    ownerConfirmedExactRevisionSelection: true,
+    oneCanonicalAcquisitionTarget: true,
+    sharedActivity: true,
+    sharedNeedsAttention: true,
+    durableLinkedAnswerResolved: true,
+    unsavedJobDraftPreserved: true,
+    managedResumeContinuity: true,
+    detachedStoreScopedAttemptBroker: true,
+    launcherTeardownAndIndependentClients: true,
+    awaitingReviewInBothClients: true,
+    privacySafeTranscript: true,
+    zeroFinalActions: true,
+    cleanupComplete: true,
+  },
+  counts: {
+    canonicalJobs: 2,
+    canonicalAcquisitionTargets: 1,
+    sequentialAcquisitions: 2,
+    finalActionEvents: 0,
+  },
+  transcript: [
+    "ux_intake_saved",
+    "agent_intake_created",
+    "duplicate_converged",
+    "comparison_shared",
+    "owner_selected_exact_revision",
+    "canonical_job_acquired",
+    "needs_attention_shared",
+    "linked_answer_resolved",
+    "canonical_job_reacquired",
+    "awaiting_review_shared",
+    "closed_without_final_action",
+  ],
+});
+
+class OracleFailure extends Error {}
+
+function check(condition, code) {
+  if (!condition) throw new OracleFailure(code);
+}
+
+function syntheticPdf() {
+  const header = "%PDF-1.7\n";
+  const objects = [
+    "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+    "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+    "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>\nendobj\n",
+  ];
+  const offsets = [];
+  let body = header;
+  for (const object of objects) {
+    offsets.push(Buffer.byteLength(body));
+    body += object;
+  }
+  const xrefOffset = Buffer.byteLength(body);
+  const entries = offsets.map((offset) => `${String(offset).padStart(10, "0")} 00000 n \n`).join("");
+  return Buffer.from(`${body}xref\n0 4\n0000000000 65535 f \n${entries}trailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`);
+}
+
+function waitForStartup(child) {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    const timeout = setTimeout(() => reject(new OracleFailure("server_start_timeout")), 10_000);
+    child.stdout.setEncoding("utf8");
+    child.stderr.resume();
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      const newline = stdout.indexOf("\n");
+      if (newline < 0) return;
+      clearTimeout(timeout);
+      try {
+        resolve(JSON.parse(stdout.slice(0, newline)));
+      } catch {
+        reject(new OracleFailure("server_start_invalid"));
+      }
+    });
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      reject(new OracleFailure("server_start_failed"));
+    });
+  });
+}
+
+function privateAttempt(script, storeRoot, jobId, owner, expectedRevision, temporary) {
+  let inputCounter = 0;
+  const client = async (name, args = [], payload) => {
+    const finalArgs = [script, "--root", storeRoot, name, ...args];
+    let inputPath;
+    if (payload !== undefined) {
+      inputPath = join(temporary, `attempt-input-${inputCounter++}.json`);
+      await writeFile(inputPath, JSON.stringify(payload));
+      finalArgs.push("--input", inputPath);
+    }
+    const result = spawnSync(PYTHON, finalArgs, {
+      cwd: REPO_ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (inputPath) await rm(inputPath, { force: true });
+    check(result.status === 0 && result.stderr === "", "attempt_client_failed");
+    let response;
+    try { response = JSON.parse(result.stdout); } catch { response = null; }
+    check(response?.ok, "attempt_command_failed");
+    return response;
+  };
+  return {
+    async start() {
+      const response = await client("start", [
+        "--id", jobId, "--owner", owner,
+        "--expected-revision", String(expectedRevision),
+      ]);
+      check(response?.ok && response.event === "acquired", "attempt_acquire_failed");
+      return response.attempt;
+    },
+    async send(request) {
+      if (request.command === "heartbeat" && Object.keys(request).length === 1) {
+        return client("heartbeat");
+      }
+      if (request.command === "progress" && Object.keys(request).length === 2) {
+        return client("progress", [], request.session);
+      }
+      if (request.command === "handoff" && Object.keys(request).length === 3) {
+        return client("handoff", ["--status", request.status], request.session);
+      }
+      throw new OracleFailure("attempt_request_invalid");
+    },
+    async completed() {},
+  };
+}
+
+async function stopServer(child) {
+  if (!child || child.exitCode !== null) return true;
+  child.kill("SIGINT");
+  const code = await new Promise((resolve) => child.once("exit", resolve));
+  return code === 0;
+}
+
+function publicReportIsSafe(report) {
+  const serialized = JSON.stringify(report);
+  const forbidden = [
+    "claim_", "https://", "http://", "answerKey", "answerValue", "resumePath",
+    "browserState", "credential", "bearer", "token", tmpdir(), REPO_ROOT,
+  ];
+  return forbidden.every((value) => !serialized.toLowerCase().includes(value.toLowerCase()));
+}
+
+export async function runOracle() {
+  const temporary = await mkdtemp(join(tmpdir(), "unified-task-spine-"));
+  const storeRoot = join(temporary, "store");
+  const storeScript = join(REPO_ROOT, "scripts", "job-apply-store.py");
+  const taskScript = join(REPO_ROOT, "scripts", "job-apply-task.py");
+  const attemptScript = join(REPO_ROOT, "scripts", "job-apply-attempt.py");
+  let inputCounter = 0;
+  let server;
+  let browser;
+  let serverStopped = false;
+  let browserStopped = false;
+  let storeRemoved = false;
+  const attempts = [];
+
+  const command = async (script, name, args = [], payload) => {
+    const finalArgs = [script, "--root", storeRoot, name, ...args];
+    if (payload !== undefined) {
+      const inputPath = join(temporary, `input-${inputCounter++}.json`);
+      await writeFile(inputPath, JSON.stringify(payload));
+      finalArgs.push("--input", inputPath);
+    }
+    const result = spawnSync(PYTHON, finalArgs, {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (result.status !== 0) {
+      let failureCode = "rejected";
+      try { failureCode = JSON.parse(result.stdout)?.error?.code || failureCode; } catch {}
+      throw new OracleFailure(`${name}_${failureCode}`);
+    }
+    try {
+      return JSON.parse(result.stdout);
+    } catch {
+      throw new OracleFailure("cli_invalid_json");
+    }
+  };
+  const store = (name, args = [], payload) => command(storeScript, name, args, payload);
+  const task = (name, args = [], payload) => command(taskScript, name, args, payload);
+
+  try {
+    await store("profile-replace", ["--expected-revision", "0", "--source", "user"], { firstName: "Synthetic" });
+    const sourceResume = join(temporary, "synthetic-resume.pdf");
+    await writeFile(sourceResume, syntheticPdf());
+    const resume = await store("resume-create", [], { id: "oracle-resume", label: "Synthetic resume", path: sourceResume });
+
+    server = spawn(PYTHON, [
+      join(REPO_ROOT, "scripts", "job-apply-workspace.py"),
+      "--root", storeRoot, "--port", "0", "--no-open", "--json",
+    ], { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"] });
+    const startup = await waitForStartup(server);
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+    const pageErrors = [];
+    page.on("pageerror", () => pageErrors.push(true));
+    await page.addInitScript(() => { globalThis.setInterval = () => 0; });
+    await page.goto(startup.url);
+    await page.getByText("Canonical store connected").waitFor();
+
+    const uxUrl = "https://ux-first.example.invalid/jobs/canonical";
+    await page.getByRole("button", { name: "Jobs", exact: true }).click();
+    await page.getByRole("button", { name: "New job" }).click();
+    const jobDialog = page.locator("#job-dialog");
+    await jobDialog.getByLabel("Job URL").fill(uxUrl);
+    await jobDialog.getByLabel("Role").fill("UX First Role");
+    await jobDialog.getByLabel("Company").fill("Synthetic Company");
+    await jobDialog.getByLabel("Priority").fill("5");
+    await jobDialog.getByLabel("Resume").selectOption(resume.id);
+    await jobDialog.getByRole("button", { name: "Save job" }).click();
+    await jobDialog.waitFor({ state: "hidden" });
+
+    let jobs = await store("job-list");
+    check(jobs.length === 1 && jobs[0].role === "UX First Role", "ux_intake_failed");
+    const selectedId = jobs[0].id;
+
+    const agentUrl = "https://agent-first.example.invalid/jobs/comparison";
+    const agent = await task("intake", [], {
+      url: agentUrl, role: "Agent First Role", company: "Synthetic Company",
+    });
+    check(agent.ok && agent.action === "create", "agent_intake_failed");
+    const duplicate = await task("intake", [], { url: uxUrl, role: "UX First Role" });
+    check(duplicate.ok && duplicate.job.id === selectedId && duplicate.action !== "create", "duplicate_did_not_converge");
+
+    const beforeSelection = await task("snapshot");
+    check(beforeSelection.ok && beforeSelection.snapshot.jobs.length === 2, "snapshot_job_count");
+    check(beforeSelection.snapshot.jobs.every((job) => (
+      typeof job.role === "string" && typeof job.company === "string"
+      && Number.isInteger(job.priority) && Number.isInteger(job.revision)
+    )), "snapshot_missing_comparison_inputs");
+    const candidate = beforeSelection.snapshot.jobs.find((job) => job.id === selectedId);
+    check(candidate?.status === "saved", "selection_candidate_missing");
+    const selection = await task("select", [
+      "--id", selectedId, "--expected-revision", String(candidate.revision), "--owner-confirmed",
+    ]);
+    check(selection.ok && selection.job.status === "ready" && selection.job.revision > candidate.revision, "selection_failed");
+
+    const firstSession = privateAttempt(
+      attemptScript, storeRoot, selectedId, "synthetic-agent", selection.job.revision, temporary,
+    );
+    attempts.push(firstSession);
+    const first = await firstSession.start();
+    const resumeBytesBefore = await readFile(first.resume.path);
+    const pending = {
+      status: "active", step: "questions", answerKeys: [],
+      pendingFields: [{ question: "Shared visible wording?", state: "missing", answerKey: "durable.target", sensitive: false }],
+    };
+    await firstSession.send({ command: "heartbeat" });
+    await firstSession.send({ command: "progress", session: pending });
+    await firstSession.send({ command: "handoff", status: "needs_info", session: pending });
+    await firstSession.completed();
+    await store("answer-put", [], {
+      key: "durable.decoy", question: "Shared visible wording?", scope: { decoy: true },
+      state: "confirmed", value: "synthetic decoy",
+    });
+    await store("answer-put", [], { key: "durable.target", question: "Different canonical wording", state: "missing" });
+
+    const activity = await task("activity", ["--id", selectedId]);
+    check(activity.activity.job.status === "needs_info", "activity_not_blocked");
+    check(activity.activity.session.pendingInformation.length === 1, "activity_pending_count");
+    check(beforeSelection.snapshot.attention.items.length === 0, "attention_not_initially_empty");
+    const blockedSnapshot = await task("snapshot");
+    check(blockedSnapshot.snapshot.attention.items.some((item) => item.jobId === selectedId), "cli_attention_missing");
+
+    await page.reload();
+    await page.getByText("Canonical store connected").waitFor();
+    await page.locator("#nav-attention").click();
+    await page.getByRole("button", { name: /UX First Role/ }).click();
+    await jobDialog.getByText(/Canonical status needs info/i).waitFor();
+    await jobDialog.getByRole("heading", { name: "Application activity" }).waitFor();
+    await jobDialog.getByLabel("Notes").fill("unsaved synthetic draft");
+    const openAnswer = jobDialog.getByRole("button", { name: "Open in Answers" });
+    await openAnswer.click();
+    const answerDialog = page.locator("#answer-dialog");
+    await answerDialog.waitFor({ state: "visible" });
+    check(await answerDialog.getByLabel("Question").inputValue() === "Different canonical wording", "wrong_linked_answer");
+    check(await jobDialog.getByLabel("Notes").inputValue() === "unsaved synthetic draft", "draft_lost_on_navigation");
+    await answerDialog.getByLabel("State").selectOption("confirmed");
+    await answerDialog.getByLabel("Value", { exact: true }).fill("synthetic accepted value");
+    await answerDialog.getByRole("button", { name: "Save answer" }).click();
+    await answerDialog.waitFor({ state: "hidden" });
+    check(await jobDialog.getByLabel("Notes").inputValue() === "unsaved synthetic draft", "draft_lost_on_answer_save");
+    await openAnswer.waitFor();
+    check(await openAnswer.evaluate((button) => document.activeElement === button), "focus_not_restored");
+    await jobDialog.getByRole("button", { name: "Recheck this revision" }).click();
+    await jobDialog.getByText(/Canonical status ready/i).waitFor();
+    check(await jobDialog.getByLabel("Notes").inputValue() === "unsaved synthetic draft", "draft_lost_on_resolution");
+    await jobDialog.getByRole("button", { name: "Close job details" }).click();
+
+    const ready = await store("job-get", ["--id", selectedId]);
+    check(ready.status === "ready" && ready.revision > first.job.revision, "resolution_not_ready");
+    const secondSession = privateAttempt(
+      attemptScript, storeRoot, selectedId, "synthetic-agent-resume", ready.revision, temporary,
+    );
+    attempts.push(secondSession);
+    const second = await secondSession.start();
+    for (const field of ["id", "revision", "contentRevision", "digest"]) {
+      check(second.resume[field] === first.resume[field], "resume_identity_changed");
+    }
+    check(Buffer.compare(await readFile(second.resume.path), resumeBytesBefore) === 0, "resume_bytes_changed");
+    await secondSession.send({
+      command: "handoff", status: "awaiting_review",
+      session: { status: "review", step: "review", pendingFields: [] },
+    });
+    await secondSession.completed();
+
+    const finalActivity = await task("activity", ["--id", selectedId]);
+    const finalSnapshot = await task("snapshot");
+    check(finalActivity.activity.job.status === "awaiting_review", "cli_not_awaiting_review");
+    check(finalSnapshot.snapshot.jobs.find((job) => job.id === selectedId)?.status === "awaiting_review", "snapshot_not_awaiting_review");
+    await page.getByRole("button", { name: "Jobs", exact: true }).click();
+    await page.locator("#refresh").click();
+    await page.getByRole("button", { name: /UX First Role/ }).click();
+    await jobDialog.getByText(/Canonical status awaiting review/i).waitFor();
+
+    jobs = await store("job-list");
+    const events = await store("history-list");
+    const selectedIds = new Set(events.filter((event) => event.event === "job-started").map((event) => event.applicationId));
+    check(jobs.length === 2, "canonical_job_count_changed");
+    check(selectedIds.size === 1 && selectedIds.has(selectedId), "multiple_acquisition_targets");
+    check(events.map((event) => event.event).join(",") === "job-started,job-blocked,job-started,reviewed", "history_not_closed");
+    check(!events.some((event) => ["applied", "completed"].includes(event.event) || event.status === "applied"), "final_action_detected");
+    check(pageErrors.length === 0, "browser_error");
+    check(publicReportIsSafe(PASS_REPORT), "report_privacy_failure");
+    assert.notEqual(process.env.JOB_APPLY_STORE_ROOT, storeRoot);
+  } finally {
+    const brokerPidPath = join(storeRoot, ".job-apply-attempt.pid");
+    try {
+      const brokerPid = Number((await readFile(brokerPidPath, "utf8")).trim());
+      if (Number.isInteger(brokerPid) && brokerPid > 1) process.kill(brokerPid, "SIGKILL");
+    } catch {}
+    if (browser) {
+      await browser.close().catch(() => {});
+      browserStopped = true;
+    }
+    serverStopped = await stopServer(server).catch(() => false);
+    await rm(temporary, { recursive: true, force: true }).catch(() => {});
+    storeRemoved = await access(temporary).then(() => false, () => true);
+  }
+  check(browserStopped && serverStopped && storeRemoved, "cleanup_failed");
+  return PASS_REPORT;
+}
+
+async function main() {
+  if (process.argv.length !== 3 || process.argv[2] !== "--json") {
+    process.stdout.write(`${JSON.stringify({ schemaVersion: 1, oracle: "unified_task_spine", result: "fail", closed: true, error: "invalid_invocation" })}\n`);
+    process.exitCode = 2;
+    return;
+  }
+  try {
+    process.stdout.write(`${JSON.stringify(await runOracle())}\n`);
+  } catch {
+    process.stdout.write(`${JSON.stringify({ schemaVersion: 1, oracle: "unified_task_spine", result: "fail", closed: true, error: "oracle_failed" })}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main();

--- a/scripts/job-apply-attempt.py
+++ b/scripts/job-apply-attempt.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Detached, Store-scoped broker for one canonical application attempt."""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import hashlib
+import importlib.util
+import json
+import os
+import signal
+import socket
+import stat
+import struct
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+HEARTBEAT_SECONDS = 60.0
+STARTUP_SECONDS = 10.0
+IDLE_SECONDS = 10.0
+PID_NAME = ".job-apply-attempt.pid"
+MAX_REQUEST_BYTES = 1024 * 1024
+
+
+def load_store_module() -> Any:
+    path = Path(__file__).resolve().with_name("job-apply-store.py")
+    spec = importlib.util.spec_from_file_location("job_apply_attempt_store", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("canonical store unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+STORE: Any | None = None
+
+
+def store_module() -> Any:
+    global STORE
+    if STORE is None:
+        STORE = load_store_module()
+    return STORE
+
+
+class InvalidInvocation(ValueError):
+    """A public command or argument is outside the closed client surface."""
+
+
+class AttemptParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        del message
+        raise InvalidInvocation("invalid invocation")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = AttemptParser(description=__doc__)
+    parser.add_argument("--root")
+    commands = parser.add_subparsers(dest="command", required=True)
+    start = commands.add_parser("start")
+    start.add_argument("--id", required=True)
+    start.add_argument("--owner", required=True)
+    start.add_argument("--expected-revision", required=True, type=int)
+    commands.add_parser("heartbeat")
+    progress = commands.add_parser("progress")
+    progress.add_argument("--input", required=True)
+    handoff = commands.add_parser("handoff")
+    handoff.add_argument("--status", required=True, choices=("needs_info", "awaiting_review"))
+    handoff.add_argument("--input", required=True)
+    return parser
+
+
+def resolve_root(configured: str | None) -> Path:
+    store = store_module()
+    value = configured or os.environ.get(store.STORE_ENV)
+    return (Path(value).expanduser() if value else Path.home() / ".job-apply").resolve()
+
+
+def socket_path(root: Path) -> Path:
+    root = root.resolve()
+    runtime = Path("/tmp") / f"job-apply-attempt-{os.getuid()}"
+    try:
+        runtime.mkdir(mode=0o700)
+    except FileExistsError:
+        pass
+    details = runtime.lstat()
+    if stat.S_ISLNK(details.st_mode) or not stat.S_ISDIR(details.st_mode):
+        raise RuntimeError("attempt runtime unavailable")
+    if details.st_uid != os.getuid() or stat.S_IMODE(details.st_mode) != 0o700:
+        raise RuntimeError("attempt runtime unavailable")
+    scope = hashlib.sha256(os.fsencode(root)).hexdigest()
+    return runtime / f"{scope}.sock"
+
+
+def pid_path(root: Path) -> Path:
+    return root / PID_NAME
+
+
+def emit(value: dict[str, Any]) -> None:
+    json.dump(value, sys.stdout, sort_keys=True, ensure_ascii=False)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def public_acquisition(acquired: dict[str, Any]) -> dict[str, Any]:
+    job = acquired["job"]
+    resume = acquired["resume"]
+    return {
+        "job": {key: job[key] for key in ("id", "revision", "url") if key in job},
+        "resume": {
+            key: resume[key]
+            for key in ("id", "revision", "contentRevision", "digest", "path")
+            if key in resume
+        },
+    }
+
+
+def read_json_object(path: str) -> dict[str, Any]:
+    value = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("invalid input")
+    return value
+
+
+def peer_is_current_user(connection: socket.socket) -> bool:
+    if hasattr(connection, "getpeereid"):
+        uid, _gid = connection.getpeereid()  # type: ignore[attr-defined]
+        return uid == os.getuid()
+    if hasattr(socket, "SO_PEERCRED"):
+        credentials = connection.getsockopt(
+            socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i")
+        )
+        _pid, uid, _gid = struct.unpack("3i", credentials)
+        return uid == os.getuid()
+    # Some macOS Python builds expose neither peer-credential API. The socket
+    # still authenticates through its 0600 mode inside the Store's 0700 root:
+    # only this OS user (and the OS superuser) can open the endpoint.
+    return os.name == "posix" and connection.family == socket.AF_UNIX
+
+
+def receive_request(connection: socket.socket) -> dict[str, Any]:
+    chunks = bytearray()
+    while b"\n" not in chunks:
+        chunk = connection.recv(65536)
+        if not chunk:
+            raise ValueError("incomplete request")
+        chunks.extend(chunk)
+        if len(chunks) > MAX_REQUEST_BYTES:
+            raise ValueError("request too large")
+    line, remainder = bytes(chunks).split(b"\n", 1)
+    if remainder or not line:
+        raise ValueError("invalid request framing")
+    value = json.loads(line.decode("utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("invalid request")
+    return value
+
+
+def send_response(connection: socket.socket, value: dict[str, Any]) -> None:
+    connection.sendall(
+        json.dumps(value, sort_keys=True, ensure_ascii=False).encode("utf-8") + b"\n"
+    )
+
+
+class AttemptBroker:
+    """Own exactly one Store claim and never disclose or persist its bearer."""
+
+    def __init__(self, root: Path, heartbeat_seconds: float = HEARTBEAT_SECONDS) -> None:
+        self.root = root
+        self.store = store_module().Store(root)
+        self.heartbeat_seconds = heartbeat_seconds
+        self.job_id: str | None = None
+        self.expected_revision: int | None = None
+        self._token: str | None = None
+        self._stop = threading.Event()
+        self._heartbeat_failed = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def acquire(self, request: dict[str, Any]) -> dict[str, Any]:
+        if self._token is not None or self.job_id is not None:
+            raise ValueError("attempt already acquired")
+        if set(request) != {"command", "id", "owner", "expectedRevision"}:
+            raise ValueError("invalid request")
+        if request["command"] != "start" or not isinstance(request["expectedRevision"], int):
+            raise ValueError("invalid request")
+        acquired = self.store.acquire_ready_job(
+            request["id"], request["owner"], request["expectedRevision"]
+        )
+        self.job_id = request["id"]
+        self._token = acquired.pop("token")
+        acquired.pop("claim", None)
+        self.expected_revision = acquired["job"]["revision"]
+        self._thread = threading.Thread(target=self._heartbeat_loop, daemon=True)
+        self._thread.start()
+        return {"ok": True, "event": "acquired", "attempt": public_acquisition(acquired)}
+
+    def _heartbeat(self) -> None:
+        if self._token is None or self.job_id is None or self._stop.is_set():
+            raise RuntimeError("attempt is not active")
+        self.store.heartbeat_claim(self.job_id, self._token)
+
+    def _heartbeat_loop(self) -> None:
+        while not self._stop.wait(self.heartbeat_seconds):
+            try:
+                self._heartbeat()
+            except Exception:
+                self._heartbeat_failed.set()
+                self._stop.set()
+                return
+
+    def dispatch(self, request: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+        if self._token is None or self.job_id is None or self._stop.is_set():
+            raise ValueError("attempt is not active")
+        if self._heartbeat_failed.is_set():
+            raise RuntimeError("attempt heartbeat failed")
+        command = request.get("command")
+        if command == "heartbeat":
+            if set(request) != {"command"}:
+                raise ValueError("invalid request")
+            self._heartbeat()
+            return {"ok": True, "event": "heartbeat"}, False
+        if command == "progress":
+            if set(request) != {"command", "session"} or not isinstance(request["session"], dict):
+                raise ValueError("invalid request")
+            self.store.save_claim_progress(self.job_id, self._token, request["session"])
+            return {"ok": True, "event": "progress_saved"}, False
+        if command == "handoff":
+            if set(request) != {"command", "status", "session"}:
+                raise ValueError("invalid request")
+            status = request["status"]
+            if status not in {"needs_info", "awaiting_review"} or not isinstance(request["session"], dict):
+                raise ValueError("invalid request")
+            self.store.handoff_claimed_job(
+                self.job_id, self._token, status, request["session"], self.expected_revision,
+            )
+            self._token = None
+            return {"ok": True, "event": "handed_off", "status": status}, True
+        raise ValueError("invalid request")
+
+    def close(self) -> None:
+        # Broker loss deliberately leaves Store claim state untouched.
+        self._stop.set()
+        self._token = None
+        if self._thread is not None and self._thread is not threading.current_thread():
+            self._thread.join(timeout=1)
+
+
+def connect(path: Path, timeout: float = STARTUP_SECONDS) -> socket.socket:
+    connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    connection.settimeout(timeout)
+    connection.connect(str(path))
+    return connection
+
+
+def broker_reachable(path: Path) -> bool:
+    try:
+        connection = connect(path, timeout=0.2)
+    except OSError:
+        return False
+    connection.close()
+    return True
+
+
+def bind_listener(path: Path) -> socket.socket:
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        listener.bind(str(path))
+    except OSError as error:
+        if error.errno != errno.EADDRINUSE or broker_reachable(path):
+            listener.close()
+            raise
+        path.unlink(missing_ok=True)
+        listener.bind(str(path))
+    path.chmod(0o600)
+    listener.listen(8)
+    listener.settimeout(0.5)
+    return listener
+
+
+def run_broker(root: Path) -> int:
+    path = socket_path(root)
+    process_path = pid_path(root)
+    broker = AttemptBroker(root)
+    listener = bind_listener(path)
+    process_path.write_text(f"{os.getpid()}\n", encoding="ascii")
+    process_path.chmod(0o600)
+    acquired = False
+    deadline = time.monotonic() + IDLE_SECONDS
+
+    def stop(_signum: int, _frame: Any) -> None:
+        broker._stop.set()
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    try:
+        while not broker._stop.is_set():
+            if not acquired and time.monotonic() >= deadline:
+                break
+            try:
+                connection, _address = listener.accept()
+            except socket.timeout:
+                continue
+            with connection:
+                try:
+                    if not peer_is_current_user(connection):
+                        raise PermissionError("peer rejected")
+                    request = receive_request(connection)
+                    if not acquired:
+                        response = broker.acquire(request)
+                        acquired = True
+                        complete = False
+                    else:
+                        response, complete = broker.dispatch(request)
+                except Exception:
+                    response = {"ok": False, "error": {"code": "request_rejected"}}
+                    complete = not acquired
+                try:
+                    send_response(connection, response)
+                except OSError:
+                    pass
+                if complete:
+                    break
+        return 0
+    finally:
+        broker.close()
+        listener.close()
+        path.unlink(missing_ok=True)
+        try:
+            if process_path.read_text(encoding="ascii").strip() == str(os.getpid()):
+                process_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def detached_broker(root: Path) -> None:
+    subprocess.Popen(
+        [sys.executable, str(Path(__file__).resolve()), "--broker", "--root", str(root)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+        close_fds=True,
+    )
+
+
+def request_broker(root: Path, request: dict[str, Any], start: bool = False) -> dict[str, Any]:
+    path = socket_path(root)
+    deadline = time.monotonic() + STARTUP_SECONDS
+    launched = False
+    while True:
+        try:
+            with connect(path, timeout=1.0) as connection:
+                send_response(connection, request)
+                return receive_request(connection)
+        except OSError:
+            if not start:
+                raise RuntimeError("attempt unavailable")
+            if not launched:
+                detached_broker(root)
+                launched = True
+            if time.monotonic() >= deadline:
+                raise RuntimeError("attempt unavailable")
+            time.sleep(0.05)
+
+
+def run_client(args: argparse.Namespace) -> int:
+    root = resolve_root(args.root)
+    if args.command == "start":
+        request = {
+            "command": "start", "id": args.id, "owner": args.owner,
+            "expectedRevision": args.expected_revision,
+        }
+    elif args.command == "heartbeat":
+        request = {"command": "heartbeat"}
+    elif args.command == "progress":
+        request = {"command": "progress", "session": read_json_object(args.input)}
+    else:
+        request = {
+            "command": "handoff", "status": args.status,
+            "session": read_json_object(args.input),
+        }
+    response = request_broker(root, request, start=args.command == "start")
+    emit(response)
+    return 0 if response.get("ok") else 2
+
+
+def main() -> int:
+    try:
+        if "--broker" in sys.argv[1:]:
+            internal = AttemptParser(add_help=False)
+            internal.add_argument("--broker", action="store_true")
+            internal.add_argument("--root", required=True)
+            args = internal.parse_args()
+            return run_broker(resolve_root(args.root))
+        return run_client(build_parser().parse_args())
+    except InvalidInvocation:
+        emit({"ok": False, "error": {"code": "invalid_invocation"}})
+        return 2
+    except Exception:
+        emit({"ok": False, "error": {"code": "attempt_unavailable"}})
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -100,6 +100,7 @@ PROFILE_NAMED_TOP_LEVEL = {
 REPLAY_TRANSITIONS = {"started", "reviewed"}
 REPLAY_ATS = {"ashby", "greenhouse", "lever", "linkedin-easy-apply"}
 SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+PENDING_REFERENCE = re.compile(r"^pending_[a-f0-9]{32}$")
 CLAIM_LEASE_SECONDS = 300
 CLAIM_HEARTBEAT_SECONDS = 60
 OVERVIEW_DIGEST_CACHE_SECONDS = 30
@@ -1231,7 +1232,7 @@ def _validate_session_document(session: dict[str, Any]) -> None:
     pending_fields = session.get("pendingFields", [])
     if not isinstance(pending_fields, list):
         raise StoreError("session pendingFields must be a list")
-    pending_allowed = {"question", "state", "answerKey", "sensitive"}
+    pending_allowed = {"question", "state", "answerKey", "sensitive", "reference"}
     for value in pending_fields:
         field = _require_object(value, "pending field")
         if set(field) - pending_allowed:
@@ -1243,6 +1244,8 @@ def _validate_session_document(session: dict[str, Any]) -> None:
             raise StoreError("pending field state is unsupported")
         if "sensitive" in field and not isinstance(field["sensitive"], bool):
             raise StoreError("pending field sensitive must be a boolean")
+        if "reference" not in field or not isinstance(field["reference"], str) or PENDING_REFERENCE.fullmatch(field["reference"]) is None:
+            raise StoreError("pending field reference is invalid")
     _validate_optional_strings(
         session,
         {
@@ -2034,6 +2037,31 @@ class Store:
                 result_claim = operation.get("resultClaim")
                 if result_claim is not None:
                     _validate_claim_record(result_claim)
+                return document
+            if kind == "answer_resolution":
+                expected = {
+                    "kind", "operationId", "jobId", "at", "answerKey",
+                    "expectedJobRevision", "expectedSessionRevision",
+                    "expectedAnswerRevision", "sourceStatus", "targetStatus",
+                    "session", "resultClaim",
+                }
+                if set(operation) != expected:
+                    raise StoreError("coordinator answer resolution operation is invalid")
+                job_id = _safe_session_id(operation.get("jobId", ""))
+                if not all(isinstance(operation.get(field), str) and operation[field] for field in ("operationId", "at", "answerKey")):
+                    raise StoreError("coordinator answer resolution operation is invalid")
+                for field in ("expectedJobRevision", "expectedSessionRevision", "expectedAnswerRevision"):
+                    revision = operation.get(field)
+                    if not isinstance(revision, int) or isinstance(revision, bool) or revision < 1:
+                        raise StoreError("coordinator answer resolution revision is invalid")
+                if operation.get("sourceStatus") != "needs_info" or operation.get("targetStatus") not in {"needs_info", "ready"}:
+                    raise StoreError("coordinator answer resolution transition is invalid")
+                session = _require_object(operation.get("session"), "coordinator session")
+                _validate_session_document(session)
+                if session.get("applicationId") != job_id:
+                    raise StoreError("coordinator answer resolution session is invalid")
+                if operation.get("resultClaim") is not None:
+                    raise StoreError("coordinator answer resolution cannot create a claim")
                 return document
             common = {"kind", "operationId", "jobId", "at", "historyEvent", "resultClaim"}
             transition = {"sourceStatus", "targetStatus", "expectedRevision"}
@@ -4033,6 +4061,145 @@ class Store:
             ),
         )
 
+    @staticmethod
+    def _task_job_projection(record: dict[str, Any]) -> dict[str, Any]:
+        """Project one canonical job without URLs, notes, or provenance."""
+
+        return {
+            key: record[key]
+            for key in (
+                "id", "role", "company", "location", "workplaceType",
+                "employmentType", "status", "priority", "revision", "createdAt",
+                "updatedAt",
+            )
+            if key in record
+        }
+
+    def task_snapshot(self) -> dict[str, Any]:
+        """Return the shared, Store-owned task view used for job discussion."""
+
+        self.initialize()
+        self._ensure_coordinator_files()
+        with exclusive_file_lock(self.store_lock_path):
+            profile = self._load_profile_document()["profile"]
+            jobs = [
+                item for item in self._load_jobs_document()["jobs"].values()
+                if item.get("deletedAt") is None
+            ]
+            resumes = [
+                item for item in self._load_resumes_document()["resumes"].values()
+                if item.get("deletedAt") is None
+            ]
+            answers = [
+                item for item in self._load_answers_document()["answers"].values()
+                if item.get("deletedAt") is None
+                and item.get("reviewStatus", "accepted") == "accepted"
+            ]
+            claim = self._load_coordinator_document()["claim"]
+            now = self._now_datetime()
+            overview = self._owner_beta_overview_locked(
+                profile, jobs, resumes, answers, claim, now
+            )
+            projected_jobs = [
+                self._task_job_projection(item)
+                for item in sorted(
+                    jobs,
+                    key=lambda item: (
+                        -item.get("priority", 0),
+                        item.get("createdAt", ""),
+                        item["id"],
+                    ),
+                )
+            ]
+            attention = self._needs_attention_locked(
+                {item["id"]: item for item in jobs}, claim, now
+            )
+        signature_input = {
+            "overview": overview,
+            "jobs": projected_jobs,
+            "attentionSignature": attention["snapshotSignature"],
+        }
+        return {
+            "overview": overview,
+            "jobs": projected_jobs,
+            "attention": attention,
+            "snapshotSignature": hashlib.sha256(
+                _canonical_json(signature_input).encode("utf-8")
+            ).hexdigest(),
+        }
+
+    def intake_task_job(
+        self, incoming: dict[str, Any], origin: str = "agent"
+    ) -> dict[str, Any]:
+        """Atomically resolve or create exactly one active canonical job."""
+
+        self.initialize()
+        origin = _job_origin(origin)
+        payload = {"jobs": [incoming]}
+        with exclusive_file_lock(self.store_lock_path):
+            document = self._load_jobs_document()
+            planned, decisions, changed = self._plan_job_upsert(
+                document, payload, origin, utc_now()
+            )
+            if len(decisions) != 1:
+                raise StoreError("task intake did not resolve exactly one job")
+            decision = decisions[0]
+            if decision["action"] in {"conflict", "invalid"}:
+                raise StoreError(f"task intake {decision['action']}")
+            job_id = decision.get("id")
+            record = planned["jobs"].get(job_id)
+            if (
+                not isinstance(job_id, str)
+                or record is None
+                or record.get("deletedAt") is not None
+            ):
+                raise StoreError("task intake did not resolve one active job")
+            if changed:
+                atomic_write_json(self.jobs_path, planned)
+        return {
+            "action": decision["action"],
+            "job": self._task_job_projection(record),
+        }
+
+    def select_task_job_ready(
+        self, job_id: str, expected_revision: int, owner_confirmed: bool
+    ) -> dict[str, Any]:
+        """Apply an explicit, revision-bound owner choice to one canonical job."""
+
+        self.initialize()
+        _safe_session_id(job_id)
+        if owner_confirmed is not True:
+            raise StoreError("task selection requires owner confirmation")
+        if not isinstance(expected_revision, int) or isinstance(expected_revision, bool):
+            raise StoreError("task selection requires an exact revision")
+        with exclusive_file_lock(self.store_lock_path):
+            document = self._load_jobs_document()
+            current = document["jobs"].get(job_id)
+            if current is None or current.get("deletedAt") is not None:
+                raise StoreError("task selection job is unavailable")
+            if current["revision"] != expected_revision:
+                raise StoreError("task selection revision conflict")
+            self._require_job_unclaimed_locked(job_id)
+            if current["status"] not in {"saved", "needs_info", "ready"}:
+                raise StoreError("task selection job is unavailable")
+            if not self._preflight_job_record(current)["ready"]:
+                raise StoreError("task selection preflight failed")
+            if current["status"] == "ready":
+                return {
+                    "action": "noop",
+                    "job": self._task_job_projection(current),
+                }
+            updated = dict(current)
+            updated["status"] = "ready"
+            updated["closedOutcome"] = None
+            updated["revision"] += 1
+            updated["updatedAt"] = utc_now()
+            _validate_job_record(job_id, updated)
+            document["jobs"][job_id] = updated
+            document["metadata"]["updatedAt"] = updated["updatedAt"]
+            atomic_write_json(self.jobs_path, document)
+        return {"action": "ready", "job": self._task_job_projection(updated)}
+
     def owner_beta_overview(self) -> dict[str, Any]:
         """Return a value-free, Store-derived projection for the companion landing page."""
 
@@ -4055,76 +4222,106 @@ class Store:
             ]
             claim = self._load_coordinator_document()["claim"]
             now = self._now_datetime()
-            attention_count = 0
-            for job in jobs:
-                status = job["status"]
-                if status in {"needs_info", "awaiting_review"}:
-                    attention_count += 1
-                elif status == "in_progress":
-                    owns_job = claim is not None and claim["jobId"] == job["id"]
-                    if not owns_job or now >= self._parse_time(claim["expiresAt"]):
-                        attention_count += 1
-
-            live_claim = (
-                claim is not None
-                and now < self._parse_time(claim["expiresAt"])
+            return self._owner_beta_overview_locked(
+                profile, jobs, resumes, answers, claim, now
             )
-            acquirable_ready_count = 0
-            if not live_claim:
-                resumes_by_id = {resume["id"]: resume for resume in resumes}
-                active_resume_ids = set(resumes_by_id)
-                self._overview_resume_digest_cache = {
-                    key: value
-                    for key, value in self._overview_resume_digest_cache.items()
-                    if key in active_resume_ids
-                }
-                resume_observations: dict[str, dict[str, Any]] = {}
-                acquirable_ready_count = sum(
-                    self._preflight_job_record(
-                        item,
-                        profile=profile,
-                        resumes=resumes_by_id,
-                        resume_observations=resume_observations,
-                        managed_digest_cache=self._overview_resume_digest_cache,
-                    )["ready"]
-                    for item in jobs
-                    if item["status"] == "ready"
-                )
-            counts = {
-                "jobs": len(jobs),
-                "readyJobs": sum(item["status"] == "ready" for item in jobs),
-                "attentionJobs": attention_count,
-                "resumes": len(resumes),
-                "answers": len(answers),
+
+    def _owner_beta_overview_locked(
+        self,
+        profile: dict[str, Any],
+        jobs: list[dict[str, Any]],
+        resumes: list[dict[str, Any]],
+        answers: list[dict[str, Any]],
+        claim: dict[str, Any] | None,
+        now: datetime,
+    ) -> dict[str, Any]:
+        """Derive the canonical overview from documents already read under the lock."""
+
+        attention_count = 0
+        for job in jobs:
+            status = job["status"]
+            if status in {"needs_info", "awaiting_review"}:
+                attention_count += 1
+            elif status == "in_progress":
+                owns_job = claim is not None and claim["jobId"] == job["id"]
+                if not owns_job or now >= self._parse_time(claim["expiresAt"]):
+                    attention_count += 1
+
+        live_claim = (
+            claim is not None
+            and now < self._parse_time(claim["expiresAt"])
+        )
+        acquirable_ready_count = 0
+        if not live_claim:
+            resumes_by_id = {resume["id"]: resume for resume in resumes}
+            active_resume_ids = set(resumes_by_id)
+            self._overview_resume_digest_cache = {
+                key: value
+                for key, value in self._overview_resume_digest_cache.items()
+                if key in active_resume_ids
             }
-            setup = {
-                "hasProfileFacts": self._has_application_facts(profile),
-                "hasResume": bool(resumes),
-            }
-            if not setup["hasResume"]:
-                next_action, target = "import_resume", "resumes"
-            elif not setup["hasProfileFacts"]:
-                next_action, target = "review_facts", "facts"
-            elif counts["attentionJobs"]:
-                next_action, target = "resolve_attention", "attention"
-            elif acquirable_ready_count:
-                next_action, target = "handoff_ready_job", "jobs"
-            elif not counts["jobs"]:
-                next_action, target = "capture_job", "jobs"
-            else:
-                next_action, target = "prepare_job", "jobs"
-            return {
-                "setup": setup,
-                "counts": counts,
-                "nextAction": next_action,
-                "targetWorkspace": target,
-            }
+            resume_observations: dict[str, dict[str, Any]] = {}
+            acquirable_ready_count = sum(
+                self._preflight_job_record(
+                    item,
+                    profile=profile,
+                    resumes=resumes_by_id,
+                    resume_observations=resume_observations,
+                    managed_digest_cache=self._overview_resume_digest_cache,
+                )["ready"]
+                for item in jobs
+                if item["status"] == "ready"
+            )
+        counts = {
+            "jobs": len(jobs),
+            "readyJobs": sum(item["status"] == "ready" for item in jobs),
+            "attentionJobs": attention_count,
+            "resumes": len(resumes),
+            "answers": len(answers),
+        }
+        setup = {
+            "hasProfileFacts": self._has_application_facts(profile),
+            "hasResume": bool(resumes),
+        }
+        if not setup["hasResume"]:
+            next_action, target = "import_resume", "resumes"
+        elif not setup["hasProfileFacts"]:
+            next_action, target = "review_facts", "facts"
+        elif counts["attentionJobs"]:
+            next_action, target = "resolve_attention", "attention"
+        elif acquirable_ready_count:
+            next_action, target = "handoff_ready_job", "jobs"
+        elif not counts["jobs"]:
+            next_action, target = "capture_job", "jobs"
+        else:
+            next_action, target = "prepare_job", "jobs"
+        return {
+            "setup": setup,
+            "counts": counts,
+            "nextAction": next_action,
+            "targetWorkspace": target,
+        }
 
     def list_needs_attention(self) -> dict[str, Any]:
         """Return one coherent, privacy-minimized cross-job attention snapshot."""
 
         self.initialize()
         self._ensure_coordinator_files()
+        with exclusive_file_lock(self.store_lock_path):
+            jobs = self._load_jobs_document()["jobs"]
+            persisted_claim = self._load_coordinator_document()["claim"]
+            return self._needs_attention_locked(
+                jobs, persisted_claim, self._now_datetime()
+            )
+
+    def _needs_attention_locked(
+        self,
+        jobs: dict[str, dict[str, Any]],
+        persisted_claim: dict[str, Any] | None,
+        now: datetime,
+    ) -> dict[str, Any]:
+        """Derive attention rows from documents already read under the Store lock."""
+
         reason_rank = {
             "expired_agent_attempt": 0,
             "claimless_interrupted_attempt": 1,
@@ -4149,72 +4346,71 @@ class Store:
                 "Open Job details and resolve the missing facts, resume, or answers, then run preflight and mark the job ready.",
             ),
         }
-        with exclusive_file_lock(self.store_lock_path):
-            jobs = self._load_jobs_document()["jobs"]
-            persisted_claim = self._load_coordinator_document()["claim"]
-            now = self._now_datetime()
-            rows: list[dict[str, Any]] = []
-            for job in jobs.values():
-                if job.get("deletedAt") is not None:
-                    continue
-                reason_code = None
-                attention_at = job["updatedAt"]
-                if job["status"] == "in_progress":
-                    selected_claim = (
-                        persisted_claim
-                        if persisted_claim is not None
-                        and persisted_claim["jobId"] == job["id"]
-                        else None
-                    )
-                    if selected_claim is None:
-                        reason_code = "claimless_interrupted_attempt"
-                    elif now >= self._parse_time(selected_claim["expiresAt"]):
-                        reason_code = "expired_agent_attempt"
-                        attention_at = selected_claim["expiresAt"]
-                elif job["status"] == "awaiting_review":
-                    reason_code = "awaiting_human_review"
-                elif job["status"] == "needs_info":
-                    reason_code = "needs_information"
-                if reason_code is None:
-                    continue
+        rows: list[dict[str, Any]] = []
+        for job in jobs.values():
+            if job.get("deletedAt") is not None:
+                continue
+            reason_code = None
+            attention_at = job["updatedAt"]
+            if job["status"] == "in_progress":
+                selected_claim = (
+                    persisted_claim
+                    if persisted_claim is not None
+                    and persisted_claim["jobId"] == job["id"]
+                    else None
+                )
+                if selected_claim is None:
+                    reason_code = "claimless_interrupted_attempt"
+                elif now >= self._parse_time(selected_claim["expiresAt"]):
+                    reason_code = "expired_agent_attempt"
+                    attention_at = selected_claim["expiresAt"]
+            elif job["status"] == "awaiting_review":
+                reason_code = "awaiting_human_review"
+            elif job["status"] == "needs_info":
+                reason_code = "needs_information"
+            if reason_code is None:
+                continue
 
-                missing_count = 0
-                if reason_code == "needs_information":
-                    session_path = self._session_path(job["id"])
-                    if session_path.exists():
-                        session = read_json_object(session_path, "session")
-                        validate_version(session, "session")
-                        _validate_session_document(session)
-                        if session["applicationId"] != job["id"]:
-                            raise StoreError("session application id does not match path")
-                        missing_count = len(session.get("pendingFields", []))
-                reason_label, guidance = reason_details[reason_code]
-                rows.append({
-                    "jobId": job["id"],
-                    "role": job.get("role"),
-                    "company": job.get("company"),
-                    "status": job["status"],
-                    "revision": job["revision"],
-                    "priority": job.get("priority", 0),
-                    "reasonCode": reason_code,
-                    "reasonLabel": reason_label,
-                    "attentionAt": attention_at,
-                    "guidance": guidance,
-                    "missingInformationCount": missing_count,
-                })
-            rows.sort(key=lambda item: (
-                reason_rank[item["reasonCode"]],
-                -item["priority"],
-                item["attentionAt"],
-                item["jobId"],
-            ))
-            serialized = json.dumps(
-                rows, ensure_ascii=False, separators=(",", ":"), sort_keys=True
-            ).encode("utf-8")
-            return {
-                "items": rows,
-                "snapshotSignature": hashlib.sha256(serialized).hexdigest(),
-            }
+            missing_count = 0
+            session_revision = None
+            if reason_code == "needs_information":
+                session_path = self._session_path(job["id"])
+                if session_path.exists():
+                    session = read_json_object(session_path, "session")
+                    validate_version(session, "session")
+                    _validate_session_document(session)
+                    if session["applicationId"] != job["id"]:
+                        raise StoreError("session application id does not match path")
+                    missing_count = len(session.get("pendingFields", []))
+                    session_revision = self._session_revision(session)
+            reason_label, guidance = reason_details[reason_code]
+            rows.append({
+                "jobId": job["id"],
+                "role": job.get("role"),
+                "company": job.get("company"),
+                "status": job["status"],
+                "revision": job["revision"],
+                "priority": job.get("priority", 0),
+                "reasonCode": reason_code,
+                "reasonLabel": reason_label,
+                "attentionAt": attention_at,
+                "guidance": guidance,
+                "missingInformationCount": missing_count,
+                "sessionRevision": session_revision,
+            })
+        rows.sort(key=lambda item: (
+            reason_rank[item["reasonCode"]],
+            -item["priority"],
+            item["attentionAt"],
+            item["jobId"],
+        ))
+        serialized = json.dumps(
+            rows, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+        return {
+            "items": rows,
+            "snapshotSignature": hashlib.sha256(serialized).hexdigest(),
+        }
 
     def _preflight_job_record(
         self,
@@ -5244,6 +5440,7 @@ class Store:
                 raise StoreError("job does not exist")
 
             session = None
+            answers_document = self._load_answers_document()
             session_path = self._session_path(job_id)
             if session_path.exists():
                 stored_session = read_json_object(session_path, "session")
@@ -5256,12 +5453,13 @@ class Store:
                     for key in ("status", "step", "createdAt", "updatedAt")
                     if key in stored_session
                 }
+                session["revision"] = self._session_revision(stored_session)
                 session["pendingInformation"] = [
                     {
                         key: pending[key]
                         for key in ("question", "state", "sensitive")
                         if key in pending
-                    }
+                    } | self._pending_resolution_projection(pending, answers_document)
                     for pending in stored_session.get("pendingFields", [])
                 ]
 
@@ -5312,6 +5510,68 @@ class Store:
                 "claim": claim,
                 "history": history,
             }
+
+    @staticmethod
+    def _session_revision(session: dict[str, Any]) -> int:
+        """Return a stable positive JSON/JavaScript-safe revision token."""
+        digest = hashlib.sha256(_canonical_json(session).encode("utf-8")).hexdigest()
+        return int(digest[:13], 16) + 1
+
+    def _pending_resolution_projection(
+        self, field: dict[str, Any], answers: dict[str, Any]
+    ) -> dict[str, Any]:
+        projection: dict[str, Any] = {"reference": field["reference"]}
+        key = field.get("answerKey")
+        if not isinstance(key, str) or not key:
+            return projection | {"resolutionEligible": False}
+        resolved = self._resolve_answer_key_in_document(answers, key)
+        answer = answers["answers"].get(resolved)
+        if answer is None or answer.get("deletedAt") is not None:
+            return projection | {"resolutionEligible": False}
+        projection["answerRevision"] = answer.get("revision", 1)
+        projection["resolutionEligible"] = bool(
+            field.get("sensitive") is not True
+            and field.get("state") != "sensitive"
+            and answer.get("reviewStatus", "accepted") == "accepted"
+            and answer.get("state") == "confirmed"
+            and answer.get("value") is not None
+            and not self._answer_is_sensitive(answer)
+        )
+        return projection
+
+    def pending_answer_detail(self, job_id: str, reference: str) -> dict[str, Any]:
+        """Resolve an opaque durable pending reference to its canonical answer."""
+        self.initialize()
+        job_id = _safe_session_id(job_id)
+        if not isinstance(reference, str) or PENDING_REFERENCE.fullmatch(reference) is None:
+            raise StoreError("pending question reference is invalid")
+        with exclusive_file_lock(self.store_lock_path):
+            job = self._load_jobs_document()["jobs"].get(job_id)
+            if job is None or job.get("deletedAt") is not None:
+                raise StoreError("job does not exist")
+            path = self._session_path(job_id)
+            if not path.exists():
+                raise StoreError("answer resolution session does not exist")
+            session = read_json_object(path, "session")
+            validate_version(session, "session")
+            _validate_session_document(session)
+            field = next(
+                (
+                    item for item in session.get("pendingFields", [])
+                    if item.get("reference") == reference
+                ),
+                None,
+            )
+            if field is None:
+                raise StoreError("pending question reference is stale")
+            key = field.get("answerKey")
+            if not isinstance(key, str) or not key:
+                raise StoreError("pending question has no referenced answer")
+            answers = self._load_answers_document()
+            answer = self._get_answer_record(key, document=answers)
+            if answer is None:
+                raise StoreError("referenced answer does not exist")
+            return self.answer_detail_projection(answer, answers)
 
     def _require_claim_locked(
         self, job_id: str, token: str, allow_expired: bool = False
@@ -5428,6 +5688,38 @@ class Store:
                 {"schemaVersion": SCHEMA_VERSION, "operation": None},
             )
             return
+        if operation["kind"] == "answer_resolution":
+            job_id = operation["jobId"]
+            jobs = self._load_jobs_document()
+            current = jobs["jobs"].get(job_id)
+            if current is None or current.get("deletedAt") is not None:
+                raise StoreError("coordinator journal references a missing job")
+            expected = operation["expectedJobRevision"]
+            if current["revision"] == expected:
+                if current["status"] != operation["sourceStatus"]:
+                    raise StoreError("coordinator journal source status drifted")
+                updated = dict(current)
+                updated["status"] = operation["targetStatus"]
+                updated["closedOutcome"] = None
+                updated["revision"] = expected + 1
+                updated["updatedAt"] = operation["at"]
+                _validate_job_record(job_id, updated)
+                jobs["jobs"][job_id] = updated
+                jobs["metadata"]["updatedAt"] = operation["at"]
+                atomic_write_json(self.jobs_path, jobs)
+            elif not (current["revision"] == expected + 1 and current["status"] == operation["targetStatus"]):
+                raise StoreError("coordinator journal cannot be reconciled")
+            session = operation["session"]
+            path = self._session_path(job_id)
+            existing = read_json_object(path, "session")
+            existing_revision = self._session_revision(existing)
+            if existing_revision == operation["expectedSessionRevision"]:
+                atomic_write_json(path, session)
+            elif _canonical_json(existing) != _canonical_json(session):
+                raise StoreError("coordinator session cannot be reconciled")
+            atomic_write_json(self.coordinator_path, {"schemaVersion": SCHEMA_VERSION, "claim": None})
+            atomic_write_json(self.coordinator_journal_path, {"schemaVersion": SCHEMA_VERSION, "operation": None})
+            return
         event = operation.get("historyEvent")
         if event is not None:
             self._history_event_is_idempotent_locked(event)
@@ -5479,6 +5771,101 @@ class Store:
             {"schemaVersion": SCHEMA_VERSION, "operation": operation},
         )
         self._roll_forward_locked()
+
+    def resolve_pending_answer(
+        self, job_id: str, reference: str, expected_job_revision: int,
+        expected_session_revision: int, expected_answer_revision: int,
+        owner_confirmed: bool = False,
+    ) -> dict[str, Any]:
+        """Recheck one pending question without copying its answer value."""
+        self.initialize()
+        self._ensure_coordinator_files()
+        job_id = _safe_session_id(job_id)
+        if not owner_confirmed:
+            raise StoreError("answer resolution requires explicit owner confirmation")
+        if not isinstance(reference, str) or PENDING_REFERENCE.fullmatch(reference) is None:
+            raise StoreError("pending question reference is invalid")
+        for revision in (expected_job_revision, expected_session_revision, expected_answer_revision):
+            if not isinstance(revision, int) or isinstance(revision, bool) or revision < 1:
+                raise StoreError("answer resolution revision is invalid")
+        with exclusive_file_lock(self.store_lock_path):
+            self._require_job_unclaimed_locked(job_id)
+            jobs = self._load_jobs_document()
+            job = jobs["jobs"].get(job_id)
+            if job is None or job.get("deletedAt") is not None:
+                raise StoreError("job does not exist")
+            if job["revision"] != expected_job_revision:
+                raise StoreError("job revision conflict")
+            if job["status"] != "needs_info":
+                raise StoreError("answer resolution requires a needs_info job")
+            path = self._session_path(job_id)
+            if not path.exists():
+                raise StoreError("answer resolution session does not exist")
+            session = read_json_object(path, "session")
+            validate_version(session, "session")
+            _validate_session_document(session)
+            if self._session_revision(session) != expected_session_revision:
+                raise StoreError("session revision conflict")
+            pending = session.get("pendingFields", [])
+            matching = [
+                (index, field) for index, field in enumerate(pending)
+                if field.get("reference") == reference
+            ]
+            if len(matching) != 1:
+                raise StoreError("pending question reference is stale")
+            index, field = matching[0]
+            key = field.get("answerKey")
+            if not isinstance(key, str) or not key:
+                raise StoreError("pending question has no referenced answer")
+            if field.get("sensitive") is True or field.get("state") == "sensitive":
+                raise StoreError("sensitive pending answers require reconfirmation")
+            answers = self._load_answers_document()
+            resolved_key = self._resolve_answer_key_in_document(answers, key)
+            answer = answers["answers"].get(resolved_key)
+            if answer is None or answer.get("deletedAt") is not None:
+                raise StoreError("referenced answer does not exist")
+            if answer.get("revision", 1) != expected_answer_revision:
+                raise StoreError("answer revision conflict")
+            if answer.get("reviewStatus", "accepted") != "accepted" or answer.get("state") != "confirmed" or answer.get("value") is None:
+                raise StoreError("referenced answer is not accepted and confirmed")
+            if self._answer_is_sensitive(answer):
+                raise StoreError("sensitive pending answers require reconfirmation")
+            now = self._now()
+            updated_session = copy.deepcopy(session)
+            del updated_session["pendingFields"][index]
+            answer_keys = list(updated_session.get("answerKeys", []))
+            if resolved_key not in answer_keys:
+                answer_keys.append(resolved_key)
+            updated_session["answerKeys"] = answer_keys
+            updated_session["updatedAt"] = now
+            _validate_session_document(updated_session)
+            target = "needs_info"
+            if not updated_session["pendingFields"]:
+                if not self._preflight_job_record(job)["ready"]:
+                    raise StoreError("job preflight failed after answer resolution")
+                target = "ready"
+            self._commit_coordinator_operation_locked({
+                "kind": "answer_resolution", "operationId": str(uuid.uuid4()),
+                "jobId": job_id, "at": now, "answerKey": resolved_key,
+                "expectedJobRevision": expected_job_revision,
+                "expectedSessionRevision": expected_session_revision,
+                "expectedAnswerRevision": expected_answer_revision,
+                "sourceStatus": "needs_info", "targetStatus": target,
+                "session": updated_session, "resultClaim": None,
+            })
+            result_job = self._load_jobs_document()["jobs"][job_id]
+            return {
+                "job": {"id": job_id, "status": result_job["status"], "revision": result_job["revision"]},
+                "session": {
+                    "revision": self._session_revision(updated_session),
+                    "pendingInformation": [
+                        {key: item[key] for key in ("question", "state", "sensitive") if key in item}
+                        | self._pending_resolution_projection(item, answers)
+                        for item in updated_session["pendingFields"]
+                    ],
+                },
+                "resolved": True, "ready": target == "ready",
+            }
 
     def acquire_ready_job(
         self, job_id: str, owner_label: str, expected_revision: int
@@ -6625,16 +7012,36 @@ class Store:
             raise StoreError("session answerKeys must be strings")
         path = self._session_path(application_id)
         created_at = incoming.get("createdAt")
+        existing = None
         if path.exists():
             existing = read_json_object(path, "session")
             _validate_session_document(existing)
             created_at = created_at or existing.get("createdAt")
+        pending_input = incoming.get("pendingFields", [])
+        if not isinstance(pending_input, list):
+            raise StoreError("session pendingFields must be a list")
+        reusable: dict[str, list[str]] = {}
+        if existing is not None:
+            for field in existing.get("pendingFields", []):
+                key = field.get("answerKey")
+                if isinstance(key, str) and key:
+                    reusable.setdefault(key, []).append(field["reference"])
+        pending_fields = []
+        for value in pending_input:
+            field = _require_object(value, "pending field")
+            if set(field) - {"question", "state", "answerKey", "sensitive"}:
+                raise StoreError("pending field contains unsupported fields")
+            copied = copy.deepcopy(field)
+            key = copied.get("answerKey")
+            references = reusable.get(key, []) if isinstance(key, str) else []
+            copied["reference"] = references.pop(0) if references else f"pending_{uuid.uuid4().hex}"
+            pending_fields.append(copied)
         timestamp = now or utc_now()
         session = {
             "schemaVersion": SCHEMA_VERSION, **incoming,
             "applicationId": application_id, "status": status,
             "answerKeys": answer_keys,
-            "pendingFields": incoming.get("pendingFields", []),
+            "pendingFields": pending_fields,
             "createdAt": created_at or timestamp, "updatedAt": timestamp,
         }
         _validate_session_document(session)

--- a/scripts/job-apply-task.py
+++ b/scripts/job-apply-task.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Redacted task-level CLI for canonical Job Apply records."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_store_module() -> Any:
+    path = Path(__file__).resolve().with_name("job-apply-store.py")
+    spec = importlib.util.spec_from_file_location("job_apply_task_store", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("canonical store unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+STORE: Any | None = None
+
+
+def store_module() -> Any:
+    global STORE
+    if STORE is None:
+        STORE = load_store_module()
+    return STORE
+
+
+class TaskParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        del message
+        raise ValueError("invalid command")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = TaskParser(description=__doc__)
+    parser.add_argument("--root")
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("snapshot")
+    activity = commands.add_parser("activity")
+    activity.add_argument("--id", required=True)
+    intake = commands.add_parser("intake")
+    intake.add_argument("--input", required=True)
+    select = commands.add_parser("select")
+    select.add_argument("--id", required=True)
+    select.add_argument("--expected-revision", required=True, type=int)
+    select.add_argument("--owner-confirmed", action="store_true")
+    resolve = commands.add_parser("resolve-pending-answer")
+    resolve.add_argument("--id", required=True)
+    resolve.add_argument("--reference", required=True)
+    resolve.add_argument("--expected-job-revision", required=True, type=int)
+    resolve.add_argument("--expected-session-revision", required=True, type=int)
+    resolve.add_argument("--expected-answer-revision", required=True, type=int)
+    resolve.add_argument("--owner-confirmed", action="store_true")
+    return parser
+
+
+def resolve_store(args: argparse.Namespace) -> Any:
+    store = store_module()
+    configured = args.root or os.environ.get(store.STORE_ENV)
+    root = Path(configured).expanduser() if configured else Path.home() / ".job-apply"
+    return store.Store(root)
+
+
+def read_intake(path_value: str) -> dict[str, Any]:
+    try:
+        value = json.loads(Path(path_value).read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError("invalid intake") from error
+    if not isinstance(value, dict):
+        raise ValueError("invalid intake")
+    return value
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    store = resolve_store(args)
+    if args.command == "snapshot":
+        return {"ok": True, "command": "snapshot", "snapshot": store.task_snapshot()}
+    if args.command == "activity":
+        return {
+            "ok": True,
+            "command": "activity",
+            "jobId": args.id,
+            "activity": store.get_job_activity(args.id),
+        }
+    if args.command == "intake":
+        return {
+            "ok": True,
+            "command": "intake",
+            **store.intake_task_job(read_intake(args.input), origin="agent"),
+        }
+    if args.command == "select":
+        return {
+            "ok": True,
+            "command": "select",
+            **store.select_task_job_ready(
+                args.id, args.expected_revision, args.owner_confirmed
+            ),
+        }
+    if args.command == "resolve-pending-answer":
+        return {
+            "ok": True,
+            "command": "resolve-pending-answer",
+            **store.resolve_pending_answer(
+                args.id, args.reference, args.expected_job_revision,
+                args.expected_session_revision, args.expected_answer_revision,
+                args.owner_confirmed,
+            ),
+        }
+    raise ValueError("invalid command")
+
+
+def classify(error: BaseException) -> tuple[str, str]:
+    if isinstance(error, ValueError):
+        return "invalid_request", "The task request is invalid."
+    if STORE is not None and isinstance(error, STORE.StoreError):
+        message = str(error)
+        if "owner confirmation" in message:
+            return "owner_confirmation_required", "Explicit owner confirmation is required."
+        if "revision conflict" in message:
+            return "stale_revision", "A selected canonical revision is stale."
+        if "reference is stale" in message:
+            return "stale_revision", "The pending question reference is stale."
+        if "sensitive pending" in message:
+            return "sensitive_answer", "Sensitive answers require fresh owner reconfirmation in Answers."
+        if "not accepted and confirmed" in message or "no referenced answer" in message:
+            return "answer_unavailable", "The referenced answer is not accepted and confirmed."
+        if "preflight failed" in message:
+            return "preflight_failed", "The selected job is not ready."
+        if "intake conflict" in message or "one active job" in message:
+            return "job_identity_conflict", "The URL does not resolve to one active job."
+        if "unavailable" in message or "does not exist" in message:
+            return "job_unavailable", "The requested job is unavailable."
+        if "intake invalid" in message or "input" in message or "URL" in message:
+            return "invalid_request", "The task request is invalid."
+        return "store_rejected", "The canonical store rejected the task request."
+    return "store_unavailable", "The canonical store is unavailable."
+
+
+def emit(value: dict[str, Any], stream: Any = sys.stdout) -> None:
+    json.dump(value, stream, sort_keys=True, ensure_ascii=False)
+    stream.write("\n")
+
+
+def main() -> int:
+    try:
+        args = build_parser().parse_args()
+        result = run(args)
+    except Exception as error:
+        code, message = classify(error)
+        emit({"ok": False, "error": {"code": code, "message": message}})
+        return 2
+    emit(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/job-apply-workspace.py
+++ b/scripts/job-apply-workspace.py
@@ -645,6 +645,15 @@ class WorkspaceHandler(BaseHTTPRequestHandler):
                 return answer
             self._store_call(encoded_answer_detail)
             return
+        if (
+            len(parts) == 6
+            and parts[1:3] == ["api", "jobs"]
+            and parts[4] == "pending-answers"
+        ):
+            self._store_call(
+                lambda: self.server.store.pending_answer_detail(parts[3], parts[5])
+            )
+            return
         if len(parts) == 4 and parts[1:3] == ["api", "answers"]:
             def answer_detail() -> dict[str, Any]:
                 answer = self.server.store.get_answer(
@@ -952,6 +961,28 @@ class WorkspaceHandler(BaseHTTPRequestHandler):
             self._bulk_create(payload)
             return
         parts = path.split("/")
+        if (
+            method == "POST" and len(parts) == 5
+            and parts[1:3] == ["api", "jobs"]
+            and parts[4] == "resolve-pending-answer"
+        ):
+            required = {
+                "reference", "expectedJobRevision", "expectedSessionRevision",
+                "expectedAnswerRevision", "ownerConfirmed",
+            }
+            if set(payload) != required or payload.get("ownerConfirmed") is not True:
+                self._error(HTTPStatus.BAD_REQUEST, "body requires an explicit owner-confirmed exact-revision recheck")
+                return
+            revisions = [payload.get(name) for name in ("expectedJobRevision", "expectedSessionRevision", "expectedAnswerRevision")]
+            if any(not isinstance(value, int) or isinstance(value, bool) or value < 1 for value in revisions):
+                self._error(HTTPStatus.BAD_REQUEST, "all expected revisions must be positive integers")
+                return
+            self._store_call(lambda: self.server.store.resolve_pending_answer(
+                parts[3], payload["reference"], payload["expectedJobRevision"],
+                payload["expectedSessionRevision"], payload["expectedAnswerRevision"],
+                owner_confirmed=True,
+            ))
+            return
         if len(parts) == 4 and parts[1:3] == ["api", "fact-groups"] and method == "PATCH":
             if set(payload) != {"patch", "expectedRevision"} or not isinstance(payload.get("patch"), dict):
                 self._error(HTTPStatus.BAD_REQUEST, "body requires patch and expectedRevision")

--- a/scripts/qa-account.py
+++ b/scripts/qa-account.py
@@ -94,6 +94,7 @@ def _start_browser(profile: Path) -> tuple[subprocess.Popen, str]:
         raise ValueError("exact signed synthetic browser is unavailable")
     child = subprocess.Popen([
         executable, "--no-first-run", "--no-default-browser-check", "--force-renderer-accessibility",
+        "--disable-background-networking", "--disable-component-update",
         "--remote-debugging-address=127.0.0.1", "--remote-debugging-port=0",
         f"--user-data-dir={profile}", "about:blank",
     ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/scripts/smoke-plugin.sh
+++ b/scripts/smoke-plugin.sh
@@ -25,6 +25,9 @@ echo "Validating plugin manifest"
 claude plugin validate "$REPO_ROOT"
 
 python3 "$REPO_ROOT/scripts/job-apply-store.py" --help >/dev/null
+python3 "$REPO_ROOT/scripts/job-apply-task.py" --help >/dev/null
+python3 "$REPO_ROOT/scripts/job-apply-attempt.py" --help >/dev/null
+node "$REPO_ROOT/qa/unified_task_spine_oracle.mjs" --json >/dev/null
 
 python3 - "$REPO_ROOT" "$SMOKE_TEMP_ROOT" <<'PY'
 import json
@@ -555,6 +558,8 @@ target = Path(sys.argv[2])
 critical = (
     ".codex-plugin/plugin.json",
     "scripts/job-apply-store.py",
+    "scripts/job-apply-task.py",
+    "scripts/job-apply-attempt.py",
     "scripts/job-apply-workspace.py",
     "skills/answer-memory/SKILL.md",
     "skills/job-apply/SKILL.md",
@@ -605,6 +610,8 @@ if installed.name != version or not installed.is_dir():
 critical = (
     ".codex-plugin/plugin.json",
     "scripts/job-apply-store.py",
+    "scripts/job-apply-task.py",
+    "scripts/job-apply-attempt.py",
     "scripts/job-apply-workspace.py",
     "skills/answer-memory/SKILL.md",
     "skills/job-apply/SKILL.md",
@@ -916,6 +923,8 @@ if installed_skills != expected:
 for relative in (
     ".codex-plugin/plugin.json",
     "scripts/job-apply-store.py",
+    "scripts/job-apply-task.py",
+    "scripts/job-apply-attempt.py",
     "scripts/job-apply-workspace.py",
     "skills/answer-memory/SKILL.md",
     "skills/job-apply/SKILL.md",

--- a/skills/job-apply/SKILL.md
+++ b/skills/job-apply/SKILL.md
@@ -32,14 +32,18 @@ Then wait for the user to provide the path before proceeding with profile extrac
 
 **If the profile contains applicant data**, first determine the application mode:
 
-- If the user supplied a job URL, do not create a canonical job or claim implicitly. Resolve the active canonical managed resume with `resume-resolve` before browser work as described below.
-- If no URL was supplied, run `claim-status` before listing ready jobs. If it returns a live claim, identify the claimed job and do not start another one. If it returns an expired claim, identify the returned claimed job ID and ask whether to recover that exact job; after confirmation run `claim-recover --id <claimed-job-id> --owner <owner-label>`. If there is no claim, run `job-list --status ready`. If ready jobs exist, show their role, company, and URL and ask the user to select one (offer the first priority-sorted result). If none exist, use the existing URL prompt below.
+- The authenticated loopback QA replay above is the only exception to canonical URL intake. Keep using its resolved run ID and coordinator lifecycle; do not create a canonical job for that synthetic fixture.
+- If the user supplied a job URL, the required ordinary behavior is canonical intake: put only the supported canonical job fields in a private temporary JSON object, run `python3 "<plugin-root>/scripts/job-apply-task.py" [--root <resolved-root>] intake --input <private-temp.json>`, and immediately remove the input. Do this before any browser work. A conflict, invalid identity, unavailable store, or any other non-success result stops the workflow without opening a browser. Retain only the returned canonical job ID, status, and revision; the task result never returns the URL or an upsert token.
+- For ordinary discussion or when no URL was supplied, run `job-apply-task.py ... snapshot`. List and compare only its canonical jobs and Needs Attention projection. Do not run the legacy `job-list --status ready` command as the ordinary agent discussion surface. Never infer a choice from priority, ordering, a URL mention, or model preference: ask the owner to choose one exact canonical job unless their current request already explicitly names that exact job as the application target.
+- After an explicit owner choice, run `job-apply-task.py ... select --id <job-id> --expected-revision <displayed-revision> --owner-confirmed`. This exact-revision operation re-runs readiness preflight, marks an eligible saved or needs-info job Ready, and returns a stable no-op when the exact job is already Ready. On success, discard the pre-select displayed revision and retain the exact revision returned in `select.job.revision`; pass that returned revision, unchanged, to the private attempt helper described below. Any stale revision, failed preflight, conflict, unavailable record, or other non-success result stops without browser work; do not run `job-acquire`, do not start an attempt, and refresh the task snapshot to discuss the changed state rather than retrying against unseen data.
+- Before starting the selected Ready job, run `claim-status`. If it returns any live or expired claim, identify only the claimed job and stop: the ordinary agent route cannot recover, steal, clear, or replace it. An interrupted attempt remains for explicit expiry/recovery outside this skill. If there is no claim, start only the explicitly selected canonical job as described below.
+- If the exact job is `needs_info` with a pending answer reference, first inspect `job-apply-task.py ... activity --id <job-id>`. Route the owner to the canonical Answers editor; do not infer, reveal, or copy an answer value. After the owner has explicitly saved an accepted, confirmed, non-sensitive answer, run `job-apply-task.py ... resolve-pending-answer --id <job-id> --reference <pending-reference> --expected-job-revision <activity-job-revision> --expected-session-revision <activity-session-revision> --expected-answer-revision <pending-answer-revision> --owner-confirmed`. Never use this operation for missing, inferred, declined, sensitive, unreferenced, or changed answers. Never retry a stale failure: refresh activity, preserve any browser draft, and ask the owner to review the changed canonical state. The result remains `needs_info` while any blocker remains; when it returns the exact job as Ready, pass that returned revision unchanged to a new private attempt helper process. The same job/session and assigned-or-default managed resume identity continue across blocking, resolution, the new private attempt, and awaiting-review handoff; do not substitute a resume or source path. This recheck does not open a portal or authorize any final action.
 
-For a selected ready job, retain its displayed revision, create a short non-sensitive owner label for this agent run, and run `job-acquire --id <job-id> --owner <owner-label> --expected-revision <revision>`. This single operation rejects a stale selection, re-runs preflight, fails closed if the assigned/default managed resume no longer matches its canonical bytes or observation, resolves the job's assigned resume before the active default, creates the exclusive 300-second claim, moves `ready` to `in_progress`, and records `job-started`. Retain the returned post-acquisition job revision for the eventual handoff. The machine-readable result returns the bearer token on stdout; treat it as ephemeral sensitive output, never repeat it in user-facing text, and never place it in logs, saved sessions, or temporary files. Use the returned job URL and returned resume path for the application; do not substitute `profile.resumePath`.
+For a selected Ready job, use only the exact revision returned by the successful `select` result, create a short non-sensitive owner label for this agent run, and run one short launcher client: `python3 "<plugin-root>/scripts/job-apply-attempt.py" [--root <resolved-root>] start --id <job-id> --owner <owner-label> --expected-revision <select.job.revision>`. Never use the pre-select displayed revision. The client returns one redacted failure or `acquired` with the exact job URL/revision and managed resume identity/path needed for the application, then exits. Acquisition starts one OS-detached broker scoped to the resolved Store. No launcher, stdin, PTY, tool session, or conversational process must remain alive. The broker privately acquires once, retains the bearer only in memory, automatically heartbeats at least every 60 seconds, and accepts later stateless clients only through its OS-user-restricted Store socket. It never accepts a different job, revision, owner, Store, or claim. Never invoke the Store's raw acquire, recovery, heartbeat, progress, or handoff commands in an ordinary workflow: in particular, never run `job-acquire --id <job-id> --owner <owner-label> --expected-revision <select.job.revision>`. Never put claim authority in argv, environment, input, output, files, runtime metadata, diagnostics, reports, or receipts.
 
-If acquisition reports a claim, run `claim-status` because the global claim can belong to a different job. Do not work around a live claim. For an expired claim, use the claimed job ID returned by `claim-status`, ask whether to resume that exact job, and only then run `claim-recover --id <claimed-job-id> --owner <owner-label>`. Recovery never steals a live claim. Retain the recovered job revision for handoff. Run `claim-heartbeat --id <job-id> --token <token>` at least every 60 seconds while actively working.
+To request an immediate heartbeat from any later conversational turn, run a fresh client: `python3 "<plugin-root>/scripts/job-apply-attempt.py" [--root <resolved-root>] heartbeat` and require one successful `heartbeat` response. The client exits immediately; the detached broker continues independently. A rejected command or unavailable broker stops browser work. Broker loss leaves the exact existing claim untouched for expiry and explicit recovery; a new launcher cannot adopt, replace, recover, or reset it.
 
-**If the profile contains applicant data and neither a supplied URL nor a selected ready job is available**, say:
+**If the profile contains applicant data and neither an ingested URL nor an explicitly selected canonical job is available**, say:
 
 > Welcome back! Your local Job Apply profile and answer memory are ready.
 >
@@ -55,7 +59,7 @@ If acquisition reports a claim, run `claim-status` because the global claim can 
 ## Required Input
 
 - **Resume source file path**: Needed only to import a new canonical managed PDF, DOCX, or TXT resume
-- **Application target**: Either a selected canonical `ready` job or a supplied job URL
+- **Application target**: A supplied URL ingested into one canonical job, or an explicitly selected canonical job
 
 ## Profile Storage
 
@@ -155,7 +159,7 @@ immediately after the helper consumes them.
 
 ### Phase 2: Application Filling
 
-1. **Initialize and load storage** through the bundled `answer-memory` skill; use `profile-get`, then check `session-list` for resumable work matching this application. In selected-ready mode, use the acquired canonical job ID as the application/session ID and the resume returned by `job-acquire`. In direct-URL mode, keep the URL-derived application/session ID but run `resume-resolve` to obtain the active default managed resume path. If it cannot resolve a default, treat the full `resume-list` records as private tool output, not as a redacted projection: never print, quote, log, or present those records to the user. If user choice is required, present a summary containing only `id`, `label`, `tags`, `default`, `revision`, and `storageKind`; never include a private path, managed filename, original filename, digest, or any other field. Resolve the user-selected active managed ID, or explicitly adopt a selected legacy record with `resume-adopt --id <id> --expected-revision <revision>` before resolving it. If no suitable record exists, ask the user for a source file, import it with `resume-import`, then resolve its returned ID. Never use `profile.resumePath` or a user source path for upload.
+1. **Initialize and load storage** through the bundled `answer-memory` skill; use `profile-get`, then inspect `job-apply-task.py ... activity --id <job-id>` for resumable work on the exact selected canonical job. For every ordinary application, use the acquired canonical job ID as the application/session ID and the managed resume returned by the private helper. If no suitable managed resume exists, ask the user for a source file, import it with `resume-import`, then return to exact-revision task selection. Never use `profile.resumePath`, a URL-derived session ID, or a user source path for upload. The authenticated loopback QA replay remains the only synthetic coordinator exception.
 2. **Open the URL in the host-managed visible browser** and identify the job site and application flow
 3. **Pause for user-only steps** if login, password, CAPTCHA, MFA, consent, or account creation appears
 4. **Open the application form**; if an Apply link opens an external portal, continue in that visible host-managed tab
@@ -163,13 +167,32 @@ immediately after the helper consumes them.
 6. **Reuse only matching, non-sensitive `confirmed` answers**. Show and confirm `inferred` answers, ask for `missing` answers, and reconfirm every `sensitive` answer before entry
 7. **Separate fill consent from remember consent** for salary, work authorization, visa status, demographic information, disability disclosure, and similar answers. Use `--remember-sensitive` only after explicit field-specific permission to remember
 8. **Upload the resume** through the visible file control and verify the selected filename
-9. **Save resumable progress**. In selected-ready mode use claim-gated `claim-progress --id <job-id> --token <token> --input <session.json>`; in direct-URL mode continue to use `session-save`. Store answer keys and pending-field states, never answer values.
+9. **Save resumable progress** by putting only the value-free session object in a private temporary JSON file, running `python3 "<plugin-root>/scripts/job-apply-attempt.py" [--root <resolved-root>] progress --input <private-temp.json>`, requiring `progress_saved`, and immediately removing the input. The session may contain only canonical answer keys and pending-field states, never answer values. Do not add an ID, revision, owner, Store, claim, command, or authority field. This is a new stateless client; it does not need the launcher process or any earlier tool session. The authenticated loopback QA replay uses only its documented coordinator commands.
 10. **Handle inaccessible controls** using the optional fallback rules above, or leave the field for the user
 11. **Advance through non-final steps** only when the control is clearly Next, Continue, Save, or Review
 12. **Stop at final review** before any Submit, Send, or equivalent final-action button
-13. **Complete the durable handoff**. In selected-ready mode, pass the post-acquisition (or post-recovery) job revision retained before browser work to `claim-handoff --id <job-id> --token <token> --status awaiting_review --expected-revision <retained-revision> --input <review-session.json>`. The session JSON must contain only value-free review metadata. This atomically saves the review session, records `reviewed`, moves the canonical job to `awaiting_review`, and releases the claim. A revision conflict means the user or another client changed the job; stop and re-evaluate instead of reloading and retrying with an unseen revision. In direct-URL mode retain the existing minimal `reviewed` history event (or the required coordinator `reviewed` command for approved local QA). Summarize every entered value, identify anything incomplete or uncertain, and tell the user to inspect the page and submit manually.
+13. **Complete the durable handoff** by putting only the value-free review session object in a private temporary JSON file, running a fresh client `python3 "<plugin-root>/scripts/job-apply-attempt.py" [--root <resolved-root>] handoff --status awaiting_review --input <private-temp.json>`, requiring one `handed_off` response, and immediately removing the input. The broker uses its privately retained post-acquisition revision, atomically saves the review session, records `reviewed`, moves the canonical job to `awaiting_review`, releases the claim, and exits. Never fall back to the former raw route `claim-handoff --id <job-id> --token <token> --status awaiting_review --input <review-session.json>`. A rejected handoff means stop and re-evaluate instead of reloading and retrying against unseen state. The authenticated loopback QA replay instead uses only its required `reviewed` coordinator command. Give only a value-free completion summary: name field groups and their status (complete, incomplete, or uncertain), never echo applicant values, and tell the user to inspect the visible page and submit manually.
 
-If selected-ready work needs a user answer, first prepare a session containing only question/state/answer-key/sensitivity metadata, then use `claim-handoff --id <job-id> --token <token> --status needs_info --expected-revision <retained-revision> --input <needs-info-session.json>`. Do not reload the job revision first; a conflict must expose concurrent changes. This atomically moves the job to `needs_info`, records `job-blocked`, and releases the claim. After the user supplies the missing information, transition `needs_info` to `ready` with the current revision (preflight is enforced), then acquire a fresh claim. Never retain a claim while waiting for the user. If the process crashes, leave the record intact for explicit stale recovery; never delete or silently clear a claim.
+### Post-readiness action-time consent
+
+Action-time consent has a closed, one-use state transition:
+
+1. Before the exact application form is visibly ready, consent is `not_ready`. Earlier approval, a URL or job selection, consent from another application, and blanket future consent are invalid and cannot authorize entering data.
+2. After the visible form is read, establish `ready_unconfirmed` only when the exact data scope, destination, purpose, remembered-answer use, and review-only limit are known. Ask for explicit action-time consent unless the owner's current message was sent after that visible readiness and already explicitly authorizes those same bounds.
+3. That matching post-readiness authorization transitions once to `consent_consumed` for the bounded filling pass. Proceed without asking for the same confirmation again. It is not reusable for another job, destination, purpose, attempt, or future application.
+4. A material change to the data scope, destination, or purpose invalidates the consumed consent. Read the changed visible state and obtain new explicit post-change consent before entering more data. Ordinary page progression within the unchanged bounds, a value-free status update, or the final manual-review handoff is not a material change and must not trigger duplicate confirmation.
+
+This action-time consent does not replace field-specific sensitive-answer consent, remember consent, login or account consent, or the manual final-action boundary. Never echo raw applicant values in chat, summaries, diagnostics, or receipts. Describe only field names or groups, counts, and states such as complete, incomplete, uncertain, or awaiting owner input. The values remain visible only in the owner-visible form where they were entered.
+
+If selected-ready work needs one non-sensitive user answer, put this exact session object in a private temporary JSON file (substituting only the exact visible question and its canonical answer key):
+
+```json
+{"status":"active","step":"questions","answerKeys":[],"pendingFields":[{"question":"How did you hear about this opportunity?","state":"missing","answerKey":"source.discovery","sensitive":false}]}
+```
+
+The object contains only `status`, `step`, `answerKeys`, and exactly one `pendingFields` item; and that item contains only `question`, `state`, `answerKey`, and `sensitive`. Run `python3 "<plugin-root>/scripts/job-apply-attempt.py" [--root <resolved-root>] handoff --status needs_info --input <private-temp.json>`, require `handed_off`, and immediately remove the input. Never include an answer value, profile value, job or application ID, revision, owner, Store or claim data, path, URL, token, reference, browser state, or other metadata. A missing profile-backed fact such as a LinkedIn URL is not an answer-backed pending field: stop and have the owner correct the canonical profile separately rather than putting it in this payload.
+
+Do not reload the job revision before this handoff; a conflict must expose concurrent changes. The broker atomically moves the job to `needs_info`, records `job-blocked`, releases the claim, emits one `handed_off` response, and exits. After the user supplies the missing information, use the exact-revision task resolution route above; if it becomes Ready, start a fresh detached broker for that same exact job. Never retain a broker or claim while waiting for the user. If the broker is lost, leave the record intact for explicit stale recovery; never delete or silently clear a claim.
 
 User confirmation never authorizes this skill to click Submit, Send, or any equivalent final-action button.
 
@@ -193,7 +216,7 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
    - Work authorization questions (dropdowns)
    - Custom screening questions (varies by employer)
 4. Click "Next" to advance, "Review" on final step
-5. Stop on the review page, summarize all entered fields, and leave "Submit application" untouched for the user
+5. Stop on the review page, give a value-free field-name/status summary, and leave "Submit application" untouched for the user
 
 **Field patterns to look for:**
 - `input[name*="phone"]` - Phone number
@@ -220,7 +243,7 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
 6. Education section similar pattern
 7. Handle custom questions at bottom
 8. Upload the resume through the visible file control and confirm the filename
-9. Stop before the final "Submit Application" button, summarize the fields, and hand control to the user
+9. Stop before the final "Submit Application" button, give a value-free field-name/status summary, and hand control to the user
 
 **Field patterns:**
 - Standard `<input>` and `<select>` elements
@@ -241,7 +264,7 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
 4. **Location combobox**: Type the location to trigger suggestions, then click the matching option
 5. **Resume upload**: Use the resume field, not the separate autofill file input, and verify the filename
 6. Review all visible values
-7. Stop before the final action, summarize the fields, and let the user submit manually
+7. Stop before the final action, give a value-free field-name/status summary, and let the user submit manually
 
 ### Lever
 
@@ -273,7 +296,7 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
 4. Correct any mis-parsed fields
 5. **Location combobox**: Clear existing value, type the correct location, wait for dropdown, click match
 6. Fill any remaining required fields
-7. Review the parsed and entered values, stop before the final action, and let the user submit manually
+7. Review the visible form without echoing its values, give a value-free field-name/status summary, stop before the final action, and let the user submit manually
 
 ### Workday
 
@@ -327,7 +350,7 @@ User confirmation never authorizes this skill to click Submit, Send, or any equi
 2. Fill standard fields and use visible controls for dropdowns, radio buttons, and checkboxes.
 3. Upload the resume through the page's file control and verify the displayed filename.
 4. After each non-final Next, Continue, or Save action, read the new page before proceeding.
-5. When Review, Submit, Send, or an equivalent final action appears, stop and summarize the application for the user.
+5. When Review, Submit, Send, or an equivalent final action appears, stop and give the user only a value-free field-name/status summary.
 
 ### Separate Playwright Integration (Claude Code Optional Fallback Only)
 

--- a/tests/test_job_apply_attempt.py
+++ b/tests/test_job_apply_attempt.py
@@ -1,0 +1,215 @@
+import importlib.util
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "job-apply-attempt.py"
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+STORE = load_module("job_apply_attempt_store_tests", ROOT / "scripts" / "job-apply-store.py")
+ATTEMPT = load_module("job_apply_attempt_tests", SCRIPT)
+
+
+class AttemptProtocolTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.store_root = self.root / "store"
+        self.store = STORE.Store(self.store_root)
+        revision = self.store.inspect_profile()["revision"]
+        self.store.replace_profile({"firstName": "Private"}, revision, "user")
+        resume_path = self.root / "private-resume.txt"
+        resume_path.write_text("private resume", encoding="utf-8")
+        self.store.create_resume({"id": "resume", "label": "Resume", "path": str(resume_path)})
+        job = self.store.create_job({"id": "exact-job", "url": "https://example.invalid/exact"})
+        self.job = self.store.transition_job(job["id"], "ready", job["revision"])
+        self.input_counter = 0
+
+    def tearDown(self):
+        process_path = ATTEMPT.pid_path(self.store_root)
+        try:
+            pid = int(process_path.read_text(encoding="ascii"))
+            os.kill(pid, signal.SIGKILL)
+        except (FileNotFoundError, ProcessLookupError, ValueError):
+            pass
+        self.temporary.cleanup()
+
+    def command(self, name, *args):
+        return [sys.executable, str(SCRIPT), "--root", str(self.store_root), name, *args]
+
+    def run_client(self, name, *args, payload=None):
+        command = self.command(name, *args)
+        if payload is not None:
+            path = self.root / f"input-{self.input_counter}.json"
+            self.input_counter += 1
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            command.extend(["--input", str(path)])
+        result = subprocess.run(command, text=True, capture_output=True, timeout=15)
+        lines = result.stdout.splitlines()
+        self.assertEqual(len(lines), 1, result)
+        return command, result, json.loads(lines[0])
+
+    def start(self):
+        return self.run_client(
+            "start", "--id", self.job["id"], "--owner", "fresh-agent",
+            "--expected-revision", str(self.job["revision"]),
+        )
+
+    def test_launcher_group_can_die_and_later_independent_clients_finish_attempt(self):
+        command = self.command(
+            "start", "--id", self.job["id"], "--owner", "fresh-agent",
+            "--expected-revision", str(self.job["revision"]),
+        )
+        launcher = subprocess.Popen(
+            ["sh", "-c", '"$@"; sleep 30', "attempt-launcher", *command],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            start_new_session=True,
+        )
+        assert launcher.stdout is not None
+        acquired = json.loads(launcher.stdout.readline())
+        self.assertTrue(acquired["ok"])
+        launcher_group = os.getpgid(launcher.pid)
+        os.killpg(launcher_group, signal.SIGKILL)
+        launcher.wait(timeout=3)
+        launcher.stdout.close()
+        assert launcher.stderr is not None
+        launcher.stderr.close()
+
+        _command, heartbeat, response = self.run_client("heartbeat")
+        self.assertEqual((heartbeat.returncode, response), (0, {"event": "heartbeat", "ok": True}))
+        progress = {"status": "active", "step": "form", "answerKeys": [], "pendingFields": []}
+        self.assertEqual(self.run_client("progress", payload=progress)[2]["event"], "progress_saved")
+        review = {"status": "review", "step": "review", "answerKeys": [], "pendingFields": []}
+        response = self.run_client("handoff", "--status", "awaiting_review", payload=review)[2]
+        self.assertEqual(response, {"event": "handed_off", "ok": True, "status": "awaiting_review"})
+        self.assertEqual(self.store.get_job(self.job["id"])["status"], "awaiting_review")
+        self.assertIsNone(self.store.claim_status()["claim"])
+
+    def test_bearer_is_absent_from_clients_outputs_and_broker_runtime_metadata(self):
+        command, result, acquired = self.start()
+        self.assertEqual(result.returncode, 0)
+        coordinator = json.loads((self.store_root / "coordinator.json").read_text())
+        bearer_hash = coordinator["claim"]["tokenHash"]
+        visible = json.dumps(acquired) + " " + " ".join(command) + json.dumps(dict(os.environ))
+        self.assertNotIn(bearer_hash, visible)
+        self.assertNotIn("token", json.dumps(acquired).lower())
+        self.assertNotIn("claim", json.dumps(acquired).lower())
+        self.assertEqual(ATTEMPT.socket_path(self.store_root).stat().st_mode & 0o777, 0o600)
+        runtime = ATTEMPT.pid_path(self.store_root).read_text(encoding="ascii")
+        self.assertRegex(runtime, r"^\d+\n$")
+        self.assertNotIn(bearer_hash, runtime)
+
+    def test_broker_loss_leaves_exact_claim_and_new_start_fails_value_free(self):
+        _command, _result, _acquired = self.start()
+        before = self.store.claim_status()["claim"]
+        process_path = ATTEMPT.pid_path(self.store_root)
+        broker_pid = int(process_path.read_text(encoding="ascii"))
+        os.kill(broker_pid, signal.SIGKILL)
+        for _ in range(100):
+            try:
+                os.kill(broker_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.01)
+        after = self.store.claim_status()["claim"]
+        self.assertEqual(after, before)
+
+        command, failed, response = self.start()
+        self.assertNotEqual(failed.returncode, 0)
+        self.assertEqual(response["ok"], False)
+        self.assertIn(response["error"]["code"], {"request_rejected", "attempt_unavailable"})
+        serialized = " ".join(command) + failed.stdout + failed.stderr
+        self.assertNotIn(before["claimId"], serialized)
+        self.assertNotIn(before["jobId"], failed.stdout)
+        self.assertEqual(self.store.claim_status()["claim"], before)
+        process_path.unlink(missing_ok=True)
+
+    def test_exact_value_free_needs_info_handoff_records_lifecycle(self):
+        command, _result, acquired = self.start()
+        payload = {
+            "status": "active", "step": "questions", "answerKeys": [],
+            "pendingFields": [{
+                "question": "How did you hear about this opportunity?", "state": "missing",
+                "answerKey": "source.discovery", "sensitive": False,
+            }],
+        }
+        response = self.run_client("handoff", "--status", "needs_info", payload=payload)[2]
+        self.assertEqual(response, {"event": "handed_off", "ok": True, "status": "needs_info"})
+        self.assertEqual(self.store.get_job(self.job["id"])["status"], "needs_info")
+        self.assertIsNone(self.store.claim_status()["claim"])
+        session = self.store.load_session(self.job["id"])
+        self.assertEqual(
+            {key: value for key, value in session["pendingFields"][0].items() if key != "reference"},
+            payload["pendingFields"][0],
+        )
+        self.assertRegex(session["pendingFields"][0]["reference"], r"^pending_[a-f0-9]{32}$")
+        self.assertEqual([event["event"] for event in self.store.read_history()], ["job-started", "job-blocked"])
+        visible = json.dumps(payload) + json.dumps(acquired) + " ".join(command)
+        for forbidden in ("Private", "private resume", "token", "claim", "ownerLabel"):
+            self.assertNotIn(forbidden, visible)
+
+    def test_closed_store_scoped_command_surface_rejects_candidate_switch(self):
+        self.start()
+        with ATTEMPT.connect(ATTEMPT.socket_path(self.store_root)) as connection:
+            ATTEMPT.send_response(connection, {"command": "progress", "id": "other", "session": {}})
+            rejected = ATTEMPT.receive_request(connection)
+        self.assertEqual(rejected, {"error": {"code": "request_rejected"}, "ok": False})
+        self.assertEqual(self.run_client("heartbeat")[2], {"event": "heartbeat", "ok": True})
+
+    def test_unsupported_invocation_never_contacts_or_changes_live_broker(self):
+        self.start()
+        before_claim = self.store.claim_status()["claim"]
+        before_job = self.store.get_job(self.job["id"])
+        before_sessions = self.store.list_sessions()
+        before_pid = ATTEMPT.pid_path(self.store_root).read_text(encoding="ascii")
+
+        _command, rejected, response = self.run_client("stop")
+
+        self.assertEqual(rejected.returncode, 2)
+        self.assertEqual(response, {"error": {"code": "invalid_invocation"}, "ok": False})
+        self.assertEqual(self.store.claim_status()["claim"], before_claim)
+        self.assertEqual(self.store.get_job(self.job["id"]), before_job)
+        self.assertEqual(self.store.list_sessions(), before_sessions)
+        self.assertEqual(ATTEMPT.pid_path(self.store_root).read_text(encoding="ascii"), before_pid)
+        self.assertEqual(self.run_client("heartbeat")[2], {"event": "heartbeat", "ok": True})
+
+    def test_invalid_invocation_is_distinct_from_genuine_broker_unavailability(self):
+        unavailable_root = self.root / "unavailable-store"
+        invalid = subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(unavailable_root), "stop"],
+            text=True, capture_output=True, timeout=15,
+        )
+        unavailable = subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(unavailable_root), "heartbeat"],
+            text=True, capture_output=True, timeout=15,
+        )
+
+        self.assertEqual(json.loads(invalid.stdout), {
+            "error": {"code": "invalid_invocation"}, "ok": False,
+        })
+        self.assertEqual(json.loads(unavailable.stdout), {
+            "error": {"code": "attempt_unavailable"}, "ok": False,
+        })
+        self.assertEqual((invalid.returncode, unavailable.returncode), (2, 2))
+        self.assertFalse(unavailable_root.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_job_apply_skill_contract.py
+++ b/tests/test_job_apply_skill_contract.py
@@ -1,0 +1,78 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = ROOT / "skills" / "job-apply" / "SKILL.md"
+README_PATH = ROOT / "README.md"
+
+
+class JobApplySkillContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.skill = SKILL_PATH.read_text(encoding="utf-8")
+        cls.readme = README_PATH.read_text(encoding="utf-8")
+
+    def test_action_time_consent_requires_visible_readiness(self):
+        self.assertIn("Post-readiness action-time consent", self.skill)
+        self.assertIn("Before the exact application form is visibly ready", self.skill)
+        self.assertIn("blanket future consent are invalid", self.skill)
+        self.assertIn("current message was sent after that visible readiness", self.skill)
+
+    def test_matching_consent_is_consumed_once_without_duplicate_confirmation(self):
+        self.assertIn("transitions once to `consent_consumed`", self.skill)
+        self.assertIn("Proceed without asking for the same confirmation again", self.skill)
+        self.assertIn("It is not reusable for another job", self.skill)
+        self.assertIn("must not trigger duplicate confirmation", self.skill)
+
+    def test_only_material_scope_destination_or_purpose_change_reconfirms(self):
+        self.assertIn(
+            "A material change to the data scope, destination, or purpose invalidates the consumed consent",
+            self.skill,
+        )
+        self.assertIn("obtain new explicit post-change consent", self.skill)
+        self.assertIn("Ordinary page progression within the unchanged bounds", self.skill)
+
+    def test_user_facing_summaries_are_value_free(self):
+        self.assertIn("Never echo raw applicant values", self.skill)
+        self.assertIn("Describe only field names or groups, counts, and states", self.skill)
+        for unsafe in (
+            "Summarize every entered value",
+            "summarize all entered fields",
+            "summarize the fields",
+            "Review the parsed and entered values",
+            "summarize the application for the user",
+        ):
+            self.assertNotIn(unsafe, self.skill)
+
+    def test_attempt_helper_surface_remains_closed(self):
+        invocations = re.findall(
+            r"job-apply-attempt\.py[^`\n]*?\s(start|heartbeat|progress|handoff)(?:\s|`)",
+            self.skill,
+        )
+        self.assertTrue(invocations)
+        self.assertEqual(set(invocations), {"start", "heartbeat", "progress", "handoff"})
+        for forbidden in (" stop", " abort", " release", " recover", " adopt"):
+            self.assertNotRegex(self.skill, rf"job-apply-attempt\.py[^`\n]*{forbidden}\b")
+
+    def test_readme_documents_detached_broker_not_attached_stdin_process(self):
+        for required in (
+            "detached broker scoped to one Store and exact selected attempt",
+            "later stateless `heartbeat`, value-free `progress`, and `handoff` clients",
+            "`needs_info` handoff so the broker releases the claim and exits",
+            "exact job, session, and answer revisions shown there",
+            "fresh broker acquisition for the same canonical job",
+        ):
+            self.assertIn(required, self.readme)
+
+        for stale in (
+            "lifetime of one attached process",
+            "accepts only value-free progress and `needs_info` or `awaiting_review` handoff messages on stdin",
+            "Start a new private attempt process",
+        ):
+            self.assertNotIn(stale, self.readme)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -2715,11 +2715,17 @@ class StoreTests(unittest.TestCase):
             ("in_progress", "active"),
         )
         self.assertEqual(activity["session"]["step"], "questions")
-        self.assertEqual(activity["session"]["pendingInformation"], [{
+        self.assertEqual(activity["session"]["pendingInformation"][0] | {"reference": "opaque"}, {
             "question": "Are you authorized to work here?",
             "state": "missing",
             "sensitive": True,
-        }])
+            "reference": "opaque",
+            "resolutionEligible": False,
+        })
+        self.assertRegex(
+            activity["session"]["pendingInformation"][0]["reference"],
+            r"^pending_[a-f0-9]{32}$",
+        )
         self.assertEqual(
             [event["event"] for event in activity["history"]], ["job-started"]
         )
@@ -2850,7 +2856,7 @@ class StoreTests(unittest.TestCase):
         allowed = {
             "jobId", "role", "company", "status", "revision", "priority",
             "reasonCode", "reasonLabel", "attentionAt", "guidance",
-            "missingInformationCount",
+            "missingInformationCount", "sessionRevision",
         }
         self.assertTrue(all(set(item) == allowed for item in projection["items"]))
         self.assertEqual(projection["items"][-1]["missingInformationCount"], 2)
@@ -2956,6 +2962,222 @@ class StoreTests(unittest.TestCase):
         self.assertNotIn(acquired["token"], stored)
         self.assertNotIn("250K", stored)
         self.assertEqual([event["event"] for event in self.store.read_history()], ["job-started", "job-blocked"])
+
+    def test_pending_answer_recheck_preserves_exact_resume_and_resumes_to_review(self):
+        self._make_ready_job(assigned=True)
+        resume_before = self.store.get_resume("assigned-resume")
+        resume_bytes_before = (
+            self.store.resume_files_path / resume_before["managedFile"]
+        ).read_bytes()
+        ready = self.store.get_job("ready-job")
+        acquired = self.store.acquire_ready_job("ready-job", "first-owner", ready["revision"])
+        pending = {
+            "status": "active", "step": "questions", "answerKeys": [],
+            "pendingFields": [
+                {"question": "Authorization?", "state": "missing", "answerKey": "question.safe", "sensitive": False},
+                {"question": "Availability?", "state": "missing", "answerKey": "question.second", "sensitive": False},
+            ],
+        }
+        self.store.save_claim_progress("ready-job", acquired["token"], pending)
+        blocked = self.store.handoff_claimed_job(
+            "ready-job", acquired["token"], "needs_info", pending,
+            acquired["job"]["revision"],
+        )
+        answer = self.store.put_answer({
+            "key": "question.safe", "question": "Authorization?",
+            "state": "confirmed", "value": "private accepted value",
+        })
+        second_answer = self.store.put_answer({
+            "key": "question.second", "question": "Availability?",
+            "state": "confirmed", "value": "another private value",
+        })
+        activity = self.store.get_job_activity("ready-job")
+        reference = activity["session"]["pendingInformation"][0]["reference"]
+        resolved = self.store.resolve_pending_answer(
+            "ready-job", reference, blocked["job"]["revision"],
+            activity["session"]["revision"], answer["revision"], True,
+        )
+        self.assertFalse(resolved["ready"])
+        self.assertEqual(resolved["job"]["status"], "needs_info")
+        self.assertEqual(len(resolved["session"]["pendingInformation"]), 1)
+        final_reference = resolved["session"]["pendingInformation"][0]["reference"]
+        managed_path = self.store.resume_files_path / resume_before["managedFile"]
+        state_before_changed_resume = (
+            self.store.jobs_path.read_bytes(),
+            self.store._session_path("ready-job").read_bytes(),
+        )
+        managed_path.write_bytes(b"changed resume bytes")
+        with self.assertRaisesRegex(STORE_MODULE.StoreError, "preflight failed"):
+            self.store.resolve_pending_answer(
+                "ready-job", final_reference, resolved["job"]["revision"],
+                resolved["session"]["revision"], second_answer["revision"], True,
+            )
+        self.assertEqual(
+            (self.store.jobs_path.read_bytes(), self.store._session_path("ready-job").read_bytes()),
+            state_before_changed_resume,
+        )
+        managed_path.write_bytes(resume_bytes_before)
+        resolved = self.store.resolve_pending_answer(
+            "ready-job", final_reference, resolved["job"]["revision"],
+            resolved["session"]["revision"], second_answer["revision"], True,
+        )
+        self.assertTrue(resolved["ready"])
+        self.assertEqual(resolved["session"]["pendingInformation"], [])
+        serialized = json.dumps(resolved) + self.store.history_path.read_text(encoding="utf-8") + self.store._session_path("ready-job").read_text(encoding="utf-8")
+        self.assertNotIn("private accepted value", serialized)
+        self.assertNotIn("another private value", serialized)
+        resumed = self.store.acquire_ready_job(
+            "ready-job", "second-owner", resolved["job"]["revision"]
+        )
+        for field in ("id", "revision", "contentRevision", "digest"):
+            self.assertEqual(resumed["resume"][field], acquired["resume"][field])
+            self.assertEqual(resumed["resume"][field], resume_before[field])
+        self.assertEqual(
+            (self.store.resume_files_path / resume_before["managedFile"]).read_bytes(),
+            resume_bytes_before,
+        )
+        reviewed = self.store.handoff_claimed_job(
+            "ready-job", resumed["token"], "awaiting_review",
+            {"status": "review", "step": "review", "pendingFields": []},
+            resumed["job"]["revision"],
+        )
+        self.assertEqual(reviewed["job"]["status"], "awaiting_review")
+        self.assertEqual(
+            [event["event"] for event in self.store.read_history()],
+            ["job-started", "job-blocked", "job-started", "reviewed"],
+        )
+
+    def test_pending_answer_resolution_negative_matrix_is_side_effect_free(self):
+        self._make_ready_job()
+        ready = self.store.get_job("ready-job")
+        safe = self.store.put_answer({"key": "safe", "state": "confirmed", "value": "private"})
+        self.store.put_answer({"key": "unconfirmed", "state": "missing"})
+        observed = self.store.observe_answer({
+            "question": "Declined?", "scope": {"kind": "declined"},
+            "state": "missing",
+        })
+        self.store.review_answer(observed["key"], "declined", observed["revision"])
+        self.store.put_answer(
+            {"key": "sensitive", "state": "sensitive", "sensitivity": "high", "value": "secret"},
+            remember_sensitive=True,
+        )
+        acquired = self.store.acquire_ready_job("ready-job", "owner", ready["revision"])
+        pending = {
+            "status": "active", "step": "questions", "answerKeys": [],
+            "pendingFields": [
+                {"question": "Safe?", "state": "missing", "answerKey": "safe", "sensitive": False},
+                {"question": "Missing?", "state": "missing", "answerKey": "absent", "sensitive": False},
+                {"question": "Unconfirmed?", "state": "missing", "answerKey": "unconfirmed", "sensitive": False},
+                {"question": "Declined?", "state": "missing", "answerKey": observed["key"], "sensitive": False},
+                {"question": "Sensitive?", "state": "missing", "answerKey": "sensitive", "sensitive": False},
+            ],
+        }
+        self.store.save_claim_progress("ready-job", acquired["token"], pending)
+        blocked = self.store.handoff_claimed_job(
+            "ready-job", acquired["token"], "needs_info", pending,
+            acquired["job"]["revision"],
+        )
+        activity = self.store.get_job_activity("ready-job")
+        references = [item["reference"] for item in activity["session"]["pendingInformation"]]
+        baseline = {
+            path: path.read_bytes()
+            for path in (
+                self.store.jobs_path, self.store._session_path("ready-job"),
+                self.store.coordinator_path, self.store.coordinator_journal_path,
+                self.store.history_path,
+            )
+        }
+        attempts = [
+            (references[0], blocked["job"]["revision"], activity["session"]["revision"], safe["revision"], False, "owner confirmation"),
+            (references[0], blocked["job"]["revision"] + 1, activity["session"]["revision"], safe["revision"], True, "job revision conflict"),
+            (references[0], blocked["job"]["revision"], activity["session"]["revision"] + 1, safe["revision"], True, "session revision conflict"),
+            (references[0], blocked["job"]["revision"], activity["session"]["revision"], safe["revision"] + 1, True, "answer revision conflict"),
+            (f"pending_{'0' * 32}", blocked["job"]["revision"], activity["session"]["revision"], safe["revision"], True, "reference is stale"),
+        ]
+        answer_revisions = [safe["revision"], 1, 1, 2, 1]
+        expected_messages = [None, "does not exist", "not accepted and confirmed", "not accepted and confirmed", "not accepted and confirmed"]
+        for reference, revision, message in zip(references, answer_revisions, expected_messages):
+            if message is None:
+                continue
+            attempts.append((reference, blocked["job"]["revision"], activity["session"]["revision"], revision, True, message))
+        for reference, job_revision, session_revision, answer_revision, confirmed, message in attempts:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(STORE_MODULE.StoreError, message):
+                    self.store.resolve_pending_answer(
+                        "ready-job", reference, job_revision, session_revision,
+                        answer_revision, confirmed,
+                    )
+                for path, content in baseline.items():
+                    self.assertEqual(path.read_bytes(), content)
+
+    def test_answer_resolution_journal_recovers_idempotently_before_and_after_each_write(self):
+        original_write = STORE_MODULE.atomic_write_json
+        for fail_at in range(1, 6):
+            for timing in ("before", "after"):
+                with self.subTest(fail_at=fail_at, timing=timing), tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary) / "store"
+                    store = STORE_MODULE.Store(root, Path(temporary) / "legacy.json")
+                    store.replace_profile(
+                        {"firstName": "Ada"},
+                        expected_revision=store.inspect_profile()["revision"],
+                        source="user",
+                    )
+                    resume_path = Path(temporary) / "resume.pdf"
+                    resume_path.write_bytes(b"%PDF-1.7\njournal")
+                    store.create_resume({"id": "resume", "label": "Resume", "path": str(resume_path)})
+                    job = store.create_job({
+                        "id": "journal-job", "url": "https://example.com/jobs/journal",
+                        "role": "Engineer", "company": "Acme",
+                    })
+                    job = store.transition_job(job["id"], "ready", job["revision"])
+                    acquired = store.acquire_ready_job(job["id"], "owner", job["revision"])
+                    pending = {
+                        "status": "active", "step": "questions", "pendingFields": [{
+                            "question": "Authorization?", "state": "missing",
+                            "answerKey": "safe", "sensitive": False,
+                        }],
+                    }
+                    store.save_claim_progress(job["id"], acquired["token"], pending)
+                    blocked = store.handoff_claimed_job(
+                        job["id"], acquired["token"], "needs_info", pending,
+                        acquired["job"]["revision"],
+                    )
+                    answer = store.put_answer({"key": "safe", "state": "confirmed", "value": "private"})
+                    activity = store.get_job_activity(job["id"])
+                    reference = activity["session"]["pendingInformation"][0]["reference"]
+                    calls = {"count": 0}
+
+                    def interrupted_write(path, payload):
+                        calls["count"] += 1
+                        if calls["count"] == fail_at and timing == "before":
+                            raise OSError("simulated answer-resolution interruption")
+                        result = original_write(path, payload)
+                        if calls["count"] == fail_at and timing == "after":
+                            raise OSError("simulated answer-resolution interruption")
+                        return result
+
+                    with mock.patch.object(STORE_MODULE, "atomic_write_json", side_effect=interrupted_write):
+                        with self.assertRaisesRegex(OSError, "simulated answer-resolution interruption"):
+                            store.resolve_pending_answer(
+                                job["id"], reference, blocked["job"]["revision"],
+                                activity["session"]["revision"], answer["revision"], True,
+                            )
+
+                    repaired = STORE_MODULE.Store(root, Path(temporary) / "legacy.json")
+                    repaired_activity = repaired.get_job_activity(job["id"])
+                    if fail_at == 1 and timing == "before":
+                        self.assertEqual(repaired.get_job(job["id"])["status"], "needs_info")
+                        repaired.resolve_pending_answer(
+                            job["id"], reference, blocked["job"]["revision"],
+                            activity["session"]["revision"], answer["revision"], True,
+                        )
+                    self.assertEqual(repaired.get_job(job["id"])["status"], "ready")
+                    self.assertEqual(repaired.get_job_activity(job["id"])["session"]["pendingInformation"], [])
+                    revision = repaired.get_job(job["id"])["revision"]
+                    repaired.get_job_activity(job["id"])
+                    repaired.initialize()
+                    self.assertEqual(repaired.get_job(job["id"])["revision"], revision)
+                    self.assertIsNone(repaired._load_coordinator_journal()["operation"])
 
     def test_coordinator_journal_rolls_forward_after_partial_failure_without_duplicates(self):
         self._make_ready_job()

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -3002,6 +3002,7 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(len(resolved["session"]["pendingInformation"]), 1)
         final_reference = resolved["session"]["pendingInformation"][0]["reference"]
         managed_path = self.store.resume_files_path / resume_before["managedFile"]
+        resume_metadata_before = managed_path.stat()
         state_before_changed_resume = (
             self.store.jobs_path.read_bytes(),
             self.store._session_path("ready-job").read_bytes(),
@@ -3017,6 +3018,10 @@ class StoreTests(unittest.TestCase):
             state_before_changed_resume,
         )
         managed_path.write_bytes(resume_bytes_before)
+        os.utime(
+            managed_path,
+            ns=(resume_metadata_before.st_atime_ns, resume_metadata_before.st_mtime_ns),
+        )
         resolved = self.store.resolve_pending_answer(
             "ready-job", final_reference, resolved["job"]["revision"],
             resolved["session"]["revision"], second_answer["revision"], True,

--- a/tests/test_job_apply_task.py
+++ b/tests/test_job_apply_task.py
@@ -1,0 +1,335 @@
+import importlib.util
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+STORE = load_module("job_apply_task_store_tests", ROOT / "scripts" / "job-apply-store.py")
+
+
+class TaskProtocolTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.store_root = self.root / "store"
+        self.store = STORE.Store(self.store_root)
+        self.task = [
+            sys.executable,
+            str(ROOT / "scripts" / "job-apply-task.py"),
+            "--root",
+            str(self.store_root),
+        ]
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def command(self, command, *arguments, payload=None, check=True):
+        final = [*self.task, command, *arguments]
+        if payload is not None:
+            input_path = self.root / f"{command}-input.json"
+            input_path.write_text(json.dumps(payload), encoding="utf-8")
+            final.extend(["--input", str(input_path)])
+        completed = subprocess.run(final, capture_output=True, text=True, check=False)
+        if check:
+            self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertEqual(completed.stderr, "")
+        return completed.returncode, json.loads(completed.stdout)
+
+    def make_ready_environment(self):
+        profile_revision = self.store.inspect_profile()["revision"]
+        self.store.replace_profile({"firstName": "Private"}, profile_revision, "user")
+        resume_path = self.root / "private-resume.txt"
+        resume_path.write_text("private resume content", encoding="utf-8")
+        self.store.create_resume({"id": "resume-primary", "label": "Primary", "path": str(resume_path)})
+
+    def test_intake_atomically_creates_or_resolves_one_job_without_token_or_url(self):
+        private_url = "https://example.invalid/private/job?candidate=secret"
+        _code, created = self.command(
+            "intake", payload={"url": private_url, "role": "Engineer", "company": "Example"}
+        )
+        self.assertEqual((created["ok"], created["action"]), (True, "create"))
+        self.assertNotIn("token", json.dumps(created).lower())
+        self.assertNotIn(private_url, json.dumps(created))
+        job_id = created["job"]["id"]
+
+        _code, resolved = self.command("intake", payload={"url": private_url})
+        self.assertEqual((resolved["action"], resolved["job"]["id"]), ("noop", job_id))
+        self.assertEqual(len(self.store.list_jobs()), 1)
+
+    def test_conflicting_or_trashed_identity_fails_closed_and_is_redacted(self):
+        private_url = "https://example.invalid/private/conflict?token=secret"
+        job = self.store.intake_task_job({"url": private_url})["job"]
+        self.store.trash_job(job["id"], job["revision"])
+        code, rejected = self.command("intake", payload={"url": private_url}, check=False)
+        self.assertEqual((code, rejected["ok"], rejected["error"]["code"]), (2, False, "job_identity_conflict"))
+        self.assertNotIn(private_url, json.dumps(rejected))
+        self.assertNotIn("secret", json.dumps(rejected))
+
+    def test_snapshot_and_exact_activity_are_store_owned_and_redacted(self):
+        private_url = "https://example.invalid/private/snapshot?secret=yes"
+        job = self.store.intake_task_job(
+            {"url": private_url, "role": "Engineer", "company": "Example"}
+        )["job"]
+        _code, snapshot = self.command("snapshot")
+        self.assertEqual(snapshot["snapshot"]["jobs"][0]["id"], job["id"])
+        self.assertIn("overview", snapshot["snapshot"])
+        self.assertIn("attention", snapshot["snapshot"])
+        self.assertNotIn(private_url, json.dumps(snapshot))
+        _code, activity = self.command("activity", "--id", job["id"])
+        self.assertEqual(activity["jobId"], job["id"])
+        self.assertEqual(activity["activity"]["job"]["revision"], job["revision"])
+
+    def test_snapshot_is_one_locked_revision_during_concurrent_job_write(self):
+        job = self.store.intake_task_job({
+            "url": "https://example.invalid/concurrent",
+            "role": "Before",
+            "company": "Example",
+        })["job"]
+        job = self.store.transition_job(job["id"], "needs_info", job["revision"])
+        snapshot_ready = self.root / "snapshot-ready"
+        snapshot_release = self.root / "snapshot-release"
+        writer_ready = self.root / "writer-ready"
+        writer_go = self.root / "writer-go"
+        writer_attempted = self.root / "writer-attempted"
+        writer_acquired = self.root / "writer-acquired"
+        module_path = ROOT / "scripts" / "job-apply-store.py"
+        snapshot_source = r'''
+import importlib.util, json, pathlib, sys, time
+module_path, root, ready, release = map(pathlib.Path, sys.argv[1:])
+spec = importlib.util.spec_from_file_location("snapshot_store", module_path)
+module = importlib.util.module_from_spec(spec); spec.loader.exec_module(module)
+store = module.Store(root); store.initialize(); store._ensure_coordinator_files()
+store.initialize = lambda: {"initialized": True}
+store._ensure_coordinator_files = lambda: None
+load_jobs = store._load_jobs_document
+def gated_load():
+    document = load_jobs()
+    ready.touch()
+    deadline = time.monotonic() + 5
+    while not release.exists():
+        if time.monotonic() >= deadline:
+            raise RuntimeError("snapshot release timed out")
+        time.sleep(0.01)
+    return document
+store._load_jobs_document = gated_load
+print(json.dumps(store.task_snapshot(), sort_keys=True))
+'''
+        writer_source = r'''
+import importlib.util, json, pathlib, sys, time
+module_path, root, ready, go, attempted, acquired, job_id, revision = sys.argv[1:]
+spec = importlib.util.spec_from_file_location("writer_store", module_path)
+module = importlib.util.module_from_spec(spec); spec.loader.exec_module(module)
+store = module.Store(pathlib.Path(root)); store.initialize()
+store.initialize = lambda: {"initialized": True}
+load_jobs = store._load_jobs_document
+def marked_load():
+    pathlib.Path(acquired).touch()
+    return load_jobs()
+store._load_jobs_document = marked_load
+pathlib.Path(ready).touch()
+deadline = time.monotonic() + 5
+while not pathlib.Path(go).exists():
+    if time.monotonic() >= deadline:
+        raise RuntimeError("writer start timed out")
+    time.sleep(0.01)
+pathlib.Path(attempted).touch()
+updated = store.update_job(job_id, {"role": "After"}, int(revision))
+print(json.dumps({"revision": updated["revision"]}, sort_keys=True))
+'''
+        writer_process = subprocess.Popen(
+            [sys.executable, "-c", writer_source, str(module_path),
+             str(self.store_root), str(writer_ready), str(writer_go),
+             str(writer_attempted), str(writer_acquired), job["id"],
+             str(job["revision"])],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        snapshot_process = None
+        try:
+            deadline = time.monotonic() + 5
+            while not writer_ready.exists() and time.monotonic() < deadline:
+                self.assertIsNone(writer_process.poll(), "writer exited before ready barrier")
+                time.sleep(0.01)
+            self.assertTrue(writer_ready.exists(), "writer did not initialize")
+            snapshot_process = subprocess.Popen(
+                [sys.executable, "-c", snapshot_source, str(module_path),
+                 str(self.store_root), str(snapshot_ready), str(snapshot_release)],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            deadline = time.monotonic() + 5
+            while not snapshot_ready.exists() and time.monotonic() < deadline:
+                self.assertIsNone(snapshot_process.poll(), "snapshot exited before barrier")
+                time.sleep(0.01)
+            self.assertTrue(snapshot_ready.exists(), "snapshot did not reach locked barrier")
+            writer_go.touch()
+            deadline = time.monotonic() + 5
+            while not writer_attempted.exists() and time.monotonic() < deadline:
+                self.assertIsNone(writer_process.poll(), "writer exited before lock attempt")
+                time.sleep(0.01)
+            self.assertTrue(writer_attempted.exists(), "writer did not attempt the lock")
+            lock_probe_deadline = time.monotonic() + 0.2
+            while not writer_acquired.exists() and time.monotonic() < lock_probe_deadline:
+                self.assertIsNone(writer_process.poll(), "writer exited during lock probe")
+                time.sleep(0.01)
+            self.assertFalse(writer_acquired.exists(), "writer bypassed the snapshot lock")
+            snapshot_release.touch()
+            snapshot_stdout, snapshot_stderr = snapshot_process.communicate(timeout=5)
+            writer_stdout, writer_stderr = writer_process.communicate(timeout=5)
+            self.assertEqual(snapshot_process.returncode, 0, snapshot_stderr)
+            self.assertEqual(writer_process.returncode, 0, writer_stderr)
+            self.assertTrue(writer_acquired.exists())
+            snapshot = json.loads(snapshot_stdout)
+            self.assertEqual(snapshot["overview"]["counts"]["attentionJobs"], 1)
+            self.assertEqual(snapshot["jobs"][0]["revision"], job["revision"])
+            self.assertEqual(snapshot["jobs"][0]["role"], "Before")
+            self.assertEqual(snapshot["attention"]["items"][0]["revision"], job["revision"])
+            self.assertEqual(snapshot["attention"]["items"][0]["role"], "Before")
+            signature_input = {
+                "overview": snapshot["overview"],
+                "jobs": snapshot["jobs"],
+                "attentionSignature": snapshot["attention"]["snapshotSignature"],
+            }
+            expected_signature = hashlib.sha256(
+                STORE._canonical_json(signature_input).encode("utf-8")
+            ).hexdigest()
+            self.assertEqual(snapshot["snapshotSignature"], expected_signature)
+            self.assertEqual(json.loads(writer_stdout)["revision"], job["revision"] + 1)
+        finally:
+            writer_go.touch()
+            snapshot_release.touch()
+            for process in (writer_process, snapshot_process):
+                if process is not None:
+                    if process.poll() is None:
+                        process.kill()
+                    process.communicate(timeout=2)
+
+    def test_selection_requires_owner_confirmation_exact_revision_and_preflight(self):
+        job = self.store.intake_task_job({"url": "https://example.invalid/select"})["job"]
+        code, unconfirmed = self.command(
+            "select", "--id", job["id"], "--expected-revision", str(job["revision"]), check=False
+        )
+        self.assertEqual((code, unconfirmed["error"]["code"]), (2, "owner_confirmation_required"))
+        code, failed = self.command(
+            "select", "--id", job["id"], "--expected-revision", str(job["revision"]),
+            "--owner-confirmed", check=False,
+        )
+        self.assertEqual((code, failed["error"]["code"]), (2, "preflight_failed"))
+
+        self.make_ready_environment()
+        _code, selected = self.command(
+            "select", "--id", job["id"], "--expected-revision", str(job["revision"]),
+            "--owner-confirmed",
+        )
+        self.assertEqual((selected["action"], selected["job"]["status"]), ("ready", "ready"))
+        code, stale = self.command(
+            "select", "--id", job["id"], "--expected-revision", str(job["revision"]),
+            "--owner-confirmed", check=False,
+        )
+        self.assertEqual((code, stale["error"]["code"]), (2, "stale_revision"))
+
+        ready_revision = selected["job"]["revision"]
+        _code, no_op = self.command(
+            "select", "--id", job["id"], "--expected-revision", str(ready_revision),
+            "--owner-confirmed",
+        )
+        self.assertEqual((no_op["action"], no_op["job"]["revision"]), ("noop", ready_revision))
+
+    def test_pending_answer_task_requires_confirmation_and_exact_safe_revisions(self):
+        self.make_ready_environment()
+        job = self.store.create_job({
+            "id": "pending-task", "url": "https://example.invalid/pending-task",
+            "role": "Engineer", "company": "Example",
+        })
+        job = self.store.transition_job(job["id"], "ready", job["revision"])
+        acquired = self.store.acquire_ready_job(job["id"], "owner", job["revision"])
+        pending = {
+            "status": "active", "step": "questions", "pendingFields": [{
+                "question": "Authorization?", "state": "missing",
+                "answerKey": "safe", "sensitive": False,
+            }],
+        }
+        self.store.save_claim_progress(job["id"], acquired["token"], pending)
+        blocked = self.store.handoff_claimed_job(
+            job["id"], acquired["token"], "needs_info", pending,
+            acquired["job"]["revision"],
+        )
+        answer = self.store.put_answer({
+            "key": "safe", "state": "confirmed", "value": "private value",
+        })
+        activity = self.store.get_job_activity(job["id"])
+        reference = activity["session"]["pendingInformation"][0]["reference"]
+        self.assertLessEqual(activity["session"]["revision"], 2 ** 53 - 1)
+        arguments = (
+            "--id", job["id"], "--reference", reference,
+            "--expected-job-revision", str(blocked["job"]["revision"]),
+            "--expected-session-revision", str(activity["session"]["revision"]),
+            "--expected-answer-revision", str(answer["revision"]),
+        )
+        code, unconfirmed = self.command(
+            "resolve-pending-answer", *arguments, check=False
+        )
+        self.assertEqual((code, unconfirmed["error"]["code"]), (2, "owner_confirmation_required"))
+        self.assertEqual(self.store.get_job(job["id"])["status"], "needs_info")
+        code, stale = self.command(
+            "resolve-pending-answer", *arguments[:-1], str(answer["revision"] + 1),
+            "--owner-confirmed", check=False,
+        )
+        self.assertEqual((code, stale["error"]["code"]), (2, "stale_revision"))
+        _code, resolved = self.command(
+            "resolve-pending-answer", *arguments, "--owner-confirmed"
+        )
+        self.assertTrue(resolved["ready"])
+        self.assertNotIn("private value", json.dumps(resolved))
+
+    def test_invalid_input_and_unavailable_activity_use_stable_json_errors(self):
+        invalid = self.root / "invalid.json"
+        invalid.write_text("not-json https://private.invalid/secret", encoding="utf-8")
+        code, failure = self.command("intake", "--input", str(invalid), check=False)
+        self.assertEqual((code, failure["error"]["code"]), (2, "invalid_request"))
+        self.assertNotIn("private.invalid", json.dumps(failure))
+        code, missing = self.command("activity", "--id", "job-missing", check=False)
+        self.assertEqual((code, missing["error"]["code"]), (2, "job_unavailable"))
+
+    def test_store_module_initialization_failure_is_redacted_json(self):
+        isolated = self.root / "isolated-helper"
+        isolated.mkdir()
+        task_copy = isolated / "job-apply-task.py"
+        task_copy.write_bytes((ROOT / "scripts" / "job-apply-task.py").read_bytes())
+        (isolated / "job-apply-store.py").write_text(
+            "raise RuntimeError('private path /Users/applicant and https://private.invalid')\n",
+            encoding="utf-8",
+        )
+        completed = subprocess.run(
+            [sys.executable, str(task_copy), "snapshot"],
+            capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(completed.returncode, 2)
+        self.assertEqual(completed.stderr, "")
+        self.assertEqual(json.loads(completed.stdout), {
+            "ok": False,
+            "error": {
+                "code": "store_unavailable",
+                "message": "The canonical store is unavailable.",
+            },
+        })
+        self.assertNotIn("Traceback", completed.stdout)
+        self.assertNotIn("private.invalid", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_job_apply_workspace.py
+++ b/tests/test_job_apply_workspace.py
@@ -755,9 +755,14 @@ class WorkspaceServerTests(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(activity["job"]["status"], "in_progress")
         self.assertEqual(activity["claim"]["state"], "active")
-        self.assertEqual(activity["session"]["pendingInformation"], [{
+        self.assertEqual(activity["session"]["pendingInformation"][0] | {"reference": "opaque"}, {
             "question": "Do you need sponsorship?", "state": "missing", "sensitive": True,
-        }])
+            "reference": "opaque", "resolutionEligible": False,
+        })
+        self.assertRegex(
+            activity["session"]["pendingInformation"][0]["reference"],
+            r"^pending_[a-f0-9]{32}$",
+        )
         serialized = json.dumps(activity)
         for forbidden in (
             acquired["token"], "private-api-owner", "private.api.answer",
@@ -772,6 +777,58 @@ class WorkspaceServerTests(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(unrelated_activity["claim"], {"state": "none"})
         self.assertNotIn(job["id"], json.dumps(unrelated_activity))
+
+    def test_pending_answer_route_uses_opaque_durable_reference_not_question_text(self):
+        self.server.store.replace_profile(
+            {"firstName": "Ada"},
+            expected_revision=self.server.store.inspect_profile()["revision"],
+            source="user",
+        )
+        resume_path = Path(self.temporary.name) / "pending-answer.pdf"
+        resume_path.write_bytes(b"%PDF-1.7\npending-answer")
+        self.server.store.create_resume(
+            {"id": "pending-answer-resume", "label": "Pending", "path": str(resume_path)}
+        )
+        job = self.create_job(
+            "https://example.com/jobs/pending-answer", role="Pending", company="Acme"
+        )
+        ready = self.server.store.transition_job(job["id"], "ready", job["revision"])
+        acquired = self.server.store.acquire_ready_job(job["id"], "owner", ready["revision"])
+        pending = {
+            "status": "active", "step": "questions", "answerKeys": [],
+            "pendingFields": [{
+                "question": "Same visible wording?", "state": "missing",
+                "answerKey": "durable.target", "sensitive": False,
+            }],
+        }
+        self.server.store.save_claim_progress(job["id"], acquired["token"], pending)
+        self.server.store.handoff_claimed_job(
+            job["id"], acquired["token"], "needs_info", pending,
+            acquired["job"]["revision"],
+        )
+        self.server.store.put_answer({
+            "key": "durable.decoy", "question": "Same visible wording?",
+            "scope": {"decoy": True}, "state": "confirmed", "value": "wrong",
+        })
+        target = self.server.store.put_answer({
+            "key": "durable.target", "question": "Canonical target wording",
+            "state": "missing",
+        })
+        activity = self.server.store.get_job_activity(job["id"])
+        reference = activity["session"]["pendingInformation"][0]["reference"]
+        self.assertNotIn("durable", reference)
+        route = f"/api/jobs/{job['id']}/pending-answers/{quote(reference, safe='')}"
+        status, _headers, detail = self.request("GET", route, origin=False)
+        self.assertEqual((status, detail["key"], detail["revision"]), (200, target["key"], target["revision"]))
+        status, _headers, unauthorized = self.request(
+            "GET", route, token=False, origin=False
+        )
+        self.assertEqual((status, unauthorized["error"]["code"]), (401, "token_rejected"))
+        status, _headers, stale = self.request(
+            "GET", f"/api/jobs/{job['id']}/pending-answers/pending_{'0' * 32}",
+            origin=False,
+        )
+        self.assertEqual((status, stale["error"]["code"]), (409, "stale_conflict"))
 
         status, _headers, missing = self.request(
             "GET", "/api/jobs/does-not-exist/activity", origin=False
@@ -1686,7 +1743,7 @@ class WorkspaceServerTests(unittest.TestCase):
         self.assertEqual(set(row), {
             "jobId", "role", "company", "status", "revision", "priority",
             "reasonCode", "reasonLabel", "attentionAt", "guidance",
-            "missingInformationCount",
+            "missingInformationCount", "sessionRevision",
         })
         self.server.store.transition_job(job["id"], "saved", needs["revision"])
         status, _headers, resolved = self.request(

--- a/tests/test_macos_account_flow_helper.py
+++ b/tests/test_macos_account_flow_helper.py
@@ -40,7 +40,7 @@ class MacOSAccountFlowHelperTests(unittest.TestCase):
         self.assertIn("realmPageSnapshot", source)
         self.assertIn("classifyPostOutcome(_ successor: AXUIElement)", source)
         self.assertIn("activateReviewedBrowser", source)
-        self.assertIn("for _ in 0..<20", source)
+        self.assertIn("for _ in 0..<100", source)
         self.assertIn("AXUIElementSetAttributeValue(\n            exactControl, kAXValueAttribute", source)
         self.assertIn("CFEqual(reattestedEmail, exactControl)", source)
         self.assertIn("oracleCausalSuccessorDecision", source)

--- a/tests/test_macos_account_flow_helper.py
+++ b/tests/test_macos_account_flow_helper.py
@@ -42,6 +42,7 @@ class MacOSAccountFlowHelperTests(unittest.TestCase):
         self.assertIn("activateReviewedBrowser", source)
         self.assertIn("for _ in 0..<100", source)
         self.assertIn("AXUIElementSetAttributeValue(\n            exactControl, kAXValueAttribute", source)
+        self.assertIn("Reobserve only; never repeat the effect", source)
         self.assertIn("CFEqual(reattestedEmail, exactControl)", source)
         self.assertIn("oracleCausalSuccessorDecision", source)
         self.assertIn("oracleExactEmailControlIdentityRemoved", source)

--- a/tests/test_qa_account.py
+++ b/tests/test_qa_account.py
@@ -1,7 +1,6 @@
 import importlib.util
 import json
 import os
-import shutil
 import socket
 import subprocess
 import tempfile
@@ -291,7 +290,79 @@ class SyntheticAccountQATests(unittest.TestCase):
             operation = "e" * 64
             socket_path = server.prepare_native_operation(operation)
             os.replace(binary, preserved)
-            shutil.copy2(sys.executable, binary)
+            attacker_source = root / "adversarial-peer.c"
+            attacker_source.write_text(r'''
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <time.h>
+#include <unistd.h>
+
+static int send_all(int descriptor, const char *value, size_t length) {
+    while (length > 0) {
+        ssize_t sent = send(descriptor, value, length, 0);
+        if (sent < 0 && errno == EINTR) continue;
+        if (sent < 0 && (errno == EPIPE || errno == ECONNRESET)) return 1;
+        if (sent <= 0) return -1;
+        value += sent;
+        length -= (size_t)sent;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc != 5) return 2;
+    int marker = open(argv[2], O_WRONLY | O_CREAT | O_EXCL, 0600);
+    if (marker < 0 || close(marker) != 0) return 3;
+    struct timespec pause = {0, 10000000};
+    for (int attempt = 0; access(argv[3], F_OK) != 0; attempt++) {
+        if (attempt >= 500) return 4;
+        nanosleep(&pause, NULL);
+    }
+    int channel = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (channel < 0) return 5;
+    int no_sigpipe = 1;
+    setsockopt(channel, SOL_SOCKET, SO_NOSIGPIPE, &no_sigpipe, sizeof(no_sigpipe));
+    struct timeval timeout = {3, 0};
+    setsockopt(channel, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    struct sockaddr_un address;
+    memset(&address, 0, sizeof(address));
+    address.sun_family = AF_UNIX;
+    if (strlen(argv[1]) >= sizeof(address.sun_path)) { close(channel); return 5; }
+    memcpy(address.sun_path, argv[1], strlen(argv[1]) + 1);
+    if (connect(channel, (struct sockaddr *)&address, sizeof(address)) != 0) {
+        close(channel); return 5;
+    }
+    int sent = send_all(channel, argv[4], strlen(argv[4]));
+    if (sent == 0) sent = send_all(channel, "\n", 1);
+    if (sent > 0) { close(channel); return 0; }
+    if (sent < 0) { close(channel); return 5; }
+    shutdown(channel, SHUT_WR);
+    char acknowledgment;
+    ssize_t received;
+    do { received = recv(channel, &acknowledgment, 1, 0); }
+    while (received < 0 && errno == EINTR);
+    int saved_errno = errno;
+    close(channel);
+    if (received == 0 || (received < 0 && saved_errno == ECONNRESET)) return 0;
+    return received > 0 ? 6 : 5;
+}
+''', encoding="utf-8")
+            compiled = subprocess.run(
+                ["xcrun", "clang", "-O2", "-Wall", "-Werror", "-o", str(binary),
+                 str(attacker_source)],
+                capture_output=True, check=False,
+            )
+            self.assertEqual(
+                (compiled.returncode, compiled.stdout, compiled.stderr), (0, b"", b"")
+            )
             payload = json.dumps({
                 "operationFingerprint": "sha256:" + operation,
                 "nativeOriginAttested": True,
@@ -301,49 +372,32 @@ class SyntheticAccountQATests(unittest.TestCase):
                 "afterClearAttested": True,
                 "secureControlCleared": True,
             }, sort_keys=True)
-            attacker_script = r'''
-import pathlib, socket, sys, time
-socket_path, ready_path, release_path, payload = sys.argv[1:]
-pathlib.Path(ready_path).touch()
-deadline = time.monotonic() + 5
-while not pathlib.Path(release_path).exists():
-    if time.monotonic() >= deadline:
-        raise SystemExit(4)
-    time.sleep(0.01)
-channel = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-channel.settimeout(3)
-channel.connect(socket_path)
-channel.sendall(payload.encode("utf-8") + b"\n")
-channel.shutdown(socket.SHUT_WR)
-try:
-    acknowledgment = channel.recv(1)
-except socket.timeout:
-    raise SystemExit(5)
-finally:
-    channel.close()
-raise SystemExit(6 if acknowledgment else 0)
-'''
-            attacker = subprocess.Popen([
-                str(binary), "-c", attacker_script, socket_path,
-                str(ready), str(release), payload,
-            ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            try:
-                deadline = time.monotonic() + 5
-                while not ready.exists() and time.monotonic() < deadline:
-                    if attacker.poll() is not None:
-                        break
-                    time.sleep(0.01)
-                self.assertTrue(ready.exists(), "path-swapped peer did not become ready")
-                os.replace(preserved, binary)
-                release.touch()
-                stdout, stderr = attacker.communicate(timeout=5)
-                self.assertEqual(attacker.returncode, 0, stderr.decode(errors="replace"))
-                self.assertEqual((stdout, stderr), (b"", b""))
-                self.assertIsNone(server.consume_observation(operation))
-                self.assertEqual(server._signed_identity(binary), server._native_identity)
-            finally:
-                if attacker.poll() is None:
-                    attacker.kill(); attacker.wait(timeout=2)
-                if preserved.exists():
+            with tempfile.TemporaryFile() as attacker_stderr:
+                attacker = subprocess.Popen([
+                    str(binary), socket_path, str(ready), str(release), payload,
+                ], stdout=subprocess.DEVNULL, stderr=attacker_stderr)
+                try:
+                    deadline = time.monotonic() + 5
+                    while not ready.exists() and time.monotonic() < deadline:
+                        if attacker.poll() is not None:
+                            break
+                        time.sleep(0.01)
+                    self.assertTrue(ready.exists(), "path-swapped peer did not become ready")
+                    self.assertIsNone(attacker.poll(), "adversarial peer exited before restoration")
                     os.replace(preserved, binary)
-                server.server_close()
+                    release.touch()
+                    attacker.wait(timeout=5)
+                    attacker_stderr.seek(0)
+                    stderr = attacker_stderr.read()
+                    self.assertEqual(attacker.returncode, 0, stderr.decode(errors="replace"))
+                    self.assertEqual(stderr, b"")
+                    self.assertIsNone(server.consume_observation(operation))
+                    self.assertEqual(server._signed_identity(binary), server._native_identity)
+                finally:
+                    release.touch()
+                    if attacker.poll() is None:
+                        attacker.kill()
+                    attacker.wait(timeout=2)
+                    if preserved.exists():
+                        os.replace(preserved, binary)
+                    server.server_close()

--- a/tests/test_qa_account.py
+++ b/tests/test_qa_account.py
@@ -135,6 +135,11 @@ class SyntheticAccountQATests(unittest.TestCase):
         self.assertIn("listener.settimeout(45)", server)
         self.assertEqual(source.count("provider.provision_or_reuse_and_fill"), 0)
 
+    def test_visible_browser_setup_disables_background_updates(self):
+        source = (ROOT / "scripts/qa-account.py").read_text(encoding="utf-8")
+        self.assertEqual(source.count('"--disable-background-networking"'), 1)
+        self.assertEqual(source.count('"--disable-component-update"'), 1)
+
     @unittest.skipUnless(
         os.environ.get("JOB_APPLY_OWNER_APPROVED_VISIBLE_BROWSER_TESTS") == "1",
         "visible browser tests require dedicated opt-in",

--- a/tests_js/unified_task_spine_oracle.test.mjs
+++ b/tests_js/unified_task_spine_oracle.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test("unified task spine oracle is executable, deterministic, closed, and privacy-safe", { timeout: 90_000 }, async () => {
+  const source = await readFile(join(REPO_ROOT, "qa", "unified_task_spine_oracle.mjs"), "utf8");
+  const attemptSource = await readFile(join(REPO_ROOT, "scripts", "job-apply-attempt.py"), "utf8");
+  assert.match(source, /job-apply-attempt\.py/);
+  assert.match(source, /spawnSync\(PYTHON, finalArgs/);
+  assert.doesNotMatch(source, /child\.stdin\.write/);
+  assert.doesNotMatch(source, /job-acquire|claim-(?:heartbeat|progress|handoff|recover)|--token/);
+  assert.match(attemptSource, /start_new_session=True/);
+  assert.match(attemptSource, /socket\.AF_UNIX/);
+  assert.match(attemptSource, /peer_is_current_user/);
+  assert.match(attemptSource, /path\.chmod\(0o600\)/);
+  const child = spawn(process.execPath, [join(REPO_ROOT, "qa", "unified_task_spine_oracle.mjs"), "--json"], {
+    cwd: REPO_ROOT,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const code = await new Promise((resolve) => child.once("exit", resolve));
+  assert.equal(code, 0, stdout);
+  assert.equal(stderr, "");
+  assert.equal(stdout.split("\n").filter(Boolean).length, 1);
+  const report = JSON.parse(stdout);
+  assert.deepEqual(
+    { schemaVersion: report.schemaVersion, oracle: report.oracle, result: report.result, closed: report.closed },
+    { schemaVersion: 1, oracle: "unified_task_spine", result: "pass", closed: true },
+  );
+  assert.equal(Object.values(report.proof).every((value) => value === true), true);
+  assert.deepEqual(report.counts, {
+    canonicalJobs: 2,
+    canonicalAcquisitionTargets: 1,
+    sequentialAcquisitions: 2,
+    finalActionEvents: 0,
+  });
+  assert.equal(report.transcript.at(-1), "closed_without_final_action");
+  assert.doesNotMatch(stdout, /claim_|https?:\/\/|answerKey|answerValue|resumePath|browserState|credential|bearer|token|\/tmp\//i);
+});

--- a/tests_js/workspace.test.mjs
+++ b/tests_js/workspace.test.mjs
@@ -1683,7 +1683,10 @@ test("pending answer browser journey preserves Job draft and reaches Ready, reac
     assert.equal(await jobDialog.isVisible(), true);
     assert.equal(await jobDialog.getByLabel("Notes").inputValue(), "unsaved browser draft");
     await openAnswer.waitFor();
-    assert.equal(await openAnswer.evaluate((button) => document.activeElement === button), true);
+    await page.waitForFunction(() => (
+      document.activeElement?.closest("#job-dialog")
+      && document.activeElement.textContent?.trim() === "Open in Answers"
+    ));
     await jobDialog.getByRole("button", { name: "Recheck this revision" }).click();
     await jobDialog.getByText(/Canonical status ready/i).waitFor();
     assert.equal((await cli("job-get", ["--id", job.id])).status, "ready");
@@ -2399,14 +2402,28 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     const duplicate = await cli("answer-put", [], { question: "Duplicate browser reusable answer?", state: "confirmed", value: "discarded-browser-duplicate" });
     await page.getByRole("button", { name: "Refresh" }).click();
     const duplicateCard = page.locator(".answer-card").filter({ hasText: "Duplicate browser reusable answer?" });
+    const duplicateDetailPath = answerApiPath(duplicate.key);
+    let duplicateDetailResponse = page.waitForResponse((response) => (
+      new URL(response.url()).pathname === duplicateDetailPath
+      && response.request().method() === "GET"
+    ));
     await duplicateCard.click();
+    assert.equal((await duplicateDetailResponse).status(), 200);
+    await answerDialog.waitFor({ state: "visible" });
+    assert.equal(await answerDialog.getByLabel("Question").inputValue(), "Duplicate browser reusable answer?");
     await answerDialog.getByLabel("Aliases (one per line)").fill("unsaved source merge draft");
     await answerDialog.getByRole("button", { name: "Merge duplicate…" }).click();
     await answerDialog.getByText("Save this draft or close the answer details to discard it before merging.").waitFor();
     assert.equal(await page.locator("#answer-merge-dialog").isVisible(), false);
     assert.equal(await answerDialog.getByLabel("Aliases (one per line)").inputValue(), "unsaved source merge draft");
     await answerDialog.getByRole("button", { name: "Close answer details" }).click();
+    await answerDialog.waitFor({ state: "hidden" });
+    duplicateDetailResponse = page.waitForResponse((response) => (
+      new URL(response.url()).pathname === duplicateDetailPath
+      && response.request().method() === "GET"
+    ));
     await duplicateCard.click();
+    assert.equal((await duplicateDetailResponse).status(), 200);
     await answerDialog.getByRole("button", { name: "Merge duplicate…" }).click();
     const mergeDialog = page.locator("#answer-merge-dialog");
     await mergeDialog.waitFor({ state: "visible" });

--- a/tests_js/workspace.test.mjs
+++ b/tests_js/workspace.test.mjs
@@ -930,20 +930,25 @@ test("answer browser routes encode canonical keys at every path boundary", async
   assert.doesNotMatch(app, /encodeURIComponent\((?:answer|selected|source)\.key\)/);
 });
 
-test("job-apply direct URL workflow resolves canonical managed resume storage", async () => {
+test("job-apply routes every ordinary URL through the canonical task protocol", async () => {
   const skill = await readFile(join(REPO_ROOT, "skills", "job-apply", "SKILL.md"), "utf8");
   const readme = await readFile(join(REPO_ROOT, "README.md"), "utf8");
   assert.match(skill, /resume-import --input/);
   assert.match(skill, /resume-resolve --id <resume-id>/);
-  assert.match(skill, /direct-URL mode[\s\S]{0,500}run `resume-resolve`/);
-  assert.match(skill, /full `resume-list` records as private tool output, not as a redacted projection/);
-  assert.match(skill, /summary containing only `id`, `label`, `tags`, `default`, `revision`, and `storageKind`/);
-  assert.match(skill, /never include a private path, managed filename, original filename, digest, or any other field/);
-  assert.doesNotMatch(skill, /inspect redacted metadata with `resume-list`/);
-  assert.match(skill, /Never use `profile\.resumePath` or a user source path for upload/);
+  assert.match(skill, /job-apply-task\.py[\s\S]{0,300}intake --input/);
+  assert.match(skill, /job-apply-task\.py \.\.\. snapshot/);
+  assert.match(skill, /select --id <job-id> --expected-revision <displayed-revision> --owner-confirmed/);
+  assert.match(skill, /discard the pre-select displayed revision and retain the exact revision returned in `select\.job\.revision`/);
+  assert.match(skill, /job-acquire --id <job-id> --owner <owner-label> --expected-revision <select\.job\.revision>/);
+  assert.match(skill, /other non-success result stops without browser work; do not run `job-acquire`/);
+  assert.match(skill, /Never infer a choice from priority/);
+  assert.match(skill, /use the acquired canonical job ID as the application\/session ID/);
+  assert.doesNotMatch(skill, /direct-URL mode|URL-derived application\/session ID/);
+  assert.match(skill, /Never use `profile\.resumePath`, a URL-derived session ID, or a user source path for upload/);
   assert.doesNotMatch(readme, /Every resume write uses an exact revision/);
   assert.match(readme, /Import is a new-record operation protected by ID\/content uniqueness/);
   assert.match(readme, /resume-resolve/);
+  assert.match(readme, /scripts\/job-apply-task\.py/);
 });
 
 test("styles include visible focus, reduced motion, contrast mode, and responsive behavior", async () => {
@@ -1357,7 +1362,7 @@ test("Needs Attention browser and CLI walkthrough converges all canonical reason
     assert.equal(await page.locator("#job-dialog[open]").count(), 0);
     assert.match(await page.title(), /^Facts/);
     await page.unroute(abandonedDetailPattern, delayAbandonedDetail);
-    await page.getByRole("button", { name: /Needs Attention/ }).click();
+    await page.locator("#nav-attention").click();
     await page.locator("#attention-count").getByText("4 jobs", { exact: true }).waitFor();
 
     let releaseEarlierSelection;
@@ -1611,6 +1616,94 @@ test("Facts saved views organize canonical paths without owning facts", { timeou
     assert.equal((await cli("fact-group-list")).some((group) => group.id === browserGroup.id), false);
     const finalProfile = await cli("profile-inspect");
     assert.deepEqual(finalProfile.profile, profile.profile);
+    assert.equal(pageErrors.length, 0, pageErrors.map(String).join("\n"));
+  } finally {
+    if (browser) await browser.close();
+    if (server && server.exitCode === null) { server.kill("SIGINT"); await new Promise((resolveExit) => server.once("exit", resolveExit)); }
+    await rm(temporary, { recursive: true, force: true });
+  }
+});
+
+test("pending answer browser journey preserves Job draft and reaches Ready, reacquisition, and awaiting review", { timeout: 60_000 }, async () => {
+  const temporary = await mkdtemp(join(tmpdir(), "pending-answer-browser-"));
+  const storeRoot = join(temporary, "store");
+  const storeScript = join(REPO_ROOT, "scripts", "job-apply-store.py");
+  let inputCounter = 0;
+  const cli = async (command, args = [], payload) => {
+    const finalArgs = [storeScript, "--root", storeRoot, command, ...args];
+    if (payload !== undefined) {
+      const inputPath = join(temporary, `pending-${inputCounter++}.json`);
+      await writeFile(inputPath, JSON.stringify(payload)); finalArgs.push("--input", inputPath);
+    }
+    const result = spawnSync(PYTHON, finalArgs, { cwd: REPO_ROOT, encoding: "utf8" });
+    assert.equal(result.status, 0, `${command}: ${result.stderr}`); return JSON.parse(result.stdout);
+  };
+  const waitForStartup = (child) => new Promise((resolveStartup, rejectStartup) => {
+    let stdout = ""; let stderr = "";
+    const timer = setTimeout(() => rejectStartup(new Error(`workspace startup timed out: ${stderr}`)), 10_000);
+    child.stdout.setEncoding("utf8"); child.stderr.setEncoding("utf8"); child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.stdout.on("data", (chunk) => { stdout += chunk; const newline = stdout.indexOf("\n"); if (newline < 0) return; clearTimeout(timer); try { resolveStartup(JSON.parse(stdout.slice(0, newline))); } catch (error) { rejectStartup(error); } });
+    child.once("exit", (code) => { clearTimeout(timer); rejectStartup(new Error(`workspace exited during startup (${code}): ${stderr}`)); });
+  });
+
+  let server; let browser;
+  try {
+    await cli("profile-replace", ["--expected-revision", "0", "--source", "user"], { firstName: "Synthetic" });
+    const resumePath = join(temporary, "resume.pdf"); await writeFile(resumePath, minimalSyntheticPdf());
+    const resume = await cli("resume-create", [], { id: "pending-resume", label: "Pending resume", path: resumePath });
+    let job = await cli("job-create", [], { id: "pending-job", url: "https://example.invalid/jobs/pending", role: "Pending Journey", company: "Synthetic", resumeId: resume.id });
+    job = await cli("job-transition", ["--id", job.id, "--status", "ready", "--expected-revision", String(job.revision)]);
+    const first = await cli("job-acquire", ["--id", job.id, "--owner", "first-owner", "--expected-revision", String(job.revision)]);
+    const pendingPayload = { status: "active", step: "questions", answerKeys: [], pendingFields: [{ question: "Shared visible wording?", state: "missing", answerKey: "durable.target", sensitive: false }] };
+    await cli("claim-progress", ["--id", job.id, "--token", first.token], pendingPayload);
+    job = (await cli("claim-handoff", ["--id", job.id, "--token", first.token, "--status", "needs_info", "--expected-revision", String(first.job.revision)], pendingPayload)).job;
+    await cli("answer-put", [], { key: "durable.decoy", question: "Shared visible wording?", scope: { decoy: true }, state: "confirmed", value: "decoy" });
+    await cli("answer-put", [], { key: "durable.target", question: "Different canonical wording", state: "missing" });
+
+    server = spawn(PYTHON, [join(REPO_ROOT, "scripts", "job-apply-workspace.py"), "--root", storeRoot, "--port", "0", "--no-open", "--json"], { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"] });
+    const startup = await waitForStartup(server);
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage(); const pageErrors = []; page.on("pageerror", (error) => pageErrors.push(error));
+    await page.addInitScript(() => { globalThis.setInterval = () => 0; });
+    await page.goto(startup.url); await page.getByText("Canonical store connected").waitFor();
+    await page.locator("#nav-attention").click();
+    await page.getByRole("button", { name: /Pending Journey/ }).click();
+    const jobDialog = page.locator("#job-dialog"); const answerDialog = page.locator("#answer-dialog");
+    await jobDialog.getByLabel("Notes").fill("unsaved browser draft");
+    const openAnswer = jobDialog.getByRole("button", { name: "Open in Answers" });
+    await openAnswer.click();
+    await answerDialog.waitFor({ state: "visible" });
+    assert.equal(await jobDialog.isVisible(), true);
+    assert.equal(await answerDialog.getByLabel("Question").inputValue(), "Different canonical wording");
+    assert.equal(await jobDialog.getByLabel("Notes").inputValue(), "unsaved browser draft");
+    await answerDialog.getByLabel("State").selectOption("confirmed");
+    await answerDialog.getByLabel("Value", { exact: true }).fill("accepted synthetic value");
+    await answerDialog.getByRole("button", { name: "Save answer" }).click();
+    await answerDialog.waitFor({ state: "hidden" });
+    assert.equal(await jobDialog.isVisible(), true);
+    assert.equal(await jobDialog.getByLabel("Notes").inputValue(), "unsaved browser draft");
+    await openAnswer.waitFor();
+    assert.equal(await openAnswer.evaluate((button) => document.activeElement === button), true);
+    await jobDialog.getByRole("button", { name: "Recheck this revision" }).click();
+    await jobDialog.getByText(/Canonical status ready/i).waitFor();
+    assert.equal((await cli("job-get", ["--id", job.id])).status, "ready");
+    assert.equal(await jobDialog.getByLabel("Notes").inputValue(), "unsaved browser draft");
+    await jobDialog.getByRole("button", { name: "Close job details" }).click();
+    await page.locator("#attention-workspace").waitFor({ state: "visible" });
+    assert.equal(await page.locator("#attention-list [data-attention-id='pending-job']").count(), 0);
+
+    job = await cli("job-get", ["--id", job.id]);
+    const second = await cli("job-acquire", ["--id", job.id, "--owner", "second-owner", "--expected-revision", String(job.revision)]);
+    for (const field of ["id", "revision", "contentRevision", "digest"]) assert.equal(second.resume[field], first.resume[field]);
+    assert.deepEqual(await readFile(second.resume.path), await readFile(first.resume.path));
+    job = (await cli("claim-handoff", ["--id", job.id, "--token", second.token, "--status", "awaiting_review", "--expected-revision", String(second.job.revision)], { status: "review", step: "review", pendingFields: [] })).job;
+    await page.getByRole("button", { name: "Jobs", exact: true }).click(); await page.locator("#refresh").click();
+    await page.getByRole("button", { name: /Pending Journey/ }).click();
+    await jobDialog.getByText(/Canonical status awaiting review/i).waitFor();
+    const events = await cli("history-list");
+    assert.deepEqual(events.map((event) => event.event), ["job-started", "job-blocked", "job-started", "reviewed"]);
+    assert.equal(events.some((event) => ["completed", "applied"].includes(event.event) || event.status === "applied"), false);
+    assert.equal((await cli("job-get", ["--id", job.id])).status, "awaiting_review");
     assert.equal(pageErrors.length, 0, pageErrors.map(String).join("\n"));
   } finally {
     if (browser) await browser.close();
@@ -2088,7 +2181,8 @@ test("real browser and CLI share CRUD, conflict, ready handoff, semantics, focus
     await activityCard().click();
     await activityPanel.getByText(/Canonical status needs info/).waitFor();
     assert.match(await activityPanel.innerText(), /job-blocked · needs info/i);
-    assert.equal(await activityPanel.locator("button").count(), 0);
+    assert.equal(await activityPanel.getByRole("button", { name: "Open in Answers" }).count(), 1);
+    assert.equal(await activityPanel.getByRole("button", { name: "Recheck this revision" }).count(), 0);
     await page.getByRole("button", { name: "Mark ready" }).click();
     await page.locator("#job-dialog").waitFor({ state: "hidden" });
 

--- a/workspace/app.js
+++ b/workspace/app.js
@@ -371,7 +371,7 @@ if (hasDom) {
   const profileState = { inspection: null, drafts: new Map(), draftBases: new Map(), atomic: new Set(), additionalAtomic: new Set(), deletions: new Set(), conflicts: [], latest: null, loaded: false };
   const factGroupState = { items: [], selectedView: "all", selected: null, editing: null, loaded: false, opener: null, requestSequence: 0 };
   const resumeState = { items: [], proposals: [], trash: false, loaded: false, loading: false, requestId: 0, selected: null, opener: null, proposal: null, dirtyMetadata: new Set() };
-  const answerState = { items: [], loaded: false, selected: null, offset: 0, limit: 25, total: 0, dirty: new Set(), opener: null, requestSequence: 0, detailRequestSequence: 0, dialogGeneration: 0, mergeRequestSequence: 0, mergeSource: null, mergeCandidates: [], busyControls: null };
+  const answerState = { items: [], loaded: false, selected: null, offset: 0, limit: 25, total: 0, dirty: new Set(), opener: null, pendingJobId: null, pendingReference: null, requestSequence: 0, detailRequestSequence: 0, dialogGeneration: 0, mergeRequestSequence: 0, mergeSource: null, mergeCandidates: [], busyControls: null };
   const trashState = { items: [], counts: { job: 0, resume: 0, answer: 0 }, loaded: false, selected: null, opener: null };
   const attentionState = { items: [], snapshotSignature: "", loaded: false, unavailable: false, detailRequestSequence: 0 };
   const overviewState = { projection: null, available: false, degraded: false, unavailable: false };
@@ -1157,11 +1157,16 @@ if (hasDom) {
       const company = document.createElement("p"); company.className = "attention-company"; company.textContent = item.company || "Company not set";
       const reason = document.createElement("strong"); reason.className = `attention-reason ${item.reasonCode}`; reason.textContent = item.reasonLabel;
       const guidance = document.createElement("p"); guidance.textContent = item.guidance;
+      const pendingQuestion = item.pendingInformation?.[0]?.question;
+      const question = document.createElement("p"); question.className = "attention-question";
+      question.textContent = pendingQuestion ? `Pending: ${pendingQuestion}` : "";
       const metadata = document.createElement("p"); metadata.className = "attention-meta";
       const missing = item.reasonCode === "needs_information" ? ` · ${item.missingInformationCount} missing information item${item.missingInformationCount === 1 ? "" : "s"}` : "";
       metadata.textContent = `Priority ${item.priority} · ${statusLabel(item.status)} · since ${formatActivityTime(item.attentionAt)}${missing}`;
       const action = document.createElement("span"); action.className = "attention-action"; action.textContent = attentionState.unavailable ? "Unavailable until refresh" : "Open Job details";
-      button.append(heading, company, reason, guidance, metadata, action);
+      button.append(heading, company, reason, guidance);
+      if (pendingQuestion) button.append(question);
+      button.append(metadata, action);
       button.addEventListener("click", () => openAttentionJob(item.jobId, button)); wrapper.append(button); list.append(wrapper);
     }
     $("#attention-count").textContent = `${attentionState.items.length} job${attentionState.items.length === 1 ? "" : "s"}`;
@@ -1274,17 +1279,22 @@ if (hasDom) {
     $("#answer-reference-counts").textContent = answer ? `${answer.referenceCounts?.sessions || 0} session and ${answer.referenceCounts?.history || 0} history references.` : "";
   }
 
+  function showAnswerDetail(selected, opener, pendingJobId = null, pendingReference = null) {
+    answerState.dialogGeneration += 1; answerState.opener = opener || document.activeElement;
+    answerState.pendingJobId = pendingJobId; answerState.pendingReference = pendingReference; answerState.selected = selected; populateAnswerForm(selected);
+    $("#answer-kicker").textContent = `CANONICAL · REVISION ${selected.revision}`; $("#answer-dialog").showModal(); setTimeout(() => $("#answer-form").elements.question.focus(), 0);
+  }
+
   async function openAnswer(answer, opener) {
     const requestSequence = ++answerState.detailRequestSequence;
     const requestedOpener = opener || document.activeElement;
     try {
       const selected = await api(answerApiPath(answer.key));
       if (requestSequence !== answerState.detailRequestSequence) return;
-      answerState.dialogGeneration += 1; answerState.opener = requestedOpener; answerState.selected = selected; populateAnswerForm(selected);
-      $("#answer-kicker").textContent = `CANONICAL · REVISION ${selected.revision}`; $("#answer-dialog").showModal(); setTimeout(() => $("#answer-form").elements.question.focus(), 0);
+      showAnswerDetail(selected, requestedOpener);
     } catch (error) { if (requestSequence === answerState.detailRequestSequence) answerError(error.message); }
   }
-  function newAnswer() { answerState.detailRequestSequence += 1; answerState.dialogGeneration += 1; answerState.selected = null; answerState.opener = document.activeElement; populateAnswerForm(null); $("#answer-kicker").textContent = "NEW CANONICAL RECORD"; $("#answer-dialog").showModal(); setTimeout(() => $("#answer-form").elements.question.focus(), 0); }
+  function newAnswer() { answerState.detailRequestSequence += 1; answerState.dialogGeneration += 1; answerState.selected = null; answerState.opener = document.activeElement; answerState.pendingJobId = null; answerState.pendingReference = null; populateAnswerForm(null); $("#answer-kicker").textContent = "NEW CANONICAL RECORD"; $("#answer-dialog").showModal(); setTimeout(() => $("#answer-form").elements.question.focus(), 0); }
 
   function answerFormPayload(onlyDirty = false) {
     const form = $("#answer-form"); let scope; try { scope = JSON.parse(form.elements.scope.value); } catch { throw new Error("Scope must be a valid JSON object."); } if (!scope || Array.isArray(scope) || typeof scope !== "object") throw new Error("Scope must be a JSON object.");
@@ -1307,9 +1317,10 @@ if (hasDom) {
         ? await api(answerApiPath(selected.key), { method: "PATCH", body: JSON.stringify({ patch: answer, expectedRevision: selected.revision, rememberSensitive }) })
         : await api("/api/answers", { method: "POST", body: JSON.stringify({ answer, rememberSensitive }) });
       const currentDialog = canApplyAnswerDialogMutation(answerState.selected, requestedKey, dialogGeneration, answerState.dialogGeneration, $("#answer-dialog").open);
-      if (currentDialog) { answerState.opener = null; $("#answer-dialog").close(); }
+      const pendingReturn = Boolean(answerState.pendingJobId && dialog.open);
+      if (currentDialog) { if (!pendingReturn) answerState.opener = null; $("#answer-dialog").close(); }
       await refreshAnswers({ reset: true });
-      if (currentDialog) (document.querySelector(`.answer-card[data-key="${CSS.escape(result.key)}"]`) || $("#answer-new")).focus();
+      if (currentDialog && !pendingReturn) (document.querySelector(`.answer-card[data-key="${CSS.escape(result.key)}"]`) || $("#answer-new")).focus();
       toast(`Answer ${selected ? "updated" : "created"}`); return result;
     } catch (error) { if (!canApplyAnswerDialogMutation(answerState.selected, requestedKey, dialogGeneration, answerState.dialogGeneration, $("#answer-dialog").open)) { toast(error.message); return; } if (error.status === 409) { $("#answer-conflict").classList.remove("hidden"); $("#answer-conflict").focus(); } else answerError(error.message, true); }
     finally { if (canApplyAnswerDialogMutation(answerState.selected, requestedKey, dialogGeneration, answerState.dialogGeneration, $("#answer-dialog").open)) setAnswerBusy(false); }
@@ -1324,8 +1335,9 @@ if (hasDom) {
       if (action === "accept") { payload.patch = answerFormPayload(true); payload.rememberSensitive = $("#answer-form").elements.rememberSensitive.checked; }
       await api(answerApiPath(answer.key, action), { method: "POST", body: JSON.stringify(payload) });
       const currentDialog = canApplyAnswerDialogMutation(answerState.selected, answer.key, dialogGeneration, answerState.dialogGeneration, $("#answer-dialog").open);
-      if (currentDialog) { answerState.opener = null; $("#answer-dialog").close(); }
-      await refreshAnswers({ reset: true }); if (currentDialog) $("#answer-new").focus(); toast(`Answer ${action === "accept" ? "accepted" : action === "decline" ? "declined" : `${action}d`}`);
+      const pendingReturn = Boolean(answerState.pendingJobId && dialog.open);
+      if (currentDialog) { if (!pendingReturn) answerState.opener = null; $("#answer-dialog").close(); }
+      await refreshAnswers({ reset: true }); if (currentDialog && !pendingReturn) $("#answer-new").focus(); toast(`Answer ${action === "accept" ? "accepted" : action === "decline" ? "declined" : `${action}d`}`);
     }
     catch (error) { if (!canApplyAnswerDialogMutation(answerState.selected, answer.key, dialogGeneration, answerState.dialogGeneration, $("#answer-dialog").open)) { toast(error.message); return; } if (error.code === "revision_conflict") { $("#answer-conflict").classList.remove("hidden"); $("#answer-conflict").focus(); } else answerError(lifecycleErrorText(error), true); }
     finally { if (canApplyAnswerDialogMutation(answerState.selected, answer.key, dialogGeneration, answerState.dialogGeneration, $("#answer-dialog").open)) setAnswerBusy(false); }
@@ -1821,7 +1833,18 @@ if (hasDom) {
       const pending = $("#activity-pending"); pending.replaceChildren();
       for (const item of activity.session.pendingInformation || []) {
         const row = document.createElement("li");
-        row.textContent = `${item.question || "Information requested"} · ${statusLabel(item.state || "missing")}${item.sensitive ? " · sensitive" : ""}`;
+        const text = document.createElement("span");
+        text.textContent = `${item.question || "Information requested"} · ${statusLabel(item.state || "missing")}${item.sensitive ? " · sensitive" : ""}`;
+        const actions = document.createElement("span"); actions.className = "pending-actions";
+        const edit = document.createElement("button"); edit.type = "button"; edit.className = "button secondary"; edit.textContent = "Open in Answers";
+        edit.dataset.pendingReference = item.reference;
+        edit.addEventListener("click", () => openPendingAnswerEditor(item)); actions.append(edit);
+        if (item.resolutionEligible && Number.isInteger(item.answerRevision)) {
+          const recheck = document.createElement("button"); recheck.type = "button"; recheck.className = "button accent"; recheck.textContent = "Recheck this revision";
+          recheck.dataset.pendingReference = item.reference;
+          recheck.addEventListener("click", () => recheckPendingAnswer(item, recheck)); actions.append(recheck);
+        }
+        row.append(text, actions);
         pending.append(row);
       }
       $("#activity-pending-wrap").classList.toggle("hidden", pending.children.length === 0);
@@ -1848,6 +1871,52 @@ if (hasDom) {
       ? "Durable application activity is available again."
       : activityAnnouncement(previous, activity);
     if (announce && message) $("#activity-live").textContent = message;
+  }
+
+  async function openPendingAnswerEditor(item) {
+    if (!dialog.open || !state.selected || !item.reference) return;
+    const jobId = state.selected.id;
+    const opener = document.activeElement;
+    const requestSequence = ++answerState.detailRequestSequence;
+    try {
+      const selected = await api(`/api/jobs/${encodeURIComponent(jobId)}/pending-answers/${encodeURIComponent(item.reference)}`);
+      if (requestSequence !== answerState.detailRequestSequence || !dialog.open || state.selected?.id !== jobId) return;
+      showAnswerDetail(selected, opener, jobId, item.reference);
+    } catch (error) {
+      if (requestSequence === answerState.detailRequestSequence && dialog.open && state.selected?.id === jobId) showFormError(error.message);
+    }
+  }
+
+  async function recheckPendingAnswer(item, button) {
+    if (!state.selected || !state.activity?.session || !item.reference) return;
+    button.disabled = true;
+    try {
+      const result = await api(`/api/jobs/${encodeURIComponent(state.selected.id)}/resolve-pending-answer`, {
+        method: "POST",
+        body: JSON.stringify({
+          reference: item.reference,
+          expectedJobRevision: state.activity.job.revision,
+          expectedSessionRevision: state.activity.session.revision,
+          expectedAnswerRevision: item.answerRevision,
+          ownerConfirmed: true,
+        }),
+      });
+      state.selected = { ...state.selected, status: result.job.status, revision: result.job.revision };
+      const index = state.jobs.findIndex((job) => job.id === state.selected.id);
+      if (index !== -1) state.jobs[index] = newestCanonicalJob(state.jobs[index], state.selected);
+      await Promise.all([loadActivity(state.selected.id), refreshAttention({ quiet: true }), refresh({ quiet: true })]);
+      toast(result.ready ? "Question resolved; the exact job is Ready" : "Question resolved; other blockers remain");
+    } catch (error) {
+      if (error.status === 409 || error.code === "revision_conflict") {
+        $("#form-error").textContent = "Canonical state changed. Your job draft is preserved; review the refreshed pending question before rechecking.";
+        $("#form-error").classList.remove("hidden");
+        await loadActivity(state.selected.id, { announce: false });
+      } else {
+        $("#form-error").textContent = error.message; $("#form-error").classList.remove("hidden");
+      }
+    } finally {
+      if (button.isConnected) button.disabled = false;
+    }
   }
 
   function loadActivity(jobId = state.selected?.id, { announce = true } = {}) {
@@ -1932,7 +2001,7 @@ if (hasDom) {
   $("#answer-merge-dialog").addEventListener("close", () => { if ($("#answer-merge-dialog").open) return; answerState.mergeRequestSequence += 1; answerState.mergeSource = null; answerState.mergeCandidates = []; });
   $("#answer-accept").addEventListener("click", () => answerAction("accept")); $("#answer-decline").addEventListener("click", () => answerAction("decline")); $("#answer-trash").addEventListener("click", () => { if (confirm("Move this answer to trash?")) answerAction("trash"); }); $("#answer-restore").addEventListener("click", () => answerAction("restore")); $("#answer-delete").addEventListener("click", () => openTrashDelete({ type: "answer", id: answerState.selected.key, revision: answerState.selected.revision, label: answerState.selected.question || answerState.selected.key }, $("#answer-delete")));
   $("#answer-conflict-refresh").addEventListener("click", async () => { const selected = answerState.selected; const dialogGeneration = answerState.dialogGeneration; setAnswerBusy(true); try { const latest = await api(answerApiPath(selected.key)); if (!canApplyAnswerDialogResponse(answerState.selected, selected.key, dialogGeneration, answerState.dialogGeneration, $("#answer-dialog").open)) return; if (!canRefreshAnswerDraft(selected, latest)) { answerError("This source answer changed identity while its canonical revision was being refreshed. Its preserved draft was not retargeted; close this dialog and review the current answer separately.", true); return; } answerState.selected = latest; $("#answer-conflict").classList.add("hidden"); $("#answer-kicker").textContent = `CANONICAL · REVISION ${answerState.selected.revision} · DRAFT PRESERVED`; toast("Canonical revision refreshed; review your preserved draft"); } catch (error) { if (canApplyAnswerDialogResponse(answerState.selected, selected.key, dialogGeneration, answerState.dialogGeneration, $("#answer-dialog").open)) answerError(error.message, true); } finally { if (canApplyAnswerDialogResponse(answerState.selected, selected.key, dialogGeneration, answerState.dialogGeneration, $("#answer-dialog").open)) setAnswerBusy(false); } });
-  $("#answer-dialog").addEventListener("close", () => { if ($("#answer-dialog").open) return; setAnswerBusy(false); answerState.dialogGeneration += 1; answerState.mergeRequestSequence += 1; answerState.mergeSource = null; answerState.selected = null; answerState.dirty.clear(); $("#answer-form").elements.value.value = ""; $("#answer-form").elements.rememberSensitive.checked = false; const target = answerState.opener?.isConnected ? answerState.opener : $("#answer-new"); target.focus(); answerState.opener = null; });
+  $("#answer-dialog").addEventListener("close", () => { if ($("#answer-dialog").open) return; setAnswerBusy(false); answerState.dialogGeneration += 1; answerState.mergeRequestSequence += 1; answerState.mergeSource = null; answerState.selected = null; answerState.dirty.clear(); $("#answer-form").elements.value.value = ""; $("#answer-form").elements.rememberSensitive.checked = false; const pendingJobId = answerState.pendingJobId; const pendingReference = answerState.pendingReference; const target = answerState.opener?.isConnected ? answerState.opener : $("#answer-new"); answerState.pendingJobId = null; answerState.pendingReference = null; answerState.opener = null; if (pendingJobId && dialog.open && state.selected?.id === pendingJobId) { Promise.all([loadActivity(pendingJobId, { announce: false }), refreshAttention({ quiet: true })]).finally(() => { const refreshedTarget = pendingReference ? document.querySelector(`[data-pending-reference="${CSS.escape(pendingReference)}"]`) : null; if (dialog.open && state.selected?.id === pendingJobId) (target?.isConnected ? target : refreshedTarget)?.focus(); }); } else target.focus(); });
   $("#resumes-refresh").addEventListener("click", () => refreshResumes());
   $("#resumes-active").addEventListener("click", async () => { resumeState.trash = false; await refreshResumes(); });
   $("#resumes-trash").addEventListener("click", async () => { resumeState.trash = true; await refreshResumes(); });

--- a/workspace/styles.css
+++ b/workspace/styles.css
@@ -137,6 +137,7 @@ dialog::backdrop { background: rgba(14,28,22,.58); backdrop-filter: blur(4px); }
 .activity-progress dt { color: var(--muted); font-weight: 750; }.activity-progress dd { margin: 0; overflow-wrap: anywhere; }
 .activity-history ol { display: grid; gap: .65rem; margin: .6rem 0 0; padding-left: 1.4rem; }
 .activity-history li { padding-left: .3rem; }.activity-history time { display: block; color: var(--muted); font-size: .8rem; }
+.pending-actions { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: .55rem; }.pending-actions .button { padding: .4rem .65rem; font-size: .82rem; }.attention-card .attention-question { font-weight: 700; color: var(--ink); }
 .close-action { display: flex; align-items: center; gap: .5rem; }.close-action select { width: auto; min-width: 9rem; }
 .error { color: var(--danger); font-weight: 700; }.bulk-results { margin-top: 1rem; display: grid; gap: .4rem; }.bulk-result { padding: .55rem .7rem; border-radius: 7px; background: #e7f3ec; overflow-wrap: anywhere; }.bulk-result.bad { background: #f8e5e2; color: #792c25; }
 .toast { position: fixed; right: 1.5rem; bottom: 1.5rem; z-index: 30; max-width: 420px; padding: .9rem 1.15rem; border-radius: 10px; color: white; background: var(--forest-2); box-shadow: var(--shadow); }


### PR DESCRIPTION
## Summary
- route agent and Companion job intake through one canonical task protocol
- add detached Store-scoped attempt handling with stateless lifecycle clients
- preserve human blocker resolution, managed resume continuity, and awaiting-review handoff
- add a deterministic real-CLI/Companion/Playwright oracle and fresh-agent contract coverage

## Verification
- 600 Python tests passed (2 expected visible-browser skips)
- 87 JavaScript/browser tests passed
- unified task-spine oracle and wrapper passed
- packaged plugin smoke and CLI/Playwright walkthrough passed
- link checks and diff hygiene passed

## Safety
- no final application action is enabled or taken
- claim authority remains broker-memory-only
- transcript and activity projections remain value-free