### PR TITLE
Clarify Python setup journey and browser launch recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Choose either supported host:
 
 Codex stays inside its selected Browser plugin surface. Claude Code does not require Playwright; an already-configured Playwright integration may be used only for one inaccessible iframe or custom control.
 
+The Python release is validated with **Python 3.12**. Check `python3 --version`
+(or `py -3.12 --version` on Windows). The local workspace needs no Node runtime
+or frontend build. See the [setup guide](docs/setup.md) for launch and troubleshooting.
+
 ## Installation
 
 ### Codex
@@ -91,17 +95,17 @@ The examples below use Codex syntax. In Claude Code, replace the leading `$` wit
 
 ### First Time Setup
 
-1. Invoke the skill:
-   ```
-   $job-apply:job-apply
-   ```
+1. Open the workspace with `$job-apply:job-workspace` in a new Codex task,
+   or `/job-apply:job-workspace` in a new Claude Code session.
+2. In **Resumes**, import a PDF, DOCX, or UTF-8 TXT file and choose
+   **Request fact extraction**.
+3. Choose **Copy agent handoff** and paste it into your host conversation.
+   The request waits until you ask an agent to process it.
+4. Review **Facts** and any **Extraction reviews** in the resume's details.
+5. Add an opportunity in **Jobs**, run its ready check, and mark it **Ready**.
 
-2. Provide your resume path when prompted:
-   ```
-   ~/Documents/resume.pdf
-   ```
-
-3. Review and confirm extracted profile information
+Follow the [setup guide](docs/setup.md) for detailed steps, restart instructions,
+and common setup problems.
 
 ### Applying to Jobs
 

--- a/docs/python-release-readiness.md
+++ b/docs/python-release-readiness.md
@@ -1,6 +1,6 @@
 # Python release readiness spec
 
-Status: phase 1 in progress. Baseline assessed: `c1b180b3` on 2026-09-09.
+Status: phase 2 in progress. Baseline assessed: `c1b180b3` on 2026-09-09.
 
 ## Objective and scope
 
@@ -15,7 +15,7 @@ Complete these phases in order; record evidence against the exact candidate
 commit. Passing synthetic tests does not establish installed-agent or live-site
 acceptance. A retry alone does not close a recurring failure.
 
-- [ ] **1. Stabilize the baseline.** Diagnose the recurring task-spine
+- [x] **1. Stabilize the baseline.** Diagnose the recurring task-spine
   `answer_save` failure, distinguish test synchronization from product behavior,
   and fix the demonstrated cause. Add a focused regression check and obtain
   passing full, cross-platform, and package validation on the resulting candidate.
@@ -44,7 +44,7 @@ acceptance. A retry alone does not close a recurring failure.
 ## Phase 1 investigation and exit criteria
 
 The failure recurred in post-merge run `34403717299`; a separate release-package
-run passed on the same commit. Root cause is unresolved.
+run passed on the same commit. The controlled focus race and its fix are recorded below.
 
 1. Preserve failed-run evidence and inspect the answer-save request, activity
    refresh, draft-preservation, and focus-restoration sequence.
@@ -67,8 +67,8 @@ testing retains its explicit opt-in.
 
 | Phase | Status | Evidence / outstanding work |
 | --- | --- | --- |
-| 1 | In progress | Controlled focus race reproduced; fix and regression pass; full/package/CI acceptance pending |
-| 2 | Planned | Prerequisites and fresh-user journey |
+| 1 | Complete | PR #57 merged; 20 repeated runs, full local/package tests, and CI run `34406170344` passed |
+| 2 | In progress | Setup guide, clearer handoffs and launch fallback; independent fresh-user acceptance remains |
 | 3 | Planned | Actual prior-release upgrade and installed-agent sessions |
 | 4 | Planned | Observed workspace QA and refinements |
 | 5 | Planned | Installed-agent and owner acceptance |
