### PR TITLE
Fix Python release CI branch and Windows fixture contracts

### DIFF
--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -61,3 +61,5 @@ After the Python release, reconcile main into staging in a dedicated integration
 | --- | --- |
 | Skill cleanup from PR #51 | Already present in staging. |
 | Release branch CI and guidance | Branch-specific setup; preserve migration CI policy during later reconciliation. |
+
+| PR #56: UTF-8 legacy report fixture | Forward-port the explicit UTF-8 fixture write to staging; its suspended CI did not establish Windows acceptance for this backported test. Pending. |

--- a/tests/test_store_jobs_legacy_1.py
+++ b/tests/test_store_jobs_legacy_1.py
@@ -12,7 +12,7 @@ class StoreTests(StoreTestCase):
 - **Posted**: 2026-09-06
 - **Salary**: Unknown
 - **URL**: https://example.com/jobs/python
-""")
+""", encoding="utf-8")
         with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
             discovery = self.store.preview_legacy_jobs([])
             self.assertEqual([item["state"] for item in discovery["items"]], ["valid"])

--- a/tests_js/workspace_markup.test.mjs
+++ b/tests_js/workspace_markup.test.mjs
@@ -139,7 +139,7 @@ test("resume extraction onboarding oracle is packaged in every protected OS vali
     const block = workflow.slice(start, next === -1 ? undefined : next);
     assert.ok(block.includes(command), job);
   }
-  assert.match(workflow, /pull_request:\n\s+branches: \[main, staging\]/);
+  assert.match(workflow, /pull_request:\n\s+branches: \[main, staging, codex\/python-release\]/);
 });
 
 test("styles include visible focus, reduced motion, contrast mode, and responsive behavior", async () => {


### PR DESCRIPTION
The Python release split exposed two test portability assumptions: onboarding CI expected only main/staging, and the backported unscored legacy report fixture used Windows default encoding for an em dash. Include the release branch in the CI expectation and write the fixture explicitly as UTF-8. Production behavior is unchanged. The fixture fix is recorded for forward-porting to staging.

Validation: 10 of 11 full local suites passed initially; the complete workspace suite passed after the branch assertion correction. All four CI contract tests and all 11 legacy job tests pass.

Current CI is not accepted. The previous Windows run identified the fixture encoding issue, now corrected. The fresh run failed the unchanged unified task spine oracle at answer_save in the workspace browser shard, despite that test passing locally and on the prior run. Investigate this timing-dependent failure before merging; do not bypass PR gate. Evidence: https://github.com/neonwatty/job-apply-plugin/actions/runs/34401640223/job/102634998511
