### PR TITLE
Fix task-spine answer-return test race and track Python release readiness

### DIFF
--- a/docs/python-release-readiness.md
+++ b/docs/python-release-readiness.md
@@ -1,6 +1,6 @@
 # Python release readiness spec
 
-Status: planned. Baseline assessed: `c1b180b3` on 2026-09-09.
+Status: phase 1 in progress. Baseline assessed: `c1b180b3` on 2026-09-09.
 
 ## Objective and scope
 
@@ -27,7 +27,9 @@ acceptance. A retry alone does not close a recurring failure.
   with the installed candidate. Upgrade from the actual previous release using
   a populated synthetic Store; verify package selection and preservation of
   Facts, Answers, jobs, managed files, sessions, and history. Cover both hosts.
-- [ ] **4. Refine through workspace QA.** Walk all eight views and test empty,
+- [ ] **4. Audit and refine workspace UX.** Produce a prioritized usability and
+  visual backlog covering navigation, layout, readability, terminology, forms,
+  and feedback, with acceptance criteria for each change. Walk all eight views and test empty,
   loading, error, conflict, restart, and recovery states. Check keyboard/focus,
   zoom, and smaller windows. Track defects and verify their fixes by journey.
 - [ ] **5. Dogfood installed-agent workflows.** Exercise actual PDF/DOCX/TXT
@@ -65,7 +67,7 @@ testing retains its explicit opt-in.
 
 | Phase | Status | Evidence / outstanding work |
 | --- | --- | --- |
-| 1 | Next | Recurring `answer_save`; cause unresolved |
+| 1 | In progress | Controlled focus race reproduced; fix and regression pass; full/package/CI acceptance pending |
 | 2 | Planned | Prerequisites and fresh-user journey |
 | 3 | Planned | Actual prior-release upgrade and installed-agent sessions |
 | 4 | Planned | Observed workspace QA and refinements |
@@ -75,3 +77,17 @@ testing retains its explicit opt-in.
 Record behavioral fixes and TypeScript follow-up in the
 [release lane ledger](python-release.md). Update this table as evidence arrives;
 historical green checks do not qualify a subsequently changed candidate.
+
+### Phase 1 investigation receipt
+
+Controlled response-body scheduling reproduced a false early focus success:
+native answer-dialog closure focused the old action; activity rendering then
+replaced that node before the separate identity assertion. The oracle now waits
+for the refreshed recheck action and its matching focused edit action together.
+The regression fails with the original focus predicate and passes with the fix.
+Additional allowlisted stages distinguish response, closure, activity, draft,
+and focus failures without exposing response contents.
+
+This establishes a test race, not an answer persistence defect. Historical CI
+reports identify only `answer_save`, so they cannot conclusively attribute every
+previous failure to this race. Final candidate checks remain required.