@@ -90,4 +90,19 @@ and focus failures without exposing response contents.
 
 This establishes a test race, not an answer persistence defect. Historical CI
 reports identify only `answer_save`, so they cannot conclusively attribute every
-previous failure to this race. Final candidate checks remain required.
+previous failure to this race. PR #57 passed all required checks before merging.
+
+
+### Phase 2 setup pass
+
+The [setup guide](setup.md) covers prerequisites, workspace launch, resume import,
+extraction handoff/review, job preparation, stopping, and returning. Overview now
+names its destination and explains the setup journey; waiting extraction requests
+say where to paste the handoff. Failed browser opening gives local fallback
+instructions without repeating the private URL or exception.
+
+A scripted clean synthetic Store walkthrough verified import, queued extraction,
+and persistence after server stop/relaunch. This is developer verification, not
+an independent fresh-user timing measurement or actual agent extraction acceptance.
+Remaining: observe a fresh user following only the guide, record time and assistance,
+and verify the host-managed launcher lifecycle on the intended desktop environment.

--- a/docs/python-release-readiness.md
+++ b/docs/python-release-readiness.md
@@ -102,7 +102,31 @@ say where to paste the handoff. Failed browser opening gives local fallback
 instructions without repeating the private URL or exception.
 
 A scripted clean synthetic Store walkthrough verified import, queued extraction,
-and persistence after server stop/relaunch. This is developer verification, not
+Facts populated through a prepared extraction candidate, job creation, ready check,
+and Ready status after server stop/relaunch. The complete path is retained in
+`tests_js/workspace_setup_journey.test.mjs`. This is developer verification, not
 an independent fresh-user timing measurement or actual agent extraction acceptance.
 Remaining: observe a fresh user following only the guide, record time and assistance,
 and verify the host-managed launcher lifecycle on the intended desktop environment.
+
+
+### Owner setup acceptance record
+
+Use a fresh host conversation and the setup guide without additional coaching.
+Record the candidate commit, host/version, OS/Python, elapsed time, extra commands,
+confusing steps, and whether help was needed. Stop at a prepared job; no submission
+is needed. Use synthetic data for the first pass.
+
+- [ ] Installed skill launches the workspace in a fresh conversation.
+- [ ] Resume import and agent handoff are understandable without extra explanation.
+- [ ] Actual agent extraction completes; the owner can find and review the result.
+- [ ] The owner creates a job, resolves its ready check, and reaches Ready.
+- [ ] Stopping and relaunching preserves saved work and opens a working new URL.
+
+These observations remain pending. Automated test duration is not a human setup time.
+
+
+Phase 4 observation: Facts provenance is nested inside field labels, so an exact
+accessible name such as “First name” changes when provenance loads. Evaluate
+separating the field name from its provenance description in the accessibility
+walkthrough; the setup regression selects the stable field path after data loads.

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -65,3 +65,4 @@ After the Python release, reconcile main into staging in a dedicated integration
 | Release branch CI and guidance | Branch-specific setup; preserve migration CI policy during later reconciliation. |
 | PR #56: UTF-8 legacy report fixture | Forward-port the explicit UTF-8 fixture write to staging; its suspended CI did not establish Windows acceptance for this backported test. Pending. |
 | Phase 1: task-spine answer-return synchronization | Test-only fix: wait for refreshed actions and focus together; controlled response-body regression and value-free stages. Audit migration oracle for the same race and port its behavioral check. Pending. |
