### PR TITLE
Add tiered local commit and push validation hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec node tools/local-checks/hook.mjs pre-commit

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec node tools/local-checks/hook.mjs pre-push "$@"

--- a/config/test-matrix.json
+++ b/config/test-matrix.json
@@ -20,6 +20,8 @@
     "include": ["tests/test_*.py", "tests_js/*.test.mjs"]
   },
   "globalPaths": [
+    ".githooks/**",
+    "tools/local-checks/**",
     "config/test-matrix.json",
     "tools/test-runner.mjs",
     "tools/test-runner/**",
@@ -129,7 +131,7 @@
     {
       "id": "node-runner-fast",
       "kind": "node-test",
-      "include": ["tests_js/test-runner*.test.mjs", "tests_js/ci-*.test.mjs"],
+      "include": ["tests_js/test-runner*.test.mjs", "tests_js/ci-*.test.mjs", "tests_js/local_checks*.test.mjs"],
       "tiers": ["fast", "full"]
     },
     {

--- a/docs/local-testing-protocol.md
+++ b/docs/local-testing-protocol.md
@@ -1,0 +1,113 @@
+# Local testing during the TypeScript migration
+
+Verified on 2026-09-06 against staging commit
+`2ca9d6e2c47948df57e7649a2211d4ec523bb364` and the live staging ruleset:
+automatic **Validate Plugin** runs and required status checks are disabled for
+staging. Manual dispatch remains available. Main validation and nightly tests
+remain enabled. **Release Validation still runs on staging pushes and includes
+Python package checks**; run `34035182132` passed for that staging commit.
+This is a limited staging exception, not a freeze of every Python CI job.
+This change does not modify workflows or branch protection.
+
+## Tiered checks
+
+| Trigger | Checks | Escalation |
+| --- | --- | --- |
+| Commit | Whitespace, all six fast matrix suites, TypeScript, source size, emitted-runtime parity, local Markdown file links | Failures block the commit; no browser/package suite starts |
+| Push, known narrow change | Commit-level checks plus explicitly mapped focused contracts | Unknown paths, deleted focused modules, broad tooling/dependency changes and tags require deep evidence |
+| Deep validation | Fast checks plus all affected heavier suites; global/unknown changes and tags include full, release and native-platform suites | Explicit command, run once per outgoing commit/base/environment; successful local evidence can be reused for 24 hours |
+| Migration wave / production cutover | Integrated behavior, browser, packaging, applicable native hosts, supported Python reference version and rollback gates from the migration plan | Local hooks cannot substitute for missing platform/reference evidence; restore staging CI before cutover |
+
+Fast checks include a small Python contract/policy suite while Python remains the
+behavioral reference. Each quick suite has a two-minute ceiling, with at most two
+suites running together. Deep checks run one suite at a time, with a default
+15-minute ceiling per suite. These are upper bounds, not expected durations.
+Timeouts, interruptions, missing executables, missing selected tests and excessive
+output fail verification. Owned subprocess groups and temporary checkouts are
+cleaned up. Neither tier installs dependencies or changes a live Store.
+
+The initial focused mappings reserve paths for the migration branch's inert numeric
+codec, raw matching reference vectors and profile-fact reference vectors. Selecting
+a mapping whose tests have not landed fails closed. New production modules must acquire
+reviewed ownership and tests before getting a narrower path rule. Existing matrix
+ownership selects other affected suites. Unknown paths escalate conservatively.
+Documentation-only pushes avoid full tests but still check local file links.
+External URLs and Markdown anchors remain the responsibility of broader checks.
+
+## Installation and use
+
+Run once in each working checkout:
+
+```sh
+npm ci
+npm run hooks:install
+```
+
+Native Git hooks provide the required commit/push behavior without adding Husky
+as a dependency. Installation sets an absolute `core.hooksPath` for this worktree
+only and refuses to disable existing custom hooks. Installation is explicit;
+dependency installation does not silently reconfigure Git.
+
+```sh
+npm run verify:commit
+npm run verify:push
+npm run verify:deep -- --head HEAD --base origin/staging
+```
+
+`verify:commit` checks the exact staged index in a disposable checkout, preserving
+unstaged edits and the original index. It refuses success if the index changes
+during validation. Commit checks therefore require all needed files to be staged.
+
+`verify:push` checks committed changes, defaulting to HEAD and its merge base with
+`origin/staging`. The installed pre-push hook instead reads Git's actual outgoing
+ref updates: every pushed commit is checked, even when it is not HEAD. Existing
+remote object IDs provide the comparison base. New branches use a merge base with
+the configured comparison ref. Missing objects or comparison refs fail with no
+fallback. Fetch the relevant refs before retrying. Deletion-only pushes have no
+new code to test; annotated tags are peeled and require release checks.
+
+For broader changes, the hook prints the exact deep command with immutable commit
+and base IDs. Run that printed command after committing, then retry the push.
+Use `--release` when validating a tag. A deep command with a different comparison
+base will not satisfy the hook. An alternate comparison branch can be configured
+with `git config --worktree localChecks.baseRef REF` after hook installation.
+
+## Evidence and limitations
+
+Receipts and bounded logs live in the worktree's Git metadata under `local-checks`.
+They bind the outgoing commit/tree, comparison base, tag mode, suite definitions,
+active hook and runner implementation, Node/Python versions, operating system,
+architecture, dependency lock and installed dependency metadata. A changed identity,
+failed run, incomplete result set or expired receipt cannot satisfy escalation.
+Only successful **deep** receipts satisfy a broader push requirement.
+
+Snapshots reuse the checkout's installed dependencies only when the target lock
+matches. Install dependencies after lock changes. Hooks do not certify arbitrary
+manual changes inside `node_modules`; dependency metadata is not a security proof.
+Treat a cached receipt as local test evidence, not a signed attestation.
+
+Foreign-platform suites are explicitly recorded as deferred, never claimed passed.
+The hooks have local macOS validation; native Windows execution remains unverified.
+Python reference tests may also report version-specific skips inside suite output;
+retain those logs and keep the corresponding migration acceptance cells open.
+Local success is not full cross-platform or full migration acceptance.
+
+Git hooks are bypassable and are not server-side enforcement; see
+[Git hook documentation](https://git-scm.com/docs/githooks).
+Do not use bypasses to describe failed or missing evidence as passing.
+
+## Parallel worker protocol
+
+The coordinator assigns disjoint `allowed_files` and a focused test command to
+each worker. Each worker runs focused tests after its last meaningful edit and
+returns the tested commit, results, skips and limitations. Commit hooks provide
+the common fast gate. The coordinator integrates a wave, resolves ownership
+conflicts and runs affected/deep validation once on the integrated outgoing commit.
+Any subsequent edits invalidate that evidence. Do not have every worker rerun
+browser/package suites for the same unchanged integration state.
+
+Keep one Store facade owner and one workspace bootstrap owner at a time. Python
+and TypeScript writers must never mutate the same live Store. The
+[migration plan](superpowers/plans/2026-09-04-typescript-strangler-migration.md) and
+[modernization checkpoint](modernization-checkpoint.md) retain the full acceptance gates,
+including human-only final submission and restoration of staging CI.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,6 +10,10 @@ output, and `npm run build:check` rejects missing, changed, stale, mapped or
 oversized output. Build errors leave the previous runtime intact; stale files
 require explicit review/removal. Existing application launchers still use Python.
 
+Install the staged commit and outgoing push hooks with `npm run hooks:install`.
+See the [local hook protocol](local-testing-protocol.md) for escalation and
+24-hour deep-validation receipt reuse.
+
 ## Supported tiers
 
 ```text

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "hooks:install": "node tools/local-checks/install.mjs",
+    "verify:commit": "node tools/local-checks/hook.mjs commit",
+    "verify:push": "node tools/local-checks/hook.mjs push",
+    "verify:deep": "node tools/local-checks/hook.mjs deep",
     "typecheck": "tsc --noEmit --project tsconfig.json",
     "build:runtime": "node tools/build-runtime.mjs",
     "build:check": "node tools/build-runtime.mjs --check",

--- a/tests_js/local_checks_git.test.mjs
+++ b/tests_js/local_checks_git.test.mjs
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { git, indexSnapshot, pushTargets, resolveCommit, withSnapshot } from "../tools/local-checks/git.mjs";
+
+const ZERO = "0".repeat(40);
+
+function command(root, args, input) {
+  const env = { ...process.env };
+  for (const key of ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"]) delete env[key];
+  const result = spawnSync("git", ["-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false", "-C", root, ...args], {
+    encoding: "utf8", input, env,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout;
+}
+
+async function fixture(t, initial = true) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "job-apply-local-checks-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  command(root, ["init", "-b", "main"]);
+  command(root, ["config", "user.name", "Synthetic Hook Test"]);
+  command(root, ["config", "user.email", "hook@example.invalid"]);
+  if (initial) {
+    await fs.writeFile(path.join(root, "value.txt"), "base\n");
+    command(root, ["add", "."]);
+    command(root, ["commit", "-m", "synthetic base"]);
+  }
+  return root;
+}
+
+async function commitValue(root, value) {
+  await fs.writeFile(path.join(root, "value.txt"), `${value}\n`);
+  command(root, ["add", "value.txt"]);
+  command(root, ["commit", "-m", `synthetic ${value}`]);
+  return command(root, ["rev-parse", "HEAD"]).trim();
+}
+
+function pushLine(localRef, localSha, remoteRef, remoteSha) {
+  return `${localRef} ${localSha} ${remoteRef} ${remoteSha}\n`;
+}
+
+test("Git helper preserves stdout and resolves only existing commits", async (t) => {
+  const root = await fixture(t);
+  assert.equal(await git(root, ["show", "HEAD:value.txt"]), "base\n");
+  assert.equal(await resolveCommit(root, "HEAD"), command(root, ["rev-parse", "HEAD"]).trim());
+  await assert.rejects(async () => resolveCommit(root, "refs/heads/missing"));
+});
+
+test("index snapshot isolates staged content and preserves dirty root/index", async (t) => {
+  const root = await fixture(t);
+  const head = command(root, ["rev-parse", "HEAD"]).trim();
+  await fs.writeFile(path.join(root, "value.txt"), "staged\n");
+  command(root, ["add", "value.txt"]);
+  await fs.writeFile(path.join(root, "value.txt"), "unstaged\n");
+  await fs.writeFile(path.join(root, "private-untracked.txt"), "untracked synthetic\n");
+  const originalIndex = await fs.readFile(path.join(root, ".git", "index"));
+  const snapshot = await indexSnapshot(root);
+  assert.equal(snapshot.tree, command(root, ["rev-parse", `${snapshot.commit}^{tree}`]).trim());
+  assert.equal(snapshot.base, head);
+  assert.equal(command(root, ["show", `${snapshot.commit}:value.txt`]), "staged\n");
+  let isolated;
+  const returned = await withSnapshot(root, snapshot.commit, async (directory) => {
+    isolated = directory;
+    assert.notEqual(directory, root);
+    assert.equal(await fs.readFile(path.join(directory, "value.txt"), "utf8"), "staged\n");
+    await assert.rejects(fs.stat(path.join(directory, "private-untracked.txt")), { code: "ENOENT" });
+    await fs.writeFile(path.join(directory, "value.txt"), "disposable mutation\n");
+    return "callback result";
+  });
+  assert.equal(returned, "callback result");
+  await assert.rejects(fs.stat(isolated), { code: "ENOENT" });
+  assert.equal(await fs.readFile(path.join(root, "value.txt"), "utf8"), "unstaged\n");
+  assert.deepEqual(await fs.readFile(path.join(root, ".git", "index")), originalIndex);
+  assert.equal(command(root, ["rev-parse", "HEAD"]).trim(), head);
+});
+
+test("unborn staged index and staged deletion/rename produce exact snapshots", async (t) => {
+  const unborn = await fixture(t, false);
+  await fs.writeFile(path.join(unborn, "first.txt"), "first staged\n");
+  command(unborn, ["add", "first.txt"]);
+  const first = await indexSnapshot(unborn);
+  assert.equal(command(unborn, ["show", `${first.commit}:first.txt`]), "first staged\n");
+  assert.equal(command(unborn, ["ls-tree", "--name-only", first.tree]), "first.txt\n");
+
+  const root = await fixture(t);
+  await fs.writeFile(path.join(root, "remove.txt"), "remove me\n");
+  command(root, ["add", "."]);
+  command(root, ["commit", "-m", "add removable fixture"]);
+  command(root, ["mv", "value.txt", "renamed.txt"]);
+  command(root, ["rm", "remove.txt"]);
+  const snapshot = await indexSnapshot(root);
+  assert.equal(command(root, ["ls-tree", "--name-only", snapshot.tree]), "renamed.txt\n");
+  assert.equal(command(root, ["show", `${snapshot.commit}:renamed.txt`]), "base\n");
+});
+
+test("snapshot callback failure removes only owned worktree and preserves original state", async (t) => {
+  const root = await fixture(t);
+  const before = command(root, ["worktree", "list", "--porcelain"]);
+  const snapshot = await indexSnapshot(root);
+  let isolated;
+  await assert.rejects(withSnapshot(root, snapshot.commit, async (directory) => {
+    isolated = directory;
+    await fs.writeFile(path.join(directory, "untracked.txt"), "disposable\n");
+    throw new Error("synthetic callback failure");
+  }), /synthetic callback failure/);
+  await assert.rejects(fs.stat(isolated), { code: "ENOENT" });
+  assert.equal(command(root, ["worktree", "list", "--porcelain"]), before);
+  assert.equal(await fs.readFile(path.join(root, "value.txt"), "utf8"), "base\n");
+});
+
+test("hook alternate index is captured without leaking Git environment into snapshots", async (t) => {
+  const root = await fixture(t);
+  const originalIndex = await fs.readFile(path.join(root, ".git", "index"));
+  await fs.writeFile(path.join(root, "value.txt"), "alternate staged\n");
+  command(root, ["add", "value.txt"]);
+  const alternate = path.join(root, ".git", "synthetic-alternate-index");
+  await fs.copyFile(path.join(root, ".git", "index"), alternate);
+  await fs.writeFile(path.join(root, ".git", "index"), originalIndex);
+  const previous = process.env.GIT_INDEX_FILE;
+  process.env.GIT_INDEX_FILE = alternate;
+  try {
+    const snapshot = await indexSnapshot(root);
+    assert.equal(command(root, ["show", `${snapshot.commit}:value.txt`]), "alternate staged\n");
+    await withSnapshot(root, snapshot.commit, async (directory) => {
+      assert.equal(await fs.readFile(path.join(directory, "value.txt"), "utf8"), "alternate staged\n");
+      assert.equal((await git(directory, ["show", ":value.txt"])), "alternate staged\n");
+    });
+    assert.deepEqual(await fs.readFile(path.join(root, ".git", "index")), originalIndex);
+  } finally {
+    if (previous === undefined) delete process.env.GIT_INDEX_FILE;
+    else process.env.GIT_INDEX_FILE = previous;
+  }
+});
+
+test("push targets use pushed commits, support multiple refs and ignore deletions", async (t) => {
+  const root = await fixture(t);
+  const base = command(root, ["rev-parse", "HEAD"]).trim();
+  const pushed = await commitValue(root, "pushed");
+  const current = await commitValue(root, "current");
+  const input = pushLine("refs/heads/topic", pushed, "refs/heads/topic", base)
+    + pushLine("refs/heads/other", current, "refs/heads/other", pushed)
+    + pushLine("(delete)", ZERO, "refs/heads/removed", base);
+  const targets = await pushTargets(root, input);
+  assert.equal(targets.length, 2);
+  assert.deepEqual(targets.map(({ commit, base: prior }) => [commit, prior]), [[pushed, base], [current, pushed]]);
+});
+
+test("new branches use merge base with explicitly configured comparison ref", async (t) => {
+  const root = await fixture(t);
+  const common = command(root, ["rev-parse", "HEAD"]).trim();
+  const pushed = await commitValue(root, "topic");
+  command(root, ["checkout", "-b", "comparison", common]);
+  const comparison = await commitValue(root, "comparison");
+  command(root, ["update-ref", "refs/remotes/origin/staging", comparison]);
+  const input = pushLine("refs/heads/topic", pushed, "refs/heads/topic", ZERO);
+  const targets = await pushTargets(root, input, "refs/heads/comparison");
+  assert.equal(targets[0].commit, pushed);
+  assert.equal(targets[0].base, common);
+  await assert.rejects(async () => pushTargets(root, input, "refs/heads/unavailable"));
+});
+
+test("push validation rejects malformed records and unavailable remote objects", async (t) => {
+  const root = await fixture(t);
+  const head = command(root, ["rev-parse", "HEAD"]).trim();
+  for (const input of [
+    "malformed\n",
+    `refs/heads/main ${head} refs/heads/main\n`,
+    `refs/heads/main ${head} refs/heads/main ${head} extra\n`,
+    pushLine("refs/heads/main", "not-a-sha", "refs/heads/main", head),
+    pushLine("refs/heads/main", head, "refs/heads/main", "f".repeat(40)),
+  ]) await assert.rejects(async () => pushTargets(root, input));
+});
+
+test("annotated tag targets peel to the commit actually pushed", async (t) => {
+  const root = await fixture(t);
+  const base = command(root, ["rev-parse", "HEAD"]).trim();
+  command(root, ["update-ref", "refs/remotes/origin/staging", base]);
+  const tagged = await commitValue(root, "tagged");
+  command(root, ["-c", "tag.gpgsign=false", "tag", "-a", "synthetic-v1", "-m", "synthetic tag"]);
+  const tagObject = command(root, ["rev-parse", "refs/tags/synthetic-v1"]).trim();
+  await commitValue(root, "later-head");
+  const targets = await pushTargets(root, pushLine("refs/tags/synthetic-v1", tagObject, "refs/tags/synthetic-v1", ZERO));
+  assert.equal(targets.length, 1);
+  assert.equal(targets[0].commit, tagged);
+  assert.equal(targets[0].base, base);
+  assert.ok(targets[0].tag);
+});

--- a/tests_js/local_checks_install.test.mjs
+++ b/tests_js/local_checks_install.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, writeFile, rm, stat, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import { cleanEnvironment, git } from '../tools/local-checks/git.mjs';
+
+const installer = fileURLToPath(new URL('../tools/local-checks/install.mjs', import.meta.url));
+async function fixture(t) {
+  const root = await mkdtemp(join(tmpdir(), 'local-install-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  git(root, ['init', '-b', 'main']);
+  await mkdir(join(root, '.githooks'));
+  for (const name of ['pre-commit', 'pre-push']) {
+    await writeFile(join(root, '.githooks', name), '#!/bin/sh\nexit 0\n');
+  }
+  return root;
+}
+function run(root) {
+  return spawnSync(process.execPath, [installer], { cwd: root, env: cleanEnvironment(), encoding: 'utf8' });
+}
+function config(root, ...args) {
+  return spawnSync('git', ['config', ...args], { cwd: root, env: cleanEnvironment(), encoding: 'utf8' });
+}
+
+test('installation enables executable hooks in worktree scope and is repeatable', async (t) => {
+  const root = await fixture(t);
+  assert.equal(run(root).status, 0);
+  assert.equal(run(root).status, 0);
+  assert.equal(config(root, '--worktree', '--get', 'core.hooksPath').stdout.trim(), join(await realpath(root), '.githooks'));
+  assert.equal(config(root, '--local', '--get', 'core.hooksPath').status, 1);
+  if (process.platform !== 'win32') assert.ok((await stat(join(root, '.githooks/pre-commit'))).mode & 0o100);
+});
+
+test('installation refuses to disable an existing default hook of any kind', async (t) => {
+  const root = await fixture(t);
+  await writeFile(join(root, '.git/hooks/post-merge'), '#!/bin/sh\nexit 0\n');
+  const result = run(root);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Existing default Git hooks/);
+  assert.equal(config(root, '--get', 'core.hooksPath').status, 1);
+});
+
+test('installation preserves a configured hook directory', async (t) => {
+  const root = await fixture(t);
+  assert.equal(config(root, '--local', 'core.hooksPath', 'custom-hooks').status, 0);
+  assert.equal(run(root).status, 1);
+  assert.equal(config(root, '--get', 'core.hooksPath').stdout.trim(), 'custom-hooks');
+});

--- a/tests_js/local_checks_policy.test.mjs
+++ b/tests_js/local_checks_policy.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { readFile, mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { selectLocalPlan } from '../tools/local-checks/policy.mjs';
+import { policyFingerprint, reusableReceipt, successfulLocalResults } from '../tools/local-checks/run.mjs';
+
+const matrix = JSON.parse(await readFile(new URL('../config/test-matrix.json', import.meta.url)));
+const ids = (suites) => suites.map((suite) => suite.id);
+
+test('receipt policy fingerprint changes when active runner implementation changes', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'local-policy-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const local = join(root, 'local-checks');
+  const runner = join(root, 'test-runner');
+  await mkdir(local);
+  await mkdir(runner);
+  await writeFile(join(local, 'run.mjs'), 'local');
+  await writeFile(join(runner, 'execute.mjs'), 'old execution');
+  const before = await policyFingerprint(local);
+  await writeFile(join(runner, 'execute.mjs'), 'new execution');
+  assert.notEqual(await policyFingerprint(local), before);
+});
+
+test('documentation stays light while exact inert codec changes add focused tests', () => {
+  const docs = selectLocalPlan(matrix, [], ['docs/migration.md']);
+  assert.equal(docs.heavy.length, 0);
+  assert.ok(ids(docs.light).includes('local-build'));
+  assert.ok(ids(docs.light).includes('local-links'));
+  const path = 'src/contracts/raw-json/numeric-atom.ts';
+  const focused = selectLocalPlan(matrix, [path], [path]);
+  assert.equal(focused.heavy.length, 0);
+  assert.ok(ids(focused.light).includes('local-numeric'));
+});
+
+test('new production modules, global edits, unknown paths and deleted codec escalate', () => {
+  for (const path of ['src/contracts/raw-json/production.ts', 'package-lock.json',
+    'tools/local-checks/run.mjs', 'unmapped.file', 'src/contracts/raw-json/numeric-atom.ts']) {
+    const plan = selectLocalPlan(matrix, [], [path]);
+    const selected = ids([...plan.light, ...plan.heavy]);
+    for (const suite of matrix.suites) assert.ok(selected.includes(suite.id), `${path}: ${suite.id}`);
+  }
+});
+
+test('tag pushes require complete local release and platform selection even with no changes', () => {
+  const plan = selectLocalPlan(matrix, [], [], { tag: true });
+  const selected = ids([...plan.light, ...plan.heavy]);
+  assert.ok(matrix.suites.every((suite) => selected.includes(suite.id)));
+});
+
+test('known renderer changes select their suite without unrelated package tests', () => {
+  const plan = selectLocalPlan(matrix, [], ['qa/renderer/render.mjs']);
+  assert.ok(ids(plan.heavy).includes('node-renderer'));
+  assert.ok(!ids(plan.heavy).includes('release-package'));
+});
+
+test('local success rejects missing, failed and wrongly skipped mandatory cells', () => {
+  const suites = [{ id: 'required' }, { id: 'foreign', platforms: ['other-platform'] }];
+  const results = [{ id: 'required', status: 'passed' }, { id: 'foreign', status: 'skipped' }];
+  assert.equal(successfulLocalResults(results, suites), true);
+  assert.equal(successfulLocalResults(results.slice(1), suites), false);
+  for (const status of ['failed', 'skipped', 'timed-out']) {
+    assert.equal(successfulLocalResults([{ id: 'required', status }, results[1]], suites), false);
+  }
+});
+
+test('only fresh complete deep receipts for the exact identity can satisfy escalation', () => {
+  const receipt = { schemaVersion: 1, key: 'exact', mode: 'deep', status: 'passed-local',
+    completedAt: 100, expiresAt: 200, suites: [{ id: 'required' }],
+    results: [{ id: 'required', status: 'passed' }] };
+  assert.equal(reusableReceipt(receipt, 'exact', 150), true);
+  assert.equal(reusableReceipt(receipt, 'different-commit-or-environment', 150), false);
+  for (const patch of [{ mode: 'commit' }, { mode: 'push' }, { status: 'failed' },
+    { completedAt: 151 }, { expiresAt: 150 }, { results: [] }, { results: undefined },
+    { results: [{ id: 'required', status: 'skipped' }] }]) {
+    assert.equal(reusableReceipt({ ...receipt, ...patch }, 'exact', 150), false);
+  }
+});

--- a/tests_js/local_checks_process.test.mjs
+++ b/tests_js/local_checks_process.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { runLocalCommand } from "../tools/local-checks/process.mjs";
+
+function settings(overrides = {}) {
+  const output = { stdout: "", stderr: "" };
+  return {
+    output,
+    options: {
+      cwd: os.tmpdir(),
+      label: "synthetic-process",
+      timeoutMs: 4000,
+      maxOutputBytes: 1024,
+      stdout: (text) => { output.stdout += text; },
+      stderr: (text) => { output.stderr += text; },
+      ...overrides,
+    },
+  };
+}
+
+test("failed commands retain exit status and bounded diagnostic streams", async () => {
+  const { options, output } = settings();
+  const result = await runLocalCommand(process.execPath, ["-e", "process.stdout.write('synthetic stdout'); process.stderr.write('synthetic stderr'); process.exitCode=7;"], options);
+  assert.equal(result.status, "failed");
+  assert.equal(result.exitCode, 7);
+  assert.equal(result.signal, null);
+  assert.match(output.stdout, /synthetic stdout/);
+  assert.match(output.stderr, /synthetic stderr/);
+  assert.ok(result.durationMs >= 0);
+});
+
+test("missing executable produces a failed receipt instead of rejecting or hanging", async () => {
+  const { options } = settings();
+  const result = await runLocalCommand(path.join(os.tmpdir(), "synthetic-unavailable-command-84912"), [], options);
+  assert.equal(result.status, "failed");
+  assert.equal(result.signal, "spawn-error");
+  assert.notEqual(result.exitCode, 0);
+});
+
+test("command children cannot inherit Git variables, including explicit env overrides", async () => {
+  const { options, output } = settings({ env: {
+    GIT_DIR: "/synthetic/unavailable",
+    GIT_INDEX_FILE: "/synthetic/index",
+    GIT_WORK_TREE: "/synthetic/tree",
+    LOCAL_CHECKS_SYNTHETIC: "retained",
+  } });
+  const code = "process.stdout.write(JSON.stringify({git:Object.keys(process.env).filter(k=>k.startsWith('GIT_')),retained:process.env.LOCAL_CHECKS_SYNTHETIC}));";
+  const result = await runLocalCommand(process.execPath, ["-e", code], options);
+  assert.equal(result.status, "passed");
+  assert.deepEqual(JSON.parse(output.stdout.replace(/^\[synthetic-process\] /, "")), {
+    git: [], retained: "retained",
+  });
+});
+
+for (const stream of ["stdout", "stderr"]) {
+  test(`${stream} output limit terminates the command and suppresses excess output`, async () => {
+    const { options, output } = settings({ maxOutputBytes: 64 });
+    const result = await runLocalCommand(process.execPath, ["-e", `process.${stream}.write('x'.repeat(8192)); setInterval(()=>{},1000);`], options);
+    assert.equal(result.status, "failed");
+    assert.equal(result.signal, "output-limit");
+    assert.match(output.stderr, /output-limit/);
+    assert.ok(!output[stream].includes("x".repeat(65)));
+    assert.ok(result.durationMs < 3500);
+  });
+}
+
+test("timeout terminates the owned descendant before it can write its delayed marker", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "local-checks-process-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const marker = path.join(root, "unexpected-descendant-write.txt");
+  const { options, output } = settings({ timeoutMs: 400, cwd: root });
+  const descendant = "require('node:fs').writeFileSync('ready.txt','ready'); setTimeout(()=>require('node:fs').writeFileSync(process.argv[1],'unexpected'),2000);";
+  const code = `require('node:child_process').spawn(process.execPath,['-e',${JSON.stringify(descendant)},${JSON.stringify(marker)}],{stdio:'inherit'}); setInterval(()=>{},1000);`;
+  const result = await runLocalCommand(process.execPath, ["-e", code], options);
+  assert.equal(await fs.readFile(path.join(root, "ready.txt"), "utf8"), "ready");
+  assert.equal(result.status, "failed");
+  assert.equal(result.signal, "timeout");
+  assert.match(output.stderr, /terminating owned process group/);
+  await new Promise((resolve) => setTimeout(resolve, 850));
+  await assert.rejects(fs.stat(marker), { code: "ENOENT" });
+});
+
+test("interruption stops active work and prevents new commands in that coordinator", () => {
+  const moduleUrl = new URL("../tools/local-checks/process.mjs", import.meta.url).href;
+  const code = `
+    import {runLocalCommand,interruptLocalChecks} from ${JSON.stringify(moduleUrl)};
+    const options={cwd:process.cwd(),label:'interrupt-fixture',stdout:()=>{},stderr:()=>{},timeoutMs:4000};
+    const active=runLocalCommand(process.execPath,['-e','setInterval(()=>{},1000)'],options);
+    setTimeout(interruptLocalChecks,100);
+    const first=await active;
+    const second=await runLocalCommand(process.execPath,['-e','process.exit(0)'],options);
+    process.stdout.write(JSON.stringify({first,second}));
+  `;
+  const result = spawnSync(process.execPath, ["--input-type=module", "-e", code], {
+    encoding: "utf8", timeout: 5000, maxBuffer: 4096,
+  });
+  assert.ifError(result.error);
+  assert.equal(result.status, 0, result.stderr);
+  const { first, second } = JSON.parse(result.stdout);
+  assert.equal(first.status, "failed");
+  assert.equal(first.signal, "interrupted");
+  assert.equal(second.status, "failed");
+  assert.equal(second.signal, "interrupted");
+  assert.equal(second.exitCode, 130);
+  assert.equal(second.durationMs, 0);
+});

--- a/tests_js/local_checks_run.test.mjs
+++ b/tests_js/local_checks_run.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { runTarget } from "../tools/local-checks/run.mjs";
+
+function git(root, args) {
+  const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")));
+  const result = spawnSync("git", ["-C", root, "-c", "core.hooksPath=/dev/null", "-c", "commit.gpgsign=false", ...args], {
+    encoding: "utf8", env, timeout: 3000,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+async function put(root, name, value) {
+  const destination = path.join(root, name);
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  await fs.writeFile(destination, value);
+}
+
+async function fixture(t, fail = false) {
+  const temporary = await fs.mkdtemp(path.join(os.tmpdir(), "local-checks-run-fixture-"));
+  t.after(() => fs.rm(temporary, { recursive: true, force: true }));
+  const root = path.join(temporary, "repo");
+  await fs.mkdir(root);
+  git(root, ["init", "-b", "main"]);
+  git(root, ["config", "user.name", "Synthetic Local Checks"]);
+  git(root, ["config", "user.email", "synthetic@example.invalid"]);
+  const marker = path.join(temporary, "executions.txt");
+  const record = `require('node:fs').appendFileSync(${JSON.stringify(marker)},'ran\\n');process.exitCode=${fail ? 5 : 0};`;
+  const matrix = {
+    schemaVersion: 1,
+    inventory: { include: [] },
+    fullInventory: { include: [] },
+    globalPaths: ["src/**"],
+    suites: [{ id: "synthetic-broad", kind: "command", command: [process.execPath, "-e", record], tiers: ["full"], timeoutMs: 1000 }],
+    ownership: [],
+  };
+  await put(root, ".gitignore", "node_modules/\n");
+  await put(root, "config/test-matrix.json", JSON.stringify(matrix));
+  await put(root, "package.json", JSON.stringify({ private: true, scripts: { "build:check": "node -e \"process.exit(0)\"" } }));
+  const lock = JSON.stringify({ name: "synthetic", lockfileVersion: 3, packages: {} });
+  await put(root, "package-lock.json", lock);
+  await put(root, "node_modules/.package-lock.json", lock);
+  await put(root, "tools/local-checks/links.mjs", "// Synthetic no-op link validation.\n");
+  await put(root, "src/domain.ts", "// synthetic base\n");
+  git(root, ["add", "."]);
+  git(root, ["commit", "-m", "synthetic base"]);
+  const base = git(root, ["rev-parse", "HEAD"]);
+  await put(root, "src/domain.ts", "// synthetic target\n");
+  git(root, ["add", "src/domain.ts"]);
+  git(root, ["commit", "-m", "synthetic target"]);
+  return { root, marker, target: { base, commit: git(root, ["rev-parse", "HEAD"]), tag: false } };
+}
+
+const changed = { paths: ["src/domain.ts"] };
+
+test("push broad selection refuses before running commands and cleans its snapshot", async (t) => {
+  const { root, marker, target } = await fixture(t);
+  const before = git(root, ["worktree", "list", "--porcelain"]);
+  await assert.rejects(runTarget(root, target, { mode: "push", ...changed }), /Broader validation required/);
+  await assert.rejects(fs.stat(marker), { code: "ENOENT" });
+  assert.equal(git(root, ["worktree", "list", "--porcelain"]), before);
+  assert.equal(git(root, ["status", "--porcelain"]), "");
+});
+
+test("deep receipt is reusable only for the same target and base", async (t) => {
+  const { root, marker, target } = await fixture(t);
+  const before = git(root, ["worktree", "list", "--porcelain"]);
+  const receipt = await runTarget(root, target, { mode: "deep", ...changed });
+  assert.equal(receipt.status, "passed-local");
+  assert.equal(receipt.mode, "deep");
+  assert.equal(receipt.commit, target.commit);
+  assert.equal(receipt.base, target.base);
+  assert.ok(receipt.results.every(({ status }) => status === "passed"));
+  const markerBefore = await fs.readFile(marker, "utf8");
+  const reused = await runTarget(root, target, { mode: "push", ...changed });
+  assert.equal(reused.key, receipt.key);
+  assert.equal(reused.completedAt, receipt.completedAt);
+  assert.equal(await fs.readFile(marker, "utf8"), markerBefore);
+  await assert.rejects(runTarget(root, { ...target, base: target.commit }, { mode: "push", ...changed }), /Broader validation required/);
+  await put(root, "src/domain.ts", "// next synthetic target\n");
+  git(root, ["add", "src/domain.ts"]);
+  git(root, ["commit", "-m", "next synthetic target"]);
+  const next = git(root, ["rev-parse", "HEAD"]);
+  await assert.rejects(runTarget(root, { ...target, commit: next }, { mode: "push", ...changed }), /Broader validation required/);
+  assert.equal(await fs.readFile(marker, "utf8"), markerBefore);
+  assert.equal(git(root, ["worktree", "list", "--porcelain"]).split("\n").filter((line) => line.startsWith("worktree ")).length,
+    before.split("\n").filter((line) => line.startsWith("worktree ")).length);
+  assert.equal(git(root, ["status", "--porcelain"]), "");
+});
+
+test("failed deep result is preserved but never reused by push", async (t) => {
+  const { root, marker, target } = await fixture(t, true);
+  const before = git(root, ["worktree", "list", "--porcelain"]);
+  await assert.rejects(runTarget(root, target, { mode: "deep", ...changed }), /validation failed; receipt retained/);
+  const receiptDirectory = path.join(root, ".git", "local-checks");
+  const receipts = (await fs.readdir(receiptDirectory)).filter((name) => name.endsWith(".json"));
+  assert.equal(receipts.length, 1);
+  const receipt = JSON.parse(await fs.readFile(path.join(receiptDirectory, receipts[0]), "utf8"));
+  assert.equal(receipt.status, "failed");
+  assert.ok(receipt.results.some(({ id, status }) => id === "synthetic-broad" && status === "failed"));
+  const markerBefore = await fs.readFile(marker, "utf8");
+  await assert.rejects(runTarget(root, target, { mode: "push", ...changed }), /Broader validation required/);
+  assert.equal(await fs.readFile(marker, "utf8"), markerBefore);
+  assert.equal(git(root, ["worktree", "list", "--porcelain"]), before);
+});

--- a/tools/local-checks/git.mjs
+++ b/tools/local-checks/git.mjs
@@ -1,0 +1,93 @@
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdtemp, readFile, realpath, rm, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export function cleanEnvironment() {
+  return Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')));
+}
+
+export function git(root, args, { input, allowFailure = false, hookIndex = false, indexFile } = {}) {
+  const env = cleanEnvironment();
+  if (hookIndex && process.env.GIT_INDEX_FILE) env.GIT_INDEX_FILE = process.env.GIT_INDEX_FILE;
+  if (indexFile) env.GIT_INDEX_FILE = indexFile;
+  const result = spawnSync('git', ['-c', 'core.hooksPath=/dev/null', ...args], {
+    cwd: root, env, input, encoding: 'utf8', timeout: 30_000, maxBuffer: 8 * 1024 * 1024,
+  });
+  if (result.error || (result.status !== 0 && !allowFailure)) {
+    throw new Error(`Local checks: git ${args[0]} failed. ${result.stderr?.trim() ?? ''}`);
+  }
+  return result.status === 0 ? result.stdout : '';
+}
+
+export function resolveCommit(root, ref) {
+  return git(root, ['rev-parse', '--verify', `${ref}^{commit}`]).trim();
+}
+
+export function indexTree(root) {
+  const original = resolve(root, process.env.GIT_INDEX_FILE
+    || git(root, ['rev-parse', '--git-path', 'index']).trim());
+  const temporary = mkdtempSync(join(tmpdir(), 'job-apply-index-'));
+  const indexFile = join(temporary, 'index');
+  try {
+    if (existsSync(original)) copyFileSync(original, indexFile);
+    return git(root, ['write-tree'], { indexFile }).trim();
+  } finally { rmSync(temporary, { recursive: true, force: true }); }
+}
+
+export function indexSnapshot(root) {
+  const tree = indexTree(root);
+  const parent = git(root, ['rev-parse', '--verify', 'HEAD'], { allowFailure: true }).trim();
+  // An unreferenced object represents the index; no user branch or index changes.
+  const commit = git(root, ['-c', 'user.name=Local checks', '-c', 'user.email=local-checks@invalid',
+    '-c', 'commit.gpgsign=false', 'commit-tree', tree, ...(parent ? ['-p', parent] : []),
+    '-m', 'Disposable staged verification snapshot']).trim();
+  return { tree, commit, base: parent || commit };
+}
+
+export async function withSnapshot(root, commit, callback, { dependencies = false } = {}) {
+  const temporary = await mkdtemp(join(tmpdir(), 'job-apply-local-checks-'));
+  const snapshot = join(temporary, 'checkout');
+  let created = false;
+  try {
+    git(root, ['worktree', 'add', '--detach', snapshot, commit]);
+    created = true;
+    if (dependencies) {
+      const sourceLock = await readFile(join(root, 'package-lock.json'));
+      if (!sourceLock.equals(await readFile(join(snapshot, 'package-lock.json')))) {
+        throw new Error('Target dependency lock differs from this checkout; verify from its matching checkout.');
+      }
+      const modules = await realpath(join(root, 'node_modules'));
+      await symlink(modules, join(snapshot, 'node_modules'), process.platform === 'win32' ? 'junction' : 'dir');
+    }
+    return await callback(snapshot);
+  } finally {
+    if (created) git(root, ['worktree', 'remove', '--force', snapshot]);
+    await rm(temporary, { recursive: true, force: true });
+  }
+}
+
+export function changedPaths(root, base, commit) {
+  // --no-renames includes both old/new paths; NUL delimiters preserve unusual names.
+  return git(root, ['diff', '--name-only', '--no-renames', '-z', base, commit])
+    .split('\0').filter(Boolean);
+}
+
+export function pushTargets(root, input, baseRef = 'origin/staging') {
+  const targets = [];
+  for (const line of input.split('\n').filter(Boolean)) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length !== 4) throw new Error('Malformed pre-push ref update.');
+    const [localRef, localOid, remoteRef, remoteOid] = parts;
+    if (![localOid, remoteOid].every((oid) => /^(?:[a-f0-9]{40}|[a-f0-9]{64})$/.test(oid))
+      || !remoteRef.startsWith('refs/')) throw new Error('Malformed pre-push ref update.');
+    if (/^0+$/.test(localOid)) continue;
+    const commit = resolveCommit(root, localOid);
+    const base = /^0+$/.test(remoteOid)
+      ? git(root, ['merge-base', resolveCommit(root, baseRef), commit]).trim()
+      : resolveCommit(root, remoteOid);
+    targets.push({ commit, base, tag: localRef.startsWith('refs/tags/') || remoteRef.startsWith('refs/tags/') });
+  }
+  return targets;
+}

--- a/tools/local-checks/hook.mjs
+++ b/tools/local-checks/hook.mjs
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { changedPaths, git, indexSnapshot, indexTree, pushTargets, resolveCommit } from './git.mjs';
+import { runTarget } from './run.mjs';
+import { interruptLocalChecks } from './process.mjs';
+
+export async function main(args = process.argv.slice(2)) {
+  const root = git(process.cwd(), ['rev-parse', '--show-toplevel']).trim();
+  const [mode, ...rest] = args;
+  if (mode === 'pre-commit' || mode === 'commit') {
+    if (rest.length) throw new Error('Commit checks take no arguments.');
+    const target = indexSnapshot(root);
+    git(root, ['diff', '--cached', '--check'], { hookIndex: true });
+    await runTarget(root, target, { mode: 'commit', paths: [] });
+    if (indexTree(root) !== target.tree) {
+      throw new Error('Index changed during validation; rerun commit checks.');
+    }
+    return;
+  }
+  let targets;
+  const baseRef = git(root, ['config', '--get', 'localChecks.baseRef'], { allowFailure: true }).trim() || 'origin/staging';
+  if (mode === 'pre-push') {
+    if (rest.length !== 2) throw new Error('Expected Git pre-push remote arguments.');
+    targets = pushTargets(root, readFileSync(0, 'utf8'), baseRef);
+  } else if (mode === 'push' || mode === 'deep') {
+    let head = 'HEAD';
+    let base;
+    let tag = false;
+    for (let index = 0; index < rest.length; index += 1) {
+      if (rest[index] === '--release') tag = true;
+      else if (rest[index] === '--head' && rest[index + 1]) head = rest[++index];
+      else if (rest[index] === '--base' && rest[index + 1]) base = rest[++index];
+      else throw new Error('Usage: verify:push|verify:deep [--head ref] [--base ref] [--release]');
+    }
+    const commit = resolveCommit(root, head);
+    targets = [{ commit, base: base ? resolveCommit(root, base)
+      : git(root, ['merge-base', resolveCommit(root, baseRef), commit]).trim(), tag }];
+  } else throw new Error('Unknown local validation tier.');
+  for (const target of targets) {
+    await runTarget(root, target, { mode: mode === 'deep' ? 'deep' : 'push',
+      paths: changedPaths(root, target.base, target.commit) });
+  }
+  if (!targets.length) console.log('No nondeleted ref updates to validate.');
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.on('SIGINT', interruptLocalChecks);
+  process.on('SIGTERM', interruptLocalChecks);
+  try { await main(); }
+  catch (error) { console.error(error.message); process.exitCode = 1; }
+}

--- a/tools/local-checks/install.mjs
+++ b/tools/local-checks/install.mjs
@@ -1,0 +1,45 @@
+import { spawnSync } from 'node:child_process';
+import { access, chmod, readdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { cleanEnvironment, git } from './git.mjs';
+
+const root = git(process.cwd(), ['rev-parse', '--show-toplevel']).trim();
+const hooks = resolve(root, '.githooks');
+function config(args, optional = false) {
+  const result = spawnSync('git', ['config', ...args], { cwd: root,
+    env: cleanEnvironment(), encoding: 'utf8', timeout: 3000 });
+  if (result.error || (result.status !== 0 && !(optional && result.status === 1))) {
+    throw new Error('Unable to configure worktree hooks.');
+  }
+  return result.stdout.trim();
+}
+try {
+  if (process.argv.length !== 2) throw new Error('hooks:install takes no arguments.');
+  const current = config(['--get', 'core.hooksPath'], true);
+  if (current && resolve(root, current) !== hooks) {
+    throw new Error('An existing hooksPath is configured; integrate these hooks without replacing it.');
+  }
+  if (!current) {
+    const common = resolve(root, git(root, ['rev-parse', '--git-common-dir']).trim());
+    let entries = [];
+    try { entries = await readdir(resolve(common, 'hooks')); }
+    catch (error) { if (error.code !== 'ENOENT') throw error; }
+    if (entries.some((name) => !name.endsWith('.sample'))) {
+      throw new Error('Existing default Git hooks found; integrate without disabling them.');
+    }
+  }
+  for (const name of ['pre-commit', 'pre-push']) {
+    await access(resolve(hooks, name));
+    await chmod(resolve(hooks, name), 0o755);
+  }
+  // Worktree-specific path avoids pointing sibling checkouts at this checkout.
+  if (config(['--get', 'extensions.worktreeConfig'], true) !== 'true') {
+    if (config(['--local', '--get', 'core.worktree'], true)
+      || config(['--local', '--get', 'core.bare'], true) === 'true') {
+      throw new Error('Custom worktree/bare configuration needs explicit hook installation.');
+    }
+    config(['--local', 'extensions.worktreeConfig', 'true']);
+  }
+  config(['--worktree', 'core.hooksPath', hooks]);
+  console.log('Installed pre-commit/pre-push hooks for this worktree only.');
+} catch (error) { console.error(error.message); process.exitCode = 1; }

--- a/tools/local-checks/links.mjs
+++ b/tools/local-checks/links.mjs
@@ -1,0 +1,30 @@
+import { readFile, stat } from 'node:fs/promises';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { git } from './git.mjs';
+
+export async function checkLocalLinks(root) {
+  const files = git(root, ['ls-files', '-z']).split('\0').filter((file) => file.endsWith('.md'));
+  const errors = [];
+  for (const file of files) {
+    const text = (await readFile(resolve(root, file), 'utf8')).replace(/```[\s\S]*?```/g, '');
+    for (const match of text.matchAll(/\]\((<[^>]+>|[^\s)]+)(?:\s+"[^"]*")?\)/g)) {
+      const target = match[1].replace(/^<|>$/g, '');
+      if (/^[a-z][a-z0-9+.-]*:/i.test(target) || target.startsWith('//') || target.startsWith('#')) continue;
+      const path = decodeURIComponent(target.split(/[?#]/)[0]);
+      const absolute = resolve(root, dirname(file), path);
+      const rel = relative(root, absolute);
+      if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+        errors.push(`${file}: link escapes repository`);
+      } else {
+        try { await stat(absolute); } catch { errors.push(`${file}: missing local target ${target}`); }
+      }
+    }
+  }
+  if (errors.length) throw new Error(errors.join('\n'));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try { await checkLocalLinks(process.cwd()); console.log('Local Markdown link targets passed.'); }
+  catch (error) { console.error(error.message); process.exitCode = 1; }
+}

--- a/tools/local-checks/policy.mjs
+++ b/tools/local-checks/policy.mjs
@@ -1,0 +1,55 @@
+import { matches } from '../test-runner/patterns.mjs';
+import { selectAffected } from '../test-runner/matrix.mjs';
+
+// Exact inert seams only. New production modules must not inherit a numeric-only test rule.
+const FOCUSED = [
+  {
+    id: 'local-numeric',
+    paths: ['src/contracts/raw-json/numeric-atom.ts', 'src/contracts/raw-json/float-scope.ts',
+      'runtime/contracts/raw-json/numeric-atom.js', 'runtime/contracts/raw-json/float-scope.js',
+      'tools/contracts/raw-json-numeric/**', 'tests_js/raw_json_numeric*.test.mjs'],
+    tests: ['tests_js/raw_json_numeric*.test.mjs'],
+  },
+  {
+    id: 'local-raw-reference',
+    paths: ['tools/contracts/answer-matching-raw/**', 'tests_js/python-answer-matching-raw.test.mjs',
+      'contracts/cli/python-answer-matching-raw.schema.json',
+      'test/contract/vectors/python-answer-matching-raw-v1.json'],
+    tests: ['tests_js/python-answer-matching-raw.test.mjs'],
+  },
+  {
+    id: 'local-profile-reference',
+    paths: ['tools/contracts/profile-facts/**', 'tests_js/python-profile-fact-contracts.test.mjs',
+      'contracts/cli/python-profile-fact-mutations.schema.json',
+      'test/contract/vectors/python-profile-fact-mutations-v1.json'],
+    tests: ['tests_js/python-profile-fact-contracts.test.mjs'],
+  },
+];
+
+export function selectLocalPlan(matrix, tracked, paths, { tag = false } = {}) {
+  const fast = matrix.suites.filter((suite) => suite.tiers.includes('fast'));
+  const light = new Map(fast.map((suite) => [suite.id, suite]));
+  light.set('local-build', { id: 'local-build', kind: 'command', command: ['npm', 'run', 'build:check'] });
+  light.set('local-links', { id: 'local-links', kind: 'command', command: ['node', 'tools/local-checks/links.mjs'] });
+  const remaining = [];
+  for (const path of paths) {
+    if (matches(path, ['docs/**', 'README.md', 'LICENSE'])) continue;
+    const rule = FOCUSED.find((rule) => matches(path, rule.paths));
+    if (rule && tracked.includes(path)) {
+      light.set(rule.id, { id: rule.id, kind: 'node-test', include: rule.tests });
+    } else remaining.push(path);
+  }
+  const heavy = new Map();
+  if (remaining.length || tag) {
+    const selection = selectAffected(matrix, tracked, remaining);
+    for (const suite of matrix.suites) {
+      if (selection.suiteIds.includes(suite.id) && !light.has(suite.id)) heavy.set(suite.id, suite);
+      // Global/unknown fallback must not omit release-only and native checks.
+      if ((selection.fallbackReason || tag) && suite.tiers.some((tier) => ['release', 'platform'].includes(tier))) {
+        heavy.set(suite.id, suite);
+      }
+      if (tag && suite.tiers.includes('full') && !light.has(suite.id)) heavy.set(suite.id, suite);
+    }
+  }
+  return { light: [...light.values()], heavy: [...heavy.values()] };
+}

--- a/tools/local-checks/process.mjs
+++ b/tools/local-checks/process.mjs
@@ -1,0 +1,68 @@
+import { spawn } from 'node:child_process';
+import { cleanEnvironment } from './git.mjs';
+
+const active = new Set();
+let interrupted = false;
+
+export function interruptLocalChecks() {
+  interrupted = true;
+  for (const stop of active) stop('interrupted');
+}
+
+export function runLocalCommand(executable, args, options) {
+  if (interrupted) return Promise.resolve({ status: 'failed', exitCode: 130, signal: 'interrupted', durationMs: 0 });
+  const started = Date.now();
+  return new Promise((resolve) => {
+    const env = Object.fromEntries(Object.entries({ ...cleanEnvironment(), ...options.env })
+      .filter(([key]) => !key.startsWith('GIT_')));
+    const child = spawn(executable, args, { cwd: options.cwd, env,
+      detached: process.platform !== 'win32', stdio: ['ignore', 'pipe', 'pipe'] });
+    let reason;
+    let finished = false;
+    let force;
+    let deadline;
+    const counts = { stdout: 0, stderr: 0 };
+    const finish = (code, signal = null) => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(deadline);
+      clearTimeout(force);
+      active.delete(stop);
+      resolve({ status: code === 0 && !reason ? 'passed' : 'failed', exitCode: code,
+        signal: reason || signal, durationMs: Date.now() - started });
+    };
+    function kill(signal) {
+      if (!child.pid) return;
+      if (process.platform === 'win32') {
+        const killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+        killer.on('error', () => {});
+      } else {
+        try { process.kill(-child.pid, signal); } catch { /* Already exited. */ }
+      }
+    }
+    function stop(cause) {
+      if (reason || finished) return;
+      reason = cause;
+      options.stderr(`[${options.label}] ${cause}; terminating owned process group\n`);
+      kill('SIGTERM');
+      force = setTimeout(() => {
+        kill('SIGKILL');
+        child.stdout.destroy();
+        child.stderr.destroy();
+        finish(cause === 'timeout' ? 124 : 130);
+      }, 1000);
+    }
+    active.add(stop);
+    for (const stream of ['stdout', 'stderr']) {
+      child[stream].on('data', (chunk) => {
+        const cap = options.maxOutputBytes ?? 2 * 1024 * 1024;
+        if (counts[stream] + chunk.length > cap) { stop('output-limit'); return; }
+        counts[stream] += chunk.length;
+        options[stream](`[${options.label}] ${chunk.toString('utf8')}`);
+      });
+    }
+    child.on('error', () => finish(1, 'spawn-error'));
+    child.on('close', (code, signal) => { if (!reason) finish(code ?? 1, signal); });
+    deadline = setTimeout(() => stop('timeout'), options.timeoutMs ?? 120_000);
+  });
+}

--- a/tools/local-checks/run.mjs
+++ b/tools/local-checks/run.mjs
@@ -1,0 +1,104 @@
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { executeSuites } from '../test-runner/execute.mjs';
+import { loadMatrix, suiteFiles, validateMatrix } from '../test-runner/matrix.mjs';
+import { trackedPaths } from '../test-runner/git.mjs';
+import { cleanEnvironment, git, withSnapshot } from './git.mjs';
+import { selectLocalPlan } from './policy.mjs';
+import { runLocalCommand } from './process.mjs';
+
+const hash = (value) => createHash('sha256').update(value).digest('hex');
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+
+export async function policyFingerprint(directory = HERE) {
+  const files = [];
+  for (const folder of [directory, resolve(directory, '../test-runner')]) {
+    for (const name of (await readdir(folder)).filter((name) => name.endsWith('.mjs')).sort()) {
+      files.push(name, await readFile(join(folder, name)));
+    }
+  }
+  return hash(Buffer.concat(files.map((value) => Buffer.from(value))));
+}
+
+export function successfulLocalResults(results, suites, platform = process.platform) {
+  return results.length === suites.length && suites.every((suite) => {
+    const result = results.find((item) => item.id === suite.id);
+    return suite.platforms && !suite.platforms.includes(platform)
+      ? result?.status === 'skipped' : result?.status === 'passed';
+  });
+}
+
+export function reusableReceipt(receipt, key, now = Date.now()) {
+  return receipt?.schemaVersion === 1 && receipt.key === key && receipt.status === 'passed-local'
+    && receipt.mode === 'deep' && Array.isArray(receipt.results) && Array.isArray(receipt.suites)
+    && successfulLocalResults(receipt.results, receipt.suites)
+    && receipt.completedAt <= now && receipt.expiresAt > now;
+}
+
+async function environmentIdentity(root) {
+  const python = process.platform === 'win32' ? 'python' : 'python3';
+  const version = spawnSync(python, ['--version'], { env: cleanEnvironment(), encoding: 'utf8', timeout: 3000 });
+  if (version.error || version.status !== 0) throw new Error('Required local Python interpreter unavailable.');
+  return { node: process.version, python: version.stdout.trim(), platform: process.platform,
+    arch: process.arch, policy: await policyFingerprint(),
+    lock: hash(await readFile(join(root, 'package-lock.json'))),
+    installedLock: hash(await readFile(join(root, 'node_modules/.package-lock.json'))) };
+}
+
+export async function runTarget(root, target, { mode, paths }) {
+  return withSnapshot(root, target.commit, async (snapshot) => {
+    const matrix = await loadMatrix(snapshot);
+    const tracked = await trackedPaths(snapshot);
+    const errors = validateMatrix(matrix, tracked);
+    if (errors.length) throw new Error(errors.join('\n'));
+    const plan = selectLocalPlan(matrix, tracked, mode === 'commit' ? [] : paths, { tag: target.tag });
+    for (const suite of [...plan.light, ...plan.heavy]) {
+      if (suite.kind !== 'command' && suiteFiles(suite, tracked).length === 0) {
+        throw new Error(`Selected suite ${suite.id} has no tests; update local coverage rules.`);
+      }
+    }
+    const identity = { commit: target.commit, tree: git(root, ['rev-parse', `${target.commit}^{tree}`]).trim(),
+      base: target.base, tag: Boolean(target.tag), environment: await environmentIdentity(root),
+      matrix: hash(JSON.stringify(matrix)), suites: [...plan.light, ...plan.heavy] };
+    const key = hash(JSON.stringify(identity));
+    const receipts = resolve(root, git(root, ['rev-parse', '--git-path', 'local-checks']).trim());
+    await mkdir(receipts, { recursive: true });
+    const receiptPath = join(receipts, `${key}.json`);
+    if (mode === 'push' && plan.heavy.length) {
+      let prior;
+      try { prior = JSON.parse(await readFile(receiptPath, 'utf8')); } catch { /* No usable receipt. */ }
+      if (reusableReceipt(prior, key)) {
+        console.log(`Reusing complete local validation for ${target.commit.slice(0, 12)}; deferred platform cells remain in receipt.`);
+        return prior;
+      }
+      throw new Error(`Broader validation required (${plan.heavy.map((s) => s.id).join(', ')}).\n`
+        + `Run: npm run verify:deep -- --head ${target.commit} --base ${target.base}${target.tag ? ' --release' : ''}\n`
+        + 'This hook did not start browser/package suites. No passing receipt is inferred.');
+    }
+    const suites = [...plan.light, ...(mode === 'deep' ? plan.heavy : [])].map((suite) => ({
+      ...suite,
+      ...(suite.id === 'source-size' ? { command: ['npm', 'run', 'check:size', '--', '--base', target.base] } : {}),
+      timeoutMs: mode === 'deep' ? (suite.timeoutMs ?? 900_000) : 120_000,
+    }));
+    const startedAt = Date.now();
+    let log = '';
+    const output = (line) => { log += line; process.stdout.write(line); };
+    const results = await executeSuites(snapshot, suites, tracked, {
+      concurrency: mode === 'deep' ? 1 : 2, stdout: output, stderr: output, run: runLocalCommand,
+    });
+    const passed = successfulLocalResults(results, suites);
+    const completedAt = Date.now();
+    const receipt = { schemaVersion: 1, key, ...identity, mode, startedAt, completedAt,
+      expiresAt: completedAt + 24 * 60 * 60 * 1000, status: passed ? 'passed-local' : 'failed',
+      results, logHash: hash(log), deferredPlatforms: suites.filter((s) => s.platforms
+        && !s.platforms.includes(process.platform)).map((s) => s.id) };
+    await writeFile(join(receipts, `${key}.log`), log, { mode: 0o600 });
+    await writeFile(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
+    if (!passed) throw new Error(`Local ${mode} validation failed; receipt retained at ${receiptPath}`);
+    console.log(`Local ${mode} checks passed; ${results.length} suites. Receipts: ${receipts}`);
+    return receipt;
+  }, { dependencies: true });
+}


### PR DESCRIPTION
Staging's temporary validation freeze needs reliable local gates. This adds executable Git hooks that check the exact staged snapshot before commits and the actual outgoing commits before pushes, while keeping routine checks small.

- Pre-commit runs fast contracts, type checking, source-size policy, emitted-runtime parity and local file-link checks in a disposable checkout.
- Pre-push adds focused tests for reviewed paths. Broad, unknown and release changes require explicit deep validation. Successful deep results are reusable for 24 hours only for the same commit/base, suite policy, tooling and recorded environment/dependencies.
- Failures, timeouts, interruptions, missing tests and stale receipts block verification. Installation preserves existing hooks and configures only the current worktree.
- Documents installation, evidence limits and parallel worker/coordinator testing responsibilities. No CI workflow or branch-protection changes.

Validation on macOS, Node 22.22.3 and Python 3.14.4, at `7b8f0eb5fb8b4276fea5a5a1ba9707bf511485a0` against staging `2ca9d6e2c47948df57e7649a2211d4ec523bb364`:

- All eight commit suites passed, including 29 new hook regression tests.
- Deep validation completed in 535 seconds: 18 suites passed; the Windows-only suite was deferred.
- Python contracts, JavaScript/browser-and-CLI walkthroughs, macOS-native checks, external links, package smoke and isolated Claude/Codex installation checks passed. Two opt-in visible-browser QA cases were skipped; Windows remains unverified.
- The actual push reused the successful deep receipt; no hook bypass was used.

This PR is isolated from the earlier migration implementation commits. It does not claim the staging CI issue is repaired or authorize production cutover.