--- a/docs/python-release-readiness.md
+++ b/docs/python-release-readiness.md
@@ -1,0 +1,77 @@
+# Python release readiness spec
+
+Status: planned. Baseline assessed: `c1b180b3` on 2026-09-09.
+
+## Objective and scope
+
+Release the Python CLI/plugin and HTML/JavaScript workspace with reliable tests,
+straightforward setup, verified upgrades, and observed owner workflows.
+Refinement PRs target `codex/python-release`; final release targets `main`.
+Keep the TypeScript migration independent, with separate Stores and ports.
+
+## Ordered acceptance checklist
+
+Complete these phases in order; record evidence against the exact candidate
+commit. Passing synthetic tests does not establish installed-agent or live-site
+acceptance. A retry alone does not close a recurring failure.
+
+- [ ] **1. Stabilize the baseline.** Diagnose the recurring task-spine
+  `answer_save` failure, distinguish test synchronization from product behavior,
+  and fix the demonstrated cause. Add a focused regression check and obtain
+  passing full, cross-platform, and package validation on the resulting candidate.
+- [ ] **2. Simplify setup.** Document supported Python/host prerequisites and one
+  concise path: install → launch → import resume → extract/review Facts → prepare
+  a job. Verify launch, stop, relaunch, and actionable failure guidance. Record
+  fresh-user completion time, confusion, and assistance required.
+- [ ] **3. Qualify installs and upgrades.** Exercise fresh Claude/Codex sessions
+  with the installed candidate. Upgrade from the actual previous release using
+  a populated synthetic Store; verify package selection and preservation of
+  Facts, Answers, jobs, managed files, sessions, and history. Cover both hosts.
+- [ ] **4. Refine through workspace QA.** Walk all eight views and test empty,
+  loading, error, conflict, restart, and recovery states. Check keyboard/focus,
+  zoom, and smaller windows. Track defects and verify their fixes by journey.
+- [ ] **5. Dogfood installed-agent workflows.** Exercise actual PDF/DOCX/TXT
+  extraction and review, job preparation, missing-answer resolution, interruption,
+  and resumed work. Complete an owner walkthrough. Record tested host/site scope;
+  distinguish closed replay from live ATS evidence. Final submission stays manual.
+- [ ] **6. Prepare and accept the release.** Coordinate version metadata,
+  changelog, upgrade notes, release checklist, and draft PR description. Complete
+  final candidate validation and review. Merge to main and verify publication
+  only when release acceptance and publication authorization are established.
+
+## Phase 1 investigation and exit criteria
+
+The failure recurred in post-merge run `34403717299`; a separate release-package
+run passed on the same commit. Root cause is unresolved.
+
+1. Preserve failed-run evidence and inspect the answer-save request, activity
+   refresh, draft-preservation, and focus-restoration sequence.
+2. Add bounded, value-free diagnostic codes where needed to identify the exact
+   failed assertion or timeout. Do not record applicant values or raw tokens.
+3. Reproduce under isolated synthetic conditions, including relevant timing
+   variation. Fix the demonstrated product or test cause without weakening
+   assertions, adding blind retries, or substituting arbitrary sleeps.
+4. Add a regression case that exposes the original cause. Record a bounded
+   repeated-run result, then pass affected and full/package/platform checks.
+5. Document cause, fix, evidence, and migration follow-up. Close the phase only
+   when the cause is explained and the resulting candidate passes its gates.
+
+## Evidence and tracking
+
+For each phase, record: candidate commit/PR, scenarios and environment, check/run
+links, defects and disposition, and remaining limitations. Keep private data out
+of receipts. Use isolated fixtures by default; owner-visible native/browser
+testing retains its explicit opt-in.
+
+| Phase | Status | Evidence / outstanding work |
+| --- | --- | --- |
+| 1 | Next | Recurring `answer_save`; cause unresolved |
+| 2 | Planned | Prerequisites and fresh-user journey |
+| 3 | Planned | Actual prior-release upgrade and installed-agent sessions |
+| 4 | Planned | Observed workspace QA and refinements |
+| 5 | Planned | Installed-agent and owner acceptance |
+| 6 | Planned | Final candidate, review, and release |
+
+Record behavioral fixes and TypeScript follow-up in the
+[release lane ledger](python-release.md). Update this table as evidence arrives;
+historical green checks do not qualify a subsequently changed candidate.

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -63,5 +63,5 @@ After the Python release, reconcile main into staging in a dedicated integration
 | --- | --- |
 | Skill cleanup from PR #51 | Already present in staging. |
 | Release branch CI and guidance | Branch-specific setup; preserve migration CI policy during later reconciliation. |
-
 | PR #56: UTF-8 legacy report fixture | Forward-port the explicit UTF-8 fixture write to staging; its suspended CI did not establish Windows acceptance for this backported test. Pending. |
+| Phase 1: task-spine answer-return synchronization | Test-only fix: wait for refreshed actions and focus together; controlled response-body regression and value-free stages. Audit migration oracle for the same race and port its behavioral check. Pending. |

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -37,6 +37,8 @@ scheduled release-branch coverage. Use explicit branch dispatch when needed.
 
 ## Release acceptance
 
+Track execution in the [Python release readiness spec](python-release-readiness.md).
+
 - [ ] Current release-head portable full tests pass.
 - [ ] Required Linux, Windows, and macOS CI jobs and aggregate PR gate pass.
 - [ ] Isolated fresh Claude/Codex installation and upgrade/package smoke pass.

