### PR TITLE
Move landing page to job-apply.neonwatty.com

### DIFF
--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+job-apply.neonwatty.com

--- a/site/index.html
+++ b/site/index.html
@@ -4,11 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="AI-powered job application assistant for Claude Code and Codex with guided workflows for LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.">
-  <link rel="canonical" href="https://neonwatty.github.io/job-apply-plugin/">
+  <link rel="canonical" href="https://job-apply.neonwatty.com/">
   <meta property="og:title" content="Job Apply Plugin for Codex and Claude Code">
   <meta property="og:description" content="Guided resume-based workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://neonwatty.github.io/job-apply-plugin/">
+  <meta property="og:url" content="https://job-apply.neonwatty.com/">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Job Apply Plugin for Codex and Claude Code">
   <meta name="twitter:description" content="Guided resume-based workflows for LinkedIn Easy Apply, Greenhouse, Ashby, Lever, Rippling, and Workday.">

--- a/tests/test_site_metadata.py
+++ b/tests/test_site_metadata.py
@@ -1,0 +1,38 @@
+import unittest
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SITE_ORIGIN = "https://job-apply.neonwatty.com/"
+
+
+class MetadataParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.canonical = None
+        self.open_graph_url = None
+
+    def handle_starttag(self, tag, attrs):
+        values = dict(attrs)
+        if tag == "link" and values.get("rel") == "canonical":
+            self.canonical = values.get("href")
+        if tag == "meta" and values.get("property") == "og:url":
+            self.open_graph_url = values.get("content")
+
+
+class SiteMetadataTests(unittest.TestCase):
+    def test_custom_domain_is_consistent_across_pages_configuration_and_metadata(self):
+        parser = MetadataParser()
+        parser.feed((REPO_ROOT / "site" / "index.html").read_text())
+
+        self.assertEqual(
+            (REPO_ROOT / "site" / "CNAME").read_text().strip(),
+            "job-apply.neonwatty.com",
+        )
+        self.assertEqual(parser.canonical, SITE_ORIGIN)
+        self.assertEqual(parser.open_graph_url, SITE_ORIGIN)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- configure GitHub Pages for job-apply.neonwatty.com
- update canonical and Open Graph metadata to the custom domain
- add a regression test covering the CNAME and metadata contract

## Verification
- Python unit suite: 308 passed
- deterministic screening and auto-submit safety checks passed
- browser QA suite: 48 passed
- isolated plugin smoke tests passed
- documentation link checks passed
- HTTPS returns 200 at the custom domain
- legacy GitHub Pages URL returns 301 to the custom domain