### PR TITLE
Verify browser field persistence during application fill

### DIFF
--- a/skills/job-apply/SKILL.md
+++ b/skills/job-apply/SKILL.md
@@ -197,6 +197,39 @@ Do not reload the job revision before this handoff; a conflict must expose concu
 
 User confirmation never authorizes this skill to click Submit, Send, or any equivalent final-action button.
 
+### Verified field entry
+
+Treat a browser write that returns without an error as an attempted write, not proof
+that the field accepted the value. Apply this bounded loop to every editable control:
+
+1. Resolve the intended value from the canonical profile or a permitted saved answer
+   before interacting with the control. If a permitted saved value exists, do not ask
+   the user for it again merely because browser entry fails.
+2. Identify the exact form instance being edited. An embedded application and a
+   separately opened fallback page are independent forms; never infer that a value,
+   selection, or upload present in one is present in the other.
+3. Perform one normal write, then immediately read the control's current state and
+   compare it privately with the intended value. Keep this verification value-free in
+   logs, progress, history, receipts, and user-facing summaries.
+4. If the value did not persist, inspect the control once and make at most one safe
+   alternate entry attempt supported by the visible browser, such as sequential
+   typing for a text control. Verify the control state again. Do not repeat the same
+   action after the bounded fallback fails.
+5. Revalidate already-filled critical controls after an upload, selection, navigation,
+   or other action that may rerender the form. Restore a cleared value at most once
+   using the same bounded loop.
+6. If a known value still cannot be entered, classify the blocker as
+   `unsupported-control` with `owner-input-required`, leave the visible form open,
+   save only value-free progress, and hand control to the user. This is a browser
+   handoff, not a missing-answer request. Never claim the field is complete merely
+   because the browser operation returned no error.
+
+An alternate entry method within the same form instance, application attempt,
+destination, and already-approved purpose does not require renewed fill consent.
+Opening or switching to another form instance is a new action surface and requires
+fresh consent before entering private data there. Keep every final action untouched
+throughout recovery.
+
 ---
 
 ## Platform-Specific Guidance

--- a/tests/test_job_apply_skill_contract.py
+++ b/tests/test_job_apply_skill_contract.py
@@ -13,6 +13,7 @@ class JobApplySkillContractTests(unittest.TestCase):
     def setUpClass(cls):
         cls.skill = SKILL_PATH.read_text(encoding="utf-8")
         cls.readme = README_PATH.read_text(encoding="utf-8")
+        cls.normalized = " ".join(cls.skill.split())
 
     def test_action_time_consent_requires_visible_readiness(self):
         self.assertIn("Post-readiness action-time consent", self.skill)
@@ -72,6 +73,28 @@ class JobApplySkillContractTests(unittest.TestCase):
             "Start a new private attempt process",
         ):
             self.assertNotIn(stale, self.readme)
+
+    def test_field_entry_requires_observed_persistence(self) -> None:
+        self.assertIn("attempted write, not proof", self.normalized)
+        self.assertIn("immediately read the control's current state", self.normalized)
+        self.assertIn("compare it privately with the intended value", self.normalized)
+        self.assertIn("merely because the browser operation returned no error", self.normalized)
+
+    def test_field_entry_recovery_is_bounded_and_rerender_safe(self) -> None:
+        self.assertIn("at most one safe", self.normalized)
+        self.assertIn("Do not repeat the same", self.normalized)
+        self.assertIn("Revalidate already-filled critical controls", self.normalized)
+        self.assertIn("Restore a cleared value at most once", self.normalized)
+
+    def test_failed_entry_is_not_misclassified_as_missing_data(self) -> None:
+        self.assertIn("do not ask the user for it again", self.normalized)
+        self.assertIn("`unsupported-control` with `owner-input-required`", self.normalized)
+        self.assertIn("browser handoff, not a missing-answer request", self.normalized)
+
+    def test_form_instances_and_consent_remain_separate(self) -> None:
+        self.assertIn("independent forms", self.normalized)
+        self.assertIn("requires fresh consent", self.normalized)
+        self.assertIn("Keep every final action untouched throughout recovery", self.normalized)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- require post-write observation before treating an application field as complete
- bound alternate entry recovery to one safe retry and revalidate critical controls after rerenders
- classify known-value entry failures as browser handoffs instead of missing applicant data
- keep embedded and fallback form instances, consent, and final-action boundaries separate

## Verification
- `python3 -m unittest discover -s tests -v` — 691 passed, 2 skipped
- `python3 -m unittest -v tests.test_job_apply_skill_contract tests.test_final_action_docs`
- `./scripts/smoke-plugin.sh`
- `./scripts/check-links.sh`
- `git diff --check`

The unfinished supervised application and its durable Needs Attention state were not modified. The detailed dogfood note remains local-only.