### PR TITLE
Add value-free form readiness contract

### DIFF
--- a/qa/contracts.py
+++ b/qa/contracts.py
@@ -26,6 +26,61 @@ PROVENANCE_KEYS = {"recorderVersion", "captureMonth", "sourceRecordingSha256"}
 FINAL_ACTION_KEYS = {"id", "label", "enabled", "tripwire"}
 ORACLE_KEYS = {"finalActionActivations"}
 
+READINESS_SCHEMA_VERSION = 1
+READINESS_OBSERVATION_KEYS = {
+    "schemaVersion",
+    "platformFamily",
+    "observationRevision",
+    "adapterState",
+    "uploadCapability",
+    "controls",
+    "validationErrorControlIds",
+    "finalControlState",
+}
+READINESS_CONTROL_KEYS = {
+    "controlId",
+    "kind",
+    "state",
+    "observationRevision",
+}
+READINESS_ADAPTER_STATES = {"accessible", "inaccessible"}
+READINESS_UPLOAD_CAPABILITY_STATES = {
+    "available",
+    "external-runtime-unavailable",
+    "not-required",
+}
+READINESS_FINAL_CONTROL_STATES = {
+    "available",
+    "unavailable",
+    "inaccessible",
+    "activated",
+}
+READINESS_CONTROL_KIND_BY_ROLE = {
+    "textbox": "text",
+    "combobox": "selection",
+    "radiogroup": "selection",
+    "checkbox": "toggle",
+    "file": "upload",
+}
+READINESS_CONTROL_STATES = {
+    "text": {"complete", "missing", "rejected", "unresolved", "inaccessible"},
+    "selection": {
+        "complete",
+        "missing",
+        "rejected",
+        "unresolved",
+        "inaccessible",
+    },
+    "toggle": {"complete", "missing", "rejected", "unresolved", "inaccessible"},
+    "upload": {
+        "accepted",
+        "missing",
+        "rejected",
+        "unresolved",
+        "inaccessible",
+    },
+}
+
 CATALOG = {
     "contact.full_name": ("textbox", "Full name"),
     "contact.first_name": ("textbox", "First name"),
@@ -342,6 +397,90 @@ def validate_fixture(value: dict[str, Any]) -> None:
         _validate_lever_flow(steps)
     _validate_final_action(review_steps[0].get("finalAction"))
     _validate_oracle(value.get("oracle"))
+
+
+def validate_readiness_observation(
+    value: Any, fixture: dict[str, Any]
+) -> None:
+    """Validate closed, value-free evidence for one fixture revision.
+
+    The observation deliberately carries no source labels, values, filenames,
+    paths, URLs, timestamps, browser handles, or application identifiers.
+    Control identity and expected kind come only from the committed fixture.
+    """
+
+    validate_fixture(fixture)
+    if not isinstance(value, dict):
+        raise ContractError("readiness observation must be an object")
+    _closed(value, READINESS_OBSERVATION_KEYS, "readiness observation")
+    if set(value) != READINESS_OBSERVATION_KEYS:
+        raise ContractError("readiness observation is incomplete")
+    schema_version = value.get("schemaVersion")
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version != READINESS_SCHEMA_VERSION
+    ):
+        raise ContractError("unsupported readiness schemaVersion")
+    if value.get("platformFamily") != fixture.get("platformFamily"):
+        raise ContractError("readiness platform family mismatch")
+    revision = value.get("observationRevision")
+    if not isinstance(revision, int) or isinstance(revision, bool) or revision < 1:
+        raise ContractError("readiness observationRevision must be positive")
+    if value.get("adapterState") not in READINESS_ADAPTER_STATES:
+        raise ContractError("unsupported readiness adapter state")
+    if value.get("uploadCapability") not in READINESS_UPLOAD_CAPABILITY_STATES:
+        raise ContractError("unsupported readiness upload capability")
+    if value.get("finalControlState") not in READINESS_FINAL_CONTROL_STATES:
+        raise ContractError("unsupported readiness final control state")
+
+    fixture_controls = {
+        control["id"]: control
+        for step in fixture["steps"]
+        for control in step["controls"]
+    }
+    observations = value.get("controls")
+    if not isinstance(observations, list):
+        raise ContractError("readiness controls must be an array")
+    observed_ids: set[str] = set()
+    for observed in observations:
+        if not isinstance(observed, dict):
+            raise ContractError("readiness control must be an object")
+        _closed(observed, READINESS_CONTROL_KEYS, "readiness control")
+        if set(observed) != READINESS_CONTROL_KEYS:
+            raise ContractError("readiness control is incomplete")
+        control_id = observed.get("controlId")
+        if not isinstance(control_id, str) or control_id not in fixture_controls:
+            raise ContractError("readiness control is unknown")
+        if control_id in observed_ids:
+            raise ContractError("duplicate readiness control")
+        observed_ids.add(control_id)
+        expected_kind = READINESS_CONTROL_KIND_BY_ROLE.get(
+            fixture_controls[control_id]["role"]
+        )
+        if observed.get("kind") != expected_kind:
+            raise ContractError("readiness control kind mismatch")
+        if observed.get("state") not in READINESS_CONTROL_STATES[expected_kind]:
+            raise ContractError("unsupported readiness control state")
+        control_revision = observed.get("observationRevision")
+        if (
+            not isinstance(control_revision, int)
+            or isinstance(control_revision, bool)
+            or control_revision < 1
+        ):
+            raise ContractError(
+                "readiness control observationRevision must be positive"
+            )
+
+    validation_errors = value.get("validationErrorControlIds")
+    if (
+        not isinstance(validation_errors, list)
+        or not all(isinstance(item, str) for item in validation_errors)
+        or len(validation_errors) != len(set(validation_errors))
+        or validation_errors != sorted(validation_errors)
+        or not set(validation_errors) <= set(fixture_controls)
+    ):
+        raise ContractError("readiness validation errors are invalid")
 
 
 def _validate_control(

--- a/qa/fixtures/greenhouse-form-readiness-v1/approval.json
+++ b/qa/fixtures/greenhouse-form-readiness-v1/approval.json
@@ -1,0 +1,8 @@
+{
+  "approvedAt": "2026-09-01T00:00:00Z",
+  "compilerVersion": "1.1.0",
+  "fixtureSha256": "ae1232593dadb806d97b7d43572b2603acd2530847309324b7e5f19a683aad8e",
+  "reviewer": "qa-owner",
+  "scannerVersion": "1.0.0",
+  "schemaVersion": 1
+}

--- a/qa/fixtures/greenhouse-form-readiness-v1/fixture.json
+++ b/qa/fixtures/greenhouse-form-readiness-v1/fixture.json
@@ -1,0 +1,80 @@
+{
+  "captureMonth": "2026-09",
+  "compilerVersion": "1.1.0",
+  "id": "greenhouse-form-readiness-v1",
+  "oracle": {
+    "finalActionActivations": 0
+  },
+  "platformFamily": "greenhouse",
+  "provenance": {
+    "captureMonth": "2026-09",
+    "recorderVersion": "1.0.0",
+    "sourceRecordingSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "schemaVersion": 1,
+  "steps": [
+    {
+      "controls": [
+        {
+          "id": "contact.first_name",
+          "kind": "contact.first_name",
+          "label": "First name",
+          "required": true,
+          "role": "textbox"
+        },
+        {
+          "choices": [
+            "United States +1",
+            "Canada +1"
+          ],
+          "id": "contact.phone_country",
+          "kind": "contact.phone_country",
+          "label": "Phone country",
+          "required": true,
+          "role": "combobox"
+        },
+        {
+          "id": "resume.file",
+          "kind": "resume.file",
+          "label": "Resume",
+          "required": true,
+          "role": "file"
+        },
+        {
+          "choices": [
+            "Yes",
+            "No"
+          ],
+          "id": "authorization.sponsorship_select",
+          "kind": "authorization.sponsorship_select",
+          "label": "Will you require employment visa sponsorship?",
+          "required": true,
+          "role": "combobox"
+        },
+        {
+          "id": "profile.website",
+          "kind": "profile.website",
+          "label": "Website",
+          "required": false,
+          "role": "textbox"
+        }
+      ],
+      "id": "step-1",
+      "kind": "form",
+      "next": "review",
+      "title": "Application form"
+    },
+    {
+      "controls": [],
+      "finalAction": {
+        "enabled": true,
+        "id": "final.apply",
+        "label": "Submit application",
+        "tripwire": true
+      },
+      "id": "review",
+      "kind": "review",
+      "title": "Review application"
+    }
+  ]
+}

--- a/qa/fixtures/greenhouse-form-readiness-v1/provenance.json
+++ b/qa/fixtures/greenhouse-form-readiness-v1/provenance.json
@@ -1,0 +1,14 @@
+{
+  "approvedAt": "2026-09-01T00:00:00Z",
+  "approvedBy": "qa-owner",
+  "captureMonth": "2026-09",
+  "compilerVersion": "1.1.0",
+  "fixtureId": "greenhouse-form-readiness-v1",
+  "fixtureSha256": "ae1232593dadb806d97b7d43572b2603acd2530847309324b7e5f19a683aad8e",
+  "platformFamily": "greenhouse",
+  "promotedAt": "2026-09-01T00:00:01Z",
+  "recorderVersion": "1.0.0",
+  "scannerVersion": "1.0.0",
+  "schemaVersion": 1,
+  "sourceRecordingSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}

--- a/qa/oracle.py
+++ b/qa/oracle.py
@@ -11,6 +11,10 @@ import stat
 from typing import Any
 
 from qa.contracts import validate_fixture
+from scripts.job_apply_form_readiness import (
+    FormReadinessError,
+    evaluate_readiness,
+)
 
 
 MAX_EVENTS = 10_000
@@ -78,6 +82,24 @@ APPLICATION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 class OracleError(ValueError):
     """An invalid untrusted oracle input with a stable, value-free diagnostic."""
+
+
+def evaluate_form_readiness(
+    fixture: dict[str, Any],
+    observation: dict[str, Any],
+    *,
+    expected_observation_revision: int,
+) -> dict[str, Any]:
+    """Evaluate the repository replay contract with a closed diagnostic."""
+
+    try:
+        return evaluate_readiness(
+            fixture,
+            observation,
+            expected_observation_revision=expected_observation_revision,
+        )
+    except (FormReadinessError, TypeError, ValueError):
+        raise OracleError("invalid form readiness evidence") from None
 
 
 def _has_forbidden_value_key(key: str) -> bool:

--- a/scripts/job_apply_form_readiness.py
+++ b/scripts/job_apply_form_readiness.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Deterministic, value-free application-form readiness evaluation.
+
+This module evaluates repository-owned fixture observations only. It does not
+navigate a browser, transfer a file, inspect applicant data, or activate a final
+action. A passing replay report is never evidence that an external browser
+upload bridge works in a live application.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from qa.contracts import (
+    READINESS_CONTROL_KIND_BY_ROLE,
+    READINESS_SCHEMA_VERSION,
+    ContractError,
+    validate_fixture,
+    validate_readiness_observation,
+)
+
+
+PROOF_SCOPE = "repository-replay-only"
+
+
+class FormReadinessError(ValueError):
+    """A closed readiness-contract failure with a value-free diagnostic."""
+
+
+def _positive_revision(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise FormReadinessError(f"{label} must be a positive integer")
+    return value
+
+
+def make_readiness_observation(
+    fixture: dict[str, Any],
+    control_states: Mapping[str, str],
+    *,
+    observation_revision: int,
+    adapter_state: str = "accessible",
+    upload_capability: str = "available",
+    validation_error_control_ids: Iterable[str] = (),
+    final_control_state: str = "available",
+) -> dict[str, Any]:
+    """Build a closed observation from semantic states, never field values."""
+
+    _positive_revision(observation_revision, "observation revision")
+    try:
+        validate_fixture(fixture)
+    except Exception:
+        raise FormReadinessError("invalid readiness fixture") from None
+    if not isinstance(control_states, Mapping):
+        raise FormReadinessError("invalid readiness control states")
+    controls_by_id = {
+        control["id"]: control
+        for step in fixture["steps"]
+        for control in step["controls"]
+    }
+    if not all(
+        isinstance(control_id, str) and isinstance(state, str)
+        for control_id, state in control_states.items()
+    ):
+        raise FormReadinessError("invalid readiness control states")
+    validation_ids = list(validation_error_control_ids)
+    if not all(isinstance(control_id, str) for control_id in validation_ids):
+        raise FormReadinessError("invalid readiness validation errors")
+    observation = {
+        "schemaVersion": READINESS_SCHEMA_VERSION,
+        "platformFamily": fixture["platformFamily"],
+        "observationRevision": observation_revision,
+        "adapterState": adapter_state,
+        "uploadCapability": upload_capability,
+        "controls": [
+            {
+                "controlId": control_id,
+                "kind": READINESS_CONTROL_KIND_BY_ROLE[
+                    controls_by_id.get(control_id, {}).get("role")
+                ],
+                "state": state,
+                "observationRevision": observation_revision,
+            }
+            for control_id, state in sorted(control_states.items())
+            if control_id in controls_by_id
+        ],
+        "validationErrorControlIds": sorted(validation_ids),
+        "finalControlState": final_control_state,
+    }
+    # Fail rather than silently dropping an unknown control identifier.
+    if set(control_states) != set(item["controlId"] for item in observation["controls"]):
+        raise FormReadinessError("invalid readiness control states")
+    try:
+        validate_readiness_observation(observation, fixture)
+    except ContractError:
+        raise FormReadinessError("invalid readiness observation") from None
+    return observation
+
+
+def evaluate_readiness(
+    fixture: dict[str, Any],
+    observation: dict[str, Any],
+    *,
+    expected_observation_revision: int,
+) -> dict[str, Any]:
+    """Return a deterministic readiness report containing stable IDs only."""
+
+    expected_revision = _positive_revision(
+        expected_observation_revision, "expected observation revision"
+    )
+    try:
+        validate_readiness_observation(observation, fixture)
+    except Exception:
+        raise FormReadinessError("invalid readiness observation") from None
+
+    fixture_controls = {
+        control["id"]: control
+        for step in fixture["steps"]
+        for control in step["controls"]
+    }
+    required_ids = {
+        control_id
+        for control_id, control in fixture_controls.items()
+        if control["required"]
+    }
+    required_upload_ids = {
+        control_id
+        for control_id in required_ids
+        if fixture_controls[control_id]["role"] == "file"
+    }
+    observed = {
+        control["controlId"]: control for control in observation["controls"]
+    }
+    missing_ids = required_ids - set(observed)
+    stale_ids = {
+        control_id
+        for control_id in required_ids & set(observed)
+        if observed[control_id]["observationRevision"] != expected_revision
+    }
+    incomplete_ids: set[str] = set()
+    missing_upload_ids: set[str] = set()
+    for control_id in required_ids & set(observed):
+        item = observed[control_id]
+        accepted_state = "accepted" if item["kind"] == "upload" else "complete"
+        if item["state"] != accepted_state:
+            incomplete_ids.add(control_id)
+            if item["kind"] == "upload" and item["state"] == "missing":
+                missing_upload_ids.add(control_id)
+    missing_upload_ids |= missing_ids & required_upload_ids
+
+    observation_current = (
+        observation["observationRevision"] == expected_revision and not stale_ids
+    )
+    adapter_accessible = observation["adapterState"] == "accessible"
+    required_controls_complete = not (missing_ids | stale_ids | incomplete_ids)
+    required_uploads_accepted = not (
+        (missing_ids | stale_ids | incomplete_ids) & required_upload_ids
+    )
+    validation_clear = not observation["validationErrorControlIds"]
+    final_control_available = observation["finalControlState"] == "available"
+    final_action_untouched = observation["finalControlState"] != "activated"
+
+    checks = {
+        "observation-current": observation_current,
+        "adapter-accessible": adapter_accessible,
+        "required-controls-complete": required_controls_complete,
+        "required-uploads-accepted": required_uploads_accepted,
+        "validation-clear": validation_clear,
+        "final-control-available": final_control_available,
+        "final-action-untouched": final_action_untouched,
+    }
+    blockers: set[str] = set()
+    if not observation_current:
+        blockers.add("readiness-evidence-stale")
+    if not adapter_accessible:
+        blockers.add("form-observation-inaccessible")
+    if missing_ids:
+        blockers.add("required-control-evidence-missing")
+    if missing_upload_ids:
+        blockers.add("required-upload-missing")
+    for control_id in incomplete_ids:
+        state = observed[control_id]["state"]
+        kind = observed[control_id]["kind"]
+        if state == "rejected":
+            blockers.add(
+                "required-upload-rejected"
+                if kind == "upload"
+                else "required-control-rejected"
+            )
+        elif state == "unresolved":
+            blockers.add("required-control-unresolved")
+        elif state == "inaccessible":
+            blockers.add("required-control-inaccessible")
+        elif state == "missing" and kind != "upload":
+            blockers.add("required-control-incomplete")
+    if not validation_clear:
+        blockers.add("validation-error-present")
+    if observation["finalControlState"] == "activated":
+        blockers.add("final-action-activated")
+    elif observation["finalControlState"] == "inaccessible":
+        blockers.add("final-control-inaccessible")
+    elif observation["finalControlState"] == "unavailable":
+        blockers.add("final-control-unavailable")
+
+    fallback_code = None
+    if (
+        missing_upload_ids
+        and observation["uploadCapability"] == "external-runtime-unavailable"
+    ):
+        blockers.add("external-upload-capability-unavailable")
+        fallback_code = "owner-upload-required"
+
+    unresolved_ids = (
+        missing_ids
+        | stale_ids
+        | incomplete_ids
+        | set(observation["validationErrorControlIds"])
+    )
+    return {
+        "schemaVersion": READINESS_SCHEMA_VERSION,
+        "proofScope": PROOF_SCOPE,
+        "status": "ready" if all(checks.values()) else "blocked",
+        "platformFamily": fixture["platformFamily"],
+        "observationRevision": observation["observationRevision"],
+        "assertions": {
+            name: "passed" if passed else "failed" for name, passed in checks.items()
+        },
+        "unresolvedControlIds": sorted(unresolved_ids),
+        "blockerCodes": sorted(blockers),
+        "fallbackCode": fallback_code,
+    }
+

--- a/tests/test_job_apply_form_readiness.py
+++ b/tests/test_job_apply_form_readiness.py
@@ -1,0 +1,209 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "job_apply_form_readiness_test",
+    ROOT / "scripts" / "job_apply_form_readiness.py",
+)
+READINESS = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(READINESS)
+FIXTURE_PATH = (
+    ROOT / "qa" / "fixtures" / "greenhouse-form-readiness-v1" / "fixture.json"
+)
+
+
+class FormReadinessTests(unittest.TestCase):
+    def setUp(self):
+        self.fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        self.states = {
+            "contact.first_name": "complete",
+            "contact.phone_country": "complete",
+            "resume.file": "accepted",
+            "authorization.sponsorship_select": "complete",
+        }
+
+    def observation(self, **overrides):
+        states = overrides.pop("control_states", self.states)
+        return READINESS.make_readiness_observation(
+            self.fixture,
+            states,
+            observation_revision=overrides.pop("observation_revision", 7),
+            **overrides,
+        )
+
+    def evaluate(self, observation=None, expected_revision=7):
+        return READINESS.evaluate_readiness(
+            self.fixture,
+            observation or self.observation(),
+            expected_observation_revision=expected_revision,
+        )
+
+    def test_complete_greenhouse_observation_is_ready_and_value_free(self):
+        report = self.evaluate(
+            self.observation(upload_capability="external-runtime-unavailable")
+        )
+        self.assertEqual(
+            set(report),
+            {
+                "schemaVersion",
+                "proofScope",
+                "status",
+                "platformFamily",
+                "observationRevision",
+                "assertions",
+                "unresolvedControlIds",
+                "blockerCodes",
+                "fallbackCode",
+            },
+        )
+        self.assertEqual(report["proofScope"], "repository-replay-only")
+        self.assertEqual(report["status"], "ready")
+        self.assertEqual(set(report["assertions"].values()), {"passed"})
+        self.assertEqual(report["unresolvedControlIds"], [])
+        self.assertEqual(report["blockerCodes"], [])
+        self.assertIsNone(report["fallbackCode"])
+        serialized = json.dumps(report)
+        for forbidden in ("filename", "filepath", "https://", "browser", "value"):
+            self.assertNotIn(forbidden, serialized.lower())
+
+    def test_optional_control_may_be_absent(self):
+        self.assertEqual(self.evaluate()["status"], "ready")
+
+    def test_missing_required_control_fails_closed(self):
+        states = dict(self.states)
+        del states["contact.first_name"]
+        report = self.evaluate(self.observation(control_states=states))
+        self.assertEqual(report["status"], "blocked")
+        self.assertIn(
+            "required-control-evidence-missing", report["blockerCodes"]
+        )
+        self.assertEqual(report["unresolvedControlIds"], ["contact.first_name"])
+
+    def test_each_non_success_required_state_blocks(self):
+        cases = (
+            ("contact.first_name", "missing", "required-control-incomplete"),
+            ("contact.first_name", "rejected", "required-control-rejected"),
+            ("contact.first_name", "unresolved", "required-control-unresolved"),
+            ("contact.first_name", "inaccessible", "required-control-inaccessible"),
+            ("resume.file", "rejected", "required-upload-rejected"),
+            ("resume.file", "unresolved", "required-control-unresolved"),
+            ("resume.file", "inaccessible", "required-control-inaccessible"),
+        )
+        for control_id, state, blocker in cases:
+            with self.subTest(control_id=control_id, state=state):
+                states = dict(self.states)
+                states[control_id] = state
+                report = self.evaluate(self.observation(control_states=states))
+                self.assertEqual(report["status"], "blocked")
+                self.assertIn(blocker, report["blockerCodes"])
+                self.assertIn(control_id, report["unresolvedControlIds"])
+
+    def test_external_upload_failure_has_bounded_owner_fallback(self):
+        states = dict(self.states)
+        states["resume.file"] = "missing"
+        report = self.evaluate(
+            self.observation(
+                control_states=states,
+                upload_capability="external-runtime-unavailable",
+            )
+        )
+        self.assertEqual(report["status"], "blocked")
+        self.assertEqual(report["fallbackCode"], "owner-upload-required")
+        self.assertIn("required-upload-missing", report["blockerCodes"])
+        self.assertIn(
+            "external-upload-capability-unavailable", report["blockerCodes"]
+        )
+
+    def test_stale_top_level_or_control_evidence_blocks(self):
+        stale_top = self.evaluate(expected_revision=8)
+        self.assertEqual(stale_top["status"], "blocked")
+        self.assertIn("readiness-evidence-stale", stale_top["blockerCodes"])
+
+        observation = self.observation()
+        observation["controls"][0]["observationRevision"] = 6
+        stale_control = self.evaluate(observation)
+        self.assertEqual(stale_control["status"], "blocked")
+        self.assertIn("readiness-evidence-stale", stale_control["blockerCodes"])
+        self.assertIn(
+            observation["controls"][0]["controlId"],
+            stale_control["unresolvedControlIds"],
+        )
+
+    def test_inaccessible_adapter_and_hidden_validation_error_block(self):
+        inaccessible = self.evaluate(
+            self.observation(adapter_state="inaccessible")
+        )
+        self.assertEqual(inaccessible["status"], "blocked")
+        self.assertIn("form-observation-inaccessible", inaccessible["blockerCodes"])
+
+        invalid = self.evaluate(
+            self.observation(
+                validation_error_control_ids=["contact.phone_country"]
+            )
+        )
+        self.assertEqual(invalid["status"], "blocked")
+        self.assertIn("validation-error-present", invalid["blockerCodes"])
+        self.assertIn("contact.phone_country", invalid["unresolvedControlIds"])
+
+    def test_final_control_must_be_available_and_never_activated(self):
+        cases = (
+            ("unavailable", "final-control-unavailable"),
+            ("inaccessible", "final-control-inaccessible"),
+            ("activated", "final-action-activated"),
+        )
+        for state, blocker in cases:
+            with self.subTest(state=state):
+                report = self.evaluate(
+                    self.observation(final_control_state=state)
+                )
+                self.assertEqual(report["status"], "blocked")
+                self.assertIn(blocker, report["blockerCodes"])
+                if state == "activated":
+                    self.assertEqual(
+                        report["assertions"]["final-action-untouched"], "failed"
+                    )
+
+    def test_contract_rejects_unknown_value_bearing_or_malformed_evidence(self):
+        observation = self.observation()
+        cases = []
+        with_value = copy.deepcopy(observation)
+        with_value["controls"][0]["value"] = "PRIVATE"
+        cases.append(with_value)
+        unknown = copy.deepcopy(observation)
+        unknown["controls"][0]["controlId"] = "unknown.private"
+        cases.append(unknown)
+        wrong_kind = copy.deepcopy(observation)
+        wrong_kind["controls"][0]["kind"] = "upload"
+        cases.append(wrong_kind)
+        duplicate = copy.deepcopy(observation)
+        duplicate["controls"].append(copy.deepcopy(duplicate["controls"][0]))
+        cases.append(duplicate)
+        invalid_revision = copy.deepcopy(observation)
+        invalid_revision["observationRevision"] = True
+        cases.append(invalid_revision)
+
+        for candidate in cases:
+            with self.subTest(candidate=candidate):
+                with self.assertRaisesRegex(
+                    READINESS.FormReadinessError,
+                    "^invalid readiness observation$",
+                ) as raised:
+                    self.evaluate(candidate)
+                self.assertNotIn("PRIVATE", str(raised.exception))
+
+    def test_builder_rejects_unknown_controls_without_echoing_identity(self):
+        with self.assertRaisesRegex(
+            READINESS.FormReadinessError,
+            "^invalid readiness control states$",
+        ):
+            self.observation(control_states={"unknown.private": "complete"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qa_contracts.py
+++ b/tests/test_qa_contracts.py
@@ -1,7 +1,17 @@
 import copy
+import json
+from pathlib import Path
 import unittest
 
-from qa.contracts import ContractError, generic_control, validate_fixture
+from qa.contracts import (
+    ContractError,
+    generic_control,
+    validate_fixture,
+    validate_readiness_observation,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 class ContractTests(unittest.TestCase):
@@ -599,6 +609,98 @@ class ContractTests(unittest.TestCase):
                 del fixture[key]
                 with self.assertRaises(ContractError):
                     validate_fixture(fixture)
+
+    def test_committed_greenhouse_readiness_fixture_is_closed(self):
+        fixture = json.loads(
+            (
+                ROOT
+                / "qa/fixtures/greenhouse-form-readiness-v1/fixture.json"
+            ).read_text(encoding="utf-8")
+        )
+        self.assertIsNone(validate_fixture(fixture))
+        self.assertEqual(fixture["platformFamily"], "greenhouse")
+        self.assertEqual(
+            [
+                control["role"]
+                for step in fixture["steps"]
+                for control in step["controls"]
+            ],
+            ["textbox", "combobox", "file", "combobox", "textbox"],
+        )
+
+    def test_readiness_observation_contract_is_closed_and_revisioned(self):
+        fixture = self.valid_greenhouse_fixture()
+        observation = {
+            "schemaVersion": 1,
+            "platformFamily": "greenhouse",
+            "observationRevision": 3,
+            "adapterState": "accessible",
+            "uploadCapability": "available",
+            "controls": [
+                {
+                    "controlId": "contact.first_name",
+                    "kind": "text",
+                    "state": "complete",
+                    "observationRevision": 3,
+                },
+                {
+                    "controlId": "contact.phone_country",
+                    "kind": "selection",
+                    "state": "complete",
+                    "observationRevision": 3,
+                },
+                {
+                    "controlId": "resume.file",
+                    "kind": "upload",
+                    "state": "accepted",
+                    "observationRevision": 3,
+                },
+            ],
+            "validationErrorControlIds": [],
+            "finalControlState": "available",
+        }
+        self.assertIsNone(validate_readiness_observation(observation, fixture))
+
+        private = copy.deepcopy(observation)
+        private["controls"][0]["value"] = "PRIVATE"
+        with self.assertRaisesRegex(
+            ContractError, "^unknown readiness control key: value$"
+        ) as raised:
+            validate_readiness_observation(private, fixture)
+        self.assertNotIn("PRIVATE", str(raised.exception))
+
+    def test_readiness_observation_rejects_kind_and_platform_drift(self):
+        fixture = self.valid_greenhouse_fixture()
+        base = {
+            "schemaVersion": 1,
+            "platformFamily": "greenhouse",
+            "observationRevision": 1,
+            "adapterState": "accessible",
+            "uploadCapability": "not-required",
+            "controls": [
+                {
+                    "controlId": "contact.first_name",
+                    "kind": "text",
+                    "state": "complete",
+                    "observationRevision": 1,
+                }
+            ],
+            "validationErrorControlIds": [],
+            "finalControlState": "available",
+        }
+        wrong_kind = copy.deepcopy(base)
+        wrong_kind["controls"][0]["kind"] = "upload"
+        with self.assertRaisesRegex(
+            ContractError, "^readiness control kind mismatch$"
+        ):
+            validate_readiness_observation(wrong_kind, fixture)
+
+        wrong_platform = copy.deepcopy(base)
+        wrong_platform["platformFamily"] = "ashby"
+        with self.assertRaisesRegex(
+            ContractError, "^readiness platform family mismatch$"
+        ):
+            validate_readiness_observation(wrong_platform, fixture)
 
 
 if __name__ == "__main__":

--- a/tests/test_qa_server_oracle.py
+++ b/tests/test_qa_server_oracle.py
@@ -13,8 +13,9 @@ from urllib.parse import urlsplit
 
 from qa.compiler import compile_capture
 from qa.contracts import LEVER_CONTROL_PROFILE, generic_control
-from qa.oracle import OracleError, evaluate_run
+from qa.oracle import OracleError, evaluate_form_readiness, evaluate_run
 from qa.server import ReplayHTTPServer
+from scripts.job_apply_form_readiness import make_readiness_observation
 from scripts.job_apply_policy import PolicyStore, confirmation_authority_revision
 
 
@@ -1379,6 +1380,77 @@ class SemanticOracleTests(unittest.TestCase):
                 self.evaluate()
         self.assertTrue(swapped)
         self.assertNotIn("OUTSIDE SECRET", str(caught.exception))
+
+
+class FormReadinessOracleTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = json.loads(
+            (
+                ROOT
+                / "qa/fixtures/greenhouse-form-readiness-v1/fixture.json"
+            ).read_text(encoding="utf-8")
+        )
+        cls.states = {
+            "contact.first_name": "complete",
+            "contact.phone_country": "complete",
+            "resume.file": "accepted",
+            "authorization.sponsorship_select": "complete",
+        }
+
+    def test_readiness_oracle_returns_only_closed_replay_evidence(self):
+        observation = make_readiness_observation(
+            self.fixture,
+            self.states,
+            observation_revision=4,
+            upload_capability="external-runtime-unavailable",
+        )
+        report = evaluate_form_readiness(
+            self.fixture,
+            observation,
+            expected_observation_revision=4,
+        )
+        self.assertEqual(report["status"], "ready")
+        self.assertEqual(report["proofScope"], "repository-replay-only")
+        self.assertEqual(report["blockerCodes"], [])
+        serialized = json.dumps(report).lower()
+        for forbidden in ("filename", "filepath", "https://", "browser", "value"):
+            self.assertNotIn(forbidden, serialized)
+
+    def test_readiness_oracle_preserves_value_free_failure_categories(self):
+        states = dict(self.states)
+        states["resume.file"] = "missing"
+        observation = make_readiness_observation(
+            self.fixture,
+            states,
+            observation_revision=4,
+            upload_capability="external-runtime-unavailable",
+        )
+        report = evaluate_form_readiness(
+            self.fixture,
+            observation,
+            expected_observation_revision=4,
+        )
+        self.assertEqual(report["status"], "blocked")
+        self.assertEqual(report["fallbackCode"], "owner-upload-required")
+        self.assertIn("required-upload-missing", report["blockerCodes"])
+
+    def test_readiness_oracle_closes_malformed_diagnostics(self):
+        observation = make_readiness_observation(
+            self.fixture,
+            self.states,
+            observation_revision=4,
+        )
+        observation["privateValue"] = "ORACLE SECRET"
+        with self.assertRaisesRegex(
+            OracleError, "^invalid form readiness evidence$"
+        ) as raised:
+            evaluate_form_readiness(
+                self.fixture,
+                observation,
+                expected_observation_revision=4,
+            )
+        self.assertNotIn("ORACLE SECRET", str(raised.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements the repository-owned Wave 1 form-readiness core for owner-beta hardening. Adds deterministic, value-free readiness evaluation and closed Greenhouse replay evidence. It does not patch or claim proof of the external Chrome upload bridge, access owner data, or change final-action authority.