### PR TITLE
Fix legacy session ATS compatibility

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "job-apply",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "AI-powered job application assistant for Claude Code and Codex covering LinkedIn, Greenhouse, Ashby, Lever, Rippling, and Workday.",
   "author": {
     "name": "Jeremy Watt",

--- a/scripts/job-apply-store.py
+++ b/scripts/job-apply-store.py
@@ -152,6 +152,8 @@ REPLAY_TRANSITIONS = {"started", "reviewed"}
 REPLAY_ATS = {"ashby", "greenhouse", "lever", "linkedin-easy-apply"}
 SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 PENDING_REFERENCE = re.compile(r"^pending_[a-f0-9]{32}$")
+LEGACY_PENDING_FIELD_KEYS = frozenset({"question", "state", "answerKey", "sensitive"})
+_ATS_UNSET = object()
 CLAIM_LEASE_SECONDS = 300
 CLAIM_HEARTBEAT_SECONDS = 60
 OVERVIEW_DIGEST_CACHE_SECONDS = 30
@@ -723,6 +725,100 @@ def _scope_fingerprint(value: dict[str, Any]) -> str:
 def _question_fingerprint(value: str) -> str:
     normalized = " ".join(value.split()).casefold()
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _legacy_pending_reference(application_id: str, field: dict[str, Any]) -> str:
+    """Project a stable opaque identity without persisting or returning legacy text."""
+
+    digest = hashlib.sha256(
+        _canonical_json({"applicationId": application_id, "pendingField": field}).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+    return f"pending_{digest[:32]}"
+
+
+def _project_legacy_session(
+    session: dict[str, Any], expected_ats: Any = _ATS_UNSET
+) -> dict[str, Any]:
+    """Return a value-free modern view of the exact closed 1.2 pending shape."""
+
+    pending_fields = session.get("pendingFields", [])
+    if not isinstance(pending_fields, list):
+        _validate_session_document(session)
+        return session
+    if not any(
+        isinstance(value, dict) and "reference" not in value
+        for value in pending_fields
+    ):
+        _validate_session_document(session)
+        return session
+
+    application_id = _safe_session_id(session.get("applicationId", ""))
+    if any(
+        isinstance(value, dict) and "reference" in value
+        for value in pending_fields
+    ):
+        raise StoreError("legacy and modern pending fields cannot be mixed")
+    _validate_optional_strings(session, {"company", "role", "url"}, "session")
+    canonical_ats_supplied = expected_ats is not _ATS_UNSET
+    ats = expected_ats if canonical_ats_supplied else session.get("ats")
+    legacy_scope_fingerprint = (
+        _scope_fingerprint({"ats": ats})
+        if isinstance(ats, str) and ats
+        else None
+    )
+    projected = copy.deepcopy(session)
+    if canonical_ats_supplied:
+        projected["ats"] = copy.deepcopy(expected_ats)
+    for legacy_job_field in ("company", "role", "url"):
+        projected.pop(legacy_job_field, None)
+    projected_fields: list[dict[str, Any]] = []
+    references: set[str] = set()
+    for value in pending_fields:
+        field = _require_object(value, "pending field")
+        if not set(field).issubset(LEGACY_PENDING_FIELD_KEYS):
+            raise StoreError("pending field reference is invalid")
+        _validate_optional_strings(
+            field, {"question", "state", "answerKey"}, "pending field"
+        )
+        if "state" in field and field["state"] not in ANSWER_STATES:
+            raise StoreError("pending field state is unsupported")
+        if "sensitive" in field and not isinstance(field["sensitive"], bool):
+            raise StoreError("pending field sensitive must be a boolean")
+        candidate = copy.deepcopy(field)
+        question = candidate.pop("question", None)
+        if isinstance(question, str) and question.strip():
+            candidate["questionFingerprint"] = _question_fingerprint(question)
+        if legacy_scope_fingerprint is not None:
+            candidate["scopeFingerprint"] = legacy_scope_fingerprint
+        candidate["reference"] = _legacy_pending_reference(application_id, field)
+        reference = candidate.get("reference")
+        if reference in references:
+            raise StoreError("pending field references must be unique")
+        references.add(reference)
+        projected_fields.append(candidate)
+    projected["pendingFields"] = projected_fields
+    _validate_session_document(projected)
+    return projected
+
+
+def _pending_reference_identity(field: dict[str, Any]) -> str:
+    """Match durable field meaning while excluding refreshed match evidence."""
+
+    return _canonical_json(
+        {
+            key: copy.deepcopy(value)
+            for key, value in field.items()
+            if key
+            not in {
+                "reference",
+                "matchConfidence",
+                "matchReasonCodes",
+                "matchAnswerRevision",
+            }
+        }
+    )
 
 
 def _job_origin(origin: str) -> str:
@@ -1321,6 +1417,7 @@ def _validate_session_document(session: dict[str, Any]) -> None:
         "fieldClass", "scopeFingerprint", "matchConfidence", "matchReasonCodes",
         "matchAnswerRevision", "questionFingerprint",
     }
+    pending_references: set[str] = set()
     for value in pending_fields:
         field = _require_object(value, "pending field")
         if set(field) - pending_allowed:
@@ -1334,6 +1431,9 @@ def _validate_session_document(session: dict[str, Any]) -> None:
             raise StoreError("pending field sensitive must be a boolean")
         if "reference" not in field or not isinstance(field["reference"], str) or PENDING_REFERENCE.fullmatch(field["reference"]) is None:
             raise StoreError("pending field reference is invalid")
+        if field["reference"] in pending_references:
+            raise StoreError("pending field references must be unique")
+        pending_references.add(field["reference"])
         if "fieldClass" in field and (
             not isinstance(field["fieldClass"], str)
             or re.fullmatch(r"[a-z][a-z0-9_]{0,63}", field["fieldClass"]) is None
@@ -2181,7 +2281,7 @@ class Store:
                     if descriptor >= 0:
                         os.close(descriptor)
                 validate_version(session, "session")
-                _validate_session_document(session)
+                _project_legacy_session(session)
                 if session["applicationId"] != application_id:
                     raise StoreError("session application id does not match path")
             closed_directory = self.sessions_path.lstat()
@@ -4783,11 +4883,9 @@ class Store:
             if reason_code in {"needs_information", "awaiting_human_review"}:
                 session_path = self._session_path(job["id"])
                 if session_path.exists():
-                    session = read_json_object(session_path, "session")
-                    validate_version(session, "session")
-                    _validate_session_document(session)
-                    if session["applicationId"] != job["id"]:
-                        raise StoreError("session application id does not match path")
+                    session = self._read_session_projection(
+                        session_path, job["id"], job.get("ats")
+                    )
                     missing_count = len(session.get("pendingFields", []))
                     session_revision = self._session_revision(session)
                     session_projection = {
@@ -5856,11 +5954,9 @@ class Store:
             answers_document = self._load_answers_document()
             session_path = self._session_path(job_id)
             if session_path.exists():
-                stored_session = read_json_object(session_path, "session")
-                validate_version(stored_session, "session")
-                _validate_session_document(stored_session)
-                if stored_session["applicationId"] != job_id:
-                    raise StoreError("session application id does not match path")
+                stored_session = self._read_session_projection(
+                    session_path, job_id, job.get("ats")
+                )
                 session = {
                     key: stored_session[key]
                     for key in (
@@ -6012,9 +6108,7 @@ class Store:
             path = self._session_path(job_id)
             if not path.exists():
                 raise StoreError("answer resolution session does not exist")
-            session = read_json_object(path, "session")
-            validate_version(session, "session")
-            _validate_session_document(session)
+            session = self._read_session_projection(path, job_id, job.get("ats"))
             field = next(
                 (
                     item for item in session.get("pendingFields", [])
@@ -6171,7 +6265,9 @@ class Store:
                 raise StoreError("coordinator journal cannot be reconciled")
             session = operation["session"]
             path = self._session_path(job_id)
-            existing = read_json_object(path, "session")
+            existing = self._read_session_projection(
+                path, job_id, current.get("ats")
+            )
             existing_revision = self._session_revision(existing)
             if existing_revision == operation["expectedSessionRevision"]:
                 atomic_write_json(path, session)
@@ -6261,9 +6357,7 @@ class Store:
             path = self._session_path(job_id)
             if not path.exists():
                 raise StoreError("answer resolution session does not exist")
-            session = read_json_object(path, "session")
-            validate_version(session, "session")
-            _validate_session_document(session)
+            session = self._read_session_projection(path, job_id, job.get("ats"))
             if self._session_revision(session) != expected_session_revision:
                 raise StoreError("session revision conflict")
             pending = session.get("pendingFields", [])
@@ -6498,11 +6592,9 @@ class Store:
                 raise StoreError("job must be trashed before permanent deletion")
             session_path = self._session_path(job_id)
             if session_path.exists():
-                session = read_json_object(session_path, "session")
-                validate_version(session, "session")
-                _validate_session_document(session)
-                if session["applicationId"] != job_id:
-                    raise StoreError("session application id does not match path")
+                session = self._read_session_projection(
+                    session_path, job_id, current.get("ats")
+                )
                 if session["status"] not in {"completed", "abandoned"}:
                     raise StoreError("job is referenced by a nonterminal application session")
             del document["jobs"][job_id]
@@ -7462,6 +7554,80 @@ class Store:
     def _session_path(self, application_id: str) -> Path:
         return self.sessions_path / f"{_safe_session_id(application_id)}.json"
 
+    def _read_session_projection(
+        self,
+        path: Path,
+        application_id: str | None = None,
+        expected_ats: Any = _ATS_UNSET,
+    ) -> dict[str, Any]:
+        session = read_json_object(path, "session")
+        validate_version(session, "session")
+        pending_fields = session.get("pendingFields", [])
+        if not isinstance(pending_fields, list):
+            _validate_session_document(session)
+        legacy_pending = any(
+            isinstance(value, dict) and "reference" not in value
+            for value in pending_fields
+        )
+        projected = _project_legacy_session(session, expected_ats)
+        if legacy_pending and self.answers_path.exists():
+            answers = self._load_answers_document()
+            ats = (
+                expected_ats
+                if expected_ats is not _ATS_UNSET
+                else session.get("ats")
+            )
+            scope = {"ats": ats} if isinstance(ats, str) and ats else {}
+            for raw, field in zip(
+                session.get("pendingFields", []), projected["pendingFields"]
+            ):
+                question = raw.get("question")
+                bound_key = raw.get("answerKey")
+                answer = (
+                    self._get_answer_record(bound_key, document=answers)
+                    if isinstance(bound_key, str) and bound_key
+                    else None
+                )
+                if answer is None:
+                    continue
+                if (
+                    isinstance(question, str)
+                    and question.strip()
+                    and isinstance(answer.get("question"), str)
+                    and answer["question"].strip()
+                ):
+                    try:
+                        match = ANSWER_MATCH_MODULE.rank_candidates(
+                            question=question,
+                            scope=scope,
+                            field_class="general",
+                            sensitivity=(
+                                answer.get("sensitivity", "none")
+                                if answer.get("sensitivity", "none") != "none"
+                                else "high"
+                                if raw.get("sensitive") is True
+                                or raw.get("state") == "sensitive"
+                                else "none"
+                            ),
+                            candidates=[self._semantic_candidate(answer)],
+                            limit=1,
+                        )[0]
+                    except Exception:
+                        raise StoreError(
+                            "pending field semantic match is invalid"
+                        ) from None
+                    field["matchConfidence"] = match["confidenceBand"]
+                    field["matchReasonCodes"] = match["reasonCodes"]
+                else:
+                    field["matchConfidence"] = "none"
+                    field["matchReasonCodes"] = ["no_semantic_match"]
+                field["matchAnswerRevision"] = answer.get("revision", 1)
+            _validate_session_document(projected)
+        expected_id = application_id if application_id is not None else path.stem
+        if projected["applicationId"] != expected_id:
+            raise StoreError("session application id does not match path")
+        return projected
+
     @staticmethod
     def _readiness_blocker_type(code: str) -> str:
         if "upload" in code:
@@ -7560,7 +7726,7 @@ class Store:
         now: str | None = None,
         *,
         expected_attempt_revision: int | None = None,
-        expected_ats: str | None = None,
+        expected_ats: Any = _ATS_UNSET,
         internal_approvals: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         allowed = {
@@ -7586,8 +7752,9 @@ class Store:
         created_at = incoming.get("createdAt")
         existing = None
         if path.exists():
-            existing = read_json_object(path, "session")
-            _validate_session_document(existing)
+            existing = self._read_session_projection(
+                path, application_id, expected_ats
+            )
             created_at = created_at or existing.get("createdAt")
         pending_input = incoming.get("pendingFields", [])
         if not isinstance(pending_input, list):
@@ -7596,12 +7763,7 @@ class Store:
         reusable: dict[str, list[str]] = {}
         if existing is not None:
             for field in existing.get("pendingFields", []):
-                identity = {
-                    key: copy.deepcopy(value)
-                    for key, value in field.items()
-                    if key != "reference"
-                }
-                reusable.setdefault(_canonical_json(identity), []).append(
+                reusable.setdefault(_pending_reference_identity(field), []).append(
                     field["reference"]
                 )
         pending_fields = []
@@ -7620,7 +7782,13 @@ class Store:
                 copied["questionFingerprint"] = _question_fingerprint(question)
             raw_scope = copied.pop("scope", None)
             if raw_scope is None:
-                ats = expected_ats or incoming.get("ats")
+                ats = (
+                    expected_ats
+                    if expected_ats is not _ATS_UNSET
+                    else incoming.get("ats")
+                    if "ats" in incoming
+                    else (existing or {}).get("ats")
+                )
                 raw_scope = {"ats": ats} if isinstance(ats, str) and ats else {}
             try:
                 scope_object = _require_object(raw_scope, "pending field scope")
@@ -7666,7 +7834,7 @@ class Store:
                 copied["matchConfidence"] = "none"
                 copied["matchReasonCodes"] = ["no_semantic_match"]
                 copied["matchAnswerRevision"] = answer.get("revision", 1)
-            references = reusable.get(_canonical_json(copied), [])
+            references = reusable.get(_pending_reference_identity(copied), [])
             copied["reference"] = references.pop(0) if references else f"pending_{uuid.uuid4().hex}"
             pending_fields.append(copied)
         timestamp = now or utc_now()
@@ -7763,6 +7931,10 @@ class Store:
                 "updatedAt", "attemptRevision",
             }
         }
+        if expected_ats is not _ATS_UNSET:
+            durable_input["ats"] = copy.deepcopy(expected_ats)
+        elif "ats" not in incoming and "ats" in (existing or {}):
+            durable_input["ats"] = copy.deepcopy(existing["ats"])
         current_references = {field["reference"] for field in pending_fields}
         carried_approvals = (
             existing.get("approvals", [])
@@ -7912,8 +8084,7 @@ class Store:
             path = self._session_path(job_id)
             if not path.exists():
                 raise StoreError("grouped approval session does not exist")
-            session = read_json_object(path, "session")
-            _validate_session_document(session)
+            session = self._read_session_projection(path, job_id, job.get("ats"))
             if self._session_revision(session) != expected_session_revision:
                 raise StoreError("session revision conflict")
             pending = {
@@ -8064,7 +8235,7 @@ class Store:
             path = self._session_path(job_id)
             if job is None or job.get("revision") != expected_job_revision or not path.exists():
                 raise StoreError("grouped approval state changed")
-            session = read_json_object(path, "session")
+            session = self._read_session_projection(path, job_id, job.get("ats"))
             if self._session_revision(session) != expected_session_revision:
                 raise StoreError("session revision conflict")
             pending = {
@@ -8129,12 +8300,13 @@ class Store:
         path = self._session_path(application_id)
         if not path.exists():
             raise StoreError("session does not exist")
-        session = read_json_object(path, "session")
-        validate_version(session, "session")
-        _validate_session_document(session)
-        if session["applicationId"] != application_id:
-            raise StoreError("session application id does not match path")
-        return session
+        job = (
+            self._load_jobs_document()["jobs"].get(application_id)
+            if self.jobs_path.exists()
+            else None
+        )
+        return self._read_session_projection(path, application_id, job.get("ats")) \
+            if job is not None else self._read_session_projection(path, application_id)
 
     def list_sessions(self) -> list[dict[str, Any]]:
         self.initialize()
@@ -8142,12 +8314,13 @@ class Store:
 
     def _list_sessions_uninitialized(self) -> list[dict[str, Any]]:
         sessions: list[dict[str, Any]] = []
+        jobs = (
+            self._load_jobs_document()["jobs"] if self.jobs_path.exists() else {}
+        )
         for path in sorted(self.sessions_path.glob("*.json")):
-            session = read_json_object(path, "session")
-            validate_version(session, "session")
-            _validate_session_document(session)
-            if path.stem != session["applicationId"]:
-                raise StoreError("session application id does not match path")
+            job = jobs.get(path.stem)
+            session = self._read_session_projection(path, path.stem, job.get("ats")) \
+                if job is not None else self._read_session_projection(path, path.stem)
             sessions.append(session)
         return sessions
 

--- a/scripts/smoke-plugin.sh
+++ b/scripts/smoke-plugin.sh
@@ -207,6 +207,47 @@ coordinator_path.write_text(json.dumps(coordinator), encoding="utf-8")
 store_spec = importlib.util.spec_from_file_location("smoke_job_apply_store", root / "scripts" / "job-apply-store.py")
 store_module = importlib.util.module_from_spec(store_spec)
 store_spec.loader.exec_module(store_module)
+legacy_session_path = attention_store / "sessions" / "legacy-smoke.json"
+legacy_pending = [{
+    "question": "Private legacy compatibility question?",
+    "state": "missing",
+    "answerKey": "private.legacy.answer",
+    "sensitive": True,
+}]
+legacy_session_path.write_text(json.dumps({
+    "schemaVersion": 1,
+    "applicationId": "legacy-smoke",
+    "status": "active",
+    "ats": "greenhouse",
+    "step": "questions",
+    "answerKeys": ["private.legacy.answer"],
+    "pendingFields": legacy_pending,
+    "createdAt": "2026-08-01T00:00:00Z",
+    "updatedAt": "2026-08-01T00:01:00Z",
+}), encoding="utf-8")
+legacy_bytes = legacy_session_path.read_bytes()
+legacy_first = attention_command("session-load", None, "--id", "legacy-smoke")
+legacy_second = attention_command("session-load", None, "--id", "legacy-smoke")
+legacy_listed = attention_command("session-list")
+if legacy_first != legacy_second or legacy_session_path.read_bytes() != legacy_bytes:
+    raise SystemExit("packaged legacy session projection was unstable or mutated bytes")
+legacy_serialized = json.dumps([legacy_first, legacy_listed])
+if "Private legacy compatibility question?" in legacy_serialized or "private.legacy.answer" not in legacy_serialized:
+    raise SystemExit("packaged legacy session projection leaked question text or lost answer linkage")
+legacy_reference = legacy_first["pendingFields"][0].get("reference", "")
+if re.fullmatch(r"pending_[a-f0-9]{32}", legacy_reference) is None:
+    raise SystemExit("packaged legacy session projection did not create an opaque reference")
+legacy_normalized = attention_command("session-save", {
+    "status": "active",
+    "step": "questions",
+    "answerKeys": ["private.legacy.answer"],
+    "pendingFields": legacy_pending,
+}, "--id", "legacy-smoke")
+if legacy_normalized["pendingFields"][0].get("reference") != legacy_reference:
+    raise SystemExit("packaged legacy session normalization changed its projected reference")
+legacy_persisted = json.loads(legacy_session_path.read_text(encoding="utf-8"))
+if legacy_persisted != legacy_normalized or any("question" in field for field in legacy_persisted["pendingFields"]):
+    raise SystemExit("packaged legacy session normalization was incomplete")
 attention_projection = store_module.Store(attention_store).list_needs_attention()
 if [item["reasonCode"] for item in attention_projection["items"]] != ["expired_agent_attempt", "claimless_interrupted_attempt", "awaiting_human_review", "needs_information"]:
     raise SystemExit("packaged Needs Attention taxonomy or ordering failed")
@@ -431,8 +472,8 @@ if codex_manifest.get("name") != "job-apply":
     raise SystemExit(".codex-plugin/plugin.json name must be job-apply")
 if not re.fullmatch(r"\d+\.\d+\.\d+", codex_manifest.get("version", "")):
     raise SystemExit(".codex-plugin/plugin.json version must be strict SemVer")
-if codex_manifest["version"] != "1.3.0":
-    raise SystemExit("human-attention package identity must be 1.3.0")
+if codex_manifest["version"] != "1.3.1":
+    raise SystemExit("legacy-session compatibility package identity must be 1.3.1")
 if codex_manifest.get("skills") != "./skills/":
     raise SystemExit(".codex-plugin/plugin.json must expose ./skills/")
 if codex_manifest.get("interface", {}).get("displayName") != "Job Apply":

--- a/tests/test_job_apply_store.py
+++ b/tests/test_job_apply_store.py
@@ -69,6 +69,32 @@ class StoreTests(unittest.TestCase):
             },
         }
 
+    @staticmethod
+    def legacy_1_2_session(application_id="legacy-session", pending_fields=None):
+        return {
+            "schemaVersion": 1,
+            "applicationId": application_id,
+            "status": "active",
+            "step": "questions",
+            "answerKeys": ["answer.work_authorization"],
+            "pendingFields": pending_fields if pending_fields is not None else [
+                {
+                    "question": "Are you authorized to work in the United States?",
+                    "state": "missing",
+                    "answerKey": "answer.work_authorization",
+                    "sensitive": True,
+                },
+                {
+                    "question": "Will you require sponsorship?",
+                    "state": "inferred",
+                    "answerKey": "answer.sponsorship",
+                    "sensitive": False,
+                },
+            ],
+            "createdAt": "2026-08-01T00:00:00Z",
+            "updatedAt": "2026-08-01T00:01:00Z",
+        }
+
     def test_migrates_legacy_profile_once_and_preserves_unknown_fields(self):
         legacy = {
             "firstName": "Ada",
@@ -548,6 +574,463 @@ class StoreTests(unittest.TestCase):
             self.store.validate_workspace_startup()
         self.assertTrue(calls)
         self.assertEqual(self.store.load_session("windows-session"), session)
+
+    def test_legacy_1_2_session_reads_are_stable_value_free_and_byte_preserving(self):
+        self.store.initialize()
+        job = self.store.create_job({
+            "id": "legacy-attention",
+            "url": "https://example.com/jobs/legacy-attention",
+            "role": "Engineer",
+            "company": "Example",
+            "ats": "greenhouse",
+        })
+        self.store.transition_job(job["id"], "needs_info", job["revision"])
+        path = self.store._session_path(job["id"])
+        legacy = self.legacy_1_2_session(job["id"])
+        legacy.update({
+            "company": "Legacy Company Copy",
+            "role": "Legacy Role Copy",
+            "url": "https://legacy.example/jobs/copy",
+        })
+        path.write_text(json.dumps(legacy, separators=(",", ":")), encoding="utf-8")
+        before = path.read_bytes()
+
+        projections = []
+        for _ in range(2):
+            fresh = STORE_MODULE.Store(self.root, self.legacy)
+            fresh.initialize()
+            projections.append({
+                "load": fresh.load_session(job["id"]),
+                "list": fresh.list_sessions(),
+                "activity": fresh.get_job_activity(job["id"]),
+                "attention": fresh.list_needs_attention(),
+            })
+            self.assertEqual(path.read_bytes(), before)
+
+        self.assertEqual(projections[0], projections[1])
+        serialized = json.dumps(projections[0], sort_keys=True)
+        self.assertNotIn("authorized to work", serialized)
+        self.assertNotIn("require sponsorship", serialized)
+        self.assertNotIn("Legacy Company Copy", serialized)
+        self.assertNotIn("Legacy Role Copy", serialized)
+        self.assertNotIn("https://legacy.example/jobs/copy", serialized)
+        fields = projections[0]["load"]["pendingFields"]
+        attention_row = next(
+            item
+            for item in projections[0]["attention"]["items"]
+            if item["jobId"] == job["id"]
+        )
+        self.assertEqual(
+            self.store._session_revision(projections[0]["load"]),
+            projections[0]["activity"]["session"]["revision"],
+        )
+        self.assertEqual(
+            attention_row["sessionRevision"],
+            projections[0]["activity"]["session"]["revision"],
+        )
+        for legacy_job_field in ("company", "role", "url"):
+            self.assertNotIn(legacy_job_field, projections[0]["load"])
+        self.assertEqual(len(fields), 2)
+        self.assertEqual(
+            [(field["state"], field["answerKey"], field["sensitive"]) for field in fields],
+            [
+                ("missing", "answer.work_authorization", True),
+                ("inferred", "answer.sponsorship", False),
+            ],
+        )
+        for field in fields:
+            self.assertRegex(field["reference"], r"^pending_[a-f0-9]{32}$")
+            self.assertRegex(field["questionFingerprint"], r"^[a-f0-9]{64}$")
+
+    def test_legacy_1_2_next_session_and_coordinator_writes_normalize_in_place(self):
+        self.store.initialize()
+        generic_path = self.store._session_path("legacy-session")
+        legacy = self.legacy_1_2_session()
+        legacy["ats"] = "greenhouse"
+        generic_path.write_text(json.dumps(legacy), encoding="utf-8")
+        projected = self.store.load_session("legacy-session")
+        saved = self.store.save_session(
+            "legacy-session",
+            {
+                "status": "active",
+                "step": "questions",
+                "answerKeys": legacy["answerKeys"],
+                "pendingFields": legacy["pendingFields"],
+            },
+        )
+        self.assertEqual(
+            [field["reference"] for field in saved["pendingFields"]],
+            [field["reference"] for field in projected["pendingFields"]],
+        )
+        self.assertEqual(saved["ats"], "greenhouse")
+        persisted = json.loads(generic_path.read_text(encoding="utf-8"))
+        self.assertEqual(persisted, saved)
+        self.assertTrue(all("question" not in field for field in persisted["pendingFields"]))
+
+        ready = self._make_ready_job(ats="greenhouse")
+        acquired = self.store.acquire_ready_job(
+            ready["id"], "legacy-normalizer", ready["revision"]
+        )
+        coordinator_path = self.store._session_path(ready["id"])
+        coordinator_legacy = self.legacy_1_2_session(ready["id"])
+        coordinator_path.write_text(json.dumps(coordinator_legacy), encoding="utf-8")
+        coordinator_projection = self.store.load_session(ready["id"])
+        progressed = self.store.save_claim_progress(
+            ready["id"],
+            acquired["token"],
+            {
+                "status": "active",
+                "step": "questions",
+                "answerKeys": coordinator_legacy["answerKeys"],
+                "pendingFields": coordinator_legacy["pendingFields"],
+            },
+        )
+        self.assertEqual(
+            [field["reference"] for field in progressed["pendingFields"]],
+            [field["reference"] for field in coordinator_projection["pendingFields"]],
+        )
+        self.assertEqual(
+            json.loads(coordinator_path.read_text(encoding="utf-8")), progressed
+        )
+        self.assertTrue(
+            all(
+                "question" not in field
+                for field in progressed["pendingFields"]
+            )
+        )
+
+    def test_legacy_1_2_compatibility_rejects_broader_or_colliding_shapes(self):
+        self.store.initialize()
+        path = self.store._session_path("legacy-session")
+        valid = self.legacy_1_2_session()
+        invalid_fields = {
+            "malformed explicit reference": [{"state": "missing", "reference": "pending_bad"}],
+            "reference-less modern metadata": [{"state": "missing", "fieldClass": "general"}],
+            "private value": [{"state": "missing", "value": "secret"}],
+            "duplicate legacy fields": [valid["pendingFields"][0], valid["pendingFields"][0]],
+            "duplicate explicit references": [
+                {"state": "missing", "reference": "pending_" + "a" * 32},
+                {"state": "inferred", "reference": "pending_" + "a" * 32},
+            ],
+            "mixed legacy and modern fields": [
+                valid["pendingFields"][0],
+                {"state": "missing", "reference": "pending_" + "b" * 32},
+            ],
+        }
+        for label, fields in invalid_fields.items():
+            with self.subTest(label=label):
+                document = self.legacy_1_2_session(pending_fields=copy.deepcopy(fields))
+                path.write_text(json.dumps(document), encoding="utf-8")
+                before = path.read_bytes()
+                with self.assertRaises(STORE_MODULE.StoreError):
+                    STORE_MODULE.Store(self.root, self.legacy).validate_workspace_startup()
+                self.assertEqual(path.read_bytes(), before)
+
+        for field, value in {
+            "company": {"private": "secret"},
+            "role": ["nested"],
+            "url": 42,
+        }.items():
+            with self.subTest(label=f"invalid legacy {field}"):
+                document = self.legacy_1_2_session()
+                document[field] = value
+                path.write_text(json.dumps(document), encoding="utf-8")
+                before = path.read_bytes()
+                with self.assertRaises(STORE_MODULE.StoreError):
+                    STORE_MODULE.Store(self.root, self.legacy).validate_workspace_startup()
+                self.assertEqual(path.read_bytes(), before)
+
+        invalid_document = self.legacy_1_2_session()
+        invalid_document["pendingFields"] = None
+        path.write_text(json.dumps(invalid_document), encoding="utf-8")
+        before = path.read_bytes()
+        with self.assertRaisesRegex(
+            STORE_MODULE.StoreError, "session pendingFields must be a list"
+        ):
+            self.store.load_session("legacy-session")
+        self.assertEqual(path.read_bytes(), before)
+
+    def test_legacy_1_2_non_sensitive_resolution_uses_canonical_job_ats(self):
+        ready = self._make_ready_job(ats="greenhouse")
+        answer = self.store.put_answer({
+            "question": "Authorized?",
+            "state": "confirmed",
+            "value": "yes",
+            "scope": {"ats": "greenhouse"},
+        })
+        acquired = self.store.acquire_ready_job(
+            ready["id"], "legacy-resolution", ready["revision"]
+        )
+        handed = self.store.handoff_claimed_job(
+            ready["id"], acquired["token"], "needs_info", {
+                "status": "active",
+                "attemptRevision": acquired["job"]["revision"],
+                "pendingFields": [{
+                    "question": "Authorized?",
+                    "state": "missing",
+                    "answerKey": answer["key"],
+                    "sensitive": False,
+                }],
+            }, acquired["job"]["revision"],
+        )
+        legacy = self.legacy_1_2_session(ready["id"], [{
+            "question": "Authorized?",
+            "state": "missing",
+            "answerKey": answer["key"],
+            "sensitive": False,
+        }])
+        legacy.update({
+            "company": "Legacy Company Copy",
+            "role": "Legacy Role Copy",
+            "url": "https://legacy.example/jobs/copy",
+        })
+        path = self.store._session_path(ready["id"])
+        path.write_text(json.dumps(legacy), encoding="utf-8")
+        activity = self.store.get_job_activity(ready["id"])
+        pending = activity["session"]["pendingInformation"][0]
+        resolved = self.store.resolve_pending_answer(
+            ready["id"], pending["reference"], handed["job"]["revision"],
+            activity["session"]["revision"], answer["revision"],
+            owner_confirmed=True,
+        )
+        self.assertTrue(resolved["ready"])
+        persisted = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(persisted["pendingFields"], [])
+        self.assertEqual(persisted["ats"], "greenhouse")
+        for legacy_job_field in ("company", "role", "url"):
+            self.assertNotIn(legacy_job_field, persisted)
+
+    def test_legacy_1_2_sensitive_grouped_approval_normalizes_coordinator_session(self):
+        ready = self._make_ready_job(ats="greenhouse")
+        answer = self.store.put_answer(
+            {
+                "question": "Sensitive legacy choice?",
+                "state": "confirmed",
+                "value": "private choice",
+                "scope": {"ats": "greenhouse"},
+                "sensitivity": "high",
+            },
+            remember_sensitive=True,
+        )
+        acquired = self.store.acquire_ready_job(
+            ready["id"], "legacy-sensitive", ready["revision"]
+        )
+        handed = self.store.handoff_claimed_job(
+            ready["id"],
+            acquired["token"],
+            "needs_info",
+            {
+                "status": "active",
+                "attemptRevision": acquired["job"]["revision"],
+                "pendingFields": [
+                    {
+                        "question": "Sensitive legacy choice?",
+                        "state": "sensitive",
+                        "answerKey": answer["key"],
+                        "sensitive": True,
+                    }
+                ],
+            },
+            acquired["job"]["revision"],
+        )
+        legacy = self.legacy_1_2_session(
+            ready["id"],
+            [
+                {
+                    "question": "Sensitive legacy choice?",
+                    "state": "sensitive",
+                    "answerKey": answer["key"],
+                    "sensitive": True,
+                }
+            ],
+        )
+        legacy.update({
+            "company": "Legacy Company Copy",
+            "role": "Legacy Role Copy",
+            "url": "https://legacy.example/jobs/copy",
+        })
+        path = self.store._session_path(ready["id"])
+        path.write_text(json.dumps(legacy), encoding="utf-8")
+        legacy_bytes = path.read_bytes()
+        activity = self.store.get_job_activity(ready["id"])
+        self.assertEqual(path.read_bytes(), legacy_bytes)
+        pending = activity["session"]["pendingInformation"][0]
+        self.assertIn("matchConfidence", pending)
+        decisions = [
+            {
+                "reference": pending["reference"],
+                "answerKey": answer["key"],
+                "currentUse": True,
+                "remember": False,
+                "policyMode": "strict",
+                "useAuthority": "per_use",
+                "allowedSensitiveFieldClasses": ["general"],
+            }
+        ]
+        preview = self.store.preview_grouped_approval(
+            ready["id"],
+            handed["job"]["revision"],
+            activity["session"]["revision"],
+            decisions,
+        )
+        self.assertTrue(preview["approvals"][0]["eligible"])
+        self.assertNotIn(
+            "scope_mismatch", preview["approvals"][0]["reasonCodes"]
+        )
+        self.assertEqual(path.read_bytes(), legacy_bytes)
+        approved = self.store.approve_grouped_approval(
+            ready["id"],
+            handed["job"]["revision"],
+            activity["session"]["revision"],
+            decisions,
+            preview["previewToken"],
+            owner_confirmed=True,
+        )
+        self.assertEqual(approved["approvals"][0]["reference"], pending["reference"])
+        persisted = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            persisted["pendingFields"][0]["reference"], pending["reference"]
+        )
+        self.assertEqual(persisted["ats"], "greenhouse")
+        self.assertEqual(
+            persisted["pendingFields"][0]["scopeFingerprint"],
+            STORE_MODULE._scope_fingerprint({"ats": "greenhouse"}),
+        )
+        self.assertIn(
+            "scope_match", persisted["pendingFields"][0]["matchReasonCodes"]
+        )
+        self.assertNotIn("question", persisted["pendingFields"][0])
+        for legacy_job_field in ("company", "role", "url"):
+            self.assertNotIn(legacy_job_field, persisted)
+
+    def test_session_explicit_ats_clear_does_not_inherit_scope_or_match_evidence(self):
+        answer = self.store.put_answer({
+            "question": "Authorized?", "state": "confirmed", "value": "private",
+            "scope": {"ats": "greenhouse"}, "fieldClass": "authorization",
+        })
+        pending = [{
+            "question": "Authorized?", "state": "missing",
+            "answerKey": answer["key"], "sensitive": False,
+            "fieldClass": "authorization",
+        }]
+        greenhouse_scope = STORE_MODULE._scope_fingerprint({"ats": "greenhouse"})
+
+        for label, cleared_ats in (("null", None), ("empty", "")):
+            with self.subTest(label=label):
+                application_id = f"explicit-ats-{label}"
+                initial = self.store.save_session(application_id, {
+                    "status": "active", "ats": "greenhouse",
+                    "pendingFields": pending,
+                })
+                self.assertEqual(
+                    initial["pendingFields"][0]["scopeFingerprint"], greenhouse_scope
+                )
+                updated = self.store.save_session(application_id, {
+                    "status": "active", "ats": cleared_ats,
+                    "pendingFields": pending,
+                })
+                field = updated["pendingFields"][0]
+                self.assertEqual(updated["ats"], cleared_ats)
+                self.assertNotIn("scopeFingerprint", field)
+                self.assertEqual(field["matchConfidence"], "none")
+                self.assertIn("scope_mismatch", field["matchReasonCodes"])
+                self.assertNotIn("scope_match", field["matchReasonCodes"])
+                persisted = json.loads(
+                    self.store._session_path(application_id).read_text(encoding="utf-8")
+                )
+                self.assertEqual(persisted, updated)
+                serialized = json.dumps(persisted, sort_keys=True)
+                self.assertNotIn("private", serialized)
+                self.assertNotIn("Authorized?", serialized)
+
+    def test_canonical_ats_clear_overrides_legacy_scope_before_grouped_approval(self):
+        answer = self.store.put_answer({
+            "question": "Sensitive legacy choice?", "state": "confirmed",
+            "value": "private", "scope": {"ats": "greenhouse"},
+            "sensitivity": "high",
+        }, remember_sensitive=True)
+        for label, cleared_ats in (("null", None), ("empty", "")):
+            with self.subTest(label=label):
+                job_id = f"canonical-clear-{label}"
+                job = self.store.create_job({
+                    "id": job_id, "url": f"https://example.com/jobs/{job_id}",
+                    "role": "Engineer", "company": "Example", "ats": "greenhouse",
+                })
+                job = self.store.transition_job(job_id, "needs_info", job["revision"])
+                legacy = self.legacy_1_2_session(job_id, [{
+                    "question": "Sensitive legacy choice?", "state": "sensitive",
+                    "answerKey": answer["key"], "sensitive": True,
+                }])
+                legacy.update({
+                    "ats": "greenhouse", "company": "Legacy Company Copy",
+                    "role": "Legacy Role Copy",
+                    "url": "https://legacy.example/jobs/copy",
+                })
+                path = self.store._session_path(job_id)
+                path.write_text(json.dumps(legacy), encoding="utf-8")
+                cleared = self.store.update_job(
+                    job_id, {"ats": cleared_ats}, job["revision"]
+                )
+                activity = self.store.get_job_activity(job_id)
+                pending = activity["session"]["pendingInformation"][0]
+                self.assertEqual(pending["matchConfidence"], "none")
+                self.assertIn("scope_mismatch", pending["matchReasonCodes"])
+                self.assertNotIn("scope_match", pending["matchReasonCodes"])
+                decision = {
+                    "reference": pending["reference"], "answerKey": answer["key"],
+                    "currentUse": True, "remember": False, "policyMode": "strict",
+                    "useAuthority": "per_use",
+                    "allowedSensitiveFieldClasses": ["general"],
+                }
+                preview = self.store.preview_grouped_approval(
+                    job_id, cleared["revision"], activity["session"]["revision"],
+                    [decision],
+                )
+                self.assertFalse(preview["approvals"][0]["eligible"])
+                self.assertIn(
+                    "scope_mismatch", preview["approvals"][0]["reasonCodes"]
+                )
+                self.store.approve_grouped_approval(
+                    job_id, cleared["revision"], activity["session"]["revision"],
+                    [decision], preview["previewToken"], owner_confirmed=True,
+                )
+                persisted = json.loads(path.read_text(encoding="utf-8"))
+                self.assertEqual(persisted["ats"], cleared_ats)
+                field = persisted["pendingFields"][0]
+                self.assertNotIn("scopeFingerprint", field)
+                self.assertEqual(field["matchConfidence"], "none")
+                self.assertIn("scope_mismatch", field["matchReasonCodes"])
+                self.assertNotIn("question", field)
+                for legacy_job_field in ("company", "role", "url"):
+                    self.assertNotIn(legacy_job_field, persisted)
+
+    def test_session_omitted_ats_retains_existing_scope_and_match_evidence(self):
+        answer = self.store.put_answer({
+            "question": "Authorized?", "state": "confirmed", "value": "private",
+            "scope": {"ats": "greenhouse"}, "fieldClass": "authorization",
+        })
+        pending = [{
+            "question": "Authorized?", "state": "missing",
+            "answerKey": answer["key"], "sensitive": False,
+            "fieldClass": "authorization",
+        }]
+        initial = self.store.save_session("omitted-ats", {
+            "status": "active", "ats": "greenhouse", "pendingFields": pending,
+        })
+        updated = self.store.save_session("omitted-ats", {
+            "status": "active", "pendingFields": pending,
+        })
+        field = updated["pendingFields"][0]
+        self.assertEqual(updated["ats"], "greenhouse")
+        self.assertEqual(
+            field["scopeFingerprint"],
+            STORE_MODULE._scope_fingerprint({"ats": "greenhouse"}),
+        )
+        self.assertIn("scope_match", field["matchReasonCodes"])
+        self.assertNotIn("scope_mismatch", field["matchReasonCodes"])
+        self.assertEqual(
+            field["reference"], initial["pendingFields"][0]["reference"]
+        )
 
     def test_answer_key_normalization_alias_lookup_and_confirmed_reuse(self):
         first = STORE_MODULE.answer_key(
@@ -6964,7 +7447,8 @@ class StoreTests(unittest.TestCase):
         )
         handed = self.store.handoff_claimed_job(
             ready["id"], acquired["token"], "needs_info", {
-                "status": "active", "attemptRevision": acquired["job"]["revision"],
+                "status": "active", "ats": "lever",
+                "attemptRevision": acquired["job"]["revision"],
                 "pendingFields": [{
                     "question": "Authorized?", "state": "missing",
                     "answerKey": answer["key"], "sensitive": False,
@@ -7013,6 +7497,14 @@ class StoreTests(unittest.TestCase):
             }, acquired["job"]["revision"],
         )
         activity = self.store.get_job_activity(ready["id"])
+        persisted = json.loads(
+            self.store._session_path(ready["id"]).read_text(encoding="utf-8")
+        )
+        self.assertEqual(persisted["ats"], "greenhouse")
+        self.assertEqual(
+            persisted["pendingFields"][0]["scopeFingerprint"],
+            STORE_MODULE._scope_fingerprint({"ats": "greenhouse"}),
+        )
         pending = activity["session"]["pendingInformation"][0]
         preview = self.store.preview_grouped_approval(
             ready["id"], handed["job"]["revision"],


### PR DESCRIPTION
## Summary
- project released legacy sessions into stable value-free modern session views
- preserve canonical ATS across legacy direct writers and coordinator session updates
- distinguish explicit ATS clearing from omitted ATS fallback and add upgrade regressions

## Validation
- `python3 -m unittest tests.test_job_apply_store -v`
- `python3 -m unittest discover -s tests -q`
- `node --test --test-concurrency=1 tests_js/*.test.mjs`
- `node qa/unified_task_spine_oracle.mjs --json`
- `PYTHONPATH=. python3 qa/oracle.py`
- `bash scripts/smoke-plugin.sh`
- `bash scripts/check-links.sh`
- `git diff --check`

This PR intentionally targets `staging` and remains unmerged.