+| Phase 2: setup guidance and browser-open fallback | Port user-facing handoff wording where applicable; validate the migration launcher independently. Pending. |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,70 @@
+# Set up Job Apply
+
+## Before you start
+
+Install the plugin using the [installation instructions](../README.md#installation),
+then start a new host conversation so it loads the installed skills.
+
+The Python release is validated with Python 3.12. Check `python3 --version` on
+macOS/Linux or `py -3.12 --version` on Windows. If Python is missing, install
+Python 3.12 and reopen your terminal and host. Other Python versions are not
+established by this release's cross-platform acceptance checks.
+
+You do not need Node, npm, Playwright, or a frontend build to use the workspace.
+The browser integration described in the README is needed for agent interaction
+with application sites. The local workspace opens in your default browser.
+
+## From installation to your first prepared job
+
+1. **Open the workspace.** Invoke `$job-apply:job-workspace` in Codex or
+   `/job-apply:job-workspace` in Claude Code. The agent resolves the installed
+   plugin location and launches the workspace. Keep the launcher process running.
+2. **Import a resume.** From Overview choose **Open Resumes**. Give the file a
+   label and import a PDF, DOCX, or UTF-8 TXT file, up to 10 MiB. Job Apply keeps
+   a managed copy; importing does not edit your source document.
+3. **Ask the agent to extract facts.** Choose **Request fact extraction**, then
+   **Copy agent handoff**. Paste the handoff into your Codex task or Claude Code
+   session. Copying or queuing a request alone does not start an agent.
+4. **Review the result.** Return to **Facts** to check the extracted information.
+   Extraction can fill absent, unprotected facts. Open the resume's **Manage**
+   details and **Extraction reviews** for changes requiring your decision.
+   Accept only changes you want; resolve conflicts explicitly.
+5. **Prepare a job.** Open **Jobs**, choose **New job**, and save the opportunity.
+   Open its details, choose **Run ready check**, resolve listed blockers, and
+   mark it **Ready**. Use resume details to choose a default if needed.
+6. **Hand off when ready.** Copy your host's Job Apply command from Overview and
+   paste it into that host. The agent prepares the application and stops for your
+   review. You control final submission on the application site.
+
+## Stop and return later
+
+Closing the browser tab does not stop the server. Press Ctrl-C in the launcher
+process to stop it, or ask the launching agent to stop that process.
+
+Invoke the workspace skill again to return. Your saved work remains local.
+Use the newly opened page or the complete URL printed by the new launcher;
+an old bookmark may contain an expired connection token. Unsaved browser edits
+are not a substitute for saving before stopping.
+
+## Troubleshooting
+
+| Symptom | Next step |
+| --- | --- |
+| Skill is missing | Confirm installation in the intended host, then start a new conversation. |
+| Python command is missing | Install Python 3.12 and reopen the host. On Windows, check the `py -3.12` launcher and ask the agent to use that interpreter. |
+| Browser does not open | Keep the launcher running and open its complete printed URL locally. Do not paste the token-bearing URL into chat or issues. |
+| Old page cannot connect | Start the workspace again and use its newly printed URL. |
+| A chosen port is occupied | Omit `--port` so the launcher selects a free one. |
+| Extraction stays waiting | Paste **Copy agent handoff** into an active host conversation and ask it to process the request. |
+| A record changed elsewhere | Refresh the record, review the preserved draft, and explicitly reapply your changes. |
+| Store recovery message appears | Stop the workspace and preserve the data directory. Follow the recovery guidance; do not delete or reset your Store to bypass it. |
+
+For a manual launch, resolve the installed plugin directory and run:
+
+```text
+python3 "<plugin-root>/scripts/job-apply-workspace.py"
+```
+
+On Windows with the Python launcher, use `py -3.12` in place of `python3`.
+For isolated development QA, add `--root <synthetic-store-directory> --port 0
+--no-open`. Never use the same Store for Python and TypeScript migration writers.

--- a/scripts/job_apply_workspace/cli.py
+++ b/scripts/job_apply_workspace/cli.py
@@ -16,10 +16,24 @@ from . import LOOPBACK, runtime
 from .handler import WorkspaceServer
 
 
+def open_browser(browser: Any, url: str) -> None:
+    try:
+        opened = browser.open(url)
+    except (webbrowser.Error, OSError):
+        opened = False
+    if not opened:
+        print(
+            "The browser could not be opened automatically. Open the complete "
+            "workspace URL printed above in your browser. Keep this process "
+            "running while you work.",
+            file=sys.stderr, flush=True,
+        )
+
+
 def build_parser() -> argparse.ArgumentParser:
     store_module = runtime()["STORE_MODULE"]
     parser = argparse.ArgumentParser(
-        description="Start the local Job Apply Jobs workspace"
+        description="Start the local Job Apply workspace"
     )
     parser.add_argument(
         "--root",
@@ -81,7 +95,7 @@ def main() -> int:
         )
     if not args.no_open:
         browser = workspace_runtime.get("webbrowser", webbrowser)
-        threading.Timer(0.15, lambda: browser.open(url)).start()
+        threading.Timer(0.15, lambda: open_browser(browser, url)).start()
 
     stopping = threading.Event()
 

--- a/tests/test_job_apply_workspace_launcher.py
+++ b/tests/test_job_apply_workspace_launcher.py
@@ -1,7 +1,28 @@
 from tests.support.workspace_case import *
+import io
+from contextlib import redirect_stderr
 
 
 class WorkspaceProcessTests(unittest.TestCase):
+    def test_browser_open_failure_keeps_private_url_out_of_guidance(self):
+        for failure in (False, OSError("private-path")):
+            browser = mock.Mock()
+            if isinstance(failure, Exception):
+                browser.open.side_effect = failure
+            else:
+                browser.open.return_value = failure
+            output = io.StringIO()
+            with redirect_stderr(output):
+                WORKSPACE._cli.open_browser(browser, "http://127.0.0.1/#token=private")
+            self.assertIn("complete workspace URL printed above", output.getvalue())
+            self.assertNotIn("private", output.getvalue())
+
+    def test_successful_browser_open_needs_no_fallback(self):
+        output = io.StringIO()
+        with redirect_stderr(output):
+            WORKSPACE._cli.open_browser(mock.Mock(open=mock.Mock(return_value=True)), "http://127.0.0.1/")
+        self.assertEqual(output.getvalue(), "")
+
     def test_launcher_reports_fragment_token_and_stops_cleanly(self):
         with tempfile.TemporaryDirectory() as temporary:
             process = subprocess.Popen(

--- a/tests_js/workspace_setup_journey.test.mjs
+++ b/tests_js/workspace_setup_journey.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import {
+  createOwnerBetaScenario, startOwnerBetaScenario, cleanupOwnerBetaScenario,
+} from './workspace_owner_beta_scenario_support.mjs';
+test("guided setup reaches Ready and survives restart", { timeout: 90_000 }, async () => {
+  const context = await createOwnerBetaScenario();
+  try {
+    await startOwnerBetaScenario(context);
+    const page = await context.browser.newPage();
+    await page.goto(context.running.startup.url);
+    await page.getByRole('button',{name:'Open Resumes',exact:true}).click();
+    const form = page.locator('#resume-import');
+    await form.getByLabel('Label',{exact:true}).fill('Setup example');
+    const source = 'Ada Example\nada@example.invalid\nSoftware Engineer\nSkills: Python, JavaScript\n';
+    await form.locator('input[type=file]').setInputFiles({
+      name: 'setup-example.txt', mimeType: 'text/plain', buffer: Buffer.from(source),
+    });
+    await form.getByRole('button',{name:'Import resume',exact:true}).click();
+    await page.getByRole('button',{name:'Request fact extraction',exact:true}).first().click();
+    await page.getByRole('button',{name:'Copy agent handoff',exact:true}).first().waitFor();
+    const [request] = await context.cli('resume-extraction-request-list',['--status','requested']);
+    const resolved = await context.cli('resume-resolve',['--id',request.resumeId]);
+    assert.equal(await readFile(resolved.path,'utf8'),source);
+    const profile = await context.cli('profile-inspect');
+    // Prepared candidate tests the handoff contract; it does not measure agent extraction.
+    const completion = await context.cli('resume-extraction-request-complete', [
+      '--id', request.requestId,
+      '--expected-request-revision', String(request.revision),
+      '--expected-profile-revision', String(profile.revision),
+    ], {
+      firstName: 'Ada', lastName: 'Example', email: 'ada@example.invalid',
+      skills: ['Python', 'JavaScript'],
+    });
+    assert.equal(completion.request.status,'completed');
+    assert.equal(completion.proposalSummary.pendingCount,0);
+    await page.getByRole('button',{name:'Facts',exact:true}).click();
+    await page.waitForFunction(() =>
+      document.querySelector('#facts-workspace input[data-path="/firstName"]')?.value === 'Ada');
+    assert.equal(await page.locator('#facts-workspace input[data-path="/firstName"]').inputValue(),'Ada');
+    await page.getByRole('button',{name:'Jobs',exact:true}).click();
+    await page.getByRole('button',{name:'New job',exact:true}).click();
+    const dialog = page.locator('#job-dialog');
+    await dialog.getByLabel('Job URL',{exact:true}).fill('https://example.invalid/jobs/setup');
+    await dialog.getByLabel('Role',{exact:true}).fill('Setup Engineer');
+    await dialog.getByLabel('Company',{exact:true}).fill('Example');
+    await dialog.getByRole('button',{name:'Save job',exact:true}).click();
+    await dialog.waitFor({state:'hidden'});
+    await page.getByRole('button',{name:/Setup Engineer/}).click();
+    await dialog.getByRole('button',{name:'Run ready check',exact:true}).click();
+    await page.locator('#preflight-panel').waitFor();
+    await dialog.getByText('No blocking issues').waitFor();
+    await dialog.getByRole('button',{name:'Mark ready',exact:true}).click();
+    await dialog.waitFor({state:'hidden'});
+    await page.getByRole('button',{name:'Overview',exact:true}).click();
+    await page.getByRole('heading',{name:'Hand off a ready job',exact:true}).waitFor();
+    await context.stop(context.running.child);
+    context.running = await context.launch();
+    await page.goto(context.running.startup.url);
+    await page.getByRole('heading',{name:'Hand off a ready job',exact:true}).waitFor();
+  } finally {
+    await cleanupOwnerBetaScenario(context);
+  }
+});

--- a/workspace/features/overview.js
+++ b/workspace/features/overview.js
@@ -79,6 +79,7 @@ export function installOverview(context) {
     $("#next-step-heading").textContent = heading;
     $("#next-step-copy").textContent = copy;
     $("#next-step-action").dataset.workspace = projection.targetWorkspace;
+    $("#next-step-action").textContent = ({ resumes: "Open Resumes", facts: "Open Facts", jobs: "Open Jobs", attention: "Open Needs Attention" })[projection.targetWorkspace] || "Open workspace";
     $("#setup-resume").textContent = `${projection.setup.hasResume ? "✓" : "○"} Resume ${projection.setup.hasResume ? "available" : "needed"}`;
     $("#setup-facts").textContent = `${projection.setup.hasProfileFacts ? "✓" : "○"} Application facts ${projection.setup.hasProfileFacts ? "available" : "need review"}`;
     $("#setup-resume").classList.toggle("complete", projection.setup.hasResume);

--- a/workspace/features/resumes.js
+++ b/workspace/features/resumes.js
@@ -59,7 +59,7 @@ export function installResumes(context) {
     const request = resume.extractionRequest;
     if (request?.status === "failed") return `${view.label}. ${extractionFailureText[request.failureReason] || "Try again when a Job Apply agent is available."}`;
     if (request?.status === "stale") return `${view.label}. The old request cannot be applied to the new content.`;
-    if (request?.status === "requested") return `${view.label}. No agent is assigned until you hand off this request.`;
+    if (request?.status === "requested") return `${view.label}. Copy the agent handoff and paste it into your Codex task or Claude Code session. The agent reads your resume; return here to review any proposed changes.`;
     return view.label;
   }
 

--- a/workspace/index.html
+++ b/workspace/index.html
@@ -50,7 +50,7 @@
   <main id="workspace-content">
     <div id="overview-workspace">
       <section class="hero overview-hero" aria-labelledby="overview-title">
-        <div><p class="eyebrow">PRIVATE OWNER WORKSPACE</p><h2 id="overview-title">Know what to do next.</h2><p>Your setup and next step are derived from the canonical local Store. This browser keeps no onboarding-complete flag and never submits an application.</p></div>
+        <div><p class="eyebrow">PRIVATE OWNER WORKSPACE</p><h2 id="overview-title">Know what to do next.</h2><p>Start with a resume, review your application facts, then prepare a job. Your progress stays on this computer. Only you can submit an application.</p></div>
         <div class="hero-actions"><button id="overview-refresh" class="button secondary" type="button">Refresh</button></div>
       </section>
       <div id="boot-recovery" class="recovery-panel hidden" role="alert" tabindex="-1">
@@ -71,14 +71,14 @@
         </article>
         <article class="handoff-card" aria-labelledby="handoff-heading">
           <p class="eyebrow">READY-JOB HANDOFF</p><h2 id="handoff-heading">Start an application agent</h2>
-          <p>When a job is Ready, use one supported copy-only invocation. The workspace does not detect your host, run commands, or submit.</p>
+          <p>When a job is Ready, copy the command for your host and paste it into a Codex task or Claude Code session. Copying does not start an agent.</p>
           <div class="invocation"><span>Codex</span><code>$job-apply:job-apply</code><button class="button secondary copy-invocation" data-copy="$job-apply:job-apply" type="button">Copy Codex invocation</button></div>
           <div class="invocation"><span>Claude Code</span><code>/job-apply:job-apply</code><button class="button secondary copy-invocation" data-copy="/job-apply:job-apply" type="button">Copy Claude Code invocation</button></div>
           <label class="clipboard-fallback hidden" role="alert">Clipboard unavailable. Select and copy this invocation manually. <input class="clipboard-fallback-value" readonly aria-label="Invocation to copy"></label>
           <p class="safety-note">The agent stops for final review. Only you may submit on the third-party site.</p>
         </article>
         <article class="recovery-card" aria-labelledby="recovery-heading">
-          <p class="eyebrow">RESTART &amp; RECOVERY</p><h2 id="recovery-heading">Canonical state survives this browser</h2>
+          <p class="eyebrow">RESTART &amp; RECOVERY</p><h2 id="recovery-heading">Your progress survives a restart</h2>
           <p>Restart the launcher to reconnect. Stale revision conflicts preserve your draft and require review; interrupted attempts appear in Needs Attention; Trash restores individual records.</p>
           <div class="button-row"><button class="button secondary overview-link" data-workspace="attention" type="button">Open Needs Attention</button><button class="button secondary overview-link" data-workspace="trash" type="button">Open Trash</button></div>
         </article>


### PR DESCRIPTION
New owners encounter storage terminology and an extraction handoff without a clear destination. Provide a concise setup guide, name Overview destinations, and explain where to paste extraction and application handoffs. If automatic browser opening fails, keep the workspace running and print fallback instructions without repeating the private URL or exception.

Validation: four launcher tests pass, including false/exception browser-open outcomes; all 53 workspace browser tests pass; release tier passes (package installs, upgrade fixture, packaged browser journeys, links); source-size and matrix checks pass. A retained guided-setup regression verifies import, prepared-candidate extraction completion, Facts population, job creation, ready check, and Ready status through stop/relaunch; the updated Overview was visually inspected. This does not establish live agent extraction accuracy.

Phase 1 is recorded complete with PR #57 evidence. Phase 2 remains open for an independent fresh-user walkthrough, timing/assistance observations, and host-managed launcher lifecycle acceptance. Actual agent extraction and real-version upgrade qualification remain separate acceptance work. No live applicant Store or active user browser was used.
