### PR TITLE
Add native managed resume library

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -110,6 +110,13 @@ jobs:
           node-version: '20'
           cache: npm
           cache-dependency-path: package-lock.json
+      - name: Provision all required CPython reference profiles
+        uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.13
+            3.14
+            3.12
       - run: npm ci
       - uses: actions/cache@v4
         with:

--- a/apps/companion/components/Companion.tsx
+++ b/apps/companion/components/Companion.tsx
@@ -5,13 +5,14 @@ import type { Boot } from './contracts';
 import { Overview } from './Overview';
 import { Facts } from './Facts';
 import { Jobs } from './Jobs';
+import { Resumes } from './Resumes';
 import './companion.css';
 export default function Companion() {
     const [client,setClient]=useState<Client|null>(null);
     const [boot,setBoot]=useState<Boot|null>(null);
     const [error,setError]=useState('');
     const [token,setToken]=useState('');
-    const [tab,setTab]=useState<'overview'|'jobs'|'facts'>('overview');
+    const [tab,setTab]=useState<'overview'|'jobs'|'facts'|'resumes'>('overview');
     const [dirty,setDirty]=useState(false);
     const [attempt,setAttempt]=useState(0);
     useEffect(() => {
@@ -52,7 +53,7 @@ export default function Companion() {
         return () => window.removeEventListener('beforeunload',before);
     },[dirty]);
     const dirtyChanged=useCallback((value: boolean) => setDirty(value),[]);
-    function navigate(next: 'overview'|'jobs'|'facts') {
+    function navigate(next: 'overview'|'jobs'|'facts'|'resumes') {
         if(next===tab)
             return;
         if(dirty&&!confirm('Discard unsaved changes?'))
@@ -82,6 +83,7 @@ export default function Companion() {
             <button aria-current={tab==='jobs'? 'page':undefined} onClick={() => navigate('jobs')}>Jobs
             </button>
             <button aria-current={tab==='facts'?'page':undefined} onClick={()=>navigate('facts')}>Facts</button>
+            <button aria-current={tab==='resumes'?'page':undefined} onClick={()=>navigate('resumes')}>Resumes</button>
             {token&&!nativeFixture&&<a href={legacyHref} onClick={event => {
                 if(dirty&&!confirm('Discard unsaved changes?'))
                     event.preventDefault();
@@ -90,7 +92,7 @@ export default function Companion() {
         </nav>
         <p className="trust">Your canonical data stays local. You direct changes and submissions; agents assist from the same record.
         </p>
-        {nativeFixture&&<p role="status">Synthetic native Jobs workspace. Create and edit jobs and facts here; other workflows are not available yet.</p>}
+        {nativeFixture&&<p role="status">Synthetic native workspace. Create and edit jobs, facts, and managed resumes here; other workflows are not available yet.</p>}
         {error&&<p role="alert" className="error">
             {error}{' '}
             {token&&<button onClick={() => setAttempt(value => value+1)}>Retry connection</button>}
@@ -105,7 +107,7 @@ export default function Companion() {
         </section>:boot?.status==='ready'&&client? (tab==='overview'? <Overview
             client={client}
             openJobs={() => navigate('jobs')}
-            legacyHref={legacyHref} />:tab==='facts'?<Facts client={client} dirtyChanged={dirtyChanged}/>:<Jobs client={client} dirtyChanged={dirtyChanged} />):!error&&<p>Loading workspace…
+            legacyHref={legacyHref} />:tab==='facts'?<Facts client={client} dirtyChanged={dirtyChanged}/>:tab==='resumes'?<Resumes client={client} dirtyChanged={dirtyChanged}/>:<Jobs client={client} dirtyChanged={dirtyChanged} />):!error&&<p>Loading workspace…
             </p>}
     </main>;
 }

--- a/apps/companion/components/Resumes.tsx
+++ b/apps/companion/components/Resumes.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react';
+import { ApiError, type Client } from './client';
+import type { ResumeRecord } from './contracts';
+
+const accept = '.pdf,.docx,.txt';
+const tags = (value: string) => value.split(',').map(item => item.trim()).filter(Boolean);
+
+export function Resumes({ client, dirtyChanged }: { client: Client; dirtyChanged: (dirty: boolean) => void }) {
+    const [records, setRecords] = useState<ResumeRecord[]>([]), [selected, setSelected] = useState<ResumeRecord | null>(null);
+    const [creating, setCreating] = useState(false);
+    const [label, setLabel] = useState(''), [tagText, setTagText] = useState(''), [file, setFile] = useState<File | null>(null);
+    const [loading, setLoading] = useState(true), [busy, setBusy] = useState(false), [error, setError] = useState(''), [notice, setNotice] = useState('');
+    const alive = useRef(true), request = useRef<AbortController | null>(null);
+    const dirty = Boolean(selected && (label !== selected.label || tagText !== selected.tags.join(', '))) || file !== null;
+    async function refresh() {
+        request.current?.abort(); const controller = new AbortController(); request.current = controller; setLoading(true);
+        try {
+            const next = await client.resumes(controller.signal);
+            if (!alive.current) return;
+            setRecords(next); setSelected(current => current ? next.find(item => item.id === current.id) ?? null : null); setError('');
+        } catch (cause) { if (alive.current && !controller.signal.aborted) setError(cause instanceof Error ? cause.message : 'Unable to load resumes'); }
+        finally { if (alive.current) setLoading(false); }
+    }
+    useEffect(() => { alive.current = true; void refresh(); return () => { alive.current = false; request.current?.abort(); }; }, [client]);
+    useEffect(() => { dirtyChanged(dirty || busy); return () => dirtyChanged(false); }, [dirty, busy, dirtyChanged]);
+    function open(record: ResumeRecord | null) {
+        if (dirty && !confirm('Discard unsaved resume changes?')) return;
+        setCreating(record === null); setSelected(record); setLabel(record?.label ?? ''); setTagText(record?.tags.join(', ') ?? ''); setFile(null); setError(''); setNotice('');
+    }
+    function close() {
+        if (dirty && !confirm('Discard unsaved resume changes?')) return;
+        setCreating(false); setSelected(null); setLabel(''); setTagText(''); setFile(null); setError('');
+    }
+    async function mutate(operation: (signal: AbortSignal) => Promise<ResumeRecord>, message: string) {
+        const controller = new AbortController(); setBusy(true); setError(''); setNotice('');
+        try {
+            const saved = await operation(controller.signal); if (!alive.current) return;
+            setSelected(saved); setLabel(saved.label); setTagText(saved.tags.join(', ')); setFile(null); setNotice(message); await refresh();
+        } catch (cause) {
+            if (alive.current) setError(cause instanceof ApiError && cause.code === 'revision_conflict'
+                ? 'This resume changed elsewhere. Refresh it before saving again.' : cause instanceof Error ? cause.message : 'The resume change was not confirmed.');
+        } finally { if (alive.current) setBusy(false); }
+    }
+    async function save() {
+        if (!label.trim()) { setError('Enter a resume label.'); return; }
+        if (!selected) {
+            if (!file) { setError('Choose a PDF, DOCX, or TXT resume.'); return; }
+            await mutate(signal => client.importResume({ label: label.trim(), tags: tags(tagText) }, file, signal), 'Resume imported'); return;
+        }
+        const metadataChanged = label !== selected.label || tagText !== selected.tags.join(', ');
+        if (metadataChanged && file) { setError('Save the label and tags before replacing the resume file.'); return; }
+        if (metadataChanged) await mutate(signal => client.updateResume(selected.id, selected.revision,
+            { label: label.trim(), tags: tags(tagText) }, signal), 'Resume details saved');
+        else if (file) await mutate(signal => client.replaceResume(selected.id, selected.revision, file,
+            selected.storageKind !== 'managed', signal), selected.storageKind === 'managed' ? 'Resume file replaced' : 'Resume adopted');
+    }
+    return <section>
+        <header><div><p className="eyebrow">Your documents</p><h1>Resumes</h1></div><div>
+            <button disabled={busy} onClick={() => void refresh()}>Refresh</button>{' '}
+            <button className="primary" disabled={busy} onClick={() => open(null)}>Import resume</button>
+        </div></header>
+        <p role="status">{loading ? 'Loading resumes…' : notice}</p>
+        {error && <p role="alert" className="error">{error}</p>}
+        <div className="job-list">
+            {records.map(record => <button className="job-card" key={record.id} onClick={() => open(record)}>
+                <strong>{record.label}{record.default ? ' · Default' : ''}</strong>
+                <span>{record.mediaType ?? 'External file'} · {record.tags.join(', ') || 'No tags'}</span>
+                <small>revision {record.revision}</small>
+            </button>)}
+        </div>
+        {!loading && !records.length && <p>No resumes yet. Import one to use it with applications.</p>}
+        {(selected || creating) && <div className="editor-panel">
+            <h2>{selected ? selected.label : 'Import resume'}</h2>
+            <label>Label<input value={label} onChange={event => setLabel(event.target.value)} disabled={busy} /></label>
+            <label>Tags, separated by commas<input value={tagText} onChange={event => setTagText(event.target.value)} disabled={busy} /></label>
+            <label>{selected?.storageKind === 'managed' ? 'Replacement file' : selected ? 'File to adopt' : 'Resume file'}
+                <input type="file" accept={accept} onChange={event => setFile(event.target.files?.[0] ?? null)} disabled={busy} />
+            </label>
+            <div><button disabled={busy} onClick={close}>Cancel</button>{' '}
+                <button className="primary" disabled={busy || !dirty && Boolean(selected)} onClick={() => void save()}>Save</button>{' '}
+                {selected && !selected.default && <button disabled={busy || dirty} onClick={() => void mutate(signal => client.setDefaultResume(selected.id, selected.revision, signal), 'Default resume changed')}>Make default</button>}
+            </div>
+        </div>}
+    </section>;
+}

--- a/apps/companion/components/Resumes.tsx
+++ b/apps/companion/components/Resumes.tsx
@@ -4,55 +4,118 @@ import type { ResumeRecord } from './contracts';
 
 const accept = '.pdf,.docx,.txt';
 const tags = (value: string) => value.split(',').map(item => item.trim()).filter(Boolean);
+type Editor = {
+    base: ResumeRecord | null;
+    latest: ResumeRecord | null;
+    missing: boolean;
+    label: string;
+    tagText: string;
+    file: File | null;
+};
+const openEditor = (base: ResumeRecord | null): Editor => ({
+    base, latest: null, missing: false, label: base?.label ?? '', tagText: base?.tags.join(', ') ?? '', file: null
+});
+const isDirty = (editor: Editor | null) => Boolean(editor && (
+    editor.label !== (editor.base?.label ?? '') || editor.tagText !== (editor.base?.tags.join(', ') ?? '') || editor.file
+));
 
 export function Resumes({ client, dirtyChanged }: { client: Client; dirtyChanged: (dirty: boolean) => void }) {
-    const [records, setRecords] = useState<ResumeRecord[]>([]), [selected, setSelected] = useState<ResumeRecord | null>(null);
-    const [creating, setCreating] = useState(false);
-    const [label, setLabel] = useState(''), [tagText, setTagText] = useState(''), [file, setFile] = useState<File | null>(null);
-    const [loading, setLoading] = useState(true), [busy, setBusy] = useState(false), [error, setError] = useState(''), [notice, setNotice] = useState('');
-    const alive = useRef(true), request = useRef<AbortController | null>(null);
-    const dirty = Boolean(selected && (label !== selected.label || tagText !== selected.tags.join(', '))) || file !== null;
+    const [records, setRecords] = useState<ResumeRecord[]>([]), [editor, setEditor] = useState<Editor | null>(null);
+    const [loading, setLoading] = useState(true), [busy, setBusy] = useState(false);
+    const [error, setError] = useState(''), [notice, setNotice] = useState('');
+    const alive = useRef(true), request = useRef<AbortController | null>(null), mutation = useRef<AbortController | null>(null);
+    const fileInput = useRef<HTMLInputElement | null>(null);
+    const dirty = isDirty(editor);
     async function refresh() {
-        request.current?.abort(); const controller = new AbortController(); request.current = controller; setLoading(true);
+        request.current?.abort();
+        const controller = new AbortController();
+        request.current = controller;
+        setLoading(true);
         try {
             const next = await client.resumes(controller.signal);
-            if (!alive.current) return;
-            setRecords(next); setSelected(current => current ? next.find(item => item.id === current.id) ?? null : null); setError('');
-        } catch (cause) { if (alive.current && !controller.signal.aborted) setError(cause instanceof Error ? cause.message : 'Unable to load resumes'); }
-        finally { if (alive.current) setLoading(false); }
+            if (!alive.current || controller.signal.aborted || request.current !== controller) return;
+            setRecords(next);
+            setEditor(current => {
+                if (!current?.base) return current;
+                const latest = next.find(item => item.id === current.base?.id);
+                if (!latest) return { ...current, latest: null, missing: true };
+                if (latest.revision < Math.max(current.base.revision, current.latest?.revision ?? 0)) return current;
+                if (!isDirty(current)) return openEditor(latest);
+                return { ...current, missing: false, latest: latest.revision > current.base.revision ? latest : null };
+            });
+            setError('');
+        } catch (cause) {
+            if (alive.current && !controller.signal.aborted && request.current === controller)
+                setError(cause instanceof Error ? cause.message : 'Unable to load resumes');
+        } finally {
+            if (alive.current && request.current === controller) setLoading(false);
+        }
     }
-    useEffect(() => { alive.current = true; void refresh(); return () => { alive.current = false; request.current?.abort(); }; }, [client]);
+    useEffect(() => {
+        alive.current = true;
+        void refresh();
+        return () => { alive.current = false; request.current?.abort(); mutation.current?.abort(); };
+    }, [client]);
     useEffect(() => { dirtyChanged(dirty || busy); return () => dirtyChanged(false); }, [dirty, busy, dirtyChanged]);
     function open(record: ResumeRecord | null) {
-        if (dirty && !confirm('Discard unsaved resume changes?')) return;
-        setCreating(record === null); setSelected(record); setLabel(record?.label ?? ''); setTagText(record?.tags.join(', ') ?? ''); setFile(null); setError(''); setNotice('');
+        if (busy || dirty && !confirm('Discard unsaved resume changes?')) return;
+        setEditor(openEditor(record));
+        if (fileInput.current) fileInput.current.value = '';
+        setError(''); setNotice('');
     }
     function close() {
-        if (dirty && !confirm('Discard unsaved resume changes?')) return;
-        setCreating(false); setSelected(null); setLabel(''); setTagText(''); setFile(null); setError('');
+        if (busy || dirty && !confirm('Discard unsaved resume changes?')) return;
+        setEditor(null); setError('');
+    }
+    function reapply() {
+        setEditor(current => {
+            if (!current?.latest || current.missing) return current;
+            const next = openEditor(current.latest);
+            if (current.label !== current.base?.label) next.label = current.label;
+            if (current.tagText !== current.base?.tags.join(', ')) next.tagText = current.tagText;
+            next.file = current.file;
+            return next;
+        });
+        setError('');
     }
     async function mutate(operation: (signal: AbortSignal) => Promise<ResumeRecord>, message: string) {
-        const controller = new AbortController(); setBusy(true); setError(''); setNotice('');
+        request.current?.abort();
+        const controller = new AbortController();
+        mutation.current = controller;
+        setBusy(true); setError(''); setNotice('');
         try {
-            const saved = await operation(controller.signal); if (!alive.current) return;
-            setSelected(saved); setLabel(saved.label); setTagText(saved.tags.join(', ')); setFile(null); setNotice(message); await refresh();
+            const saved = await operation(controller.signal);
+            if (!alive.current || controller.signal.aborted) return;
+            setEditor(openEditor(saved));
+            if (fileInput.current) fileInput.current.value = '';
+            setNotice(message);
+            await refresh();
         } catch (cause) {
-            if (alive.current) setError(cause instanceof ApiError && cause.code === 'revision_conflict'
-                ? 'This resume changed elsewhere. Refresh it before saving again.' : cause instanceof Error ? cause.message : 'The resume change was not confirmed.');
+            if (alive.current && !controller.signal.aborted) {
+                setError(cause instanceof ApiError && cause.code === 'revision_conflict'
+                    ? 'This resume changed elsewhere. Refresh to compare it with your draft.'
+                    : cause instanceof Error ? cause.message : 'The resume change was not confirmed.');
+            }
         } finally { if (alive.current) setBusy(false); }
     }
     async function save() {
+        if (!editor || busy || editor.latest || editor.missing) return;
+        const { base, label, tagText, file } = editor;
         if (!label.trim()) { setError('Enter a resume label.'); return; }
-        if (!selected) {
+        if (!base) {
             if (!file) { setError('Choose a PDF, DOCX, or TXT resume.'); return; }
-            await mutate(signal => client.importResume({ label: label.trim(), tags: tags(tagText) }, file, signal), 'Resume imported'); return;
+            await mutate(signal => client.importResume({ label: label.trim(), tags: tags(tagText) }, file, signal), 'Resume imported');
+            return;
         }
-        const metadataChanged = label !== selected.label || tagText !== selected.tags.join(', ');
-        if (metadataChanged && file) { setError('Save the label and tags before replacing the resume file.'); return; }
-        if (metadataChanged) await mutate(signal => client.updateResume(selected.id, selected.revision,
-            { label: label.trim(), tags: tags(tagText) }, signal), 'Resume details saved');
-        else if (file) await mutate(signal => client.replaceResume(selected.id, selected.revision, file,
-            selected.storageKind !== 'managed', signal), selected.storageKind === 'managed' ? 'Resume file replaced' : 'Resume adopted');
+        const patch: { label?: string; tags?: string[] } = {};
+        if (label !== base.label) patch.label = label.trim();
+        if (tagText !== base.tags.join(', ')) patch.tags = tags(tagText);
+        if (Object.keys(patch).length && file) { setError('Save the label and tags before replacing the resume file.'); return; }
+        if (Object.keys(patch).length)
+            await mutate(signal => client.updateResume(base.id, base.revision, patch, signal), 'Resume details saved');
+        else if (file)
+            await mutate(signal => client.replaceResume(base.id, base.revision, file, base.storageKind !== 'managed', signal),
+                base.storageKind === 'managed' ? 'Resume file replaced' : 'Resume adopted');
     }
     return <section>
         <header><div><p className="eyebrow">Your documents</p><h1>Resumes</h1></div><div>
@@ -62,23 +125,30 @@ export function Resumes({ client, dirtyChanged }: { client: Client; dirtyChanged
         <p role="status">{loading ? 'Loading resumes…' : notice}</p>
         {error && <p role="alert" className="error">{error}</p>}
         <div className="job-list">
-            {records.map(record => <button className="job-card" key={record.id} onClick={() => open(record)}>
+            {records.map(record => <button className="job-card" key={record.id} disabled={busy} onClick={() => open(record)}>
                 <strong>{record.label}{record.default ? ' · Default' : ''}</strong>
                 <span>{record.mediaType ?? 'External file'} · {record.tags.join(', ') || 'No tags'}</span>
                 <small>revision {record.revision}</small>
             </button>)}
         </div>
-        {!loading && !records.length && <p>No resumes yet. Import one to use it with applications.</p>}
-        {(selected || creating) && <div className="editor-panel">
-            <h2>{selected ? selected.label : 'Import resume'}</h2>
-            <label>Label<input value={label} onChange={event => setLabel(event.target.value)} disabled={busy} /></label>
-            <label>Tags, separated by commas<input value={tagText} onChange={event => setTagText(event.target.value)} disabled={busy} /></label>
-            <label>{selected?.storageKind === 'managed' ? 'Replacement file' : selected ? 'File to adopt' : 'Resume file'}
-                <input type="file" accept={accept} onChange={event => setFile(event.target.files?.[0] ?? null)} disabled={busy} />
+        {!loading && !error && !records.length && <p>No resumes yet. Import one to use it with applications.</p>}
+        {editor && <div className="editor-panel">
+            <h2>{editor.base ? editor.base.label : 'Import resume'}</h2>
+            {editor.missing && <p role="alert">This resume is no longer available. Your draft is preserved; saving is disabled.</p>}
+            {editor.latest && <div role="alert">
+                <p>This resume changed elsewhere. Your draft is preserved.</p>
+                <button disabled={busy} onClick={reapply}>Reapply my draft</button>{' '}
+                <button disabled={busy} onClick={() => open(editor.latest)}>Use latest resume</button>
+            </div>}
+            <label>Label<input value={editor.label} onChange={event => setEditor({ ...editor, label: event.target.value })} disabled={busy} /></label>
+            <label>Tags, separated by commas<input value={editor.tagText} onChange={event => setEditor({ ...editor, tagText: event.target.value })} disabled={busy} /></label>
+            <label>{editor.base?.storageKind === 'managed' ? 'Replacement file' : editor.base ? 'File to adopt' : 'Resume file'}
+                <input ref={fileInput} type="file" accept={accept} onChange={event => setEditor({ ...editor, file: event.target.files?.[0] ?? null })} disabled={busy} />
             </label>
             <div><button disabled={busy} onClick={close}>Cancel</button>{' '}
-                <button className="primary" disabled={busy || !dirty && Boolean(selected)} onClick={() => void save()}>Save</button>{' '}
-                {selected && !selected.default && <button disabled={busy || dirty} onClick={() => void mutate(signal => client.setDefaultResume(selected.id, selected.revision, signal), 'Default resume changed')}>Make default</button>}
+                <button className="primary" disabled={busy || loading || Boolean(editor.latest) || editor.missing || !dirty && Boolean(editor.base)} onClick={() => void save()}>Save</button>{' '}
+                {editor.base && !editor.base.default && <button disabled={busy || loading || dirty || Boolean(editor.latest) || editor.missing}
+                    onClick={() => void mutate(signal => client.setDefaultResume(editor.base!.id, editor.base!.revision, signal), 'Default resume changed')}>Make default</button>}
             </div>
         </div>}
     </section>;

--- a/apps/companion/components/client.ts
+++ b/apps/companion/components/client.ts
@@ -1,5 +1,5 @@
 import { snapshot } from './facts-model';
-import { boot, job, object, overview, workspaceState, type JobFields } from './contracts';
+import { boot, job, object, overview, resume, resumeList, workspaceState, type JobFields } from './contracts';
 export class ApiError extends Error {
     constructor(public status: number, public code: string, message: string) {
         super(message);
@@ -29,6 +29,13 @@ export function createClient(token: string) {
         }
         return payload;
     }
+    async function encoded(file: File): Promise<string> {
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        let binary = '';
+        for (let offset = 0; offset < bytes.length; offset += 32768)
+            binary += String.fromCharCode(...bytes.subarray(offset, offset + 32768));
+        return btoa(binary);
+    }
     return {
         profile: async (signal?: AbortSignal) => snapshot(await request('/api/profile', 'GET', undefined, signal, true) as string),
         patchProfile: async (body: string, signal?: AbortSignal) => snapshot(await request('/api/profile', 'PATCH', body, signal, true) as string),
@@ -45,6 +52,19 @@ export function createClient(token: string) {
         }, signal)),
         update: async (id: string, revision: number, fields: JobFields, signal?: AbortSignal) => job(await request(`/api/jobs/${encodeURIComponent(id)}`, 'PATCH', {
             patch: fields, expectedRevision: revision
+        }, signal)),
+        resumes: async (signal?: AbortSignal) => resumeList(await request('/api/resumes', 'GET', undefined, signal)),
+        importResume: async (metadata: unknown, file: File, signal?: AbortSignal) => resume(await request('/api/resumes/import', 'POST', {
+            metadata, filename: file.name, content: await encoded(file)
+        }, signal)),
+        updateResume: async (id: string, expectedRevision: number, patch: unknown, signal?: AbortSignal) => resume(await request(`/api/resumes/${encodeURIComponent(id)}`, 'PATCH', {
+            patch, expectedRevision
+        }, signal)),
+        setDefaultResume: async (id: string, expectedRevision: number, signal?: AbortSignal) => resume(await request(`/api/resumes/${encodeURIComponent(id)}/default`, 'POST', {
+            expectedRevision
+        }, signal)),
+        replaceResume: async (id: string, expectedRevision: number, file: File, adopt: boolean, signal?: AbortSignal) => resume(await request(`/api/resumes/${encodeURIComponent(id)}/${adopt ? 'adopt' : 'replace'}`, 'POST', {
+            metadata: { expectedRevision }, filename: file.name, content: await encoded(file)
         }, signal))
     };
 }

--- a/apps/companion/components/companion.css
+++ b/apps/companion/components/companion.css
@@ -137,6 +137,15 @@ section {
 .job-card span,.job-card small {
   color:var(--muted)
 }
+.editor-panel {
+  display:grid;
+  gap:1rem;
+  margin-top:1.5rem;
+  padding:1.5rem;
+  border:1px solid var(--line);
+  border-radius:16px;
+  background:var(--paper)
+}
 label {
   display:grid;
   gap:.45rem;

--- a/apps/companion/components/contracts.ts
+++ b/apps/companion/components/contracts.ts
@@ -79,12 +79,12 @@ export function workspaceState(value: unknown): WorkspaceState {
 export function resume(value: unknown): ResumeRecord {
     if (!object(value) || typeof value.id !== 'string' || typeof value.label !== 'string'
         || typeof value.default !== 'boolean' || typeof value.revision !== 'number'
-        || !Number.isSafeInteger(value.revision) || value.revision < 1 || !Array.isArray(value.tags)
-        || value.tags.some(tag => typeof tag !== 'string') || typeof value.createdAt !== 'string'
+        || !Number.isSafeInteger(value.revision) || value.revision < 1
+        || value.tags !== undefined && (!Array.isArray(value.tags) || value.tags.some(tag => typeof tag !== 'string')) || typeof value.createdAt !== 'string'
         || typeof value.updatedAt !== 'string' || value.storageKind !== undefined && value.storageKind !== 'managed')
         return invalid();
     return { ...value, id: value.id, label: value.label, default: value.default,
-        revision: value.revision, tags: value.tags as string[], createdAt: value.createdAt,
+        revision: value.revision, tags: value.tags === undefined ? [] : value.tags as string[], createdAt: value.createdAt,
         updatedAt: value.updatedAt, storageKind: value.storageKind } as ResumeRecord;
 }
 export function resumeList(value: unknown): ResumeRecord[] {

--- a/apps/companion/components/contracts.ts
+++ b/apps/companion/components/contracts.ts
@@ -21,6 +21,16 @@ export type Resume = {
     label: string;
     default: boolean;
 };
+export type ResumeRecord = Resume & {
+    storageKind?: 'managed';
+    mediaType?: string;
+    tags: string[];
+    observedSize?: number;
+    observedModifiedAt?: string;
+    revision: number;
+    createdAt: string;
+    updatedAt: string;
+};
 export type WorkspaceState = {
     jobs: Job[];
     resumes: Resume[];
@@ -65,6 +75,21 @@ export function workspaceState(value: unknown): WorkspaceState {
             };
         })
     };
+}
+export function resume(value: unknown): ResumeRecord {
+    if (!object(value) || typeof value.id !== 'string' || typeof value.label !== 'string'
+        || typeof value.default !== 'boolean' || typeof value.revision !== 'number'
+        || !Number.isSafeInteger(value.revision) || value.revision < 1 || !Array.isArray(value.tags)
+        || value.tags.some(tag => typeof tag !== 'string') || typeof value.createdAt !== 'string'
+        || typeof value.updatedAt !== 'string' || value.storageKind !== undefined && value.storageKind !== 'managed')
+        return invalid();
+    return { ...value, id: value.id, label: value.label, default: value.default,
+        revision: value.revision, tags: value.tags as string[], createdAt: value.createdAt,
+        updatedAt: value.updatedAt, storageKind: value.storageKind } as ResumeRecord;
+}
+export function resumeList(value: unknown): ResumeRecord[] {
+    if (!object(value) || !Array.isArray(value.resumes)) return invalid();
+    return value.resumes.map(resume);
 }
 export function boot(value: unknown): Boot {
     if (!object(value))

--- a/config/migration/browser-g02-next-surfaces.json
+++ b/config/migration/browser-g02-next-surfaces.json
@@ -572,6 +572,48 @@
         "recovery": "unverified",
         "platform": "unverified"
       }
+    },
+    {
+      "id": "browser:apps/companion/components/Resumes.tsx:Resumes",
+      "kind": "browser",
+      "export": "Resumes",
+      "node": "UIF",
+      "sources": ["apps/companion/components/Resumes.tsx"],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified", "invalid": "unverified", "missing": "unverified",
+        "noop": "unverified", "privacy": "unverified", "conflict": "unverified",
+        "concurrency": "unverified", "interruption": "unverified",
+        "recovery": "unverified", "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/contracts.ts:resume",
+      "kind": "browser",
+      "export": "resume",
+      "node": "UIF",
+      "sources": ["apps/companion/components/contracts.ts"],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified", "invalid": "unverified", "missing": "unverified",
+        "noop": "unverified", "privacy": "unverified", "conflict": "unverified",
+        "concurrency": "unverified", "interruption": "unverified",
+        "recovery": "unverified", "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/contracts.ts:resumeList",
+      "kind": "browser",
+      "export": "resumeList",
+      "node": "UIF",
+      "sources": ["apps/companion/components/contracts.ts"],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified", "invalid": "unverified", "missing": "unverified",
+        "noop": "unverified", "privacy": "unverified", "conflict": "unverified",
+        "concurrency": "unverified", "interruption": "unverified",
+        "recovery": "unverified", "platform": "unverified"
+      }
     }
   ]
 }

--- a/config/migration/cli-native-resumes-surfaces.json
+++ b/config/migration/cli-native-resumes-surfaces.json
@@ -1,0 +1,230 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-import",
+      "kind": "cli",
+      "command": "resume-import",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts",
+        "src/workspace-core/resumes.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-get",
+      "kind": "cli",
+      "command": "resume-get",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts",
+        "src/workspace-core/resumes.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-list",
+      "kind": "cli",
+      "command": "resume-list",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts",
+        "src/workspace-core/resumes.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-update",
+      "kind": "cli",
+      "command": "resume-update",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts",
+        "src/workspace-core/resumes.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-replace",
+      "kind": "cli",
+      "command": "resume-replace",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts",
+        "src/workspace-core/resumes.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-adopt",
+      "kind": "cli",
+      "command": "resume-adopt",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts",
+        "src/workspace-core/resumes.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-set-default",
+      "kind": "cli",
+      "command": "resume-set-default",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts",
+        "src/workspace-core/resumes.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-resolve",
+      "kind": "cli",
+      "command": "resume-resolve",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts",
+        "src/workspace-core/resumes.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-check",
+      "kind": "cli",
+      "command": "resume-check",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts",
+        "src/workspace-core/resumes.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/document-01-surfaces.json
+++ b/config/migration/document-01-surfaces.json
@@ -100,7 +100,10 @@
       "artifact": "json",
       "node": "RES",
       "sources": [
-        "scripts/job_apply_store/base.py"
+        "scripts/job_apply_store/base.py",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts",
+        "src/workspace-core/resumes.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -399,7 +402,10 @@
       "artifact": "binary",
       "node": "RES",
       "sources": [
-        "scripts/job_apply_store/domains/resumes/storage.py"
+        "scripts/job_apply_store/domains/resumes/storage.py",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts",
+        "src/workspace-core/resumes.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/document-native-resumes-surfaces.json
+++ b/config/migration/document-native-resumes-surfaces.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "document:resume-operation.json",
+      "kind": "document",
+      "path": "resume-operation.json",
+      "artifact": "json",
+      "node": "RES",
+      "sources": [
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "document:resume-files/.native-<uuid>.tmp",
+      "kind": "document",
+      "path": "resume-files/.native-<uuid>.tmp",
+      "artifact": "temporary",
+      "node": "RES",
+      "sources": [
+        "src/store/native-resume-files.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/http-read-detail-surfaces.json
+++ b/config/migration/http-read-detail-surfaces.json
@@ -179,7 +179,13 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/cli/native-jobs-server.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/resumes-http.ts",
+        "src/workspace-core/resumes.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -206,7 +212,13 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/cli/native-jobs-server.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/resumes-http.ts",
+        "src/workspace-core/resumes.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-read-surfaces.json
+++ b/config/migration/http-read-surfaces.json
@@ -352,7 +352,13 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/cli/native-jobs-server.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/resumes-http.ts",
+        "src/workspace-core/resumes.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-write-resumes-surfaces.json
+++ b/config/migration/http-write-resumes-surfaces.json
@@ -13,7 +13,13 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/cli/native-jobs-server.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/resumes-http.ts",
+        "src/workspace-core/resumes.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -125,7 +131,13 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/cli/native-jobs-server.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/resumes-http.ts",
+        "src/workspace-core/resumes.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -153,7 +165,13 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/cli/native-jobs-server.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/resumes-http.ts",
+        "src/workspace-core/resumes.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -181,7 +199,13 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/cli/native-jobs-server.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/resumes-http.ts",
+        "src/workspace-core/resumes.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -321,7 +345,13 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/cli/native-jobs-server.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/resumes-http.ts",
+        "src/workspace-core/resumes.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/journal-native-resumes-surfaces.json
+++ b/config/migration/journal-native-resumes-surfaces.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "journal:resume-operation.json:operation:null",
+      "kind": "journal",
+      "path": "resume-operation.json",
+      "discriminator": "operation",
+      "value": null,
+      "node": "RES",
+      "sources": [
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "journal:resume-operation.json:operation.kind:install",
+      "kind": "journal",
+      "path": "resume-operation.json",
+      "discriminator": "operation.kind",
+      "value": "install",
+      "node": "RES",
+      "sources": [
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -23,7 +23,7 @@
     },
     {
       "path": "browser-g02-next-surfaces.json",
-      "sha256": "41ab076190a4efbc76187a8b4a7fc7548e26c2173a94597f459f474f534e1a2d"
+      "sha256": "9add2687760c1d47831e02903d5b2840394f86f9672507b522a33f5e461d8656"
     },
     {
       "path": "browser-lib-01-surfaces.json",
@@ -78,16 +78,24 @@
       "sha256": "8757138a819fd1166abfeb7e86aed548a42f3d2d6f832da404370f9c483e8963"
     },
     {
+      "path": "cli-native-resumes-surfaces.json",
+      "sha256": "23b9fd1e5a29720b5b4143d59a9767dfb9ee98a00e09ef3962f9112c9cda4e5c"
+    },
+    {
       "path": "cli-root-01-surfaces.json",
       "sha256": "12f7e2a79b07b0f67b299487ac7d0a06d967a0d373e3da336a91b06fc040695a"
     },
     {
       "path": "document-01-surfaces.json",
-      "sha256": "587549e629a01ff979f134e5b36f5fe64b22704a72568b9b2b7031583979cf97"
+      "sha256": "832cba04c3b722bbea66f242d3e2ce587e988732c8abcd7d0f3cd8f2cdf5f7de"
     },
     {
       "path": "document-02-surfaces.json",
       "sha256": "387d7d0e5cd60e6ce9b68fae4de02853de3f9cad1bcf9661d90183e9f3a63995"
+    },
+    {
+      "path": "document-native-resumes-surfaces.json",
+      "sha256": "ccdefde93534faa31fc3c45e772b83703914b11323f45d1d858dd86c127de42d"
     },
     {
       "path": "http-asset-head-surfaces.json",
@@ -107,11 +115,11 @@
     },
     {
       "path": "http-read-detail-surfaces.json",
-      "sha256": "5091bb0404d8e6e287b3bb17bf75dd896084e70686596263e455cfefd5b8e641"
+      "sha256": "6b35b0079111a16eb7cc3b9a197c646467983d8d2e083b4d4d662dcefbc19bfc"
     },
     {
       "path": "http-read-surfaces.json",
-      "sha256": "dc366ac18df0c8f83dff4760c4c72a7735c197820b66eacb5494dd3c4b8de60e"
+      "sha256": "91c59a29e0b3cad192438bbdeb11858abb377bab1e7cb9bb45cef54919a99a1a"
     },
     {
       "path": "http-write-accounts-surfaces.json",
@@ -135,7 +143,7 @@
     },
     {
       "path": "http-write-resumes-surfaces.json",
-      "sha256": "ca80dc8b73ef731cec47536ec4f55eda522d8f43d979443dc0efdc4d2b43a4df"
+      "sha256": "bd5d9621cdd4a79983c36c74517ebebdc69c1dc530bb1cc676e238680f6fabf6"
     },
     {
       "path": "http-write-surfaces.json",
@@ -152,6 +160,10 @@
     {
       "path": "journal-03-surfaces.json",
       "sha256": "20e3c3ab40814076290bb43fd37c91dec03884686abe372fbe0908b224b171da"
+    },
+    {
+      "path": "journal-native-resumes-surfaces.json",
+      "sha256": "85609a0155cb88c4335662b0ed827ebc4e09745840bce1c16f40897321c15ad4"
     },
     {
       "path": "nodes.json",
@@ -215,7 +227,7 @@
     },
     {
       "path": "source-catalog-g02-next.json",
-      "sha256": "58aa2cdb60b38bf86cd6f5ba70206706810959e841b2fe378027695d2e1213f3"
+      "sha256": "6034a417e2fff287534e08c18bca8f613787456c9d2c1612df1899d59b8e4bb2"
     },
     {
       "path": "source-catalog-m01.json",
@@ -231,7 +243,11 @@
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "e1d6ab27a514f8315c5b35b2b07f51850047a980760ff18de62b2ed7769ab931"
+      "sha256": "9919e0c9935d3ea92654fef70c5f06c2502fac4d86967d45acc2424f1c0c893e"
+    },
+    {
+      "path": "source-catalog-native-resumes.json",
+      "sha256": "e82dad4597982c84b76c845d3069eb80d963dda1efdad575f7faf74fbca5edb1"
     },
     {
       "path": "source-catalog-s01.json",

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -227,7 +227,7 @@
     },
     {
       "path": "source-catalog-g02-next.json",
-      "sha256": "6034a417e2fff287534e08c18bca8f613787456c9d2c1612df1899d59b8e4bb2"
+      "sha256": "dc5a2fedfd6cf2a532e623e9c2da77ba5b0c69f6b96af8fcd30d41a7a11dcda2"
     },
     {
       "path": "source-catalog-m01.json",
@@ -247,7 +247,7 @@
     },
     {
       "path": "source-catalog-native-resumes.json",
-      "sha256": "e82dad4597982c84b76c845d3069eb80d963dda1efdad575f7faf74fbca5edb1"
+      "sha256": "29dd7f8508a7d203df336e2dad4c4b643daf4c4441f4cbee96d4ea0f5d15cc17"
     },
     {
       "path": "source-catalog-s01.json",

--- a/config/migration/source-catalog-g02-next.json
+++ b/config/migration/source-catalog-g02-next.json
@@ -33,7 +33,7 @@
     },
     {
       "path": "apps/companion/components/Resumes.tsx",
-      "sha256": "924b557ccba6d8d5615eeac3621f9aa6c395e7cc51375a16963142432ea0486c",
+      "sha256": "2db9aa0f85931033ef5271a2100f1c46fc25634f2110511c7bdaebde219576dc",
       "classification": "unreviewed"
     },
     {
@@ -48,7 +48,7 @@
     },
     {
       "path": "apps/companion/components/contracts.ts",
-      "sha256": "036484999b9d81303e2c1fc94f002fd6d262363e5b3a770dc73ebbd86193e550",
+      "sha256": "60f7bc222c5c34bc861666edef1991ee9713f97b8bdfbda6abec9c941c2f8529",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-g02-next.json
+++ b/config/migration/source-catalog-g02-next.json
@@ -13,7 +13,7 @@
     },
     {
       "path": "apps/companion/components/Companion.tsx",
-      "sha256": "0234c0ce69b8e8786e547d53090d1069d8552ebe0cfb22110906664813a5450c",
+      "sha256": "bf9e06f2b21b57c64309eaa3ebaa209e7bec90dfa8624c13b3b65f8f63b6be59",
       "classification": "unreviewed"
     },
     {
@@ -32,18 +32,23 @@
       "classification": "unreviewed"
     },
     {
+      "path": "apps/companion/components/Resumes.tsx",
+      "sha256": "924b557ccba6d8d5615eeac3621f9aa6c395e7cc51375a16963142432ea0486c",
+      "classification": "unreviewed"
+    },
+    {
       "path": "apps/companion/components/client.ts",
-      "sha256": "97942aea7092eeef123d7853f08907cd5aee0cf79dba3283fa2d5056a85b6ceb",
+      "sha256": "808fd59c56821aaaf2e479a6eff3c5aaaa5b364b73a3f1ccf4fe37eecee55b0c",
       "classification": "unreviewed"
     },
     {
       "path": "apps/companion/components/companion.css",
-      "sha256": "79d6c01e3af8cf2de1f81df91f9eb086fbb484ec25c2ac1b5eec515a2b711f34",
+      "sha256": "c99f25c3d09d42272391980aec1b07c3d9b4d14b880ed7609626760eb7ff0a20",
       "classification": "unreviewed"
     },
     {
       "path": "apps/companion/components/contracts.ts",
-      "sha256": "0f5c5b8b2c7d242cca706253d74aa89a1848136302678a0a1579a587e3de497c",
+      "sha256": "036484999b9d81303e2c1fc94f002fd6d262363e5b3a770dc73ebbd86193e550",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -3,12 +3,12 @@
   "sources": [
     {
       "path": "runtime/cli/native-jobs-server.js",
-      "sha256": "a0da41c227e4235ee8cdcf65cb96eb3f5b2ab0e2bbacee4428ada64643ab489d",
+      "sha256": "f81a73d8573e9ce8f64710a763ac8c7809a3074085c6a42ae38ee0504a9f6afc",
       "classification": "unreviewed"
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "80f1aa8ed770f313abb20d789edfc6a5e60f5215c5b9f2bf60edf5b2e087aa8c",
+      "sha256": "6992347e011b548511a53ab4dde361cbebf08185c90cc235647dff1d9a0fc61f",
       "classification": "unreviewed"
     },
     {
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "a1c147a50d9c01abd2e8c926e540946d86f7e16f35f071dc05aa509a8e24942a",
+      "sha256": "ca6492adc02592ba9c6b10a879a85117310cf15bed320c440323fd1799192f57",
       "classification": "unreviewed"
     },
     {
@@ -43,7 +43,7 @@
     },
     {
       "path": "runtime/workspace-core/jobs-http.js",
-      "sha256": "0281d1e2d3cea000844bffd4f93511a83dfd7f97a3b845fc494c640e9b62e8b1",
+      "sha256": "5a3b865192d62d1b429507f6077fbe71d57a9896c8587f624f0686b3880783c3",
       "classification": "unreviewed"
     },
     {
@@ -53,12 +53,12 @@
     },
     {
       "path": "src/cli/native-jobs-server.ts",
-      "sha256": "fb5cf4367d37f54fcd2aec78c1cbf3be5372ba328b5e2e8b7b4776fa6197baf4",
+      "sha256": "0843746ac6a8fea46a3c1beab4881fd1b917af22bd5d69cb0735ef3cc7187a27",
       "classification": "unreviewed"
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "9f70966574cba2e8bc9232c1c2141202c1fcece4a336dd7dcb4c82ea1b42b4c5",
+      "sha256": "410df4f173a9a65c18384851d1938f405e71eee1229d7898fc8507fe275b74fc",
       "classification": "unreviewed"
     },
     {
@@ -83,7 +83,7 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "214eafb12ecd052a09c5b8362e5434817ac3926c3f8c5259a0b3946e9d9db3c0",
+      "sha256": "2a21fb048a412e38869391bc9ce074ad1501779f21d8c31e14eacabf481c3459",
       "classification": "unreviewed"
     },
     {
@@ -93,7 +93,7 @@
     },
     {
       "path": "src/workspace-core/jobs-http.ts",
-      "sha256": "697662b16923c6c065826dc63aa53022797fffbed62985779f660bb9d02fb8f5",
+      "sha256": "6f99dfc8d2bcf0594114bf71bd8304cf6c78fac3f9ae5d3b2a04108addbab266",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-resumes.json
+++ b/config/migration/source-catalog-native-resumes.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": 1,
   "sources": [
-    { "path": "runtime/contracts/workspace/resume-content.js", "sha256": "6d9a7d54e66d20f0869511c8a0cb76edb860afdea3e9ac00131e5b2b6ff2dd1e", "classification": "unreviewed" },
+    { "path": "runtime/contracts/workspace/resume-content.js", "sha256": "6e1aeb9b02c7a3ecfc904e6ececb7cd74ba01b80003cc3e788c8076a4755be18", "classification": "unreviewed" },
     { "path": "runtime/store/native-resume-files.js", "sha256": "1bb45c99fb1981c921e0dcd1250dca7d8c946308cd46fa59b54f3d9849b3136d", "classification": "unreviewed" },
     { "path": "runtime/workspace-core/resumes-http.js", "sha256": "bdbb6b958bab5e7ed03818a98d2a7a7c2170c480eccb1aa4dd58b90fc81de287", "classification": "unreviewed" },
     { "path": "runtime/workspace-core/resumes.js", "sha256": "393a21b96618bed15b8317df5442cb403353f489c6d2acdd0360a3cd1724c623", "classification": "unreviewed" },
-    { "path": "src/contracts/workspace/resume-content.ts", "sha256": "d94910fda6f99b52090eedca2050f4b7561e777ac4b1a67d0e6599f172aac8d8", "classification": "unreviewed" },
+    { "path": "src/contracts/workspace/resume-content.ts", "sha256": "6578551f4655b6e9fd9db3b7f9aeecc3ddaee67d6f9270742a67e32eb15be2f9", "classification": "unreviewed" },
     { "path": "src/store/native-resume-files.ts", "sha256": "56c43f6de09e97e20d329d671ab6cd01c5b72b56c6ac979dbc02fb5ac2cf0769", "classification": "unreviewed" },
     { "path": "src/workspace-core/resumes-http.ts", "sha256": "bf29e88b477f5b0cee81154e4f9ddb7b85c186700ea519c024e843f16d9ae15f", "classification": "unreviewed" },
     { "path": "src/workspace-core/resumes.ts", "sha256": "246072b9292684976f461a0fe4b31297f955b6b2dece93dc2ef63b0988747903", "classification": "unreviewed" }

--- a/config/migration/source-catalog-native-resumes.json
+++ b/config/migration/source-catalog-native-resumes.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    { "path": "runtime/contracts/workspace/resume-content.js", "sha256": "6d9a7d54e66d20f0869511c8a0cb76edb860afdea3e9ac00131e5b2b6ff2dd1e", "classification": "unreviewed" },
+    { "path": "runtime/store/native-resume-files.js", "sha256": "1bb45c99fb1981c921e0dcd1250dca7d8c946308cd46fa59b54f3d9849b3136d", "classification": "unreviewed" },
+    { "path": "runtime/workspace-core/resumes-http.js", "sha256": "bdbb6b958bab5e7ed03818a98d2a7a7c2170c480eccb1aa4dd58b90fc81de287", "classification": "unreviewed" },
+    { "path": "runtime/workspace-core/resumes.js", "sha256": "393a21b96618bed15b8317df5442cb403353f489c6d2acdd0360a3cd1724c623", "classification": "unreviewed" },
+    { "path": "src/contracts/workspace/resume-content.ts", "sha256": "d94910fda6f99b52090eedca2050f4b7561e777ac4b1a67d0e6599f172aac8d8", "classification": "unreviewed" },
+    { "path": "src/store/native-resume-files.ts", "sha256": "56c43f6de09e97e20d329d671ab6cd01c5b72b56c6ac979dbc02fb5ac2cf0769", "classification": "unreviewed" },
+    { "path": "src/workspace-core/resumes-http.ts", "sha256": "bf29e88b477f5b0cee81154e4f9ddb7b85c186700ea519c024e843f16d9ae15f", "classification": "unreviewed" },
+    { "path": "src/workspace-core/resumes.ts", "sha256": "246072b9292684976f461a0fe4b31297f955b6b2dece93dc2ef63b0988747903", "classification": "unreviewed" }
+  ]
+}

--- a/config/test-matrix.json
+++ b/config/test-matrix.json
@@ -180,7 +180,15 @@
       "id": "node-workspace-other",
       "kind": "node-test",
       "include": ["tests_js/typed_json_points.test.mjs", "tests_js/typed_json_points_profiles.test.mjs", "tests_js/typed_json_points_compat.test.mjs", "tests_js/workspace*.test.mjs", "tests_js/unified_task_spine_oracle.test.mjs", "tests_js/python-contracts.test.mjs", "tests_js/python-startup-contracts.test.mjs", "tests_js/python-profile-fact-contracts.test.mjs", "tests_js/python-answer-matching-raw.test.mjs", "tests_js/raw_json_numeric*.test.mjs", "tests_js/typed_json*.test.mjs", "tests_js/store_validation_ts.test.mjs", "tests_js/python_json_ingress.test.mjs", "tests_js/python_json_stdin.test.mjs", "tests_js/store_raw_read_reference.test.mjs", "tests_js/store_raw_read_ts.test.mjs", "tests_js/private_file_digest_reference.test.mjs", "tests_js/private_file_digest_ts.test.mjs", "tests_js/managed_resume_path_reference.test.mjs", "tests_js/managed_resume_path_ts.test.mjs", "tests_js/managed_observation_reference.test.mjs", "tests_js/posix_path_bytes_reference.test.mjs", "tests_js/posix_path_bytes_ts.test.mjs", "tests_js/resume_modified_at_reference.test.mjs", "tests_js/resume_modified_at_ts.test.mjs", "tests_js/managed_observation_ts.test.mjs", "tests_js/managed_observation_native_ts.test.mjs", "tests_js/exclusive_file_lock_reference.test.mjs", "tests_js/atomic_write_json_reference.test.mjs", "tests_js/installed_artifacts_reference.test.mjs", "tests_js/atomic_write_json_ts.test.mjs", "tests_js/persisted_json_ts.test.mjs", "tests_js/installed_artifacts_ts.test.mjs", "tests_js/filesystem_error_ts.test.mjs", "tests_js/jsonl_append_reference.test.mjs", "tests_js/artifact_copy_metadata_reference.test.mjs", "tests_js/jsonl_history_ts.test.mjs", "tests_js/jsonl_json_ts.test.mjs", "tests_js/history_read_idempotency_reference.test.mjs", "tests_js/artifact_copy_order_reference.test.mjs", "tests_js/python_text_reference.test.mjs", "tests_js/http_json_bytes_reference.test.mjs", "tests_js/artifact_data_copy_reference.test.mjs", "tests_js/python_text_ts.test.mjs", "tests_js/python_text_acceptance.test.mjs", "tests_js/data_copy_ts.test.mjs", "tests_js/python_object_reference.test.mjs", "tests_js/python_json_bytes_reference.test.mjs", "tests_js/codepoint_json_reference.test.mjs", "tests_js/python_object_ts.test.mjs", "tests_js/python_json_bytes_ts.test.mjs"],
+      "exclude": ["tests_js/typed_json_points_profiles.test.mjs"],
       "tiers": ["full"]
+    },
+    {
+      "id": "native-frozen-reference-profiles",
+      "kind": "node-test",
+      "include": ["tests_js/typed_json_points_profiles.test.mjs"],
+      "platforms": ["darwin"],
+      "tiers": ["full", "platform"]
     },
     {
       "id": "native-posix-lock",
@@ -251,7 +259,7 @@
     {"paths": ["tests_js/migration_task_handoff_support.mjs"], "suites": ["node-migration-evidence"]},
     {"paths": ["native/posix/timestamps.c", "native/posix/*.h", "tools/build-native-timestamps.mjs", "tests_js/posix_timestamps_support.mjs"], "suites": ["native-posix-timestamps"]},
     {"paths": ["tools/contracts/heavy-run-lease/reference.mjs", "native/posix/flock.c", "native/posix/*.h", "tools/build-native-lock.mjs", "tests_js/exclusive_file_lock_support.mjs"], "suites": ["native-posix-lock"]},
-    {"paths": ["tests_js/managed_resume_path_ts_support.mjs", "tests_js/posix_path_bytes_ts_support.mjs", "tests_js/managed_observation_ts_support.mjs", "tests_js/atomic_write_json_ts_support.mjs", "tests_js/installed_artifacts_ts_support.mjs", "tests_js/jsonl_history_support.mjs", "tests_js/data_copy_support.mjs", "tests_js/python_object_ts_support.mjs", "tests_js/python_json_bytes_ts_support.mjs"], "suites": ["node-workspace-other"]},
+    {"paths": ["tests_js/resume_stat_profile_support.mjs", "tests_js/managed_resume_path_ts_support.mjs", "tests_js/posix_path_bytes_ts_support.mjs", "tests_js/managed_observation_ts_support.mjs", "tests_js/atomic_write_json_ts_support.mjs", "tests_js/installed_artifacts_ts_support.mjs", "tests_js/jsonl_history_support.mjs", "tests_js/data_copy_support.mjs", "tests_js/python_object_ts_support.mjs", "tests_js/python_json_bytes_ts_support.mjs"], "suites": ["node-workspace-other"]},
     {"paths": ["tools/probe-installed-runtime.mjs"], "suites": ["node-foundation-fast"]},
     {"paths": ["tools/capture-python-contracts.mjs", "tools/verify-contract-redaction.mjs", "tools/contracts/**"], "suites": ["node-workspace-other", "node-reference-s04", "node-reference-s05"]},
     {

--- a/docs/migration/resume-modified-at-reference.md
+++ b/docs/migration/resume-modified-at-reference.md
@@ -19,7 +19,11 @@ Four additional cases set exact nanosecond mtimes on an owned temporary file,
 then capture actual stat float bits and formatted output. They include negative
 600 nanoseconds: the native stat float differs from the directly supplied
 decimal float `-0.0000006`. File content, size, mode and mtime remain unchanged
-during observation. These exact native conversion checks fail closed if another
+during observation. The negative fixture identifies one of two exact CPython
+build arithmetic profiles: fused multiplication/addition or separately rounded
+operations. Every native row must match that same profile; the operating system
+alone does not select it. Both modes retain independent exact-arithmetic tests.
+These exact native conversion checks fail closed if another
 filesystem rounds differently; they do not silently normalize away differences.
 
 Each capture binds the production source hash and interpreter/platform profile.
@@ -32,3 +36,7 @@ This bounded reference does not cover every representable float, all calendar
 boundaries, malformed metadata objects, property access errors or all native
 nanosecond-to-float conversions. Those obligations remain for the timestamp and
 observation implementations and their broader independent tests.
+
+The S05 native domain probes in the reference test use a Darwin-only driver and
+are explicitly skipped elsewhere. These skips do not establish S05 acceptance on
+another platform; Darwin retains the mandatory interpreter probes.

--- a/docs/native-facts-fixture.md
+++ b/docs/native-facts-fixture.md
@@ -6,8 +6,8 @@ services between HTTP and the native CLI. The default launcher remains Python.
 No live Store is adopted, migrated or activated by this change.
 
 Create a new root using the [native fixture instructions](native-jobs-fixture.md).
-The fixture marker is now version 2 and initialization also creates
-`fact-groups.json`. Version 1 disposable fixtures must be recreated at a new
+The fixture marker is now version 3 and initialization also creates
+`fact-groups.json`. Version 1 and 2 disposable fixtures must be recreated at a new
 path; existing roots are never automatically upgraded. Profile replacement with
 revision zero cannot initialize or recover a missing profile in this mode.
 

--- a/docs/native-jobs-fixture.md
+++ b/docs/native-jobs-fixture.md
@@ -6,9 +6,11 @@ launcher continues to use Python compatibility mode.
 
 Supported operations are `job-create`, `job-get`, `job-list` and `job-update`,
 including URL deduplication, revisions and human/agent provenance. Resume
-selection validates a read-only registry; it does not inspect content or assert
-preflight readiness. Jobs operations leave profile and resume documents unchanged.
-Facts/profile operations are also available; see the linked guide below. Other workflows return `unsupported_native_workflow`; they never fall back to Python.
+selection validates the shared registry. Managed resume import, list, get,
+metadata update, file replacement, legacy adoption, default selection, integrity
+check, content read and resolution are available through the same Store lock.
+Facts/profile operations are also available; see the linked guide below. Other
+workflows return `unsupported_native_workflow`; they never fall back to Python.
 
 ## Run against a new synthetic root
 
@@ -39,6 +41,11 @@ The CLI accepts the same input shapes as the corresponding Python Jobs commands:
 node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node job-create --input /absolute/synthetic-job.json --origin human
 node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node job-list
 node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node job-update --id JOB_ID --expected-revision 1 --input /absolute/synthetic-patch.json
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node resume-import --path /absolute/resume.pdf --input /absolute/resume-metadata.json
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node resume-list
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node resume-replace --id RESUME_ID --path /absolute/replacement.pdf --expected-revision 1
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node resume-set-default --id RESUME_ID --expected-revision 2
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node resume-check --id RESUME_ID
 ```
 
 Input can also come from stdin with `--input -`. CLI JSON output uses the
@@ -46,11 +53,13 @@ lossless numeric/text codec; browser editing requires safe integer revisions.
 
 ## Boundaries and recovery
 
-Only the readiness marker, Store lock, Jobs, profile, fact-groups and read-only resume
-documents are permitted in the fixture root. Unsupported domain state, journals,
-leftover temporary files, symlinks, hard links and non-private files are rejected.
-Keep the failed fixture for diagnosis; do not remove unknown state to force it
-open. No automatic recovery or repair is implemented here.
+Only the readiness marker, Store lock, Jobs, profile, fact-groups, resume registry,
+resume operation journal and private managed-file directory are permitted in the
+fixture root. Resume replacement writes a durable intent before installing bytes;
+the next locked operation rolls that exact record forward after interruption and
+clears owned staging files. Unknown state, symlinks, hard links, permissive files
+and mismatched recovery identities are rejected. Keep the failed fixture for
+diagnosis; do not remove unknown state to force it open.
 
 The marker restricts this native implementation; it cannot stop an older Python
 writer. Do not point Python, compatibility mode or real applicant data at this
@@ -59,9 +68,11 @@ milestones.
 
 The tests create independent Python and native roots, compare Jobs behavior,
 exercise native CLI contention with an empty PATH, inject persistence failures,
-kill a lock holder, and run a production Next/browser conflict-and-reload flow.
+verify resume byte/metadata recovery, reject file swaps, kill a lock holder, and
+run a production Next/browser conflict-and-reload flow with managed resume import.
 No owner account, live Store, visible browser or plugin installation is used.
 
-Facts/profile is also available in newly initialized version 2 synthetic fixtures.
-See [Facts/profile commands and limits](native-facts-fixture.md). Older version 1
-fixtures must be recreated at a new path; they are not automatically upgraded.
+Facts/profile and managed resumes are available in newly initialized version 3
+synthetic fixtures. See [Facts/profile commands and limits](native-facts-fixture.md).
+Older version 1 and 2 fixtures must be recreated at a new path; they are not
+automatically upgraded.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -137,3 +137,17 @@ manual nightly workflow. Release installation evidence runs nightly and for
 staging/main, version tags, and manual dispatch. No CI timing percentile or
 observation-window completion is claimed yet; current timings are individual
 local measurements.
+
+## Portable and historical interpreter evidence
+
+The Linux workspace CI job provisions CPython 3.12, 3.13 and 3.14 and runs fresh
+codepoint-JSON differential observations, including interpreter/module provenance.
+These comparisons do not grant historical migration acceptance to a new build.
+
+`native-frozen-reference-profiles` remains in the full and platform tiers on
+Darwin. It runs the unchanged S08 acceptance test against the exact recorded
+macOS ARM64 interpreter/stdlib/native-module hashes; missing or different builds
+fail that native gate. The Linux workspace suite excludes this host-bound test
+and includes the separate portable comparison instead. Frozen receipts and their
+strict checks are unchanged. A green portable CI run does not certify replay of
+historical native acceptance; local deep verification retains that requirement.

--- a/runtime/cli/native-jobs-server.js
+++ b/runtime/cli/native-jobs-server.js
@@ -4,6 +4,8 @@ import { JobsService } from "../workspace-core/jobs.js";
 import { jobsHttp, apiError } from "../workspace-core/jobs-http.js";
 import { NativeJobsRepository } from "../store/native-jobs.js";
 import { loadPosixFlockProvider } from "../store/posix-flock.js";
+const maxBody = 64 * 1024;
+const maxUpload = 4 * Math.ceil(10 * 1024 * 1024 / 3) + maxBody;
 const args = process.argv.slice(2);
 if (args.length !== 4 || args[0] !== "--root" || args[2] !== "--native-lock") {
     throw new Error("usage: native-jobs-server --root /synthetic/root --native-lock /artifact.node");
@@ -15,8 +17,9 @@ const token = randomBytes(32).toString("base64url");
 let origin = "";
 const server = createServer(async (request, response) => {
     const send = (result) => {
-        response.writeHead(result.status, { "Content-Type": "application/json", "Cache-Control": "no-store",
-            "X-Content-Type-Options": "nosniff", "Connection": "close" });
+        response.writeHead(result.status, { "Content-Type": result.contentType ?? "application/json", "Cache-Control": "no-store",
+            "X-Content-Type-Options": "nosniff", "Connection": "close",
+            ...(result.disposition ? { "Content-Disposition": result.disposition } : {}) });
         response.end(result.body);
     };
     const fail = (status, code, message) => send(apiError(status, code, message));
@@ -46,14 +49,15 @@ const server = createServer(async (request, response) => {
             const length = request.headers["content-length"];
             if (!length || !/^\d+$/.test(length))
                 return fail(411, "request_error", "a valid Content-Length is required");
-            if (Number(length) > 65536)
+            const limit = path === "/api/resumes/import" || /^\/api\/resumes\/[^/]+\/(replace|adopt)$/.test(path) ? maxUpload : maxBody;
+            if (Number(length) > limit)
                 return fail(413, "request_error", "request body is too large");
             request.setTimeout(30_000, () => request.destroy());
             const chunks = [];
             let size = 0;
             for await (const chunk of request) {
                 size += chunk.length;
-                if (size > 65536)
+                if (size > limit)
                     return fail(413, "request_error", "request body is too large");
                 chunks.push(Buffer.from(chunk));
             }

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,11 +1,14 @@
 import { profileCommands, runProfileCommand } from "./native-profile.js";
 import { readFile } from "node:fs/promises";
 import { realpathSync } from "node:fs";
+import { basename } from "node:path";
 import { pathToFileURL } from "node:url";
 import { JobsService } from "../workspace-core/jobs.js";
 import { NativeJobsRepository, initializeJobsFixture, fixtureError } from "../store/native-jobs.js";
 import { loadPosixFlockProvider } from "../store/posix-flock.js";
 import { parse, serialize, JobsError } from "../contracts/workspace/values.js";
+import { ResumeService } from "../workspace-core/resumes.js";
+import { NativeResumeFiles } from "../store/native-resume-files.js";
 export async function runJobsCli(args, input) {
     const options = new Map();
     let command;
@@ -34,6 +37,10 @@ export async function runJobsCli(args, input) {
         "fixture-init": [], "job-create": ["--input", "--origin"], "job-get": ["--id", "--include-trashed"],
         "job-list": ["--status", "--include-trashed", "--trashed-only"],
         "job-update": ["--id", "--input", "--expected-revision", "--origin"],
+        "resume-import": ["--input", "--path"], "resume-get": ["--id", "--include-trashed"],
+        "resume-list": ["--include-trashed", "--trashed-only"], "resume-update": ["--id", "--input", "--expected-revision"],
+        "resume-replace": ["--id", "--path", "--expected-revision"], "resume-adopt": ["--id", "--path", "--expected-revision"],
+        "resume-set-default": ["--id", "--expected-revision"], "resume-resolve": ["--id"], "resume-check": ["--id"],
     };
     const allowed = fields[command ?? ""];
     if (!allowed || [...options.keys()].some(key => !["--root", "--native-lock", ...allowed].includes(key))) {
@@ -52,12 +59,25 @@ export async function runJobsCli(args, input) {
     }
     const repository = new NativeJobsRepository(root, loadPosixFlockProvider(required("--native-lock")));
     const service = new JobsService(repository);
+    const resumes = new ResumeService(repository);
     const payload = async () => {
         const file = required("--input");
         return parse(file === "-" ? await input() : await readFile(file, "utf8"));
     };
     if (Object.hasOwn(profileCommands, command))
         return serialize(await runProfileCommand(command, repository, options, payload));
+    if (command === "resume-import") {
+        const path = required("--path"), content = await new NativeResumeFiles(root).readPath(path);
+        return serialize(await resumes.import(await payload(), basename(path), content, true));
+    }
+    if (command === "resume-get")
+        return serialize(await resumes.get(required("--id"), options.has("--include-trashed")));
+    if (command === "resume-list")
+        return serialize(await resumes.list(options.has("--include-trashed"), options.has("--trashed-only")));
+    if (command === "resume-resolve")
+        return serialize(await resumes.resolve(options.get("--id")));
+    if (command === "resume-check")
+        return serialize(await resumes.check(required("--id")));
     if (command === "job-create")
         return serialize(await service.create(await payload(), options.get("--origin")));
     if (command === "job-get")
@@ -70,6 +90,14 @@ export async function runJobsCli(args, input) {
     const revision = required("--expected-revision");
     if (!/^[0-9]+$/.test(revision) || BigInt(revision) < 1n)
         throw new JobsError("expected revision must be a positive integer");
+    if (command === "resume-update")
+        return serialize(await resumes.update(required("--id"), await payload(), BigInt(revision)));
+    if (command === "resume-set-default")
+        return serialize(await resumes.setDefault(required("--id"), BigInt(revision)));
+    if (command === "resume-replace" || command === "resume-adopt") {
+        const path = required("--path"), content = await new NativeResumeFiles(root).readPath(path);
+        return serialize(await resumes.replace(required("--id"), basename(path), content, BigInt(revision), command === "resume-adopt", true));
+    }
     return serialize(await service.update(required("--id"), await payload(), BigInt(revision), options.get("--origin")));
 }
 if (process.argv[1] && pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url) {

--- a/runtime/contracts/workspace/resume-content.js
+++ b/runtime/contracts/workspace/resume-content.js
@@ -51,7 +51,7 @@ export function validateResumeContent(filename, content) {
     if (!content.length)
         throw new JobsError('resume file is empty');
     try {
-        if (extension === '.pdf' && content.subarray(0, 5).toString('ascii') !== '%PDF-')
+        if (extension === '.pdf' && !content.subarray(0, 5).equals(Buffer.from('%PDF-')))
             throw Error('pdf');
         if (extension === '.txt') {
             if (content.includes(0))

--- a/runtime/contracts/workspace/resume-content.js
+++ b/runtime/contracts/workspace/resume-content.js
@@ -1,0 +1,72 @@
+import { posix } from 'node:path';
+import { JobsError } from './values.js';
+export const resumeLimit = 10 * 1024 * 1024;
+export const resumeMedia = {
+    '.pdf': 'application/pdf',
+    '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    '.txt': 'text/plain; charset=utf-8',
+};
+export function resumeExtension(filename) {
+    if (!filename || posix.basename(filename) !== filename || filename.includes('\0') || ['.', '..'].includes(filename))
+        throw new JobsError('resume filename is invalid');
+    const extension = posix.extname(filename).toLowerCase();
+    if (!Object.hasOwn(resumeMedia, extension))
+        throw new JobsError('resume format must be PDF, DOCX, or UTF-8 TXT');
+    return extension;
+}
+/** Validate the ZIP directory without extracting or inflating untrusted content. */
+function docxNames(bytes) {
+    let end = -1;
+    for (let offset = bytes.length - 22; offset >= Math.max(0, bytes.length - 65557); offset--) {
+        if (bytes.readUInt32LE(offset) === 0x06054b50 && offset + 22 + bytes.readUInt16LE(offset + 20) === bytes.length) {
+            end = offset;
+            break;
+        }
+    }
+    if (end < 0 || bytes.readUInt16LE(end + 4) || bytes.readUInt16LE(end + 6))
+        throw Error('zip');
+    const count = bytes.readUInt16LE(end + 10), size = bytes.readUInt32LE(end + 12);
+    if (count === 65535 || bytes.readUInt16LE(end + 8) !== count || size > end)
+        throw Error('zip');
+    let offset = end - size;
+    const names = [];
+    for (let i = 0; i < count; i++) {
+        if (offset + 46 > end || bytes.readUInt32LE(offset) !== 0x02014b50)
+            throw Error('zip');
+        const length = bytes.readUInt16LE(offset + 28), extra = bytes.readUInt16LE(offset + 30), comment = bytes.readUInt16LE(offset + 32);
+        if (offset + 46 + length + extra + comment > end)
+            throw Error('zip');
+        const name = bytes.subarray(offset + 46, offset + 46 + length).toString('utf8').split('\0')[0];
+        names.push(name);
+        offset += 46 + length + extra + comment;
+    }
+    if (offset !== end)
+        throw Error('zip');
+    return names;
+}
+export function validateResumeContent(filename, content) {
+    const extension = resumeExtension(filename);
+    if (content.length > resumeLimit)
+        throw new JobsError('resume file exceeds the 10 MiB limit');
+    if (!content.length)
+        throw new JobsError('resume file is empty');
+    try {
+        if (extension === '.pdf' && content.subarray(0, 5).toString('ascii') !== '%PDF-')
+            throw Error('pdf');
+        if (extension === '.txt') {
+            if (content.includes(0))
+                throw Error('nul');
+            new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(content);
+        }
+        if (extension === '.docx') {
+            const names = docxNames(content);
+            if (!names.includes('[Content_Types].xml') || !names.includes('word/document.xml')
+                || names.some(name => name.startsWith('/') || name.replaceAll('\\', '/').split('/').includes('..')))
+                throw Error('docx');
+        }
+    }
+    catch {
+        throw new JobsError('resume content does not match its extension');
+    }
+    return { extension, mediaType: resumeMedia[extension] };
+}

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -1,17 +1,20 @@
 import { constants } from "node:fs";
-import { lstat, mkdir, open, readdir, realpath } from "node:fs/promises";
+import { chmod, lstat, mkdir, open, readdir, realpath } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
 import { parsePythonPointJsonBytes } from "../contracts/raw-json/point-parser.js";
 import { validateJobsDocument, safeId } from "../contracts/workspace/jobs.js";
 import { validateResumeReferences } from "../contracts/workspace/resume-reference.js";
-import { fromJSON, get, int, object, string, serialize, JobsError } from "../contracts/workspace/values.js";
+import { fromJSON, get, int, object, set, string, serialize, JobsError } from "../contracts/workspace/values.js";
 import { atomicWritePointJson } from "./point-persistence.js";
 import { withExclusiveFileLock } from "./exclusive-file-lock.js";
+import { NativeResumeFiles } from "./native-resume-files.js";
 import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 };
-const marker = '{"mode":"native-jobs-fixture","version":2}\n';
-const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json"]);
+const marker = '{"mode":"native-jobs-fixture","version":3}\n';
+const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "resume-operation.json", "resume-files"]);
+const journalName = "resume-operation";
+const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 };
 /** Creates a NEW synthetic root only. Never adopts or initializes an existing Store. */
 export async function initializeJobsFixture(root) {
     if (!isAbsolute(root) || root !== resolve(root))
@@ -24,6 +27,9 @@ export async function initializeJobsFixture(root) {
                 : { schemaVersion: 1, [name]: {}, metadata: { updatedAt: now } };
         await atomicWritePointJson(join(root, `${name}.json`), fromJSON(payload), options);
     }
+    await atomicWritePointJson(join(root, `${journalName}.json`), fromJSON({ schemaVersion: 1, operation: null }), options);
+    await mkdir(join(root, "resume-files"), { mode: 0o700 });
+    await chmod(join(root, "resume-files"), 0o700);
     const lock = await open(join(root, ".store.lock"), "wx", 0o600);
     await lock.close();
     // The readiness marker is written last; partial initialization is never adopted.
@@ -93,14 +99,42 @@ export class NativeJobsRepository {
         object(get(value, "metadata"), `${name}.metadata`);
         return value;
     }
+    async journal() {
+        const value = object(parsePythonPointJsonBytes(await this.read(`${journalName}.json`), {
+            diagnosticProfile: "3.12", intMaxStrDigits: 4300,
+        }), journalName);
+        if (int(get(value, "schemaVersion")) !== 1n)
+            throw new JobsError("resume recovery schema version is unsupported");
+        return value;
+    }
+    async saveJournal(operation) {
+        const journal = fromJSON({ schemaVersion: 1, operation: null });
+        set(journal, "operation", operation);
+        await this.write(join(this.root, `${journalName}.json`), journal, documentOptions);
+    }
+    async recoverResumes() {
+        const files = new NativeResumeFiles(this.root);
+        const journal = await this.journal();
+        if (journal.size !== 2)
+            throw new JobsError("invalid resume recovery journal");
+        let resumes = await this.document("resumes");
+        const operation = get(journal, "operation");
+        await files.recover(operation === null ? null : object(operation, "resume recovery operation"), resumes, async (document) => {
+            validateResumeReferences(object(get(document, "resumes"), "resumes.resumes"));
+            await this.write(join(this.root, "resumes.json"), document, documentOptions);
+            resumes = document;
+        }, async () => this.saveJournal(null));
+        return resumes;
+    }
     async transaction(operation) {
         await this.validateRoot();
         return withExclusiveFileLock(join(this.root, ".store.lock"), async () => {
             await this.validateRoot(true);
+            const resumesDocument = await this.recoverResumes();
             const document = validateJobsDocument(await this.document("jobs"));
             // Read-only projections: no Python initialization, repair, extraction or preflight.
             object(get(await this.document("profile"), "profile"), "profile.profile");
-            const resumes = object(get(await this.document("resumes"), "resumes"), "resumes.resumes");
+            const resumes = object(get(resumesDocument, "resumes"), "resumes.resumes");
             validateResumeReferences(resumes);
             return operation({ document,
                 requireResume: async (id) => {
@@ -121,6 +155,22 @@ export class NativeJobsRepository {
                     validateJobsDocument(value);
                     await this.write(join(this.root, "jobs.json"), value, options);
                 }, });
+        }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
+    }
+    async resumeTransaction(operation) {
+        await this.validateRoot();
+        return withExclusiveFileLock(join(this.root, ".store.lock"), async () => {
+            await this.validateRoot(true);
+            const files = new NativeResumeFiles(this.root);
+            const document = await this.recoverResumes();
+            validateResumeReferences(object(get(document, "resumes"), "resumes.resumes"));
+            return operation({ document, files,
+                save: async (value) => {
+                    validateResumeReferences(object(get(value, "resumes"), "resumes.resumes"));
+                    await this.write(join(this.root, "resumes.json"), value, documentOptions);
+                },
+                saveJournal: async (value) => this.saveJournal(value),
+            });
         }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
     }
     async profileTransaction(operation) {

--- a/runtime/store/native-resume-files.js
+++ b/runtime/store/native-resume-files.js
@@ -1,0 +1,228 @@
+import { constants } from 'node:fs';
+import { lstat, open, readdir, rename, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+import { resumeLimit, validateResumeContent } from '../contracts/workspace/resume-content.js';
+import { get, has, int, integer, keys, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { resumeModifiedAt } from './resume-modified-at.js';
+const filePattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\.(pdf|docx|txt)$/;
+const tempPattern = /^\.native-[a-f0-9-]{36}\.tmp$/;
+const hash = (bytes) => createHash('sha256').update(bytes).digest('hex');
+const absent = (error) => error instanceof Error && 'code' in error && error.code === 'ENOENT';
+export async function syncDirectory(path) {
+    const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    try {
+        await handle.sync();
+    }
+    finally {
+        await handle.close();
+    }
+}
+export class NativeResumeFiles {
+    checkpoint;
+    directory;
+    constructor(root, checkpoint = async () => { }) {
+        this.checkpoint = checkpoint;
+        this.directory = join(root, 'resume-files');
+    }
+    async validate() {
+        const metadata = await lstat(this.directory);
+        if (!metadata.isDirectory() || metadata.isSymbolicLink() || metadata.uid !== process.getuid?.() || metadata.mode & 0o077)
+            throw new JobsError('resume directory must be private and owned');
+        for (const name of await readdir(this.directory)) {
+            if (!filePattern.test(name) && !tempPattern.test(name))
+                throw new JobsError('unsupported resume recovery state');
+            const stat = await lstat(join(this.directory, name));
+            if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || stat.uid !== process.getuid?.() || stat.mode & 0o077)
+                throw new JobsError('resume file must be private and owned, without links');
+        }
+    }
+    async readPath(path, privateFile = false) {
+        let handle;
+        try {
+            handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+            const before = await handle.stat({ bigint: true });
+            if (!before.isFile() || before.size > BigInt(resumeLimit) || privateFile && (before.nlink !== 1n || before.uid !== BigInt(process.getuid()) || (before.mode & 63n) !== 0n))
+                throw Error('file');
+            const parts = [];
+            let size = 0;
+            while (true) {
+                const buffer = Buffer.alloc(Math.min(1024 * 1024, resumeLimit + 1 - size));
+                const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+                if (!bytesRead)
+                    break;
+                parts.push(buffer.subarray(0, bytesRead));
+                size += bytesRead;
+                if (size > resumeLimit)
+                    throw new JobsError('resume file exceeds the 10 MiB limit');
+            }
+            const after = await handle.stat({ bigint: true }), pathStat = await lstat(path, { bigint: true });
+            if (size !== Number(before.size) || ['dev', 'ino', 'size', 'mtimeNs', 'ctimeNs'].some(key => before[key] !== after[key])
+                || pathStat.dev !== after.dev || pathStat.ino !== after.ino || pathStat.isSymbolicLink())
+                throw new JobsError('resume source changed during import');
+            return Buffer.concat(parts);
+        }
+        catch (error) {
+            if (error instanceof JobsError)
+                throw error;
+            throw new JobsError(privateFile ? 'managed resume content is unavailable' : 'resume source must be a readable regular file');
+        }
+        finally {
+            await handle?.close();
+        }
+    }
+    async stage(id, filename, content) {
+        const { extension, mediaType } = validateResumeContent(filename, content);
+        const temporary = `.native-${randomUUID()}.tmp`, path = join(this.directory, temporary);
+        const handle = await open(path, 'wx', 0o600);
+        try {
+            await handle.writeFile(content);
+            await handle.sync();
+            const stat = await handle.stat();
+            await syncDirectory(this.directory);
+            return { temporary, managedFile: id + extension, originalFilename: filename, mediaType,
+                digest: hash(content), observedSize: content.length, observedModifiedAt: resumeModifiedAt(stat.mtimeMs / 1000) };
+        }
+        catch (error) {
+            await unlink(path).catch(() => { });
+            throw error;
+        }
+        finally {
+            await handle.close();
+        }
+    }
+    async discard(stage) {
+        try {
+            await unlink(join(this.directory, stage.temporary));
+        }
+        catch (error) {
+            if (!absent(error))
+                throw error;
+        }
+    }
+    async content(record) {
+        if (string(get(record, 'storageKind')) !== 'managed')
+            throw new JobsError('resume must be adopted before use');
+        const bytes = await this.readPath(join(this.directory, string(get(record, 'managedFile'))), true);
+        if (hash(bytes) !== string(get(record, 'digest')))
+            throw new JobsError('managed resume content is unavailable');
+        return bytes;
+    }
+    path(record) {
+        if (string(get(record, 'storageKind')) !== 'managed')
+            throw new JobsError('resume must be adopted before use');
+        const file = string(get(record, 'managedFile'));
+        if (!file || !filePattern.test(file))
+            throw new JobsError('managed resume content is unavailable');
+        return join(this.directory, file);
+    }
+    async observation(record) {
+        const path = this.path(record);
+        let stat;
+        try {
+            stat = await lstat(path);
+        }
+        catch (error) {
+            if (absent(error))
+                return { exists: false, size: null, modifiedAt: null, digest: null };
+            throw error;
+        }
+        const bytes = await this.readPath(path, true);
+        stat = await lstat(path);
+        return { exists: true, size: bytes.length, modifiedAt: resumeModifiedAt(stat.mtimeMs / 1000), digest: hash(bytes) };
+    }
+    async externalObservation(path) {
+        try {
+            const stat = await lstat(path);
+            if (!stat.isFile() || stat.isSymbolicLink())
+                throw new JobsError('resume source must be a readable regular file');
+            return { exists: true, size: stat.size, modifiedAt: resumeModifiedAt(stat.mtimeMs / 1000), digest: null };
+        }
+        catch (error) {
+            if (absent(error))
+                return { exists: false, size: null, modifiedAt: null, digest: null };
+            throw error;
+        }
+    }
+    /** Journal is durable before any canonical rename. Recovery completes only its exact intended record. */
+    async install(stage, document, previous, saveJournal, save) {
+        const journal = emptyObject();
+        set(journal, 'version', integer(1n));
+        set(journal, 'kind', text('install'));
+        set(journal, 'temporary', text(stage.temporary));
+        set(journal, 'destination', text(stage.managedFile));
+        set(journal, 'previous', previous === null ? null : text(previous));
+        set(journal, 'digest', text(stage.digest));
+        set(journal, 'document', document);
+        await saveJournal(journal);
+        await this.checkpoint('journal');
+        await rename(join(this.directory, stage.temporary), join(this.directory, stage.managedFile));
+        await syncDirectory(this.directory);
+        await this.checkpoint('installed');
+        await save(document);
+        await this.checkpoint('metadata');
+        if (previous && previous !== stage.managedFile) {
+            try {
+                await unlink(join(this.directory, previous));
+            }
+            catch (error) {
+                if (!absent(error))
+                    throw error;
+            }
+        }
+        await syncDirectory(this.directory);
+        await saveJournal(null);
+        await this.checkpoint('cleared');
+    }
+    async recover(journal, current, save, clear) {
+        await this.validate();
+        if (journal) {
+            if (int(get(journal, 'version')) !== 1n || string(get(journal, 'kind')) !== 'install' || journal.size !== 7
+                || keys(journal).some(key => !['version', 'kind', 'temporary', 'destination', 'previous', 'digest', 'document'].includes(key)))
+                throw new JobsError('invalid resume recovery journal');
+            const temporary = string(get(journal, 'temporary')), destination = string(get(journal, 'destination')), previous = string(get(journal, 'previous')), digest = string(get(journal, 'digest'));
+            if (!temporary || !tempPattern.test(temporary) || !destination || !filePattern.test(destination) || !digest || !/^[a-f0-9]{64}$/.test(digest)
+                || get(journal, 'previous') !== null && (!previous || !filePattern.test(previous)))
+                throw new JobsError('invalid resume recovery journal');
+            const document = object(get(journal, 'document'), 'resume recovery document');
+            const records = object(get(document, 'resumes'), 'resumes.resumes');
+            const matches = records.entries().filter(([, value]) => string(get(object(value, 'resume'), 'managedFile')) === destination && string(get(object(value, 'resume'), 'digest')) === digest);
+            if (matches.length !== 1)
+                throw new JobsError('resume recovery identity differs');
+            const oldRecords = object(get(current, 'resumes'), 'resumes.resumes');
+            const targetId = string(matches[0][0]);
+            if (previous && (!has(oldRecords, targetId) || ![previous, destination].includes(string(get(object(get(oldRecords, targetId), 'resume'), 'managedFile')))))
+                throw new JobsError('resume recovery previous identity differs');
+            let installed = false;
+            try {
+                installed = hash(await this.readPath(join(this.directory, destination), true)) === digest;
+            }
+            catch { /* Staged bytes must prove the expected digest below. */ }
+            if (!installed) {
+                const bytes = await this.readPath(join(this.directory, temporary), true);
+                if (hash(bytes) !== digest)
+                    throw new JobsError('resume recovery bytes are unavailable');
+                await rename(join(this.directory, temporary), join(this.directory, destination));
+                await syncDirectory(this.directory);
+            }
+            await save(document);
+            if (previous && previous !== destination) {
+                try {
+                    await unlink(join(this.directory, previous));
+                }
+                catch (error) {
+                    if (!absent(error))
+                        throw error;
+                }
+            }
+            await syncDirectory(this.directory);
+            await clear();
+        }
+        // Only owned native staging names are collected under the Store lock.
+        for (const name of await readdir(this.directory))
+            if (tempPattern.test(name))
+                await unlink(join(this.directory, name));
+        await syncDirectory(this.directory);
+    }
+}

--- a/runtime/workspace-core/jobs-http.js
+++ b/runtime/workspace-core/jobs-http.js
@@ -3,12 +3,17 @@ import { fixtureError } from "../store/native-jobs.js";
 import { JobsError, fromJSON, get, int, keys, object, parse, serialize, set } from "../contracts/workspace/values.js";
 import { emptyObject } from "../contracts/workspace/jobs.js";
 import { PythonObject } from "../contracts/python-object.js";
+import { ResumeService } from "./resumes.js";
+import { resumesHttp } from "./resumes-http.js";
 const response = (value, status = 200) => ({ status, body: serialize(value) });
 export const apiError = (status, code, message) => response(fromJSON({ error: { code, message } }), status);
 const envelope = (key, value) => set(emptyObject(), key, value);
 /** Transport-independent dispatch. Host/token/Origin/body bounds belong to the adapter. */
 export async function jobsHttp(service, repository, method, path, body = "") {
     try {
+        const resumes = await resumesHttp(new ResumeService(repository), method, path, body);
+        if (resumes)
+            return resumes;
         const facts = await profileHttp(repository, method, path, body);
         if (facts)
             return facts;
@@ -54,9 +59,12 @@ export async function jobsHttp(service, repository, method, path, body = "") {
     catch (error) {
         if (error instanceof JobsError) {
             return error.message.includes("revision conflict") ? apiError(409, "revision_conflict", error.message)
-                : error.message.includes("does not exist") ? apiError(404, "not_found", error.message)
-                    : error.message === "active job URL already exists" ? apiError(409, "duplicate_active_blocked", error.message)
-                        : apiError(400, "store_rejected", error.message);
+                : error.message.includes("content is too large") ? apiError(413, "request_error", error.message)
+                    : error.message === "managed resume content is unavailable" ? apiError(409, "content_unavailable", error.message)
+                        : error.message.includes("does not exist") ? apiError(404, "not_found", error.message)
+                            : error.message === "active job URL already exists" ? apiError(409, "duplicate_active_blocked", error.message)
+                                : ["resume id already exists", "resume file is already managed"].includes(error.message) ? apiError(409, "duplicate_resume_blocked", error.message)
+                                    : apiError(400, "store_rejected", error.message);
         }
         if (error instanceof Error && ["JSONDecodeError", "ValueError"].includes(error.name)) {
             return apiError(400, "request_error", "body must be valid JSON");

--- a/runtime/workspace-core/resumes-http.js
+++ b/runtime/workspace-core/resumes-http.js
@@ -1,0 +1,84 @@
+import { resumeLimit } from '../contracts/workspace/resume-content.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { copy, fromJSON, get, int, keys, object, parse, serialize, set, string, text, JobsError } from '../contracts/workspace/values.js';
+const hidden = ['path', 'managedFile', 'originalFilename', 'digest', 'contentRevision'];
+export function publicResume(record) {
+    const result = copy(record);
+    for (const field of hidden)
+        result.delete(text(field));
+    return result;
+}
+const response = (value, status = 200) => ({ status, body: serialize(value) });
+function upload(body) {
+    const payload = object(parse(body), 'body');
+    if (payload.size !== 3 || keys(payload).some(key => !['metadata', 'filename', 'content'].includes(key))) {
+        throw new JobsError('upload body requires metadata, filename, and content');
+    }
+    object(get(payload, 'metadata'), 'upload metadata');
+    const filename = string(get(payload, 'filename')), encoded = string(get(payload, 'content'));
+    if (filename === null || encoded === null)
+        throw new JobsError('upload envelope fields have invalid types');
+    if (encoded.length > Math.ceil(resumeLimit / 3) * 4)
+        throw new JobsError('encoded resume content is too large');
+    if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(encoded)) {
+        throw new JobsError('resume content must be strict base64');
+    }
+    const content = Buffer.from(encoded, 'base64');
+    if (content.length > resumeLimit)
+        throw new JobsError('decoded resume content is too large');
+    return { metadata: get(payload, 'metadata'), filename, content };
+}
+function expected(value) {
+    const payload = object(value, 'body');
+    if (payload.size !== 1 || keys(payload)[0] !== 'expectedRevision')
+        throw new JobsError('body requires expectedRevision');
+    const revision = int(get(payload, 'expectedRevision'));
+    if (revision === null || revision < 1n)
+        throw new JobsError('expectedRevision must be a positive integer');
+    return revision;
+}
+export async function resumesHttp(service, method, path, body) {
+    if (method === 'GET' && path === '/api/resumes') {
+        const result = emptyObject();
+        set(result, 'resumes', (await service.list()).map(publicResume));
+        return response(result);
+    }
+    const match = /^\/api\/resumes\/([^/]+)$/.exec(path);
+    if (method === 'GET' && match) {
+        const record = await service.get(decodeURIComponent(match[1]));
+        return record === null ? responseError(404, 'not_found', 'resume does not exist') : response(publicResume(record));
+    }
+    const contentMatch = /^\/api\/resumes\/([^/]+)\/content$/.exec(path);
+    if (method === 'GET' && contentMatch) {
+        const { record, content } = await service.content(decodeURIComponent(contentMatch[1]));
+        const mediaType = string(get(record, 'mediaType')), extension = mediaType === 'application/pdf' ? '.pdf'
+            : mediaType.startsWith('text/plain') ? '.txt' : '.docx';
+        return { status: 200, body: content, contentType: mediaType,
+            disposition: `${extension === '.docx' ? 'attachment' : 'inline'}; filename="resume-${string(get(record, 'id'))}${extension}"` };
+    }
+    if (method === 'POST' && path === '/api/resumes/import') {
+        const value = upload(body);
+        return response(publicResume(await service.import(value.metadata, value.filename, value.content)));
+    }
+    if (method === 'PATCH' && match) {
+        const payload = object(parse(body), 'body');
+        if (payload.size !== 2 || keys(payload).some(key => !['patch', 'expectedRevision'].includes(key)))
+            throw new JobsError('body requires patch and expectedRevision');
+        const revision = int(get(payload, 'expectedRevision'));
+        if (revision === null || revision < 1n)
+            throw new JobsError('expectedRevision must be a positive integer');
+        return response(publicResume(await service.update(decodeURIComponent(match[1]), get(payload, 'patch'), revision)));
+    }
+    const action = /^\/api\/resumes\/([^/]+)\/(replace|adopt|default)$/.exec(path);
+    if (method === 'POST' && action) {
+        const id = decodeURIComponent(action[1]);
+        if (action[2] === 'default')
+            return response(publicResume(await service.setDefault(id, expected(parse(body)))));
+        const value = upload(body), revision = expected(value.metadata);
+        return response(publicResume(await service.replace(id, value.filename, value.content, revision, action[2] === 'adopt')));
+    }
+    return path.startsWith('/api/resumes') ? responseError(501, 'unsupported_native_workflow', 'This native resume workflow is not available yet.') : null;
+}
+function responseError(status, code, message) {
+    return response(fromJSON({ error: { code, message } }), status);
+}

--- a/runtime/workspace-core/resumes.js
+++ b/runtime/workspace-core/resumes.js
@@ -1,0 +1,285 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import { casefold } from '../contracts/workspace/casefold.js';
+import { safeId, emptyObject } from '../contracts/workspace/jobs.js';
+import { strip } from '../contracts/workspace/job-url.js';
+import { validateResumeReferences } from '../contracts/workspace/resume-reference.js';
+import { resumeExtension } from '../contracts/workspace/resume-content.js';
+import { copy, get, has, int, integer, keys, object, set, string, text, truth, JobsError } from '../contracts/workspace/values.js';
+const compareText = (left, right) => {
+    const a = [...left], b = [...right];
+    for (let index = 0; index < Math.min(a.length, b.length); index++) {
+        const difference = a[index].codePointAt(0) - b[index].codePointAt(0);
+        if (difference)
+            return difference;
+    }
+    return a.length - b.length;
+};
+const active = (record) => get(record, 'deletedAt') === null;
+function tags(value) {
+    if (!Array.isArray(value))
+        throw new JobsError('resume tags must be a list');
+    const result = value.map(item => {
+        const tag = string(item);
+        if (tag === null)
+            throw new JobsError('resume tags must be non-empty strings');
+        return strip(tag);
+    });
+    if (result.some(tag => !tag))
+        throw new JobsError('resume tags must be non-empty strings');
+    if (new Set(result).size !== result.length)
+        throw new JobsError('resume tags must be unique');
+    return result;
+}
+export function resumeMetadata(value, patch = false) {
+    const input = object(value, patch ? 'resume patch' : 'resume input');
+    const allowed = patch ? ['label', 'tags'] : ['id', 'label', 'tags', 'default'];
+    if (patch && !input.size || keys(input).some(key => !allowed.includes(key))) {
+        throw new JobsError(`resume ${patch ? 'patch' : 'input'} contains unsupported fields`);
+    }
+    const result = {};
+    if (has(input, 'id') && truth(get(input, 'id')))
+        result.id = safeId(string(get(input, 'id')));
+    if (has(input, 'label')) {
+        const label = string(get(input, 'label'));
+        if (label === null || !strip(label))
+            throw new JobsError('resume label must be a non-empty string');
+        result.label = strip(label);
+    }
+    else if (!patch)
+        throw new JobsError('resume label must be a non-empty string');
+    if (has(input, 'tags'))
+        result.tags = tags(get(input, 'tags'));
+    else if (!patch)
+        result.tags = [];
+    if (has(input, 'default')) {
+        if (typeof get(input, 'default') !== 'boolean')
+            throw new JobsError('resume default must be a boolean');
+        result.default = get(input, 'default');
+    }
+    return result;
+}
+function updatedDocument(document) {
+    const next = copy(document), records = copy(object(get(document, 'resumes'), 'resumes.resumes'));
+    const metadata = copy(object(get(document, 'metadata'), 'resumes.metadata'));
+    set(next, 'resumes', records);
+    set(next, 'metadata', metadata);
+    return { document: next, records, metadata };
+}
+function applyStage(record, stage, contentRevision) {
+    set(record, 'storageKind', text('managed'));
+    set(record, 'managedFile', text(stage.managedFile));
+    set(record, 'originalFilename', text(stage.originalFilename));
+    set(record, 'mediaType', text(stage.mediaType));
+    set(record, 'digest', text(stage.digest));
+    set(record, 'contentRevision', text(contentRevision));
+    set(record, 'observedSize', integer(BigInt(stage.observedSize)));
+    set(record, 'observedModifiedAt', text(stage.observedModifiedAt));
+}
+export class ResumeService {
+    repository;
+    now;
+    id;
+    contentRevision;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'), id = () => `resume-${randomUUID()}`, contentRevision = () => `content_${randomBytes(24).toString('base64url')}`) {
+        this.repository = repository;
+        this.now = now;
+        this.id = id;
+        this.contentRevision = contentRevision;
+    }
+    uploadedFilename(filename, preserve) {
+        return preserve ? filename : `.browser-upload.${randomBytes(6).toString('base64url')}${resumeExtension(filename)}`;
+    }
+    import(value, filename, content, preserveFilename = false) {
+        const input = resumeMetadata(value), id = safeId(input.id ?? this.id());
+        return this.repository.resumeTransaction(async (transaction) => {
+            const { document, records, metadata } = updatedDocument(transaction.document);
+            if (has(records, id))
+                throw new JobsError('resume id already exists');
+            const stage = await transaction.files.stage(id, this.uploadedFilename(filename, preserveFilename), content);
+            if (records.entries().some(([, item]) => string(get(object(item, 'resume record'), 'digest')) === stage.digest)) {
+                await transaction.files.discard(stage);
+                throw new JobsError('resume file is already managed');
+            }
+            const timestamp = this.now(), activeRecords = records.entries().map(([, item]) => object(item, 'resume record')).filter(active);
+            const makeDefault = input.default ?? activeRecords.length === 0;
+            if (makeDefault)
+                for (const [key, item] of records.entries()) {
+                    const record = object(item, 'resume record');
+                    if (active(record) && get(record, 'default') === true) {
+                        const changed = copy(record);
+                        set(changed, 'default', false);
+                        set(changed, 'revision', integer(int(get(record, 'revision')) + 1n));
+                        set(changed, 'updatedAt', text(timestamp));
+                        set(records, string(key), changed);
+                    }
+                }
+            const record = emptyObject();
+            set(record, 'id', text(id));
+            set(record, 'label', text(input.label));
+            applyStage(record, stage, this.contentRevision());
+            set(record, 'tags', input.tags.map(text));
+            set(record, 'default', makeDefault);
+            set(record, 'revision', integer(1n));
+            set(record, 'createdAt', text(timestamp));
+            set(record, 'updatedAt', text(timestamp));
+            set(record, 'deletedAt', null);
+            set(records, id, record);
+            set(metadata, 'updatedAt', text(timestamp));
+            validateResumeReferences(records);
+            await transaction.files.install(stage, document, null, transaction.saveJournal, transaction.save);
+            return record;
+        });
+    }
+    get(id, includeTrashed = false) {
+        safeId(id);
+        return this.repository.resumeTransaction(async ({ document }) => {
+            const value = get(object(get(document, 'resumes'), 'resumes.resumes'), id);
+            if (value === null)
+                return null;
+            const record = object(value, 'resume record');
+            return includeTrashed || active(record) ? record : null;
+        });
+    }
+    list(includeTrashed = false, trashedOnly = false) {
+        return this.repository.resumeTransaction(async ({ document }) => object(get(document, 'resumes'), 'resumes.resumes').entries()
+            .map(([, value]) => object(value, 'resume record'))
+            .filter(record => (includeTrashed || trashedOnly || active(record)) && (!trashedOnly || !active(record)))
+            .sort((a, b) => Number(get(b, 'default')) - Number(get(a, 'default'))
+            || compareText(casefold(string(get(a, 'label'))), casefold(string(get(b, 'label'))))
+            || compareText(string(get(a, 'id')), string(get(b, 'id')))));
+    }
+    update(id, value, expectedRevision) {
+        safeId(id);
+        const patch = resumeMetadata(value, true);
+        return this.repository.resumeTransaction(async (transaction) => {
+            const { document, records, metadata } = updatedDocument(transaction.document);
+            const value = get(records, id);
+            if (value === null || !active(object(value, 'resume record')))
+                throw new JobsError('resume does not exist');
+            const current = object(value, 'resume record');
+            if (int(get(current, 'revision')) !== expectedRevision)
+                throw new JobsError('resume revision conflict');
+            const record = copy(current), timestamp = this.now();
+            if (patch.label !== undefined)
+                set(record, 'label', text(patch.label));
+            if (patch.tags !== undefined)
+                set(record, 'tags', patch.tags.map(text));
+            set(record, 'revision', integer(expectedRevision + 1n));
+            set(record, 'updatedAt', text(timestamp));
+            set(records, id, record);
+            set(metadata, 'updatedAt', text(timestamp));
+            validateResumeReferences(records);
+            await transaction.save(document);
+            return record;
+        });
+    }
+    replace(id, filename, content, expectedRevision, adopt = false, preserveFilename = false) {
+        safeId(id);
+        return this.repository.resumeTransaction(async (transaction) => {
+            const { document, records, metadata } = updatedDocument(transaction.document);
+            const value = get(records, id);
+            if (value === null || !active(object(value, 'resume record')))
+                throw new JobsError('resume does not exist');
+            const current = object(value, 'resume record'), managed = string(get(current, 'storageKind')) === 'managed';
+            if (int(get(current, 'revision')) !== expectedRevision)
+                throw new JobsError('resume revision conflict');
+            if (adopt === managed)
+                throw new JobsError(managed ? 'resume is already managed' : 'legacy resume bytes require resume-adopt');
+            const stage = await transaction.files.stage(id, this.uploadedFilename(filename, preserveFilename), content);
+            if (records.entries().some(([key, item]) => string(key) !== id && string(get(object(item, 'resume record'), 'digest')) === stage.digest)) {
+                await transaction.files.discard(stage);
+                throw new JobsError('resume file is already managed');
+            }
+            const record = copy(current), timestamp = this.now();
+            if (has(record, 'path'))
+                record.delete(text('path'));
+            applyStage(record, stage, this.contentRevision());
+            set(record, 'revision', integer(expectedRevision + 1n));
+            set(record, 'updatedAt', text(timestamp));
+            set(records, id, record);
+            set(metadata, 'updatedAt', text(timestamp));
+            validateResumeReferences(records);
+            await transaction.files.install(stage, document, managed ? string(get(current, 'managedFile')) : null, transaction.saveJournal, transaction.save);
+            return record;
+        });
+    }
+    setDefault(id, expectedRevision) {
+        safeId(id);
+        return this.repository.resumeTransaction(async (transaction) => {
+            const { document, records, metadata } = updatedDocument(transaction.document), value = get(records, id);
+            if (value === null || !active(object(value, 'resume record')))
+                throw new JobsError('resume does not exist');
+            const target = object(value, 'resume record');
+            if (int(get(target, 'revision')) !== expectedRevision)
+                throw new JobsError('resume revision conflict');
+            if (get(target, 'default') === true)
+                return target;
+            const timestamp = this.now();
+            for (const [key, item] of records.entries()) {
+                const current = object(item, 'resume record'), currentId = string(key);
+                if (active(current) && (get(current, 'default') === true || currentId === id)) {
+                    const changed = copy(current);
+                    set(changed, 'default', currentId === id);
+                    set(changed, 'revision', integer(int(get(current, 'revision')) + 1n));
+                    set(changed, 'updatedAt', text(timestamp));
+                    set(records, currentId, changed);
+                }
+            }
+            set(metadata, 'updatedAt', text(timestamp));
+            validateResumeReferences(records);
+            await transaction.save(document);
+            return object(get(records, id), 'resume record');
+        });
+    }
+    content(id) {
+        safeId(id);
+        return this.repository.resumeTransaction(async ({ document, files }) => {
+            const value = get(object(get(document, 'resumes'), 'resumes.resumes'), id);
+            if (value === null || !active(object(value, 'resume record')))
+                throw new JobsError('managed resume does not exist');
+            const record = object(value, 'resume record');
+            return { record, content: await files.content(record) };
+        });
+    }
+    async resolve(id) {
+        const record = id === undefined
+            ? (await this.list()).find(item => get(item, 'default') === true) ?? null
+            : await this.get(id);
+        if (record === null)
+            throw new JobsError('active resume does not exist');
+        if (string(get(record, 'storageKind')) !== 'managed')
+            throw new JobsError('resume must be adopted before use');
+        const resolved = await this.repository.resumeTransaction(async ({ files }) => {
+            await files.content(record);
+            return files.path(record);
+        });
+        const result = emptyObject();
+        set(result, 'id', get(record, 'id'));
+        set(result, 'revision', get(record, 'revision'));
+        set(result, 'mediaType', get(record, 'mediaType'));
+        set(result, 'path', text(resolved));
+        return result;
+    }
+    check(id) {
+        safeId(id);
+        return this.repository.resumeTransaction(async ({ document, files }) => {
+            const value = get(object(get(document, 'resumes'), 'resumes.resumes'), id);
+            if (value === null)
+                throw new JobsError('resume does not exist');
+            const record = object(value, 'resume record');
+            const managed = string(get(record, 'storageKind')) === 'managed';
+            const current = managed ? await files.observation(record) : await files.externalObservation(string(get(record, 'path')));
+            const result = emptyObject(), observedSize = int(get(record, 'observedSize'));
+            set(result, 'id', text(id));
+            set(result, 'exists', current.exists);
+            set(result, 'changed', !current.exists || current.size !== (observedSize === null ? null : Number(observedSize))
+                || current.modifiedAt !== string(get(record, 'observedModifiedAt')) || managed && current.digest !== string(get(record, 'digest')));
+            set(result, 'observedSize', get(record, 'observedSize'));
+            set(result, 'observedModifiedAt', get(record, 'observedModifiedAt'));
+            set(result, 'currentSize', current.size === null ? null : integer(BigInt(current.size)));
+            set(result, 'currentModifiedAt', current.modifiedAt === null ? null : text(current.modifiedAt));
+            set(result, 'storageKind', text(managed ? 'managed' : 'external'));
+            return result;
+        });
+    }
+}

--- a/src/cli/native-jobs-server.ts
+++ b/src/cli/native-jobs-server.ts
@@ -5,6 +5,9 @@ import { jobsHttp, apiError } from "../workspace-core/jobs-http.js";
 import { NativeJobsRepository } from "../store/native-jobs.js";
 import { loadPosixFlockProvider } from "../store/posix-flock.js";
 
+const maxBody = 64 * 1024;
+const maxUpload = 4 * Math.ceil(10 * 1024 * 1024 / 3) + maxBody;
+
 const args = process.argv.slice(2);
 if (args.length !== 4 || args[0] !== "--root" || args[2] !== "--native-lock") {
   throw new Error("usage: native-jobs-server --root /synthetic/root --native-lock /artifact.node");
@@ -15,9 +18,10 @@ await service.list();
 const token = randomBytes(32).toString("base64url");
 let origin = "";
 const server = createServer(async (request, response) => {
-  const send = (result: { status: number; body: string }) => {
-    response.writeHead(result.status, { "Content-Type": "application/json", "Cache-Control": "no-store",
-      "X-Content-Type-Options": "nosniff", "Connection": "close" });
+  const send = (result: { status: number; body: string | Buffer; contentType?: string; disposition?: string }) => {
+    response.writeHead(result.status, { "Content-Type": result.contentType ?? "application/json", "Cache-Control": "no-store",
+      "X-Content-Type-Options": "nosniff", "Connection": "close",
+      ...(result.disposition ? { "Content-Disposition": result.disposition } : {}) });
     response.end(result.body);
   };
   const fail = (status: number, code: string, message: string) => send(apiError(status, code, message));
@@ -35,13 +39,14 @@ const server = createServer(async (request, response) => {
       if (request.headers["content-type"] !== "application/json") return fail(415, "request_error", "Content-Type must be application/json");
       const length = request.headers["content-length"];
       if (!length || !/^\d+$/.test(length)) return fail(411, "request_error", "a valid Content-Length is required");
-      if (Number(length) > 65536) return fail(413, "request_error", "request body is too large");
+      const limit = path === "/api/resumes/import" || /^\/api\/resumes\/[^/]+\/(replace|adopt)$/.test(path) ? maxUpload : maxBody;
+      if (Number(length) > limit) return fail(413, "request_error", "request body is too large");
       request.setTimeout(30_000, () => request.destroy());
       const chunks: Buffer[] = [];
       let size = 0;
       for await (const chunk of request) {
         size += chunk.length;
-        if (size > 65536) return fail(413, "request_error", "request body is too large");
+        if (size > limit) return fail(413, "request_error", "request body is too large");
         chunks.push(Buffer.from(chunk));
       }
       if (size !== Number(length)) return fail(400, "request_error", "request body length differs");

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,11 +1,14 @@
 import { profileCommands, runProfileCommand } from "./native-profile.js";
 import { readFile } from "node:fs/promises";
 import { realpathSync } from "node:fs";
+import { basename } from "node:path";
 import { pathToFileURL } from "node:url";
 import { JobsService } from "../workspace-core/jobs.js";
 import { NativeJobsRepository, initializeJobsFixture, fixtureError } from "../store/native-jobs.js";
 import { loadPosixFlockProvider } from "../store/posix-flock.js";
 import { parse, serialize, JobsError } from "../contracts/workspace/values.js";
+import { ResumeService } from "../workspace-core/resumes.js";
+import { NativeResumeFiles } from "../store/native-resume-files.js";
 
 export async function runJobsCli(args: string[], input: () => Promise<string>): Promise<string> {
   const options = new Map<string, string>();
@@ -30,6 +33,10 @@ export async function runJobsCli(args: string[], input: () => Promise<string>): 
     "fixture-init": [], "job-create": ["--input", "--origin"], "job-get": ["--id", "--include-trashed"],
     "job-list": ["--status", "--include-trashed", "--trashed-only"],
     "job-update": ["--id", "--input", "--expected-revision", "--origin"],
+    "resume-import": ["--input", "--path"], "resume-get": ["--id", "--include-trashed"],
+    "resume-list": ["--include-trashed", "--trashed-only"], "resume-update": ["--id", "--input", "--expected-revision"],
+    "resume-replace": ["--id", "--path", "--expected-revision"], "resume-adopt": ["--id", "--path", "--expected-revision"],
+    "resume-set-default": ["--id", "--expected-revision"], "resume-resolve": ["--id"], "resume-check": ["--id"],
   };
   const allowed = fields[command ?? ""];
   if (!allowed || [...options.keys()].some(key => !["--root", "--native-lock", ...allowed].includes(key))) {
@@ -44,11 +51,20 @@ export async function runJobsCli(args: string[], input: () => Promise<string>): 
   if (command === "fixture-init") { await initializeJobsFixture(root); return '{"initialized":true}'; }
   const repository = new NativeJobsRepository(root, loadPosixFlockProvider(required("--native-lock")));
   const service = new JobsService(repository);
+  const resumes = new ResumeService(repository);
   const payload = async () => {
     const file = required("--input");
     return parse(file === "-" ? await input() : await readFile(file, "utf8"));
   };
   if (Object.hasOwn(profileCommands, command!)) return serialize(await runProfileCommand(command!, repository, options, payload));
+  if (command === "resume-import") {
+    const path = required("--path"), content = await new NativeResumeFiles(root).readPath(path);
+    return serialize(await resumes.import(await payload(), basename(path), content, true));
+  }
+  if (command === "resume-get") return serialize(await resumes.get(required("--id"), options.has("--include-trashed")));
+  if (command === "resume-list") return serialize(await resumes.list(options.has("--include-trashed"), options.has("--trashed-only")));
+  if (command === "resume-resolve") return serialize(await resumes.resolve(options.get("--id")));
+  if (command === "resume-check") return serialize(await resumes.check(required("--id")));
   if (command === "job-create") return serialize(await service.create(await payload(), options.get("--origin")));
   if (command === "job-get") return serialize(await service.get(required("--id"), options.has("--include-trashed")));
   if (command === "job-list") return serialize(await service.list({
@@ -57,6 +73,12 @@ export async function runJobsCli(args: string[], input: () => Promise<string>): 
   }));
   const revision = required("--expected-revision");
   if (!/^[0-9]+$/.test(revision) || BigInt(revision) < 1n) throw new JobsError("expected revision must be a positive integer");
+  if (command === "resume-update") return serialize(await resumes.update(required("--id"), await payload(), BigInt(revision)));
+  if (command === "resume-set-default") return serialize(await resumes.setDefault(required("--id"), BigInt(revision)));
+  if (command === "resume-replace" || command === "resume-adopt") {
+    const path = required("--path"), content = await new NativeResumeFiles(root).readPath(path);
+    return serialize(await resumes.replace(required("--id"), basename(path), content, BigInt(revision), command === "resume-adopt", true));
+  }
   return serialize(await service.update(required("--id"), await payload(), BigInt(revision), options.get("--origin")));
 }
 

--- a/src/contracts/workspace/resume-content.ts
+++ b/src/contracts/workspace/resume-content.ts
@@ -1,0 +1,54 @@
+import { posix } from 'node:path';
+import { JobsError } from './values.js';
+export const resumeLimit = 10 * 1024 * 1024;
+export const resumeMedia: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.txt': 'text/plain; charset=utf-8',
+};
+export function resumeExtension(filename: string): string {
+  if (!filename || posix.basename(filename) !== filename || filename.includes('\0') || ['.', '..'].includes(filename)) throw new JobsError('resume filename is invalid');
+  const extension = posix.extname(filename).toLowerCase();
+  if (!Object.hasOwn(resumeMedia, extension)) throw new JobsError('resume format must be PDF, DOCX, or UTF-8 TXT');
+  return extension;
+}
+/** Validate the ZIP directory without extracting or inflating untrusted content. */
+function docxNames(bytes: Buffer): string[] {
+  let end = -1;
+  for (let offset = bytes.length - 22; offset >= Math.max(0, bytes.length - 65557); offset--) {
+    if (bytes.readUInt32LE(offset) === 0x06054b50 && offset + 22 + bytes.readUInt16LE(offset + 20) === bytes.length) { end = offset; break; }
+  }
+  if (end < 0 || bytes.readUInt16LE(end + 4) || bytes.readUInt16LE(end + 6)) throw Error('zip');
+  const count = bytes.readUInt16LE(end + 10), size = bytes.readUInt32LE(end + 12);
+  if (count === 65535 || bytes.readUInt16LE(end + 8) !== count || size > end) throw Error('zip');
+  let offset = end - size;
+  const names: string[] = [];
+  for (let i = 0; i < count; i++) {
+    if (offset + 46 > end || bytes.readUInt32LE(offset) !== 0x02014b50) throw Error('zip');
+    const length = bytes.readUInt16LE(offset + 28), extra = bytes.readUInt16LE(offset + 30), comment = bytes.readUInt16LE(offset + 32);
+    if (offset + 46 + length + extra + comment > end) throw Error('zip');
+    const name = bytes.subarray(offset + 46, offset + 46 + length).toString('utf8').split('\0')[0]!;
+    names.push(name);
+    offset += 46 + length + extra + comment;
+  }
+  if (offset !== end) throw Error('zip');
+  return names;
+}
+export function validateResumeContent(filename: string, content: Buffer): { extension: string; mediaType: string } {
+  const extension = resumeExtension(filename);
+  if (content.length > resumeLimit) throw new JobsError('resume file exceeds the 10 MiB limit');
+  if (!content.length) throw new JobsError('resume file is empty');
+  try {
+    if (extension === '.pdf' && content.subarray(0, 5).toString('ascii') !== '%PDF-') throw Error('pdf');
+    if (extension === '.txt') {
+      if (content.includes(0)) throw Error('nul');
+      new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(content);
+    }
+    if (extension === '.docx') {
+      const names = docxNames(content);
+      if (!names.includes('[Content_Types].xml') || !names.includes('word/document.xml')
+        || names.some(name => name.startsWith('/') || name.replaceAll('\\', '/').split('/').includes('..'))) throw Error('docx');
+    }
+  } catch { throw new JobsError('resume content does not match its extension'); }
+  return { extension, mediaType: resumeMedia[extension]! };
+}

--- a/src/contracts/workspace/resume-content.ts
+++ b/src/contracts/workspace/resume-content.ts
@@ -39,7 +39,7 @@ export function validateResumeContent(filename: string, content: Buffer): { exte
   if (content.length > resumeLimit) throw new JobsError('resume file exceeds the 10 MiB limit');
   if (!content.length) throw new JobsError('resume file is empty');
   try {
-    if (extension === '.pdf' && content.subarray(0, 5).toString('ascii') !== '%PDF-') throw Error('pdf');
+    if (extension === '.pdf' && !content.subarray(0, 5).equals(Buffer.from('%PDF-'))) throw Error('pdf');
     if (extension === '.txt') {
       if (content.includes(0)) throw Error('nul');
       new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(content);

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -1,22 +1,32 @@
 import { constants } from "node:fs";
-import { lstat, mkdir, open, readdir, realpath } from "node:fs/promises";
+import { chmod, lstat, mkdir, open, readdir, realpath } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
 import { parsePythonPointJsonBytes } from "../contracts/raw-json/point-parser.js";
 import { validateJobsDocument, safeId } from "../contracts/workspace/jobs.js";
 import { validateResumeReferences } from "../contracts/workspace/resume-reference.js";
-import { fromJSON, get, int, object, string, serialize, JobsError } from "../contracts/workspace/values.js";
+import { fromJSON, get, int, object, set, string, serialize, JobsError } from "../contracts/workspace/values.js";
 import type { Document, Value } from "../contracts/workspace/values.js";
 import type { JobsRepository, JobsTransaction } from "../workspace-core/jobs.js";
 import { atomicWritePointJson } from "./point-persistence.js";
 import { withExclusiveFileLock } from "./exclusive-file-lock.js";
 import type { PosixFlockProvider } from "./posix-flock.js";
+import { NativeResumeFiles } from "./native-resume-files.js";
 
 import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
 
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
-const marker = '{"mode":"native-jobs-fixture","version":2}\n';
-const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json"]);
+const marker = '{"mode":"native-jobs-fixture","version":3}\n';
+const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "resume-operation.json", "resume-files"]);
+const journalName = "resume-operation";
+const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
+
+export interface ResumeTransaction {
+  document: Document;
+  files: NativeResumeFiles;
+  save(document: Document): Promise<void>;
+  saveJournal(operation: Value): Promise<void>;
+}
 
 /** Creates a NEW synthetic root only. Never adopts or initializes an existing Store. */
 export async function initializeJobsFixture(root: string): Promise<void> {
@@ -29,6 +39,9 @@ export async function initializeJobsFixture(root: string): Promise<void> {
       : { schemaVersion: 1, [name]: {}, metadata: { updatedAt: now } };
     await atomicWritePointJson(join(root, `${name}.json`), fromJSON(payload), options);
   }
+  await atomicWritePointJson(join(root, `${journalName}.json`), fromJSON({ schemaVersion: 1, operation: null }), options);
+  await mkdir(join(root, "resume-files"), { mode: 0o700 });
+  await chmod(join(root, "resume-files"), 0o700);
   const lock = await open(join(root, ".store.lock"), "wx", 0o600);
   await lock.close();
   // The readiness marker is written last; partial initialization is never adopted.
@@ -81,14 +94,44 @@ export class NativeJobsRepository implements JobsRepository {
     return value;
   }
 
+  private async journal(): Promise<Document> {
+    const value = object(parsePythonPointJsonBytes(await this.read(`${journalName}.json`), {
+      diagnosticProfile: "3.12", intMaxStrDigits: 4300,
+    }), journalName);
+    if (int(get(value, "schemaVersion")) !== 1n) throw new JobsError("resume recovery schema version is unsupported");
+    return value;
+  }
+
+  private async saveJournal(operation: Value): Promise<void> {
+    const journal = fromJSON({ schemaVersion: 1, operation: null }) as Document;
+    set(journal, "operation", operation);
+    await this.write(join(this.root, `${journalName}.json`), journal, documentOptions);
+  }
+
+  private async recoverResumes(): Promise<Document> {
+    const files = new NativeResumeFiles(this.root);
+    const journal = await this.journal();
+    if (journal.size !== 2) throw new JobsError("invalid resume recovery journal");
+    let resumes = await this.document("resumes");
+    const operation = get(journal, "operation");
+    await files.recover(operation === null ? null : object(operation, "resume recovery operation"), resumes,
+      async document => {
+        validateResumeReferences(object(get(document, "resumes"), "resumes.resumes"));
+        await this.write(join(this.root, "resumes.json"), document, documentOptions);
+        resumes = document;
+      }, async () => this.saveJournal(null));
+    return resumes;
+  }
+
   async transaction<T>(operation: (transaction: JobsTransaction) => Promise<T>): Promise<T> {
     await this.validateRoot();
     return withExclusiveFileLock(join(this.root, ".store.lock"), async () => {
       await this.validateRoot(true);
+      const resumesDocument = await this.recoverResumes();
       const document = validateJobsDocument(await this.document("jobs"));
       // Read-only projections: no Python initialization, repair, extraction or preflight.
       object(get(await this.document("profile"), "profile"), "profile.profile");
-      const resumes = object(get(await this.document("resumes"), "resumes"), "resumes.resumes");
+      const resumes = object(get(resumesDocument, "resumes"), "resumes.resumes");
       validateResumeReferences(resumes);
       return operation({ document,
         requireResume: async (id: Value) => {
@@ -106,6 +149,23 @@ export class NativeJobsRepository implements JobsRepository {
           validateJobsDocument(value);
           await this.write(join(this.root, "jobs.json"), value, options);
         },
+      });
+    }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
+  }
+
+  async resumeTransaction<T>(operation: (transaction: ResumeTransaction) => Promise<T>): Promise<T> {
+    await this.validateRoot();
+    return withExclusiveFileLock(join(this.root, ".store.lock"), async () => {
+      await this.validateRoot(true);
+      const files = new NativeResumeFiles(this.root);
+      const document = await this.recoverResumes();
+      validateResumeReferences(object(get(document, "resumes"), "resumes.resumes"));
+      return operation({ document, files,
+        save: async value => {
+          validateResumeReferences(object(get(value, "resumes"), "resumes.resumes"));
+          await this.write(join(this.root, "resumes.json"), value, documentOptions);
+        },
+        saveJournal: async value => this.saveJournal(value),
       });
     }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
   }

--- a/src/store/native-resume-files.ts
+++ b/src/store/native-resume-files.ts
@@ -1,0 +1,166 @@
+import { constants } from 'node:fs';
+import { lstat, open, readdir, rename, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+import { resumeLimit, validateResumeContent } from '../contracts/workspace/resume-content.js';
+import { get, has, int, integer, keys, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { resumeModifiedAt } from './resume-modified-at.js';
+export type StagedResume = { temporary: string; managedFile: string; originalFilename: string; mediaType: string; digest: string; observedSize: number; observedModifiedAt: string };
+const filePattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\.(pdf|docx|txt)$/;
+const tempPattern = /^\.native-[a-f0-9-]{36}\.tmp$/;
+const hash = (bytes: Buffer): string => createHash('sha256').update(bytes).digest('hex');
+const absent = (error: unknown): boolean => error instanceof Error && 'code' in error && error.code === 'ENOENT';
+export async function syncDirectory(path: string): Promise<void> {
+  const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try { await handle.sync(); } finally { await handle.close(); }
+}
+export class NativeResumeFiles {
+  readonly directory: string;
+  constructor(root: string, private readonly checkpoint: (stage: string) => Promise<void> = async () => {}) {
+    this.directory = join(root, 'resume-files');
+  }
+  async validate(): Promise<void> {
+    const metadata = await lstat(this.directory);
+    if (!metadata.isDirectory() || metadata.isSymbolicLink() || metadata.uid !== process.getuid?.() || metadata.mode & 0o077) throw new JobsError('resume directory must be private and owned');
+    for (const name of await readdir(this.directory)) {
+      if (!filePattern.test(name) && !tempPattern.test(name)) throw new JobsError('unsupported resume recovery state');
+      const stat = await lstat(join(this.directory, name));
+      if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || stat.uid !== process.getuid?.() || stat.mode & 0o077) throw new JobsError('resume file must be private and owned, without links');
+    }
+  }
+  async readPath(path: string, privateFile = false): Promise<Buffer> {
+    let handle;
+    try {
+      handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+      const before = await handle.stat({ bigint: true });
+      if (!before.isFile() || before.size > BigInt(resumeLimit) || privateFile && (before.nlink !== 1n || before.uid !== BigInt(process.getuid!()) || (before.mode & 0o077n) !== 0n)) throw Error('file');
+      const parts: Buffer[] = [];
+      let size = 0;
+      while (true) {
+        const buffer = Buffer.alloc(Math.min(1024 * 1024, resumeLimit + 1 - size));
+        const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+        if (!bytesRead) break;
+        parts.push(buffer.subarray(0, bytesRead)); size += bytesRead;
+        if (size > resumeLimit) throw new JobsError('resume file exceeds the 10 MiB limit');
+      }
+      const after = await handle.stat({ bigint: true }), pathStat = await lstat(path, { bigint: true });
+      if (size !== Number(before.size) || ['dev', 'ino', 'size', 'mtimeNs', 'ctimeNs'].some(key => before[key as keyof typeof before] !== after[key as keyof typeof after])
+        || pathStat.dev !== after.dev || pathStat.ino !== after.ino || pathStat.isSymbolicLink()) throw new JobsError('resume source changed during import');
+      return Buffer.concat(parts);
+    } catch (error) {
+      if (error instanceof JobsError) throw error;
+      throw new JobsError(privateFile ? 'managed resume content is unavailable' : 'resume source must be a readable regular file');
+    } finally { await handle?.close(); }
+  }
+  async stage(id: string, filename: string, content: Buffer): Promise<StagedResume> {
+    const { extension, mediaType } = validateResumeContent(filename, content);
+    const temporary = `.native-${randomUUID()}.tmp`, path = join(this.directory, temporary);
+    const handle = await open(path, 'wx', 0o600);
+    try {
+      await handle.writeFile(content); await handle.sync();
+      const stat = await handle.stat();
+      await syncDirectory(this.directory);
+      return { temporary, managedFile: id + extension, originalFilename: filename, mediaType,
+        digest: hash(content), observedSize: content.length, observedModifiedAt: resumeModifiedAt(stat.mtimeMs / 1000) };
+    } catch (error) { await unlink(path).catch(() => {}); throw error; }
+    finally { await handle.close(); }
+  }
+  async discard(stage: StagedResume): Promise<void> {
+    try { await unlink(join(this.directory, stage.temporary)); }
+    catch (error) { if (!absent(error)) throw error; }
+  }
+  async content(record: Document): Promise<Buffer> {
+    if (string(get(record, 'storageKind')) !== 'managed') throw new JobsError('resume must be adopted before use');
+    const bytes = await this.readPath(join(this.directory, string(get(record, 'managedFile'))!), true);
+    if (hash(bytes) !== string(get(record, 'digest'))) throw new JobsError('managed resume content is unavailable');
+    return bytes;
+  }
+  path(record: Document): string {
+    if (string(get(record, 'storageKind')) !== 'managed') throw new JobsError('resume must be adopted before use');
+    const file = string(get(record, 'managedFile'));
+    if (!file || !filePattern.test(file)) throw new JobsError('managed resume content is unavailable');
+    return join(this.directory, file);
+  }
+  async observation(record: Document): Promise<{ exists: boolean; size: number | null; modifiedAt: string | null; digest: string | null }> {
+    const path = this.path(record);
+    let stat;
+    try {
+      stat = await lstat(path);
+    } catch (error) {
+      if (absent(error)) return { exists: false, size: null, modifiedAt: null, digest: null };
+      throw error;
+    }
+    const bytes = await this.readPath(path, true);
+    stat = await lstat(path);
+    return { exists: true, size: bytes.length, modifiedAt: resumeModifiedAt(stat.mtimeMs / 1000), digest: hash(bytes) };
+  }
+  async externalObservation(path: string): Promise<{ exists: boolean; size: number | null; modifiedAt: string | null; digest: null }> {
+    try {
+      const stat = await lstat(path);
+      if (!stat.isFile() || stat.isSymbolicLink()) throw new JobsError('resume source must be a readable regular file');
+      return { exists: true, size: stat.size, modifiedAt: resumeModifiedAt(stat.mtimeMs / 1000), digest: null };
+    } catch (error) {
+      if (absent(error)) return { exists: false, size: null, modifiedAt: null, digest: null };
+      throw error;
+    }
+  }
+  /** Journal is durable before any canonical rename. Recovery completes only its exact intended record. */
+  async install(stage: StagedResume, document: Document, previous: string | null, saveJournal: (value: Value) => Promise<void>, save: (value: Document) => Promise<void>): Promise<void> {
+    const journal = emptyObject();
+    set(journal, 'version', integer(1n));
+    set(journal, 'kind', text('install'));
+    set(journal, 'temporary', text(stage.temporary));
+    set(journal, 'destination', text(stage.managedFile));
+    set(journal, 'previous', previous === null ? null : text(previous));
+    set(journal, 'digest', text(stage.digest));
+    set(journal, 'document', document);
+    await saveJournal(journal);
+    await this.checkpoint('journal');
+    await rename(join(this.directory, stage.temporary), join(this.directory, stage.managedFile));
+    await syncDirectory(this.directory);
+    await this.checkpoint('installed');
+    await save(document);
+    await this.checkpoint('metadata');
+    if (previous && previous !== stage.managedFile) {
+      try { await unlink(join(this.directory, previous)); } catch (error) { if (!absent(error)) throw error; }
+    }
+    await syncDirectory(this.directory);
+    await saveJournal(null);
+    await this.checkpoint('cleared');
+  }
+  async recover(journal: Document | null, current: Document, save: (value: Document) => Promise<void>, clear: () => Promise<void>): Promise<void> {
+    await this.validate();
+    if (journal) {
+      if (int(get(journal, 'version')) !== 1n || string(get(journal, 'kind')) !== 'install' || journal.size !== 7
+        || keys(journal).some(key => !['version','kind','temporary','destination','previous','digest','document'].includes(key))) throw new JobsError('invalid resume recovery journal');
+      const temporary = string(get(journal, 'temporary')), destination = string(get(journal, 'destination')), previous = string(get(journal, 'previous')), digest = string(get(journal, 'digest'));
+      if (!temporary || !tempPattern.test(temporary) || !destination || !filePattern.test(destination) || !digest || !/^[a-f0-9]{64}$/.test(digest)
+        || get(journal, 'previous') !== null && (!previous || !filePattern.test(previous))) throw new JobsError('invalid resume recovery journal');
+      const document = object(get(journal, 'document'), 'resume recovery document');
+      const records = object(get(document, 'resumes'), 'resumes.resumes');
+      const matches = records.entries().filter(([, value]) => string(get(object(value, 'resume'), 'managedFile')) === destination && string(get(object(value, 'resume'), 'digest')) === digest);
+      if (matches.length !== 1) throw new JobsError('resume recovery identity differs');
+      const oldRecords = object(get(current, 'resumes'), 'resumes.resumes');
+      const targetId = string(matches[0]![0])!;
+      if (previous && (!has(oldRecords, targetId) || ![previous, destination].includes(string(get(object(get(oldRecords,targetId),'resume'),'managedFile'))!))) throw new JobsError('resume recovery previous identity differs');
+      let installed = false;
+      try { installed = hash(await this.readPath(join(this.directory, destination), true)) === digest; } catch { /* Staged bytes must prove the expected digest below. */ }
+      if (!installed) {
+        const bytes = await this.readPath(join(this.directory, temporary), true);
+        if (hash(bytes) !== digest) throw new JobsError('resume recovery bytes are unavailable');
+        await rename(join(this.directory, temporary), join(this.directory, destination));
+        await syncDirectory(this.directory);
+      }
+      await save(document);
+      if (previous && previous !== destination) {
+        try { await unlink(join(this.directory, previous)); } catch (error) { if (!absent(error)) throw error; }
+      }
+      await syncDirectory(this.directory); await clear();
+    }
+    // Only owned native staging names are collected under the Store lock.
+    for (const name of await readdir(this.directory)) if (tempPattern.test(name)) await unlink(join(this.directory, name));
+    await syncDirectory(this.directory);
+  }
+}

--- a/src/workspace-core/jobs-http.ts
+++ b/src/workspace-core/jobs-http.ts
@@ -6,8 +6,10 @@ import { JobsError, fromJSON, get, int, keys, object, parse, serialize, set } fr
 import type { Value } from "../contracts/workspace/values.js";
 import { emptyObject } from "../contracts/workspace/jobs.js";
 import { PythonObject } from "../contracts/python-object.js";
+import { ResumeService } from "./resumes.js";
+import { resumesHttp } from "./resumes-http.js";
 
-export type ApiResult = { status: number; body: string };
+export type ApiResult = { status: number; body: string | Buffer; contentType?: string; disposition?: string };
 const response = (value: Value, status = 200): ApiResult => ({ status, body: serialize(value) });
 export const apiError = (status: number, code: string, message: string): ApiResult =>
   response(fromJSON({ error: { code, message } }), status);
@@ -17,6 +19,8 @@ const envelope = (key: string, value: Value): Value => set(emptyObject(), key, v
 export async function jobsHttp(service: JobsService, repository: NativeJobsRepository,
   method: string, path: string, body = ""): Promise<ApiResult> {
   try {
+    const resumes = await resumesHttp(new ResumeService(repository), method, path, body);
+    if (resumes) return resumes;
     const facts = await profileHttp(repository, method, path, body);
     if (facts) return facts;
     if (method === "GET") {
@@ -58,8 +62,11 @@ export async function jobsHttp(service: JobsService, repository: NativeJobsRepos
   } catch (error) {
     if (error instanceof JobsError) {
       return error.message.includes("revision conflict") ? apiError(409, "revision_conflict", error.message)
+        : error.message.includes("content is too large") ? apiError(413, "request_error", error.message)
+        : error.message === "managed resume content is unavailable" ? apiError(409, "content_unavailable", error.message)
         : error.message.includes("does not exist") ? apiError(404, "not_found", error.message)
         : error.message === "active job URL already exists" ? apiError(409, "duplicate_active_blocked", error.message)
+        : ["resume id already exists", "resume file is already managed"].includes(error.message) ? apiError(409, "duplicate_resume_blocked", error.message)
         : apiError(400, "store_rejected", error.message);
     }
     if (error instanceof Error && ["JSONDecodeError", "ValueError"].includes(error.name)) {

--- a/src/workspace-core/resumes-http.ts
+++ b/src/workspace-core/resumes-http.ts
@@ -1,0 +1,79 @@
+import { resumeLimit } from '../contracts/workspace/resume-content.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { copy, fromJSON, get, int, keys, object, parse, serialize, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import type { ApiResult } from './jobs-http.js';
+import type { ResumeService } from './resumes.js';
+
+const hidden = ['path', 'managedFile', 'originalFilename', 'digest', 'contentRevision'];
+export function publicResume(record: Document): Document {
+  const result = copy(record);
+  for (const field of hidden) result.delete(text(field));
+  return result;
+}
+const response = (value: Value, status = 200): ApiResult => ({ status, body: serialize(value) });
+
+function upload(body: string): { metadata: Value; filename: string; content: Buffer } {
+  const payload = object(parse(body), 'body');
+  if (payload.size !== 3 || keys(payload).some(key => !['metadata', 'filename', 'content'].includes(key))) {
+    throw new JobsError('upload body requires metadata, filename, and content');
+  }
+  object(get(payload, 'metadata'), 'upload metadata');
+  const filename = string(get(payload, 'filename')), encoded = string(get(payload, 'content'));
+  if (filename === null || encoded === null) throw new JobsError('upload envelope fields have invalid types');
+  if (encoded.length > Math.ceil(resumeLimit / 3) * 4) throw new JobsError('encoded resume content is too large');
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(encoded)) {
+    throw new JobsError('resume content must be strict base64');
+  }
+  const content = Buffer.from(encoded, 'base64');
+  if (content.length > resumeLimit) throw new JobsError('decoded resume content is too large');
+  return { metadata: get(payload, 'metadata'), filename, content };
+}
+function expected(value: Value): bigint {
+  const payload = object(value, 'body');
+  if (payload.size !== 1 || keys(payload)[0] !== 'expectedRevision') throw new JobsError('body requires expectedRevision');
+  const revision = int(get(payload, 'expectedRevision'));
+  if (revision === null || revision < 1n) throw new JobsError('expectedRevision must be a positive integer');
+  return revision;
+}
+
+export async function resumesHttp(service: ResumeService, method: string, path: string, body: string): Promise<ApiResult | null> {
+  if (method === 'GET' && path === '/api/resumes') {
+    const result = emptyObject(); set(result, 'resumes', (await service.list()).map(publicResume)); return response(result);
+  }
+  const match = /^\/api\/resumes\/([^/]+)$/.exec(path);
+  if (method === 'GET' && match) {
+    const record = await service.get(decodeURIComponent(match[1]!));
+    return record === null ? responseError(404, 'not_found', 'resume does not exist') : response(publicResume(record));
+  }
+  const contentMatch = /^\/api\/resumes\/([^/]+)\/content$/.exec(path);
+  if (method === 'GET' && contentMatch) {
+    const { record, content } = await service.content(decodeURIComponent(contentMatch[1]!));
+    const mediaType = string(get(record, 'mediaType'))!, extension = mediaType === 'application/pdf' ? '.pdf'
+      : mediaType.startsWith('text/plain') ? '.txt' : '.docx';
+    return { status: 200, body: content, contentType: mediaType,
+      disposition: `${extension === '.docx' ? 'attachment' : 'inline'}; filename="resume-${string(get(record, 'id'))}${extension}"` };
+  }
+  if (method === 'POST' && path === '/api/resumes/import') {
+    const value = upload(body); return response(publicResume(await service.import(value.metadata, value.filename, value.content)));
+  }
+  if (method === 'PATCH' && match) {
+    const payload = object(parse(body), 'body');
+    if (payload.size !== 2 || keys(payload).some(key => !['patch', 'expectedRevision'].includes(key))) throw new JobsError('body requires patch and expectedRevision');
+    const revision = int(get(payload, 'expectedRevision'));
+    if (revision === null || revision < 1n) throw new JobsError('expectedRevision must be a positive integer');
+    return response(publicResume(await service.update(decodeURIComponent(match[1]!), get(payload, 'patch'), revision)));
+  }
+  const action = /^\/api\/resumes\/([^/]+)\/(replace|adopt|default)$/.exec(path);
+  if (method === 'POST' && action) {
+    const id = decodeURIComponent(action[1]!);
+    if (action[2] === 'default') return response(publicResume(await service.setDefault(id, expected(parse(body)))));
+    const value = upload(body), revision = expected(value.metadata);
+    return response(publicResume(await service.replace(id, value.filename, value.content, revision, action[2] === 'adopt')));
+  }
+  return path.startsWith('/api/resumes') ? responseError(501, 'unsupported_native_workflow', 'This native resume workflow is not available yet.') : null;
+}
+
+function responseError(status: number, code: string, message: string): ApiResult {
+  return response(fromJSON({ error: { code, message } }), status);
+}

--- a/src/workspace-core/resumes.ts
+++ b/src/workspace-core/resumes.ts
@@ -1,0 +1,251 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import { casefold } from '../contracts/workspace/casefold.js';
+import { safeId, emptyObject } from '../contracts/workspace/jobs.js';
+import { strip } from '../contracts/workspace/job-url.js';
+import { validateResumeReferences } from '../contracts/workspace/resume-reference.js';
+import { resumeExtension } from '../contracts/workspace/resume-content.js';
+import { copy, get, has, int, integer, keys, object, set, string, text, truth, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import type { NativeResumeFiles, StagedResume } from '../store/native-resume-files.js';
+
+export interface ResumeTransaction {
+  document: Document;
+  files: NativeResumeFiles;
+  save(document: Document): Promise<void>;
+  saveJournal(operation: Value): Promise<void>;
+}
+export interface ResumeRepository {
+  resumeTransaction<T>(operation: (transaction: ResumeTransaction) => Promise<T>): Promise<T>;
+}
+type Metadata = { id?: string; label: string; tags: string[]; default?: boolean };
+
+const compareText = (left: string, right: string): number => {
+  const a = [...left], b = [...right];
+  for (let index = 0; index < Math.min(a.length, b.length); index++) {
+    const difference = a[index]!.codePointAt(0)! - b[index]!.codePointAt(0)!;
+    if (difference) return difference;
+  }
+  return a.length - b.length;
+};
+const active = (record: Document): boolean => get(record, 'deletedAt') === null;
+
+function tags(value: Value): string[] {
+  if (!Array.isArray(value)) throw new JobsError('resume tags must be a list');
+  const result = value.map(item => {
+    const tag = string(item);
+    if (tag === null) throw new JobsError('resume tags must be non-empty strings');
+    return strip(tag);
+  });
+  if (result.some(tag => !tag)) throw new JobsError('resume tags must be non-empty strings');
+  if (new Set(result).size !== result.length) throw new JobsError('resume tags must be unique');
+  return result;
+}
+
+export function resumeMetadata(value: Value, patch = false): Partial<Metadata> {
+  const input = object(value, patch ? 'resume patch' : 'resume input');
+  const allowed = patch ? ['label', 'tags'] : ['id', 'label', 'tags', 'default'];
+  if (patch && !input.size || keys(input).some(key => !allowed.includes(key))) {
+    throw new JobsError(`resume ${patch ? 'patch' : 'input'} contains unsupported fields`);
+  }
+  const result: Partial<Metadata> = {};
+  if (has(input, 'id') && truth(get(input, 'id'))) result.id = safeId(string(get(input, 'id')));
+  if (has(input, 'label')) {
+    const label = string(get(input, 'label'));
+    if (label === null || !strip(label)) throw new JobsError('resume label must be a non-empty string');
+    result.label = strip(label);
+  } else if (!patch) throw new JobsError('resume label must be a non-empty string');
+  if (has(input, 'tags')) result.tags = tags(get(input, 'tags'));
+  else if (!patch) result.tags = [];
+  if (has(input, 'default')) {
+    if (typeof get(input, 'default') !== 'boolean') throw new JobsError('resume default must be a boolean');
+    result.default = get(input, 'default') as boolean;
+  }
+  return result;
+}
+
+function updatedDocument(document: Document): { document: Document; records: Document; metadata: Document } {
+  const next = copy(document), records = copy(object(get(document, 'resumes'), 'resumes.resumes'));
+  const metadata = copy(object(get(document, 'metadata'), 'resumes.metadata'));
+  set(next, 'resumes', records); set(next, 'metadata', metadata);
+  return { document: next, records, metadata };
+}
+
+function applyStage(record: Document, stage: StagedResume, contentRevision: string): void {
+  set(record, 'storageKind', text('managed'));
+  set(record, 'managedFile', text(stage.managedFile));
+  set(record, 'originalFilename', text(stage.originalFilename));
+  set(record, 'mediaType', text(stage.mediaType));
+  set(record, 'digest', text(stage.digest));
+  set(record, 'contentRevision', text(contentRevision));
+  set(record, 'observedSize', integer(BigInt(stage.observedSize)));
+  set(record, 'observedModifiedAt', text(stage.observedModifiedAt));
+}
+
+export class ResumeService {
+  constructor(readonly repository: ResumeRepository,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    private readonly id = () => `resume-${randomUUID()}`,
+    private readonly contentRevision = () => `content_${randomBytes(24).toString('base64url')}`) {}
+
+  private uploadedFilename(filename: string, preserve: boolean): string {
+    return preserve ? filename : `.browser-upload.${randomBytes(6).toString('base64url')}${resumeExtension(filename)}`;
+  }
+
+  import(value: Value, filename: string, content: Buffer, preserveFilename = false): Promise<Document> {
+    const input = resumeMetadata(value) as Metadata, id = safeId(input.id ?? this.id());
+    return this.repository.resumeTransaction(async transaction => {
+      const { document, records, metadata } = updatedDocument(transaction.document);
+      if (has(records, id)) throw new JobsError('resume id already exists');
+      const stage = await transaction.files.stage(id, this.uploadedFilename(filename, preserveFilename), content);
+      if (records.entries().some(([, item]) => string(get(object(item, 'resume record'), 'digest')) === stage.digest)) {
+        await transaction.files.discard(stage); throw new JobsError('resume file is already managed');
+      }
+      const timestamp = this.now(), activeRecords = records.entries().map(([, item]) => object(item, 'resume record')).filter(active);
+      const makeDefault = input.default ?? activeRecords.length === 0;
+      if (makeDefault) for (const [key, item] of records.entries()) {
+        const record = object(item, 'resume record');
+        if (active(record) && get(record, 'default') === true) {
+          const changed = copy(record);
+          set(changed, 'default', false); set(changed, 'revision', integer(int(get(record, 'revision'))! + 1n)); set(changed, 'updatedAt', text(timestamp));
+          set(records, string(key)!, changed);
+        }
+      }
+      const record = emptyObject();
+      set(record, 'id', text(id)); set(record, 'label', text(input.label));
+      applyStage(record, stage, this.contentRevision());
+      set(record, 'tags', input.tags.map(text)); set(record, 'default', makeDefault);
+      set(record, 'revision', integer(1n)); set(record, 'createdAt', text(timestamp));
+      set(record, 'updatedAt', text(timestamp)); set(record, 'deletedAt', null);
+      set(records, id, record); set(metadata, 'updatedAt', text(timestamp));
+      validateResumeReferences(records);
+      await transaction.files.install(stage, document, null, transaction.saveJournal, transaction.save);
+      return record;
+    });
+  }
+
+  get(id: string, includeTrashed = false): Promise<Document | null> {
+    safeId(id);
+    return this.repository.resumeTransaction(async ({ document }) => {
+      const value = get(object(get(document, 'resumes'), 'resumes.resumes'), id);
+      if (value === null) return null;
+      const record = object(value, 'resume record');
+      return includeTrashed || active(record) ? record : null;
+    });
+  }
+
+  list(includeTrashed = false, trashedOnly = false): Promise<Document[]> {
+    return this.repository.resumeTransaction(async ({ document }) => object(get(document, 'resumes'), 'resumes.resumes').entries()
+      .map(([, value]) => object(value, 'resume record'))
+      .filter(record => (includeTrashed || trashedOnly || active(record)) && (!trashedOnly || !active(record)))
+      .sort((a, b) => Number(get(b, 'default')) - Number(get(a, 'default'))
+        || compareText(casefold(string(get(a, 'label'))!), casefold(string(get(b, 'label'))!))
+        || compareText(string(get(a, 'id'))!, string(get(b, 'id'))!)));
+  }
+
+  update(id: string, value: Value, expectedRevision: bigint): Promise<Document> {
+    safeId(id); const patch = resumeMetadata(value, true);
+    return this.repository.resumeTransaction(async transaction => {
+      const { document, records, metadata } = updatedDocument(transaction.document);
+      const value = get(records, id);
+      if (value === null || !active(object(value, 'resume record'))) throw new JobsError('resume does not exist');
+      const current = object(value, 'resume record');
+      if (int(get(current, 'revision')) !== expectedRevision) throw new JobsError('resume revision conflict');
+      const record = copy(current), timestamp = this.now();
+      if (patch.label !== undefined) set(record, 'label', text(patch.label));
+      if (patch.tags !== undefined) set(record, 'tags', patch.tags.map(text));
+      set(record, 'revision', integer(expectedRevision + 1n)); set(record, 'updatedAt', text(timestamp));
+      set(records, id, record); set(metadata, 'updatedAt', text(timestamp));
+      validateResumeReferences(records); await transaction.save(document); return record;
+    });
+  }
+
+  replace(id: string, filename: string, content: Buffer, expectedRevision: bigint, adopt = false, preserveFilename = false): Promise<Document> {
+    safeId(id);
+    return this.repository.resumeTransaction(async transaction => {
+      const { document, records, metadata } = updatedDocument(transaction.document);
+      const value = get(records, id);
+      if (value === null || !active(object(value, 'resume record'))) throw new JobsError('resume does not exist');
+      const current = object(value, 'resume record'), managed = string(get(current, 'storageKind')) === 'managed';
+      if (int(get(current, 'revision')) !== expectedRevision) throw new JobsError('resume revision conflict');
+      if (adopt === managed) throw new JobsError(managed ? 'resume is already managed' : 'legacy resume bytes require resume-adopt');
+      const stage = await transaction.files.stage(id, this.uploadedFilename(filename, preserveFilename), content);
+      if (records.entries().some(([key, item]) => string(key) !== id && string(get(object(item, 'resume record'), 'digest')) === stage.digest)) {
+        await transaction.files.discard(stage); throw new JobsError('resume file is already managed');
+      }
+      const record = copy(current), timestamp = this.now();
+      if (has(record, 'path')) record.delete(text('path'));
+      applyStage(record, stage, this.contentRevision());
+      set(record, 'revision', integer(expectedRevision + 1n)); set(record, 'updatedAt', text(timestamp));
+      set(records, id, record); set(metadata, 'updatedAt', text(timestamp));
+      validateResumeReferences(records);
+      await transaction.files.install(stage, document, managed ? string(get(current, 'managedFile')) : null, transaction.saveJournal, transaction.save);
+      return record;
+    });
+  }
+
+  setDefault(id: string, expectedRevision: bigint): Promise<Document> {
+    safeId(id);
+    return this.repository.resumeTransaction(async transaction => {
+      const { document, records, metadata } = updatedDocument(transaction.document), value = get(records, id);
+      if (value === null || !active(object(value, 'resume record'))) throw new JobsError('resume does not exist');
+      const target = object(value, 'resume record');
+      if (int(get(target, 'revision')) !== expectedRevision) throw new JobsError('resume revision conflict');
+      if (get(target, 'default') === true) return target;
+      const timestamp = this.now();
+      for (const [key, item] of records.entries()) {
+        const current = object(item, 'resume record'), currentId = string(key)!;
+        if (active(current) && (get(current, 'default') === true || currentId === id)) {
+          const changed = copy(current);
+          set(changed, 'default', currentId === id); set(changed, 'revision', integer(int(get(current, 'revision'))! + 1n));
+          set(changed, 'updatedAt', text(timestamp)); set(records, currentId, changed);
+        }
+      }
+      set(metadata, 'updatedAt', text(timestamp)); validateResumeReferences(records); await transaction.save(document);
+      return object(get(records, id), 'resume record');
+    });
+  }
+
+  content(id: string): Promise<{ record: Document; content: Buffer }> {
+    safeId(id);
+    return this.repository.resumeTransaction(async ({ document, files }) => {
+      const value = get(object(get(document, 'resumes'), 'resumes.resumes'), id);
+      if (value === null || !active(object(value, 'resume record'))) throw new JobsError('managed resume does not exist');
+      const record = object(value, 'resume record');
+      return { record, content: await files.content(record) };
+    });
+  }
+
+  async resolve(id?: string): Promise<Document> {
+    const record = id === undefined
+      ? (await this.list()).find(item => get(item, 'default') === true) ?? null
+      : await this.get(id);
+    if (record === null) throw new JobsError('active resume does not exist');
+    if (string(get(record, 'storageKind')) !== 'managed') throw new JobsError('resume must be adopted before use');
+    const resolved = await this.repository.resumeTransaction(async ({ files }) => {
+      await files.content(record); return files.path(record);
+    });
+    const result = emptyObject();
+    set(result, 'id', get(record, 'id')); set(result, 'revision', get(record, 'revision')); set(result, 'mediaType', get(record, 'mediaType'));
+    set(result, 'path', text(resolved));
+    return result;
+  }
+
+  check(id: string): Promise<Document> {
+    safeId(id);
+    return this.repository.resumeTransaction(async ({ document, files }) => {
+      const value = get(object(get(document, 'resumes'), 'resumes.resumes'), id);
+      if (value === null) throw new JobsError('resume does not exist');
+      const record = object(value, 'resume record');
+      const managed = string(get(record, 'storageKind')) === 'managed';
+      const current = managed ? await files.observation(record) : await files.externalObservation(string(get(record, 'path'))!);
+      const result = emptyObject(), observedSize = int(get(record, 'observedSize'));
+      set(result, 'id', text(id)); set(result, 'exists', current.exists);
+      set(result, 'changed', !current.exists || current.size !== (observedSize === null ? null : Number(observedSize))
+        || current.modifiedAt !== string(get(record, 'observedModifiedAt')) || managed && current.digest !== string(get(record, 'digest')));
+      set(result, 'observedSize', get(record, 'observedSize')); set(result, 'observedModifiedAt', get(record, 'observedModifiedAt'));
+      set(result, 'currentSize', current.size === null ? null : integer(BigInt(current.size)));
+      set(result, 'currentModifiedAt', current.modifiedAt === null ? null : text(current.modifiedAt)); set(result, 'storageKind', text(managed ? 'managed' : 'external'));
+      return result;
+    });
+  }
+}

--- a/tests/test_store_jobs_legacy_1.py
+++ b/tests/test_store_jobs_legacy_1.py
@@ -12,7 +12,7 @@ class StoreTests(StoreTestCase):
 - **Posted**: 2026-09-06
 - **Salary**: Unknown
 - **URL**: https://example.com/jobs/python
-""")
+""", encoding="utf-8")
         with mock.patch.object(STORE_MODULE.Path, "home", return_value=self.home):
             discovery = self.store.preview_legacy_jobs([])
             self.assertEqual([item["state"] for item in discovery["items"]], ["valid"])

--- a/tests_js/artifact_data_copy_reference.test.mjs
+++ b/tests_js/artifact_data_copy_reference.test.mjs
@@ -204,3 +204,28 @@ test('data-only reference rejects external input', () => {
     assert.equal(run.status, 2); assert.equal(run.stdout, ''); assert.equal(run.stderr, 'artifact_data_copy_input_rejected\n');
   }
 });
+
+
+test('controlled copy_file_range fallback cannot escape through native sendfile', t => {
+  if (!['darwin', 'linux'].includes(process.platform)) return t.skip('Native POSIX reference required');
+  const script = `import contextlib,io,json,runpy,shutil
+from unittest.mock import patch
+with contextlib.redirect_stdout(io.StringIO()):
+    driver = runpy.run_path(${JSON.stringify(reference)})
+def secondary(*args):
+    raise AssertionError('controlled lane escaped through secondary accelerator')
+with patch.object(shutil, '_HAS_FCOPYFILE', False), \
+     patch.object(shutil, '_USE_CP_COPY_FILE_RANGE', True), \
+     patch.object(shutil, '_USE_CP_SENDFILE', True), \
+     patch.object(shutil, '_fastcopy_sendfile', secondary):
+    rows = [driver['capture']('accelerator', case) for case in ['fallback', 'partial-error']]
+print(json.dumps({'bufferSize':shutil.COPY_BUFSIZE, 'accelerator':'_fastcopy_copy_file_range', 'cases':rows}))`;
+  const run = spawnSync('python3.14', ['-I', '-c', script], { input: '', encoding: 'utf8', timeout: 20000, maxBuffer: 8 * 1024 * 1024 });
+  if (run.error?.code === 'ENOENT') return t.skip('Interpreter alias unavailable');
+  assert.ifError(run.error);
+  assert.equal(run.status, 0, run.stderr);
+  assert.equal(run.stderr, '');
+  const receipt = JSON.parse(run.stdout);
+  assert.deepEqual(receipt.cases.map(row => row.id), ['accelerator:fallback', 'accelerator:partial-error']);
+  for (const row of receipt.cases) checkCopy(row, receipt);
+});

--- a/tests_js/point_paths_reference.test.mjs
+++ b/tests_js/point_paths_reference.test.mjs
@@ -432,6 +432,23 @@ test('S05 path support registration preserves the exact prior matrix', t => {
     command: ['npm', 'run', 'companion:typecheck'], tiers: ['fast', 'full'] });
   assert.deepEqual(matrix.ownership.shift(), { paths: ['apps/companion/**'],
     suites: ['companion-typescript-check', 'node-workspace-other', 'migration-inventory', 'source-size'] });
+  // Validate the exact portable/native split before removing only those
+  // reviewed additions from the historical matrix comparison.
+  const nativeIndex = matrix.suites.findIndex(suite => suite.id === 'native-frozen-reference-profiles');
+  assert.ok(nativeIndex >= 0);
+  assert.deepEqual(matrix.suites.splice(nativeIndex, 1), [{
+    id: 'native-frozen-reference-profiles', kind: 'node-test',
+    include: ['tests_js/typed_json_points_profiles.test.mjs'],
+    platforms: ['darwin'], tiers: ['full', 'platform']
+  }]);
+  const workspace = matrix.suites.find(suite => suite.id === 'node-workspace-other');
+  assert.deepEqual(workspace.exclude, ['tests_js/typed_json_points_profiles.test.mjs']);
+  delete workspace.exclude;
+  const profilePath = 'tests_js/resume_stat_profile_support.mjs';
+  const profileOwners = matrix.ownership.filter(rule => rule.paths.includes(profilePath));
+  assert.equal(profileOwners.length, 1);
+  assert.deepEqual(profileOwners[0].suites, ['node-workspace-other']);
+  assert.equal(profileOwners[0].paths.shift(), profilePath);
   assert.equal(hash(JSON.stringify(matrix)), registrationBaselineSha256);
   t.diagnostic(JSON.stringify({ registrationBaselineSha256, ownership: registrationOwnership }));
 });

--- a/tests_js/resume_modified_at_reference.test.mjs
+++ b/tests_js/resume_modified_at_reference.test.mjs
@@ -1,3 +1,4 @@
+import { nativeStatTimeMode } from './resume_stat_profile_support.mjs';
 import { observeDomain, refuseDomain } from './point_paths_domain_support.mjs';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
@@ -60,8 +61,11 @@ function observeLegacy(executable, t) {
     assert.deepEqual(receipt.cases, fixtures.map(([id, secondsHex, result]) => ({ id, secondsHex,
       outcome: result.endsWith('Error') ? { kind: 'error', name: result } : { kind: 'value', value: result },
     })));
+    const mode = nativeStatTimeMode(receipt.nativeCases);
     assert.deepEqual(receipt.nativeCases, native.map(([requestedNs, secondsHex, value]) => ({
-      requestedNs, actualNs: requestedNs, secondsHex, value, unchanged: true,
+      requestedNs, actualNs: requestedNs,
+      secondsHex: requestedNs === '-600' && mode === 'separate' ? 'bea421f5f4000000' : secondsHex,
+      value, unchanged: true,
     })));
     t.diagnostic(`${receipt.profile.python}: 24 exact binary64 cases, four native stat conversions; no live Store`);
 }
@@ -81,8 +85,8 @@ test('resume timestamp reference rejects caller arguments and input', () => {
   }
 });
 
-test('S05 domain reference preserves admitted values and cache identity under default CPython', t => observeDomain(t, 'python3'));
-test('S05 domain reference preserves admitted values and cache identity under CPython 3.12', t => observeDomain(t, 'python3.12', '3.12'));
-test('S05 domain reference preserves admitted values and cache identity under CPython 3.13', t => observeDomain(t, 'python3.13', '3.13'));
-test('S05 domain reference preserves admitted values and cache identity under CPython 3.14', t => observeDomain(t, 'python3.14', '3.14'));
+test('S05 domain reference preserves admitted values and cache identity under default CPython', { skip: process.platform !== 'darwin' && 'S05 native domain driver supports Darwin only' }, t => observeDomain(t, 'python3'));
+test('S05 domain reference preserves admitted values and cache identity under CPython 3.12', { skip: process.platform !== 'darwin' && 'S05 native domain driver supports Darwin only' }, t => observeDomain(t, 'python3.12', '3.12'));
+test('S05 domain reference preserves admitted values and cache identity under CPython 3.13', { skip: process.platform !== 'darwin' && 'S05 native domain driver supports Darwin only' }, t => observeDomain(t, 'python3.13', '3.13'));
+test('S05 domain reference preserves admitted values and cache identity under CPython 3.14', { skip: process.platform !== 'darwin' && 'S05 native domain driver supports Darwin only' }, t => observeDomain(t, 'python3.14', '3.14'));
 test('S05 domain reference rejects caller arguments paths and stdin', () => refuseDomain());

--- a/tests_js/resume_modified_at_ts.test.mjs
+++ b/tests_js/resume_modified_at_ts.test.mjs
@@ -1,3 +1,4 @@
+import { nativeStatTimeMode } from './resume_stat_profile_support.mjs';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -104,12 +105,13 @@ for (const executable of [primary, 'python3.12', 'python3.13', 'python3.14']) {
     if (executable !== primary) assert.ok(receipt.profile.python.startsWith(executable.replace('python', '') + '.'));
     assert.equal(receipt.cases.length, 24);
     assert.equal(receipt.nativeCases.length, 4);
+    const nativeMode = nativeStatTimeMode(receipt.nativeCases);
     for (const item of receipt.cases) assert.deepEqual(observe(decode(item.secondsHex)), item.outcome, item.id);
     for (const item of receipt.nativeCases) {
       assert.equal(item.unchanged, true);
       assert.equal(resumeModifiedAt(decode(item.secondsHex)), item.value);
       const encoded = Buffer.alloc(8);
-      encoded.writeDoubleBE(statSecondsFromNanoseconds(BigInt(item.actualNs), 'fused'));
+      encoded.writeDoubleBE(statSecondsFromNanoseconds(BigInt(item.actualNs), nativeMode));
       assert.equal(encoded.toString('hex'), item.secondsHex, `native conversion ${item.actualNs}`);
     }
     const generated = generatedHex();
@@ -147,7 +149,7 @@ for (const executable of [primary, 'python3.12', 'python3.13', 'python3.14']) {
     assert.equal(nativeRows.length, 50);
     for (const [actualNs, secondsHex] of nativeRows) {
       const encoded = Buffer.alloc(8);
-      encoded.writeDoubleBE(statSecondsFromNanoseconds(BigInt(actualNs), 'fused'));
+      encoded.writeDoubleBE(statSecondsFromNanoseconds(BigInt(actualNs), nativeMode));
       assert.equal(encoded.toString('hex'), secondsHex, `native st_mtime ${actualNs}`);
     }
     t.diagnostic(`${receipt.profile.python}: 24 fixed, 4 native seconds values, ${generated.length} generated binary64 values; seed 343465`);

--- a/tests_js/resume_stat_profile_support.mjs
+++ b/tests_js/resume_stat_profile_support.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+
+/** Identify one observed CPython build profile; OS alone does not determine fusion. */
+export function nativeStatTimeMode(rows) {
+  const distinguishing = rows.find(row => row.requestedNs === '-600');
+  assert.ok(distinguishing, 'Native stat profile requires the -600 ns fixture');
+  assert.equal(distinguishing.actualNs, '-600', 'Native filesystem must preserve exact nanoseconds');
+  const modes = new Map([
+    ['bea421f5f40489ae', 'fused'],
+    ['bea421f5f4000000', 'separate'],
+  ]);
+  const mode = modes.get(distinguishing.secondsHex);
+  assert.ok(mode, `Unrecognized CPython native stat arithmetic: ${distinguishing.secondsHex}`);
+  return mode;
+}

--- a/tests_js/typed_json_points_portable.test.mjs
+++ b/tests_js/typed_json_points_portable.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { endianness } from 'node:os';
+import test from 'node:test';
+import { PythonText } from '../runtime/contracts/python-text.js';
+import { PythonObject } from '../runtime/contracts/python-object.js';
+import { parsePythonPointJson, parsePythonPointJsonBytes, PythonPointJsonDecodeError, PythonPointJsonValueError } from '../runtime/contracts/raw-json/point-parser.js';
+import { serializePythonPointScope } from '../runtime/contracts/raw-json/point-serializer.js';
+
+const hash = bytes => createHash('sha256').update(bytes).digest('hex');
+function fixture(name, expectedHash) {
+  const bytes = readFileSync(new URL(`../docs/migration/evidence/s08/${name}`, import.meta.url));
+  assert.equal(hash(bytes), expectedHash);
+  return JSON.parse(bytes);
+}
+const composed = fixture('composed-reference-vectors.json', '1ccb7cdb553cd70a1f6107904b595c4a9c9ea720e9d8c5cbc48955233f280e7b');
+const supplemental = fixture('additional-reference-vectors.json', '500ce6a2f35ac9f9e0bfe9ec8a676d0aa1165687a768f53e3bffeacf5048225d');
+const reference = fileURLToPath(new URL('../tools/contracts/codepoint-json/reference.py', import.meta.url));
+assert.equal(hash(readFileSync(reference)), 'fef264468e9190a80cd6edbc03ec06693f6269edc3df7f30757fb16a8d63c231');
+const moduleNames = ['json', 'json.decoder', 'json.encoder', 'json.scanner', 'codecs',
+  'encodings', 'encodings.utf_8', 'encodings.utf_8_sig', 'encodings.utf_16', 'encodings.utf_32'];
+const probe = `import importlib,json,pathlib,platform,sys
+names=${JSON.stringify(moduleNames)}
+print(json.dumps({'executable':str(pathlib.Path(sys.executable).resolve()),'python':platform.python_version(),
+ 'implementation':platform.python_implementation(),'platform':sys.platform,'machine':platform.machine(),
+ 'byteOrder':sys.byteorder,'isolated':sys.flags.isolated,
+ 'modules':{n:str(pathlib.Path(importlib.import_module(n).__file__).resolve()) for n in names},
+ 'native':{n:importlib.import_module(n).__spec__.origin for n in ['_json','_codecs']}}))`;
+
+// Fixed test-owned points/limits are observed by stdlib json. Expected outcomes
+// are never supplied to this process or generated from the implementation.
+const supplementalProbe = `import json,platform,sys
+rows=json.load(sys.stdin)
+def points(value): return list(map(ord,value))
+def typed(value):
+ if value is None: return {'kind':'null'}
+ if isinstance(value,bool): return {'kind':'boolean','value':value}
+ if isinstance(value,str): return {'kind':'text','points':points(value)}
+ if isinstance(value,int): return {'kind':'integer','decimal':str(value)}
+ if isinstance(value,float): return {'kind':'float','hex':value.hex()}
+ if isinstance(value,list): return {'kind':'array','items':[typed(x) for x in value]}
+ if isinstance(value,dict): return {'kind':'object','entries':[[points(k),typed(v)] for k,v in value.items()]}
+ raise AssertionError(type(value).__name__)
+result=[]
+for row in rows:
+ assert set(row)=={'id','documentPoints','intMaxStrDigits'}
+ previous=sys.get_int_max_str_digits()
+ try:
+  sys.set_int_max_str_digits(row['intMaxStrDigits'])
+  document=''.join(map(chr,row['documentPoints']))
+  try:
+   value=json.loads(document)
+   ascii_text=json.dumps(value,ensure_ascii=True,sort_keys=True,separators=(',',':'))
+   outcome={'kind':'value','value':typed(value),'ascii':ascii_text,'asciiReload':typed(json.loads(ascii_text))}
+  except json.JSONDecodeError as error:
+   outcome={'kind':'error','name':'JSONDecodeError','message':str(error),'reason':error.msg,
+    'position':error.pos,'line':error.lineno,'column':error.colno,'documentPoints':points(error.doc)}
+  except ValueError as error:
+   outcome={'kind':'error','name':type(error).__name__,'message':str(error)}
+  result.append(dict(row,outcome=outcome))
+ finally: sys.set_int_max_str_digits(previous)
+print(json.dumps({'version':platform.python_version(),'cases':result},ensure_ascii=True))`;
+
+function run(executable, args, input = '') {
+  const result = spawnSync(executable, ['-I', '-B', ...args], {
+    input, encoding: 'utf8', timeout: 10000, maxBuffer: 1024 * 1024,
+  });
+  assert.ifError(result.error); // Required profiles must never become skips.
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.signal, null);
+  assert.equal(result.stderr, '');
+  return JSON.parse(result.stdout);
+}
+function floatHex(value) {
+  if (Number.isNaN(value)) return 'nan';
+  if (!Number.isFinite(value)) return value < 0 ? '-inf' : 'inf';
+  const view = new DataView(new ArrayBuffer(8)); view.setFloat64(0, value);
+  const bits = view.getBigUint64(0), sign = bits >> 63n ? '-' : '';
+  const exponent = Number(bits >> 52n & 2047n), fraction = bits & 0xfffffffffffffn;
+  if (!exponent && !fraction) return `${sign}0x0.0p+0`;
+  const power = exponent ? exponent - 1023 : -1022;
+  return `${sign}0x${exponent ? 1 : 0}.${fraction.toString(16).padStart(13, '0')}p${power >= 0 ? '+' : ''}${power}`;
+}
+function typed(value) {
+  if (value === null) return { kind: 'null' };
+  if (typeof value === 'boolean') return { kind: 'boolean', value };
+  if (value instanceof PythonText) return { kind: 'text', points: [...value.codePoints] };
+  if (Array.isArray(value)) return { kind: 'array', items: value.map(typed) };
+  if (value instanceof PythonObject) return { kind: 'object', entries: value.entries().map(([key, item]) => [[...key.codePoints], typed(item)]) };
+  if (value.kind === 'int') return { kind: 'integer', decimal: value.value.toString() };
+  assert.equal(value.kind, 'float');
+  return { kind: 'float', hex: floatHex(value.value) };
+}
+function observeTs(row, version) {
+  const options = { intMaxStrDigits: row.intMaxStrDigits ?? 640, diagnosticProfile: version.split('.').slice(0, 2).join('.') };
+  try {
+    const value = row.inputHex == null ? parsePythonPointJson(PythonText.fromCodePoints(row.documentPoints), options)
+      : parsePythonPointJsonBytes(Buffer.from(row.inputHex, 'hex'), options);
+    const ascii = serializePythonPointScope(value);
+    return { kind: 'value', value: typed(value), ascii,
+      asciiReload: typed(parsePythonPointJson(PythonText.fromJavaScript(ascii), options)) };
+  } catch (error) {
+    if (error instanceof PythonPointJsonDecodeError) return {
+      kind: 'error', name: error.name, message: error.message, reason: error.msg,
+      position: error.pos, line: error.lineno, column: error.colno, documentPoints: [...error.doc.codePoints],
+    };
+    assert.ok(error instanceof PythonPointJsonValueError);
+    return { kind: 'error', name: error.name, message: error.message };
+  }
+}
+function verify(executable, t) {
+  const selected = run(executable, ['-c', probe]);
+  assert.equal(selected.implementation, 'CPython');
+  assert.equal(selected.platform, process.platform);
+  assert.equal(selected.byteOrder, endianness() === 'LE' ? 'little' : 'big');
+  assert.equal(selected.isolated, 1);
+  if (executable !== 'python3') assert.ok(selected.python.startsWith(executable.slice(6) + '.'));
+  const minor = selected.python.split('.').slice(0, 2).join('.');
+  assert.ok(['3.12', '3.13', '3.14'].includes(minor), `Unsupported CPython minor ${minor}`);
+  // Historical receipts provide only fixed inputs here. This is fresh portable
+  // differential coverage, not acceptance of a foreign build under an old identity.
+  const expected = composed.profiles.find(profile => profile.version.startsWith(`${minor}.`));
+  const extra = supplemental.profiles.find(profile => profile.receipt.profile.version.startsWith(`${minor}.`))?.receipt;
+  assert.ok(expected && extra, `Missing fixed inputs for CPython ${minor}`);
+  const actual = run(executable, [reference]);
+  assert.deepEqual(Object.keys(actual).sort(), ['cases', 'native', 'profile', 'schemaVersion', 'scope', 'serializers', 'stdlib']);
+  assert.equal(actual.schemaVersion, 1);
+  assert.equal(actual.scope, 'fixed-composed-codepoint-json');
+  assert.deepEqual(actual.profile, { python: selected.python, implementation: 'CPython', platform: process.platform,
+    byteOrder: selected.byteOrder, intMaxStrDigits: 640, executablePath: selected.executable,
+    executableSha256: hash(readFileSync(selected.executable)) });
+  assert.deepEqual(Object.keys(actual.stdlib).sort(), [...moduleNames].sort());
+  for (const name of moduleNames) assert.deepEqual(actual.stdlib[name], {
+    path: selected.modules[name], sha256: hash(readFileSync(selected.modules[name])),
+  });
+  assert.deepEqual(Object.keys(actual.native).sort(), ['_codecs', '_json']);
+  for (const [name, origin] of Object.entries(selected.native)) assert.deepEqual(actual.native[name], {
+    origin, sha256: origin === 'built-in' ? null : hash(readFileSync(origin)),
+  });
+  assert.equal(expected.cases.length, 38);
+  assert.equal(new Set(actual.cases.map(row => row.id)).size, 38);
+  assert.deepEqual(actual.cases.map(row => row.id).sort(), expected.cases.map(row => row.id).sort());
+  for (const row of expected.cases) {
+    const observed = actual.cases.find(item => item.id === row.id);
+    const input = ({ outcome, ...fields }) => fields;
+    assert.deepEqual(input(observed), input(row), `fixed input ${row.id}`);
+  }
+  assert.deepEqual(actual.serializers, composed.serializers);
+  for (const row of actual.cases) assert.deepEqual(observeTs(row, selected.python), row.outcome, row.id);
+  const inputs = extra.cases.map(({ id, documentPoints, intMaxStrDigits }) => ({ id, documentPoints, intMaxStrDigits }));
+  assert.equal(inputs.length, 48);
+  assert.equal(new Set(inputs.map(row => row.id)).size, 48);
+  const observedExtra = run(executable, ['-c', supplementalProbe], JSON.stringify(inputs));
+  assert.equal(observedExtra.version, selected.python);
+  assert.equal(observedExtra.cases.length, 48);
+  assert.deepEqual(observedExtra.cases.map(({ outcome, ...input }) => input), inputs);
+  for (const row of observedExtra.cases) assert.deepEqual(observeTs(row, selected.python), row.outcome, row.id);
+  t.diagnostic(JSON.stringify({ evidenceKind: 'portable-live-differential', ...actual.profile, stdlib: actual.stdlib, native: actual.native,
+    composedCases: 38, supplementalCases: 48, serializerGraphs: 3, defaultMayDuplicateProfile: executable === 'python3' }));
+}
+
+test('S08 portable point JSON matches fresh CPython observations under default CPython', t => verify('python3', t));
+test('S08 portable point JSON matches fresh CPython observations under CPython 3.12', t => verify('python3.12', t));
+test('S08 portable point JSON matches fresh CPython observations under CPython 3.13', t => verify('python3.13', t));
+test('S08 portable point JSON matches fresh CPython observations under CPython 3.14', t => verify('python3.14', t));

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,4 +1,5 @@
 import { nativeFactsBrowser } from './workspace_native_facts_browser_support.mjs';
+import { resumeDraftBrowser } from './workspace_native_resumes_browser_support.mjs';
 import assert from 'node:assert/strict';
 import { chromium } from 'playwright';
 import { spawn, execFile } from 'node:child_process';
@@ -92,6 +93,7 @@ export async function nativeJobsBrowser(buildRoot) {
     const browserResume = Object.values(resumeDocument.resumes)[0];
     assert.equal(browserResume.label, 'Browser resume updated');
     assert.equal(await readFile(join(root, 'resume-files', browserResume.managedFile), 'utf8'), 'updated browser resume');
+    await resumeDraftBrowser(page, root, fixture, buildRoot, browserResume.id);
     const token = new URLSearchParams(new URL(startup.url).hash.slice(1)).get('token');
     const unsupported = await fetch(startup.origin + '/api/overview', { headers: { Authorization: `Bearer ${token}` } });
     assert.equal(unsupported.status, 501);

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -44,7 +44,7 @@ export async function nativeJobsBrowser(buildRoot) {
     });
     page.on('pageerror', error => pageErrors.push(error.message));
     await page.goto(startup.url);
-    await page.getByText(/Synthetic native Jobs workspace/).waitFor();
+    await page.getByText(/Synthetic native workspace/).waitFor();
     assert.equal(await page.getByRole('link', { name: 'Open full workspace' }).count(), 0);
     await page.getByRole('button', { name: 'New job', exact: true }).click();
     await page.locator('dialog [name="url"]').fill('https://example.invalid/native');
@@ -74,11 +74,29 @@ export async function nativeJobsBrowser(buildRoot) {
     assert.equal(await page.locator('dialog [name="notes"]').inputValue(), 'Browser draft');
     assert.equal(await page.locator('dialog [name="company"]').inputValue(), 'CLI writer');
     const facts = await nativeFactsBrowser(page, root, fixture, buildRoot);
+    await page.getByRole('button', { name: 'Resumes', exact: true }).click();
+    await page.getByRole('button', { name: 'Import resume', exact: true }).click();
+    await page.getByLabel('Label', { exact: true }).fill('Browser resume');
+    await page.getByLabel('Tags, separated by commas').fill('browser, primary');
+    await page.getByLabel('Resume file').setInputFiles({ name: 'browser.txt', mimeType: 'text/plain', buffer: Buffer.from('browser resume') });
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await page.getByText('Resume imported', { exact: true }).waitFor();
+    await page.getByRole('button', { name: /Browser resume · Default/ }).click();
+    await page.getByLabel('Label', { exact: true }).fill('Browser resume updated');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await page.getByText('Resume details saved', { exact: true }).waitFor();
+    await page.getByLabel('Replacement file').setInputFiles({ name: 'updated.txt', mimeType: 'text/plain', buffer: Buffer.from('updated browser resume') });
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await page.getByText('Resume file replaced', { exact: true }).waitFor();
+    const resumeDocument = JSON.parse(await readFile(join(root, 'resumes.json'), 'utf8'));
+    const browserResume = Object.values(resumeDocument.resumes)[0];
+    assert.equal(browserResume.label, 'Browser resume updated');
+    assert.equal(await readFile(join(root, 'resume-files', browserResume.managedFile), 'utf8'), 'updated browser resume');
     const token = new URLSearchParams(new URL(startup.url).hash.slice(1)).get('token');
     const unsupported = await fetch(startup.origin + '/api/overview', { headers: { Authorization: `Bearer ${token}` } });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { facts, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { facts, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     if (browser) await browser.close();
     if (child && child.exitCode === null && child.signalCode === null) {

--- a/tests_js/workspace_native_resumes.test.mjs
+++ b/tests_js/workspace_native_resumes.test.mjs
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { chmod, lstat, readFile, realpath, symlink, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { loadPosixFlockProvider } from '../runtime/store/posix-flock.js';
+import { NativeJobsRepository, initializeJobsFixture } from '../runtime/store/native-jobs.js';
+import { ResumeService } from '../runtime/workspace-core/resumes.js';
+import { JobsService } from '../runtime/workspace-core/jobs.js';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { fromJSON, serialize } from '../runtime/contracts/workspace/values.js';
+import { validateResumeContent } from '../runtime/contracts/workspace/resume-content.js';
+
+const fixed = '2026-09-09T12:00:00Z';
+const execute = promisify(execFile);
+const plain = value => JSON.parse(serialize(value));
+const contentRevision = value => `content_${value.repeat(32)}`;
+
+test('native managed resumes preserve bytes, revisions, privacy and recovery', { timeout: 60000 }, async t => {
+  const fixture = await nativeFixture();
+  try {
+    const root = join(await realpath(fixture.root), 'native');
+    await initializeJobsFixture(root);
+    const provider = loadPosixFlockProvider(fixture.receipt.artifact);
+    const repository = new NativeJobsRepository(root, provider);
+    let revision = 0;
+    const resumes = new ResumeService(repository, () => fixed, () => 'resume-generated', () => contentRevision(String(++revision)));
+
+    await t.test('PDF, DOCX, UTF-8 and 10 MiB content boundaries fail closed', async () => {
+      assert.equal(validateResumeContent('resume.pdf', Buffer.from('%PDF-1.4\n')).mediaType, 'application/pdf');
+      assert.throws(() => validateResumeContent('resume.pdf', Buffer.from('not pdf')), /does not match/);
+      assert.throws(() => validateResumeContent('resume.txt', Buffer.from([0xff])), /does not match/);
+      assert.throws(() => validateResumeContent('resume.rtf', Buffer.from('text')), /format must/);
+      assert.throws(() => validateResumeContent('resume.txt', Buffer.alloc(10 * 1024 * 1024 + 1, 1)), /10 MiB/);
+      const valid = join(fixture.root, 'valid.docx'), unsafe = join(fixture.root, 'unsafe.docx');
+      const zip = `import sys,zipfile\nwith zipfile.ZipFile(sys.argv[1],'w') as z:z.writestr('[Content_Types].xml','x');z.writestr('word/document.xml','x')\nwith zipfile.ZipFile(sys.argv[2],'w') as z:z.writestr('[Content_Types].xml','x');z.writestr('word/document.xml','x');z.writestr('../escape','x')`;
+      await execute('python3', ['-c', zip, valid, unsafe]);
+      const validBytes = await readFile(valid), unsafeBytes = await readFile(unsafe);
+      assert.equal(validateResumeContent('resume.docx', validBytes).mediaType.includes('wordprocessingml'), true);
+      assert.throws(() => validateResumeContent('resume.docx', unsafeBytes), /does not match/);
+    });
+
+    await t.test('create, metadata update, replacement and default match Python records', async () => {
+      const parityRoot = join(await realpath(fixture.root), 'parity-native');
+      await initializeJobsFixture(parityRoot);
+      const native = new ResumeService(new NativeJobsRepository(parityRoot, provider), () => fixed,
+        () => 'resume-parity', () => contentRevision('p'));
+      const created = await native.import(fromJSON({ id: 'resume-parity', label: ' Parity ', tags: [' one '] }), 'parity.txt', Buffer.from('one'));
+      const updated = await native.update('resume-parity', fromJSON({ label: 'Updated', tags: ['two'] }), 1n);
+      const selected = await native.setDefault('resume-parity', 2n);
+      const replaced = await native.replace('resume-parity', 'replacement.txt', Buffer.from('two'), 2n);
+      const script = `
+import sys,json,importlib.util
+from pathlib import Path
+sys.path.insert(0,str(Path('scripts').resolve()))
+spec=importlib.util.spec_from_file_location('resume_reference','scripts/job-apply-store.py')
+m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m)
+m.utc_now=lambda:'${fixed}'
+s=m.Store(Path(sys.argv[1]));s.initialize();s._new_resume_content_revision=lambda:'${contentRevision('p')}'
+out=[]
+out.append(s.create_resume_bytes({'id':'resume-parity','label':' Parity ','tags':[' one ']},'parity.txt',b'one'))
+out.append(s.update_resume('resume-parity',{'label':'Updated','tags':['two']},1))
+out.append(s.set_default_resume('resume-parity',2))
+out.append(s.update_resume_bytes('resume-parity','replacement.txt',b'two',2))
+print(json.dumps(out))
+`;
+      const reference = JSON.parse((await execute('python3', ['-c', script, join(fixture.root, 'parity-python')])).stdout);
+      const comparable = record => { const result = { ...record }; delete result.observedModifiedAt; delete result.originalFilename; return result; };
+      assert.deepEqual([created, updated, selected, replaced].map(item => comparable(plain(item))), reference.map(comparable));
+      assert.notEqual(plain(created).originalFilename, 'parity.txt');
+    });
+
+    await t.test('import, metadata, default, replace and content survive restart', async () => {
+      const first = plain(await resumes.import(fromJSON({ id: 'resume-one', label: ' First ', tags: [' main '] }), 'first.txt', Buffer.from('first')));
+      assert.equal(first.label, 'First'); assert.deepEqual(first.tags, ['main']); assert.equal(first.default, true);
+      assert.equal((await lstat(join(root, 'resume-files/resume-one.txt'))).mode & 0o077, 0);
+      const second = plain(await resumes.import(fromJSON({ id: 'resume-two', label: 'Second', default: true }), 'second.txt', Buffer.from('second')));
+      assert.equal(second.default, true);
+      assert.equal(plain(await resumes.get('resume-one')).revision, 2);
+      await assert.rejects(resumes.import(fromJSON({ id: 'duplicate', label: 'Duplicate' }), 'copy.txt', Buffer.from('second')), /already managed/);
+      const updated = plain(await resumes.update('resume-one', fromJSON({ label: 'Primary', tags: ['one', 'two'] }), 2n));
+      assert.equal(updated.revision, 3);
+      const selected = plain(await resumes.setDefault('resume-one', 3n));
+      assert.equal(selected.default, true); assert.equal(selected.revision, 4);
+      const replaced = plain(await resumes.replace('resume-one', 'primary.txt', Buffer.from('replacement'), 4n));
+      assert.equal(replaced.revision, 5); assert.equal(replaced.observedSize, 11);
+      const restarted = new ResumeService(new NativeJobsRepository(root, provider));
+      assert.equal((await restarted.content('resume-one')).content.toString(), 'replacement');
+      assert.deepEqual(plain(await restarted.list()).map(item => item.id), ['resume-one', 'resume-two']);
+    });
+
+    await t.test('HTTP validates strict base64 and redacts file identity', async () => {
+      const jobs = new JobsService(repository);
+      const listed = await jobsHttp(jobs, repository, 'GET', '/api/resumes');
+      assert.equal(listed.status, 200); assert.equal(listed.body.includes('managedFile'), false); assert.equal(listed.body.includes('digest'), false);
+      const content = await jobsHttp(jobs, repository, 'GET', '/api/resumes/resume-one/content');
+      assert.equal(content.status, 200); assert.equal(content.contentType, 'text/plain; charset=utf-8'); assert.equal(content.body.toString(), 'replacement');
+      const invalid = JSON.stringify({ metadata: { label: 'Bad' }, filename: 'bad.txt', content: 'YQ= =' });
+      assert.equal((await jobsHttp(jobs, repository, 'POST', '/api/resumes/import', invalid)).status, 400);
+      const valid = JSON.stringify({ metadata: { id: 'resume-http', label: 'HTTP' }, filename: 'http.txt', content: Buffer.from('http').toString('base64') });
+      const imported = await jobsHttp(jobs, repository, 'POST', '/api/resumes/import', valid);
+      assert.equal(imported.status, 200); assert.equal(JSON.parse(imported.body).id, 'resume-http');
+      assert.notEqual(JSON.parse(await readFile(join(root, 'resumes.json'), 'utf8')).resumes['resume-http'].originalFilename, 'http.txt');
+    });
+
+    await t.test('CLI imports local paths through the native service with an empty PATH', async () => {
+      const metadata = join(fixture.root, 'resume-input.json'), source = join(fixture.root, 'cli.txt');
+      await writeFile(metadata, '{"id":"resume-cli","label":"CLI resume"}'); await writeFile(source, 'cli resume');
+      const result = await execute(process.execPath, [join(process.cwd(), 'runtime/cli/native-jobs.js'), '--root', root,
+        '--native-lock', fixture.receipt.artifact, 'resume-import', '--input', metadata, '--path', source], { env: { PATH: '' } });
+      assert.equal(JSON.parse(result.stdout).originalFilename, 'cli.txt');
+      const checked = await execute(process.execPath, [join(process.cwd(), 'runtime/cli/native-jobs.js'), '--root', root,
+        '--native-lock', fixture.receipt.artifact, 'resume-check', '--id', 'resume-cli'], { env: { PATH: '' } });
+      assert.equal(JSON.parse(checked.stdout).changed, false);
+    });
+
+    await t.test('concurrent default selection accepts one expected revision', async () => {
+      const current = plain(await resumes.get('resume-two'));
+      const outcomes = await Promise.allSettled(Array.from({ length: 4 }, () => resumes.setDefault('resume-two', BigInt(current.revision))));
+      assert.equal(outcomes.filter(item => item.status === 'fulfilled').length, 1);
+      for (const item of outcomes.filter(item => item.status === 'rejected')) assert.match(item.reason.message, /revision conflict/);
+    });
+
+    await t.test('a metadata failure after byte install rolls forward exactly once', async () => {
+      const current = plain(await resumes.get('resume-one'));
+      let failed = false;
+      const interrupted = { resumeTransaction: operation => repository.resumeTransaction(transaction => operation({
+        ...transaction, save: async document => {
+          if (!failed) { failed = true; throw Error('injected metadata failure'); }
+          await transaction.save(document);
+        },
+      })) };
+      await assert.rejects(new ResumeService(interrupted, () => fixed, undefined, () => contentRevision('r'))
+        .replace('resume-one', 'after.txt', Buffer.from('after interruption'), BigInt(current.revision)), /injected metadata failure/);
+      const recovered = plain(await resumes.get('resume-one'));
+      assert.equal(recovered.revision, current.revision + 1);
+      assert.equal((await resumes.content('resume-one')).content.toString(), 'after interruption');
+      assert.equal(JSON.parse(await readFile(join(root, 'resume-operation.json'), 'utf8')).operation, null);
+    });
+
+    await t.test('missing, linked and permissive managed files are rejected', async () => {
+      const path = join(root, 'resume-files/resume-one.txt'), backup = join(fixture.root, 'backup.txt');
+      const bytes = await readFile(path); await writeFile(backup, bytes); await unlink(path);
+      assert.deepEqual(plain(await resumes.check('resume-one')).exists, false);
+      await assert.rejects(resumes.content('resume-one'), /unavailable/);
+      await symlink(backup, path); await assert.rejects(resumes.content('resume-one'), /private and owned|unavailable/);
+      await unlink(path); await writeFile(path, bytes, { mode: 0o600 }); await chmod(path, 0o644);
+      await assert.rejects(resumes.content('resume-one'), /private and owned/);
+    });
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_resumes.test.mjs
+++ b/tests_js/workspace_native_resumes.test.mjs
@@ -31,6 +31,7 @@ test('native managed resumes preserve bytes, revisions, privacy and recovery', {
     await t.test('PDF, DOCX, UTF-8 and 10 MiB content boundaries fail closed', async () => {
       assert.equal(validateResumeContent('resume.pdf', Buffer.from('%PDF-1.4\n')).mediaType, 'application/pdf');
       assert.throws(() => validateResumeContent('resume.pdf', Buffer.from('not pdf')), /does not match/);
+      assert.throws(() => validateResumeContent('resume.pdf', Buffer.from([0xa5, 0xd0, 0xc4, 0xc6, 0xad])), /does not match/);
       assert.throws(() => validateResumeContent('resume.txt', Buffer.from([0xff])), /does not match/);
       assert.throws(() => validateResumeContent('resume.rtf', Buffer.from('text')), /format must/);
       assert.throws(() => validateResumeContent('resume.txt', Buffer.alloc(10 * 1024 * 1024 + 1, 1)), /10 MiB/);

--- a/tests_js/workspace_native_resumes_browser_support.mjs
+++ b/tests_js/workspace_native_resumes_browser_support.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const execute = promisify(execFile);
+
+export async function resumeDraftBrowser(page, root, fixture, buildRoot, id) {
+    const stored = async () => JSON.parse(await readFile(join(root, 'resumes.json'), 'utf8')).resumes[id];
+    async function externalPatch(patch) {
+        const current = await stored();
+        const input = join(fixture.root, 'resume-concurrent-patch.json');
+        await writeFile(input, JSON.stringify(patch));
+        await execute(process.execPath, [join(buildRoot, 'runtime/cli/native-jobs.js'), '--root', root,
+            '--native-lock', fixture.receipt.artifact, 'resume-update', '--id', id,
+            '--expected-revision', String(current.revision), '--input', input], { env: { PATH: '' } });
+    }
+
+    // A clean refresh adopts canonical values; it must not turn stale fields into an editable draft.
+    await externalPatch({ label: 'Concurrent label' });
+    await page.getByRole('button', { name: 'Refresh', exact: true }).click();
+    await page.getByRole('heading', { name: 'Concurrent label', exact: true }).waitFor();
+    assert.equal(await page.getByLabel('Label', { exact: true }).inputValue(), 'Concurrent label');
+    assert.equal(await page.getByRole('button', { name: 'Save', exact: true }).isDisabled(), true);
+
+    // A dirty refresh keeps the original revision until the owner explicitly reapplies changed fields.
+    await page.getByLabel('Label', { exact: true }).fill('My resume draft');
+    await externalPatch({ tags: ['concurrent-tag'] });
+    await page.getByRole('button', { name: 'Refresh', exact: true }).click();
+    await page.getByText('This resume changed elsewhere. Your draft is preserved.', { exact: true }).waitFor();
+    assert.equal(await page.getByRole('button', { name: 'Save', exact: true }).isDisabled(), true);
+    assert.equal(await page.getByLabel('Label', { exact: true }).inputValue(), 'My resume draft');
+    await page.getByRole('button', { name: 'Reapply my draft', exact: true }).click();
+    assert.equal(await page.getByLabel('Tags, separated by commas').inputValue(), 'concurrent-tag');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await page.getByText('Resume details saved', { exact: true }).waitFor();
+    assert.equal((await stored()).label, 'My resume draft');
+    assert.deepEqual((await stored()).tags, ['concurrent-tag']);
+
+    // Metadata entered before choosing a file is a real import draft.
+    await page.getByRole('button', { name: 'Import resume', exact: true }).click();
+    await page.getByLabel('Label', { exact: true }).fill('Unsaved import');
+    let prompts = 0;
+    const dismiss = async dialog => { prompts++; await dialog.dismiss(); };
+    page.on('dialog', dismiss);
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+    assert.equal(prompts, 1);
+    assert.equal(await page.getByLabel('Label', { exact: true }).inputValue(), 'Unsaved import');
+    await page.getByRole('button', { name: 'Jobs', exact: true }).click();
+    assert.equal(prompts, 2);
+    assert.equal(await page.getByLabel('Label', { exact: true }).inputValue(), 'Unsaved import');
+    page.off('dialog', dismiss);
+    page.once('dialog', dialog => dialog.accept());
+    await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+}

--- a/tests_js/workspace_next_editor_support.mjs
+++ b/tests_js/workspace_next_editor_support.mjs
@@ -62,6 +62,13 @@ async function editorDraftAssertions() {
 }
 async function editorDtoAssertions() {
     return modules((m, c) => {
+        const legacyResume = {
+            id: 'legacy', label: 'Legacy', default: true, revision: 1,
+            createdAt: '2026-09-09T00:00:00Z', updatedAt: '2026-09-09T00:00:00Z'
+        };
+        assert.deepEqual(c.resumeList({ resumes: [legacyResume] })[0].tags, []);
+        assert.throws(() => c.resume({ ...legacyResume, tags: null }));
+        assert.throws(() => c.resume({ ...legacyResume, tags: [1] }));
         assert.throws(() => c.job({
             id: 'x', revision: 0, status: 'saved', url: 'x'
         }));

--- a/tools/contracts/artifact-data-copy/reference.py
+++ b/tools/contracts/artifact-data-copy/reference.py
@@ -88,6 +88,14 @@ def capture(lane, case):
             elif lane == 'accelerator':
                 if selected is None:
                     return {'id': lane + ':' + case, 'status': 'unavailable', 'reason': 'no selected native accelerator'}
+                # This lane observes one controlled accelerator and its buffered
+                # fallback. A second native helper would bypass Streams' witnesses
+                # (copy_file_range can fall through to sendfile on Python 3.14).
+                for flag, helper in [('_HAS_FCOPYFILE', '_fastcopy_fcopyfile'),
+                                     ('_USE_CP_COPY_FILE_RANGE', '_fastcopy_copy_file_range'),
+                                     ('_USE_CP_SENDFILE', '_fastcopy_sendfile')]:
+                    if helper != selected and hasattr(shutil, flag):
+                        patches.append(patch.object(shutil, flag, False))
                 def accelerated(fsrc, fdst, *args):
                     streams.mark('accelerator', helper=selected)
                     if case == 'fallback': raise shutil._GiveupOnFastCopy(OSError(errno.ENOTSUP, 'synthetic unsupported'))


### PR DESCRIPTION
Adds the opt-in native managed resume library, shared by HTTP/CLI and React. Owners can import, inspect, update, replace, adopt and choose resumes while preserving drafts and revision conflicts. Durable file/metadata recovery rejects changed or unsafe file identities.

This is the first of three dependent migration PRs. It targets staging and is limited to newly initialized synthetic Stores; the default Python launcher and live Store behavior remain unchanged.

Validation: Python/native contract and disk parity, file identity and interruption checks, production Companion browser workflows, independent correctness/tests/contracts/silent-failure/docs review, and repository commit/push gates. The final corrected commit passed the 27-suite deep and normal push gates. The native Codex baseline could not run because the installed CLI does not support its configured model; independent review is used and this is not counted as a passed baseline.

CI repairs: use UTF-8 for the Windows legacy-report fixture, provision required CPython versions, recognize exact timestamp build profiles, retain historical Darwin-only reference validation alongside portable live comparisons, and isolate the controlled copy-accelerator fallback oracle. The latter has a regression reproducing the prior secondary-accelerator escape. Independent review verified the fixes.

Verification history: [initial validation](https://github.com/neonwatty/job-apply-plugin/actions/runs/34424127105) exposed Windows and Linux harness issues. [Second validation](https://github.com/neonwatty/job-apply-plugin/actions/runs/34427623339) passed Windows and all other jobs except the Python 3.14 copy-oracle case; its [Release Validation passed](https://github.com/neonwatty/job-apply-plugin/actions/runs/34427624780). Final commit `cad9407e2f9177e1c352696da9928111dd59b84f` passed [Validate Plugin](https://github.com/neonwatty/job-apply-plugin/actions/runs/34429992873) and [Release Validation](https://github.com/neonwatty/job-apply-plugin/actions/runs/34429994286), including Windows, Linux and macOS jobs.