--- a/qa/unified_task_spine_answer.mjs
+++ b/qa/unified_task_spine_answer.mjs
@@ -1,0 +1,13 @@
+// Response headers and dialog closure precede activity rendering. Native dialog
+// focus restoration can still point to the old action until that render finishes.
+export async function waitForLinkedAnswerReturn(page) {
+  await page.waitForFunction(() => {
+    const job = document.querySelector("#job-dialog[open]");
+    const actions = [...(job?.querySelectorAll("button[data-pending-reference]") || [])];
+    const edit = actions.find((button) => button.textContent.trim() === "Open in Answers");
+    const recheck = actions.find((button) => button.textContent.trim() === "Recheck this revision");
+    return Boolean(edit && recheck && !recheck.disabled
+      && edit.dataset.pendingReference === recheck.dataset.pendingReference
+      && document.activeElement === edit);
+  });
+}

--- a/qa/unified_task_spine_oracle.mjs
+++ b/qa/unified_task_spine_oracle.mjs
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
+import { waitForLinkedAnswerReturn } from "./unified_task_spine_answer.mjs";
 
 const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const PYTHON = process.env.PYTHON || "python3";
@@ -61,6 +62,8 @@ const PUBLIC_STAGES = new Set([
   "setup", "ux_intake", "agent_intake", "selection", "first_acquisition",
   "attention_open", "answer_open", "answer_save", "answer_recheck",
   "second_acquisition", "final_verification", "cleanup",
+  "answer_save_response", "answer_save_closed", "answer_save_activity",
+  "answer_save_draft", "answer_save_focus_wait",
 ]);
 
 class OracleFailure extends Error {
@@ -239,7 +242,7 @@ function publicReportIsSafe(report) {
   return forbidden.every((value) => !serialized.toLowerCase().includes(value.toLowerCase()));
 }
 
-export async function runOracle() {
+export async function runOracle({ configurePage = async () => {} } = {}) {
   const temporary = await mkdtemp(join(tmpdir(), "unified-task-spine-"));
   const storeRoot = join(temporary, "store");
   const storeScript = join(REPO_ROOT, "scripts", "job-apply-store.py");
@@ -293,6 +296,7 @@ export async function runOracle() {
     const startup = await waitForStartup(server);
     browser = await chromium.launch({ headless: true });
     const page = await browser.newPage();
+    await configurePage(page);
     const pageErrors = [];
     page.on("pageerror", () => pageErrors.push(true));
     await page.addInitScript(() => { globalThis.setInterval = () => 0; });
@@ -395,12 +399,16 @@ export async function runOracle() {
       && response.request().method() === "GET"
     ));
     await answerDialog.getByRole("button", { name: "Save answer" }).click();
+    stage = "answer_save_response";
     check((await answerSaved).ok(), "answer_save_response_failed");
+    stage = "answer_save_closed";
     await answerDialog.waitFor({ state: "hidden" });
+    stage = "answer_save_activity";
     check((await activityReloaded).ok(), "activity_reload_failed");
+    stage = "answer_save_draft";
     check(await jobDialog.getByLabel("Notes").inputValue() === "unsaved synthetic draft", "draft_lost_on_answer_save");
-    await page.waitForFunction(() => document.activeElement?.textContent?.trim() === "Open in Answers");
-    check(await openAnswer.evaluate((button) => document.activeElement === button), "focus_not_restored");
+    stage = "answer_save_focus_wait";
+    await waitForLinkedAnswerReturn(page);
     stage = "answer_recheck";
     const answerResolved = page.waitForResponse((response) => (
       new URL(response.url()).pathname === `/api/jobs/${encodeURIComponent(selectedId)}/resolve-pending-answer`

--- a/tests_js/unified_task_spine_oracle.test.mjs
+++ b/tests_js/unified_task_spine_oracle.test.mjs
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { publicFailureReport } from "../qa/unified_task_spine_oracle.mjs";
+import { publicFailureReport, runOracle } from "../qa/unified_task_spine_oracle.mjs";
 
 const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -20,6 +20,10 @@ test("oracle failures expose only allowlisted diagnostic stages", () => {
     error: "oracle_failed",
     stage: "answer_save",
   });
+  for (const stage of ["answer_save_response", "answer_save_closed", "answer_save_activity", "answer_save_draft", "answer_save_focus_wait"]) {
+    sensitive.stage = stage;
+    assert.equal(publicFailureReport(sensitive).stage, stage);
+  }
   sensitive.stage = "token at /tmp/private-path";
   const serialized = JSON.stringify(publicFailureReport(sensitive));
   assert.match(serialized, /"stage":"unknown"/);
@@ -71,4 +75,51 @@ test("unified task spine oracle is executable, deterministic, closed, and privac
   });
   assert.equal(report.transcript.at(-1), "closed_without_final_action");
   assert.doesNotMatch(stdout, /claim_|https?:\/\/|answerKey|answerValue|resumePath|browserState|credential|bearer|token|\/tmp\//i);
+});
+
+
+test("answer return waits for rendered activity and restored focus", { timeout: 90_000 }, async () => {
+  let completedBeforeReturn = null;
+  const report = await runOracle({ configurePage: async (page) => {
+    // Hold JSON consumption after real response headers arrive, to exercise
+    // native dialog focus restoration before the application's asynchronous return.
+    await page.addInitScript(() => {
+      const json = Response.prototype.json;
+      globalThis.answerTiming = { armed: false };
+      Response.prototype.json = async function (...args) {
+        const data = await json.apply(this, args);
+        const path = new URL(this.url).pathname;
+        const timing = globalThis.answerTiming;
+        if (timing.armed && path.endsWith("/activity")) {
+          await new Promise((resolve) => { timing.activity = resolve; });
+        }
+        if (timing.armed && path === "/api/attention") {
+          await new Promise((resolve) => { timing.attention = resolve; });
+        }
+        return data;
+      };
+      document.addEventListener("click", (event) => {
+        if (event.target.id === "answer-save") globalThis.answerTiming.armed = true;
+      }, true);
+    });
+    const wait = page.waitForFunction.bind(page);
+    page.waitForFunction = async (...args) => {
+      let completed = false;
+      const waiting = wait(...args).then((result) => { completed = true; return result; });
+      await wait(() => Boolean(globalThis.answerTiming.activity && globalThis.answerTiming.attention));
+      await wait(() => document.activeElement?.textContent?.trim() === "Open in Answers");
+      await page.evaluate(() => globalThis.answerTiming.activity());
+      await page.getByRole("button", { name: "Recheck this revision", exact: true }).waitFor();
+      assert.equal(await page.getByRole("button", { name: "Open in Answers", exact: true })
+        .evaluate((button) => button === document.activeElement), false);
+      completedBeforeReturn = completed;
+      await page.evaluate(() => {
+        globalThis.answerTiming.armed = false;
+        globalThis.answerTiming.attention();
+      });
+      return waiting;
+    };
+  } });
+  assert.equal(completedBeforeReturn, false, "must not accept focus on the pre-refresh action");
+  assert.equal(report.result, "pass");
 });


### PR DESCRIPTION
The task-spine oracle can accept focus restored by dialog closure before activity rendering replaces that button, then fail its separate identity assertion. Wait for the refreshed recheck action and focus on its matching edit action in one browser observation. Product behavior is unchanged.

A controlled response-body regression reproduces the scheduling boundary and fails with the original predicate. Add allowlisted stages for save response, dialog closure, activity, draft, and focus failures. Historical CI reports were too coarse to conclusively attribute every earlier failure to this race.

Also includes the Python release readiness spec and migration follow-up ledger.

Validation: four focused tests pass; negative control fails as expected; 20 repeated fixed-oracle runs pass; source-size and matrix checks pass; local release tier passes (isolated Claude/Codex installs, synthetic upgrade, packaged browser walkthroughs, and links). All 11 local full-test suites also pass. Cross-platform CI remains pending.

Local receipts: `/tmp/python-answer-save-full.json`, `/tmp/python-answer-save-release.json`, `/tmp/python-answer-save-fixed-repeat.log`, and `/tmp/python-answer-save-negative-control.log`. Current validation run: https://github.com/neonwatty/job-apply-plugin/actions/runs/34406170344.
