### PR TITLE
Add native answer editing and resume extraction review

### DIFF
--- a/apps/companion/components/Answers.tsx
+++ b/apps/companion/components/Answers.tsx
@@ -1,0 +1,176 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+import { AnswerFields } from './answer-fields';
+import { string, get, object, parse, serialize } from '../../../src/contracts/workspace/values';
+import { answerDraft, answerMutation, answerPath, answerSnapshot, reapplyAnswer } from './answer-model';
+import type { AnswerClient, Document } from './answer-model';
+
+export function Answers({ client, dirtyChanged }: { client: AnswerClient; dirtyChanged: (dirty: boolean) => void }) {
+  const [items, setItems] = useState<Document[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [query, setQuery] = useState('');
+  const [status, setStatus] = useState('accepted');
+  const [base, setBase] = useState<Document | null>(null);
+  const [draft, setDraft] = useState<Document | null>(null);
+  const [latest, setLatest] = useState<Document | null>(null);
+  const [remember, setRemember] = useState(false);
+  const [error, setError] = useState('');
+  const [notice, setNotice] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [invalid, setInvalid] = useState(false);
+  const [editorVersion, setEditorVersion] = useState(0);
+  const editorForm = useRef<HTMLFormElement>(null);
+  const generation = useRef(0);
+  const request = useRef<AbortController | null>(null);
+  const listGeneration = useRef(0);
+  const listRequest = useRef<AbortController | null>(null);
+  const heading = useRef<HTMLHeadingElement>(null);
+  const dirty = invalid || base !== null && draft !== null && serialize(draft) !== serialize(answerDraft(base));
+  useEffect(() => { dirtyChanged(dirty || busy); return () => dirtyChanged(false); }, [dirty, busy, dirtyChanged]);
+  useEffect(() => () => { generation.current++; listGeneration.current++; request.current?.abort(); listRequest.current?.abort(); }, []);
+  async function refreshList() {
+    listRequest.current?.abort();
+    const controller = new AbortController();
+    listRequest.current = controller;
+    const version = ++listGeneration.current;
+    setLoading(true);
+    setError('');
+    try {
+      const raw = await client.answerRequest('/api/answers/query', 'POST', JSON.stringify({ query, reviewStatus: status === 'all' ? null : status }), controller.signal);
+      const page = object(parse(raw), 'answers response'), values = get(page, 'items');
+      if (!Array.isArray(values)) throw Error('Invalid answer list');
+      if (version !== listGeneration.current) return;
+      setItems(values.map(value => object(value, 'answer')));
+      setLoaded(true);
+      if (get(page, 'hasMore') === true) setNotice('Showing the first 50 results. Narrow your search to find more.');
+    } catch (failure) {
+      if (version === listGeneration.current && !controller.signal.aborted) setError(failure instanceof Error ? failure.message : 'Unable to load answers');
+    } finally { if (version === listGeneration.current) setLoading(false); }
+  }
+  useEffect(() => { void refreshList(); }, [client]);
+  async function select(key: string, refresh = false, reveal = false) {
+    if (!refresh && dirty && !confirm('Discard your unsaved answer changes?')) return;
+    request.current?.abort();
+    const controller = new AbortController();
+    request.current = controller;
+    const version = ++generation.current;
+    setBusy(true);
+    setError('');
+    setNotice('');
+    try {
+      const raw = await client.answerRequest(answerPath(key) + (reveal ? '/reveal' : ''), reveal ? 'POST' : 'GET', reveal ? '{}' : undefined, controller.signal);
+      if (version !== generation.current) return;
+      const next = answerSnapshot(raw);
+      if (string(get(next, 'key')) !== key) throw Error('Answer identity changed. Reload the answer list.');
+      if (refresh && dirty) {
+        setLatest(next);
+        setNotice('Latest answer loaded. Your draft is retained.');
+      } else {
+        setBase(next);
+        setDraft(answerDraft(next));
+        setInvalid(false);
+        setEditorVersion(value => value + 1);
+        setLatest(null);
+        setRemember(false);
+        heading.current?.focus();
+      }
+    } catch (failure) {
+      if (version === generation.current && !controller.signal.aborted) setError(failure instanceof Error ? failure.message : 'Unable to load answer');
+    } finally { if (version === generation.current) setBusy(false); }
+  }
+  async function save(action = '') {
+    if (!base || !draft || invalid || !editorForm.current?.reportValidity()) return;
+    const key = string(get(base, 'key'))!;
+    let body: string;
+    try { body = answerMutation(base, draft, remember); }
+    catch (failure) { setError(failure instanceof Error ? failure.message : 'Invalid JSON draft'); return; }
+    const controller = new AbortController();
+    request.current?.abort();
+    request.current = controller;
+    const version = ++generation.current;
+    setBusy(true);
+    setError('');
+    setNotice('');
+    try {
+      const raw = await client.answerRequest(answerPath(key) + (action ? `/${action}` : ''), action ? 'POST' : 'PATCH', body, controller.signal);
+      if (version !== generation.current) return;
+      const next = answerSnapshot(raw);
+      setBase(next);
+      setDraft(answerDraft(next));
+        setInvalid(false);
+        setEditorVersion(value => value + 1);
+      setLatest(null);
+      setRemember(false);
+      setNotice('Answer saved.');
+      void refreshList();
+    } catch (failure) {
+      if (version !== generation.current || controller.signal.aborted) return;
+      setError(failure instanceof Error ? failure.message : 'Unable to save answer');
+      // A failed mutation never replaces the draft. Loading latest state is read-only.
+      try {
+        const raw = await client.answerRequest(answerPath(key), 'GET', undefined, controller.signal);
+        if (version === generation.current) setLatest(answerSnapshot(raw));
+      } catch { /* Preserve the original mutation error and draft. */ }
+    } finally { if (version === generation.current) setBusy(false); }
+  }
+  return <section>
+    <h1>Answers</h1>
+    <p>Find, edit and review remembered answers. Sensitive values stay hidden until you reveal them.</p>
+    <p>Merge, cleanup and pending application questions are not available in this native fixture.</p>
+    <form onSubmit={event => { event.preventDefault(); void refreshList(); }}>
+      <label>Find answers<input value={query} onChange={event => setQuery(event.target.value)} /></label>
+      <label>Review status<select aria-label="Review status" value={status} onChange={event => setStatus(event.target.value)}>
+        <option value="accepted">Accepted</option><option value="pending">Pending</option><option value="declined">Declined</option><option value="all">All</option>
+      </select></label>
+      <button disabled={loading || busy}>Search answers</button>
+    </form>
+    {loading && <p role="status">Loading answers…</p>}
+    {error && <p role="alert">{error}</p>}
+    {notice && <p role="status">{notice}</p>}
+    {loaded && !items.length && <p>{query ? 'No matching answers.' : 'No answers with this review status.'}</p>}
+    <ul>{items.map(item => {
+      const key = string(get(item, 'key'))!;
+      return <li key={key}><button disabled={busy || invalid} onClick={() => void select(key)}>{string(get(item, 'question')) || key}</button>
+        <span> {get(item, 'valueRedacted') === true ? 'Sensitive value hidden' : get(item, 'hasValue') === true ? 'Value retained' : 'No retained value'}</span>
+      </li>;
+    })}</ul>
+    <h2 ref={heading} tabIndex={-1}>Answer editor</h2>
+    {base && draft && <div>
+      <button disabled={busy || invalid} onClick={() => void select(string(get(base, 'key'))!, true)}>Refresh selected answer</button>
+      {get(base, 'valueRedacted') === true && <button disabled={busy || dirty} onClick={() => void select(string(get(base, 'key'))!, false, true)}>Reveal sensitive value</button>}
+      {latest && <aside role="alert"><p>Your draft is retained. Review the latest revision before saving.</p>
+        <button disabled={busy || invalid} onClick={() => {
+          try {
+            setDraft(reapplyAnswer(base, draft, latest));
+            setBase(latest);
+            setLatest(null);
+            setRemember(false);
+            setNotice('Draft reapplied. Review before saving.');
+          } catch (failure) { setError(failure instanceof Error ? failure.message : 'Invalid draft'); }
+        }}>Reapply my changes</button>
+        <button disabled={busy} onClick={() => {
+          if (!confirm('Discard your unsaved answer changes?')) return;
+          setBase(latest);
+          setDraft(answerDraft(latest));
+          setLatest(null);
+          setRemember(false);
+          setInvalid(false);
+          setEditorVersion(value => value + 1);
+        }}>Load saved answer</button>
+      </aside>}
+      <form ref={editorForm} onChange={event => setInvalid(!event.currentTarget.checkValidity())} onSubmit={event => { event.preventDefault(); void save(); }}>
+        <fieldset disabled={busy}>
+          <legend>Edit answer</legend>
+          <AnswerFields key={editorVersion} draft={draft} change={setDraft} remember={remember} />
+          <label><input type="checkbox" checked={remember} onChange={event => setRemember(event.target.checked)} />I consent to remembering the sensitive value in this edit.</label>
+          <button disabled={!dirty || Boolean(latest) || invalid}>Save answer</button>
+          {string(get(base, 'reviewStatus')) === 'pending' && <>
+            <button type="button" disabled={Boolean(latest) || invalid} onClick={() => void save('accept')}>Accept answer</button>
+            <button type="button" disabled={Boolean(latest) || invalid} onClick={() => void save('decline')}>Decline answer</button>
+          </>}
+        </fieldset>
+      </form>
+    </div>}
+  </section>;
+}

--- a/apps/companion/components/Companion.tsx
+++ b/apps/companion/components/Companion.tsx
@@ -6,13 +6,14 @@ import { Overview } from './Overview';
 import { Facts } from './Facts';
 import { Jobs } from './Jobs';
 import { Resumes } from './Resumes';
+import { Answers } from './Answers';
 import './companion.css';
 export default function Companion() {
     const [client,setClient]=useState<Client|null>(null);
     const [boot,setBoot]=useState<Boot|null>(null);
     const [error,setError]=useState('');
     const [token,setToken]=useState('');
-    const [tab,setTab]=useState<'overview'|'jobs'|'facts'|'resumes'>('overview');
+    const [tab,setTab]=useState<'overview'|'jobs'|'facts'|'resumes'|'answers'>('overview');
     const [dirty,setDirty]=useState(false);
     const [attempt,setAttempt]=useState(0);
     useEffect(() => {
@@ -53,7 +54,7 @@ export default function Companion() {
         return () => window.removeEventListener('beforeunload',before);
     },[dirty]);
     const dirtyChanged=useCallback((value: boolean) => setDirty(value),[]);
-    function navigate(next: 'overview'|'jobs'|'facts'|'resumes') {
+    function navigate(next: 'overview'|'jobs'|'facts'|'resumes'|'answers') {
         if(next===tab)
             return;
         if(dirty&&!confirm('Discard unsaved changes?'))
@@ -84,6 +85,7 @@ export default function Companion() {
             </button>
             <button aria-current={tab==='facts'?'page':undefined} onClick={()=>navigate('facts')}>Facts</button>
             <button aria-current={tab==='resumes'?'page':undefined} onClick={()=>navigate('resumes')}>Resumes</button>
+            {nativeFixture&&<button aria-current={tab==='answers'?'page':undefined} onClick={()=>navigate('answers')}>Answers</button>}
             {token&&!nativeFixture&&<a href={legacyHref} onClick={event => {
                 if(dirty&&!confirm('Discard unsaved changes?'))
                     event.preventDefault();
@@ -92,7 +94,7 @@ export default function Companion() {
         </nav>
         <p className="trust">Your canonical data stays local. You direct changes and submissions; agents assist from the same record.
         </p>
-        {nativeFixture&&<p role="status">Synthetic native workspace. Create and edit jobs, facts, and managed resumes here; other workflows are not available yet.</p>}
+        {nativeFixture&&<p role="status">Synthetic native workspace. Manage jobs, facts, resumes and remembered answers here; other workflows are not available yet.</p>}
         {error&&<p role="alert" className="error">
             {error}{' '}
             {token&&<button onClick={() => setAttempt(value => value+1)}>Retry connection</button>}
@@ -107,7 +109,7 @@ export default function Companion() {
         </section>:boot?.status==='ready'&&client? (tab==='overview'? <Overview
             client={client}
             openJobs={() => navigate('jobs')}
-            legacyHref={legacyHref} />:tab==='facts'?<Facts client={client} dirtyChanged={dirtyChanged}/>:tab==='resumes'?<Resumes client={client} dirtyChanged={dirtyChanged}/>:<Jobs client={client} dirtyChanged={dirtyChanged} />):!error&&<p>Loading workspace…
+            legacyHref={legacyHref} />:tab==='facts'?<Facts client={client} dirtyChanged={dirtyChanged}/>:tab==='resumes'?<Resumes client={client} dirtyChanged={dirtyChanged}/>:tab==='answers'?<Answers client={client} dirtyChanged={dirtyChanged}/>:<Jobs client={client} dirtyChanged={dirtyChanged} />):!error&&<p>Loading workspace…
             </p>}
     </main>;
 }

--- a/apps/companion/components/Companion.tsx
+++ b/apps/companion/components/Companion.tsx
@@ -7,13 +7,14 @@ import { Facts } from './Facts';
 import { Jobs } from './Jobs';
 import { Resumes } from './Resumes';
 import { Answers } from './Answers';
+import { Extractions } from './Extractions';
 import './companion.css';
 export default function Companion() {
     const [client,setClient]=useState<Client|null>(null);
     const [boot,setBoot]=useState<Boot|null>(null);
     const [error,setError]=useState('');
     const [token,setToken]=useState('');
-    const [tab,setTab]=useState<'overview'|'jobs'|'facts'|'resumes'|'answers'>('overview');
+    const [tab,setTab]=useState<'overview'|'jobs'|'facts'|'resumes'|'answers'|'extractions'>('overview');
     const [dirty,setDirty]=useState(false);
     const [attempt,setAttempt]=useState(0);
     useEffect(() => {
@@ -54,7 +55,7 @@ export default function Companion() {
         return () => window.removeEventListener('beforeunload',before);
     },[dirty]);
     const dirtyChanged=useCallback((value: boolean) => setDirty(value),[]);
-    function navigate(next: 'overview'|'jobs'|'facts'|'resumes'|'answers') {
+    function navigate(next: 'overview'|'jobs'|'facts'|'resumes'|'answers'|'extractions') {
         if(next===tab)
             return;
         if(dirty&&!confirm('Discard unsaved changes?'))
@@ -85,6 +86,7 @@ export default function Companion() {
             </button>
             <button aria-current={tab==='facts'?'page':undefined} onClick={()=>navigate('facts')}>Facts</button>
             <button aria-current={tab==='resumes'?'page':undefined} onClick={()=>navigate('resumes')}>Resumes</button>
+            {nativeFixture&&<button aria-current={tab==='extractions'?'page':undefined} onClick={()=>navigate('extractions')}>Resume extraction</button>}
             {nativeFixture&&<button aria-current={tab==='answers'?'page':undefined} onClick={()=>navigate('answers')}>Answers</button>}
             {token&&!nativeFixture&&<a href={legacyHref} onClick={event => {
                 if(dirty&&!confirm('Discard unsaved changes?'))
@@ -94,7 +96,7 @@ export default function Companion() {
         </nav>
         <p className="trust">Your canonical data stays local. You direct changes and submissions; agents assist from the same record.
         </p>
-        {nativeFixture&&<p role="status">Synthetic native workspace. Manage jobs, facts, resumes and remembered answers here; other workflows are not available yet.</p>}
+        {nativeFixture&&<p role="status">Synthetic native workspace. Manage jobs, facts, resumes, extraction reviews and remembered answers here; other workflows are not available yet.</p>}
         {error&&<p role="alert" className="error">
             {error}{' '}
             {token&&<button onClick={() => setAttempt(value => value+1)}>Retry connection</button>}
@@ -109,7 +111,7 @@ export default function Companion() {
         </section>:boot?.status==='ready'&&client? (tab==='overview'? <Overview
             client={client}
             openJobs={() => navigate('jobs')}
-            legacyHref={legacyHref} />:tab==='facts'?<Facts client={client} dirtyChanged={dirtyChanged}/>:tab==='resumes'?<Resumes client={client} dirtyChanged={dirtyChanged}/>:tab==='answers'?<Answers client={client} dirtyChanged={dirtyChanged}/>:<Jobs client={client} dirtyChanged={dirtyChanged} />):!error&&<p>Loading workspace…
+            legacyHref={legacyHref} />:tab==='facts'?<Facts client={client} dirtyChanged={dirtyChanged}/>:tab==='resumes'?<Resumes client={client} dirtyChanged={dirtyChanged}/>:tab==='extractions'?<Extractions client={client} dirtyChanged={dirtyChanged}/>:tab==='answers'?<Answers client={client} dirtyChanged={dirtyChanged}/>:<Jobs client={client} dirtyChanged={dirtyChanged} />):!error&&<p>Loading workspace…
             </p>}
     </main>;
 }

--- a/apps/companion/components/Extractions.tsx
+++ b/apps/companion/components/Extractions.tsx
@@ -1,0 +1,226 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+import { get, serialize, string } from '../../../src/contracts/workspace/values';
+import { ExtractionReview } from './extraction-review';
+import { extractionList, pendingPaths, proposalSnapshot, reapplyChoices, requestMutation, reviewMutation } from './extraction-model';
+import type { Choices, Document, ExtractionClient } from './extraction-model';
+
+const reasonMessages = new Map([
+  ['content_unreadable', 'The resume content could not be read.'],
+  ['unsupported_resume', 'This resume format could not be extracted.'],
+  ['extraction_failed', 'The extraction did not finish successfully.'],
+  ['candidate_invalid', 'The extracted facts could not be validated.'],
+  ['interrupted', 'The extraction was interrupted.'],
+  ['resume_deleted', 'The resume was deleted.'],
+  ['resume_trashed', 'The resume is in Trash.'],
+  ['resume_not_managed', 'The resume is no longer a managed file.'],
+  ['resume_content_revision_changed', 'The resume content was replaced.'],
+  ['resume_revision_changed', 'The resume changed after this extraction.'],
+  ['resume_digest_changed', 'The resume content changed after this extraction.'],
+  ['resume_file_missing', 'The resume file is missing.'],
+  ['resume_file_changed', 'The resume file changed after this extraction.'],
+]);
+const reasonMessage = (code: string): string => reasonMessages.get(code) ?? 'The extraction is no longer available for review.';
+
+export function Extractions({ client, dirtyChanged }: { client: ExtractionClient; dirtyChanged: (dirty: boolean) => void }) {
+  const [resumes, setResumes] = useState<Document[]>([]);
+  const [requests, setRequests] = useState<Document[]>([]);
+  const [proposals, setProposals] = useState<Document[]>([]);
+  const [resumeId, setResumeId] = useState('');
+  const [base, setBase] = useState<Document | null>(null);
+  const [latest, setLatest] = useState<Document | null>(null);
+  const [choices, setChoices] = useState<Choices>({});
+  const [confirmed, setConfirmed] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState('');
+  const [notice, setNotice] = useState('');
+  const generation = useRef(0), listGeneration = useRef(0);
+  const request = useRef<AbortController | null>(null), listRequest = useRef<AbortController | null>(null);
+  const heading = useRef<HTMLHeadingElement>(null);
+  const dirty = Object.keys(choices).length > 0;
+  const managed = resumes.filter(item => string(get(item, 'storageKind')) === 'managed' && get(item, 'deletedAt') === null);
+  const selectedResume = managed.find(item => string(get(item, 'id')) === resumeId);
+  useEffect(() => { dirtyChanged(dirty || busy); return () => dirtyChanged(false); }, [dirty, busy, dirtyChanged]);
+  useEffect(() => () => {
+    generation.current++;
+    listGeneration.current++;
+    request.current?.abort();
+    listRequest.current?.abort();
+  }, []);
+  async function refreshLists() {
+    listRequest.current?.abort();
+    const controller = new AbortController(), version = ++listGeneration.current;
+    listRequest.current = controller;
+    setLoading(true);
+    try {
+      const results = await Promise.all(['resumes', 'resume-extraction-requests', 'resume-proposals'].map(path =>
+        client.extractionRequest(`/api/${path}`, 'GET', undefined, controller.signal)));
+      const nextResumes = extractionList(results[0]!, 'resumes');
+      const nextRequests = extractionList(results[1]!, 'requests');
+      const nextProposals = extractionList(results[2]!, 'proposals');
+      if (version !== listGeneration.current) return;
+      setResumes(nextResumes);
+      setRequests(nextRequests);
+      setProposals(nextProposals);
+      setLoaded(true);
+    } catch (failure) {
+      if (version === listGeneration.current && !controller.signal.aborted) setError(failure instanceof Error ? failure.message : 'Unable to load extraction status');
+    } finally { if (version === listGeneration.current) setLoading(false); }
+  }
+  useEffect(() => { void refreshLists(); }, [client]);
+  function loadProposal(next: Document) {
+    setBase(next);
+    setLatest(null);
+    setChoices({});
+    setConfirmed([]);
+  }
+  async function selectProposal(id: string, refresh = false) {
+    if (!refresh && dirty && !confirm('Discard your unsaved review decisions?')) return;
+    request.current?.abort();
+    const controller = new AbortController(), version = ++generation.current;
+    request.current = controller;
+    setBusy(true);
+    setError('');
+    setNotice('');
+    try {
+      const next = proposalSnapshot(await client.extractionRequest(`/api/resume-proposals/${encodeURIComponent(id)}`, 'GET', undefined, controller.signal));
+      if (version !== generation.current) return;
+      if (string(get(next, 'id')) !== id) throw Error('Proposal identity changed. Refresh the proposal list.');
+      if (refresh && dirty) {
+        setLatest(next);
+        setNotice('Latest comparisons loaded. Your decisions are retained until you choose how to continue.');
+      } else loadProposal(next);
+      heading.current?.focus();
+    } catch (failure) {
+      if (version === generation.current && !controller.signal.aborted) setError(failure instanceof Error ? failure.message : 'Unable to load proposal');
+    } finally { if (version === generation.current) setBusy(false); }
+  }
+  async function mutateRequest(resume: Document, record?: Document, action?: string) {
+    const controller = new AbortController(), version = ++generation.current;
+    request.current?.abort();
+    request.current = controller;
+    setBusy(true);
+    setError('');
+    setNotice('');
+    const path = '/api/resume-extraction-requests' + (record ? `/${encodeURIComponent(string(get(record, 'requestId'))!)}/${action}` : '');
+    try {
+      await client.extractionRequest(path, 'POST', requestMutation(resume, record, action), controller.signal);
+      if (version !== generation.current) return;
+      setNotice(action === 'cancel' ? 'Extraction request cancelled.' : 'Extraction requested. An agent can now extract facts from this resume.');
+      await refreshLists();
+    } catch (failure) {
+      if (version === generation.current && !controller.signal.aborted) {
+        setError(failure instanceof Error ? failure.message : 'Unable to update extraction request');
+        await refreshLists();
+      }
+    } finally { if (version === generation.current) setBusy(false); }
+  }
+  async function saveReview() {
+    if (!base || latest) return;
+    let body: string;
+    try { body = reviewMutation(base, choices, confirmed); }
+    catch (failure) { setError(failure instanceof Error ? failure.message : 'Invalid review choices'); return; }
+    const controller = new AbortController(), version = ++generation.current;
+    request.current?.abort();
+    request.current = controller;
+    const id = string(get(base, 'id'))!;
+    setBusy(true);
+    setError('');
+    setNotice('');
+    try {
+      await client.extractionRequest(`/api/resume-proposals/${encodeURIComponent(id)}/review`, 'POST', body, controller.signal);
+      if (version !== generation.current) return;
+      // The mutation succeeded even if its subsequent detail refresh fails.
+      setBase(null);
+      setChoices({});
+      setConfirmed([]);
+      setLatest(null);
+      setNotice('Review decisions saved.');
+      const next = proposalSnapshot(await client.extractionRequest(`/api/resume-proposals/${encodeURIComponent(id)}`, 'GET', undefined, controller.signal));
+      if (version !== generation.current) return;
+      if (string(get(next, 'id')) !== id) throw Error('Proposal identity changed. Refresh the proposal list.');
+      loadProposal(next);
+      await refreshLists();
+    } catch (failure) {
+      if (version !== generation.current || controller.signal.aborted) return;
+      setError(failure instanceof Error ? failure.message : 'Unable to save review');
+      try {
+        const next = proposalSnapshot(await client.extractionRequest(`/api/resume-proposals/${encodeURIComponent(id)}`, 'GET', undefined, controller.signal));
+        if (version === generation.current && string(get(next, 'id')) === id) setLatest(next);
+      } catch { /* Keep the original failure and unsaved choices visible. */ }
+    } finally { if (version === generation.current) setBusy(false); }
+  }
+  const staleReasons = base ? get(base, 'staleReasons') : null;
+  const stale = Array.isArray(staleReasons) && staleReasons.length > 0;
+  return <section>
+    <h1>Resume extraction</h1>
+    <p>Request an agent to extract facts from a managed resume, then review any conflicts with your current facts.</p>
+    <button disabled={busy || loading} onClick={() => { setError(''); void refreshLists(); }}>Refresh extraction status</button>
+    {loading && <p role="status">Loading extraction status…</p>}
+    {error && <p role="alert">{error}</p>}
+    {notice && <p role="status">{notice}</p>}
+    <form onSubmit={event => { event.preventDefault(); if (selectedResume) void mutateRequest(selectedResume); }}>
+      <label>Resume to extract<select value={resumeId} disabled={busy || loading} onChange={event => setResumeId(event.target.value)}>
+        <option value="">Choose a managed resume</option>{managed.map(item => <option key={string(get(item, 'id'))!} value={string(get(item, 'id'))!}>{string(get(item, 'label')) || 'Untitled resume'}</option>)}
+      </select></label>
+      <button disabled={busy || loading || !selectedResume || requests.some(item => string(get(item, 'resumeId')) === resumeId && string(get(item, 'status')) === 'requested')}>Request extraction</button>
+    </form>
+    {loaded && !managed.length && <p>Import or adopt a resume in Resumes before requesting extraction.</p>}
+    <h2>Extraction requests</h2>
+    {loaded && !requests.length && <p>No extraction requests yet.</p>}
+    <ul>{requests.map(item => {
+      const id = string(get(item, 'requestId'))!, status = string(get(item, 'status'));
+      const resume = resumes.find(value => string(get(value, 'id')) === string(get(item, 'resumeId')));
+      return <li key={id}>
+        <p>{resume ? string(get(resume, 'label')) || 'Untitled resume' : 'Unavailable resume'} — {status}</p>
+        {string(get(item, 'failureReason')) && <p>{reasonMessage(string(get(item, 'failureReason'))!)}</p>}
+        {status === 'requested' && <button disabled={busy || loading} onClick={() => void mutateRequest(resume ?? item, item, 'cancel')}>Cancel extraction</button>}
+        {(status === 'failed' || status === 'stale') && <button disabled={busy || loading || !resume || string(get(resume, 'storageKind')) !== 'managed' || get(resume, 'deletedAt') !== null} onClick={() => { if (resume) void mutateRequest(resume, item, 'retry'); }}>Retry extraction</button>}
+        {string(get(item, 'proposalId')) && <button disabled={busy} onClick={() => void selectProposal(string(get(item, 'proposalId'))!)}>Review extraction result</button>}
+      </li>;
+    })}</ul>
+    <h2>Extracted proposals</h2>
+    {loaded && !proposals.length && <p>No extracted proposals yet.</p>}
+    <ul>{proposals.map(item => {
+      const id = string(get(item, 'id'))!;
+      const resume = resumes.find(value => string(get(value, 'id')) === string(get(item, 'resumeId')));
+      return <li key={id}><button disabled={busy} onClick={() => void selectProposal(id)}>
+        {resume ? string(get(resume, 'label')) || 'Untitled resume' : 'Unavailable resume'} — {string(get(item, 'status'))} — {serialize(get(item, 'pendingCount'))} decisions remaining
+      </button></li>;
+    })}</ul>
+    <h2 ref={heading} tabIndex={-1}>Proposal review</h2>
+    {base && <div>
+      <p>Status: {string(get(base, 'status'))}. {pendingPaths(base).length} decisions remaining.</p>
+      <p>{serialize(get(base, 'autoFilledCount'))} missing facts were filled automatically. Review existing conflicts below.</p>
+      <button disabled={busy} onClick={() => void selectProposal(string(get(base, 'id'))!, true)}>Refresh selected proposal</button>
+      {stale && <p role="alert">{staleReasons.map(value => reasonMessage(string(value) ?? '')).join(' ')} Request a new extraction before reviewing it.</p>}
+      {latest && <aside role="alert">
+        <p>Your decisions are retained. Reapply them to display the latest comparisons, then review each choice and confirm any replacements again.</p>
+        <button disabled={busy} onClick={() => {
+          setChoices(reapplyChoices(choices, latest));
+          setBase(latest);
+          setLatest(null);
+          setConfirmed([]);
+          setNotice('Decisions reapplied to the latest comparisons. Decisions for resolved fields were removed. Review before saving.');
+        }}>Reapply my decisions</button>
+        <button disabled={busy} onClick={() => { if (confirm('Discard your unsaved review decisions?')) loadProposal(latest); }}>Load saved proposal</button>
+      </aside>}
+      {string(get(base, 'status')) === 'completed' && <p>This proposal is complete. No further review is needed.</p>}
+      {string(get(base, 'status')) === 'superseded' && <p>A newer extraction replaced this proposal. Open the latest proposal to continue.</p>}
+      {pendingPaths(base).length > 0 && <form onSubmit={event => { event.preventDefault(); void saveReview(); }}>
+        <ExtractionReview proposal={base} choices={choices} confirmed={confirmed} disabled={busy || Boolean(latest) || stale || string(get(base, 'status')) !== 'pending'} change={(pointer, decision) => {
+          setChoices(previous => {
+            const next = { ...previous };
+            if (decision) next[pointer] = decision;
+            else delete next[pointer];
+            return next;
+          });
+          setConfirmed(previous => previous.filter(item => item !== pointer));
+        }} confirmReplacement={(pointer, checked) => setConfirmed(previous => checked ? [...previous.filter(item => item !== pointer), pointer] : previous.filter(item => item !== pointer))} />
+        <button disabled={busy || Boolean(latest) || stale || !dirty || string(get(base, 'status')) !== 'pending'}>Save review decisions</button>
+      </form>}
+    </div>}
+  </section>;
+}

--- a/apps/companion/components/answer-fields.tsx
+++ b/apps/companion/components/answer-fields.tsx
@@ -1,0 +1,45 @@
+import { FactValue } from './FactValue';
+import { copy, get, has, parse, set, string, text } from '../../../src/contracts/workspace/values';
+import type { Document, Value } from '../../../src/contracts/workspace/values';
+
+export function AnswerFields({ draft, change, remember }: {
+  draft: Document;
+  change: (draft: Document) => void;
+  remember: boolean;
+}) {
+  const update = (field: string, value: Value) => change(set(copy(draft), field, value));
+  const retainedValue = has(draft, 'value');
+  return <>
+    <label>Question<input value={string(get(draft, 'question')) ?? ''} onChange={event => update('question', text(event.target.value))} /></label>
+    <FactValue label="Other ways to ask" value={has(draft, 'aliases') ? get(draft, 'aliases') : []} change={value => update('aliases', value)} />
+    {retainedValue ? <>
+      <FactValue label="Answer value" value={get(draft, 'value')} change={value => update('value', value)} />
+      <label>Replace answer with<select value="" onChange={event => {
+        const kind = event.target.value;
+        if (!kind) return;
+        const value = kind === 'text' ? text('') : kind === 'number' ? parse('0') : kind === 'boolean' ? false
+          : kind === 'fields' ? parse('{}') : kind === 'list' ? [] : null;
+        update('value', value);
+      }}>
+        <option value="">Choose a new value type…</option>
+        <option value="text">Text</option><option value="number">Number</option>
+        <option value="boolean">Yes / no</option><option value="fields">Fields</option>
+        <option value="list">List</option><option value="none">No value</option>
+      </select></label>
+    </> : <div>
+      <p>The retained answer is hidden. Reveal it to view or edit it.</p>
+      <button type="button" disabled={!remember} onClick={() => update('value', text(''))}>Replace hidden answer</button>
+      {!remember && <p>To replace it without revealing it, first enable remember consent below.</p>}
+    </div>}
+    <label>Answer state<select value={string(get(draft, 'state')) ?? 'missing'} onChange={event => update('state', text(event.target.value))}>
+      <option value="confirmed">Confirmed</option><option value="inferred">Suggested</option>
+      <option value="missing">Missing</option><option value="sensitive">Sensitive</option>
+    </select></label>
+    <label>Source<input value={string(get(draft, 'source')) ?? ''} onChange={event => update('source', text(event.target.value))} /></label>
+    <FactValue label="Applies to" value={has(draft, 'scope') ? get(draft, 'scope') : parse('{}')} change={value => update('scope', value)} />
+    <label>Answer category<input value={string(get(draft, 'fieldClass')) ?? 'general'} pattern="[a-z][a-z0-9_]{0,63}" onChange={event => update('fieldClass', text(event.target.value))} /></label>
+    <label>Sensitivity<select value={string(get(draft, 'sensitivity')) ?? 'none'} onChange={event => update('sensitivity', text(event.target.value))}>
+      <option value="none">None</option><option value="personal">Personal</option><option value="high">High</option>
+    </select></label>
+  </>;
+}

--- a/apps/companion/components/answer-model.ts
+++ b/apps/companion/components/answer-model.ts
@@ -1,0 +1,42 @@
+import { PythonObject } from '../../../src/contracts/python-object';
+import { copy, get, has, int, keys, object, parse, serialize, set, text } from '../../../src/contracts/workspace/values';
+import type { Document, Value } from '../../../src/contracts/workspace/values';
+export type { Document };
+export interface AnswerClient {
+  answerRequest(path: string, method: string, body: string | undefined, signal: AbortSignal): Promise<string>;
+}
+export const answerPath = (key: string): string => {
+  const bytes = new TextEncoder().encode(key);
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return `/api/answers/by-key/${btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '')}`;
+};
+export function answerSnapshot(raw: string): Document {
+  const record = object(parse(raw), 'answer response');
+  const revision = int(get(record, 'revision'));
+  if (revision === null || revision < 1n) throw Error('Invalid answer revision');
+  return record;
+}
+export function answerDraft(record: Document): Document {
+  const result = new PythonObject<Value>();
+  for (const key of ['question', 'aliases', 'value', 'state', 'source', 'scope', 'fieldClass', 'sensitivity']) if (has(record, key)) set(result, key, get(record, key));
+  return result;
+}
+export function answerPatch(base: Document, draft: Document): Document {
+  const result = new PythonObject<Value>();
+  for (const key of keys(draft)) if (!has(base, key) || serialize(get(base, key)) !== serialize(get(draft, key))) set(result, key, get(draft, key));
+  return result;
+}
+export function reapplyAnswer(base: Document, draft: Document, latest: Document): Document {
+  const result = answerDraft(latest), patch = answerPatch(base, draft);
+  for (const key of keys(patch)) set(result, key, get(patch, key));
+  return result;
+}
+export function answerMutation(base: Document, draft: Document, remember: boolean): string {
+  const result = new PythonObject<Value>();
+  set(result, 'patch', answerPatch(base, draft));
+  set(result, 'expectedRevision', get(base, 'revision'));
+  set(result, 'rememberSensitive', remember);
+  return serialize(result);
+}
+export const cloneAnswer = (record: Document): Document => copy(record);

--- a/apps/companion/components/client.ts
+++ b/apps/companion/components/client.ts
@@ -37,6 +37,7 @@ export function createClient(token: string) {
         return btoa(binary);
     }
     return {
+        answerRequest: async (path: string, method: string, body: string | undefined, signal: AbortSignal) => request(path, method, body, signal, true) as Promise<string>,
         profile: async (signal?: AbortSignal) => snapshot(await request('/api/profile', 'GET', undefined, signal, true) as string),
         patchProfile: async (body: string, signal?: AbortSignal) => snapshot(await request('/api/profile', 'PATCH', body, signal, true) as string),
         groups: async (signal?: AbortSignal) => request('/api/fact-groups', 'GET', undefined, signal),

--- a/apps/companion/components/client.ts
+++ b/apps/companion/components/client.ts
@@ -37,6 +37,7 @@ export function createClient(token: string) {
         return btoa(binary);
     }
     return {
+        extractionRequest: async (path: string, method: string, body: string | undefined, signal: AbortSignal) => request(path, method, body, signal, true) as Promise<string>,
         answerRequest: async (path: string, method: string, body: string | undefined, signal: AbortSignal) => request(path, method, body, signal, true) as Promise<string>,
         profile: async (signal?: AbortSignal) => snapshot(await request('/api/profile', 'GET', undefined, signal, true) as string),
         patchProfile: async (body: string, signal?: AbortSignal) => snapshot(await request('/api/profile', 'PATCH', body, signal, true) as string),

--- a/apps/companion/components/extraction-model.ts
+++ b/apps/companion/components/extraction-model.ts
@@ -1,0 +1,75 @@
+import { PythonObject } from '../../../src/contracts/python-object';
+import { get, has, int, object, parse, serialize, set, string, text } from '../../../src/contracts/workspace/values';
+import type { Document, Value } from '../../../src/contracts/workspace/values';
+export type { Document };
+export interface ExtractionClient {
+  extractionRequest(path: string, method: string, body: string | undefined, signal: AbortSignal): Promise<string>;
+}
+export type Decision = 'use_extracted' | 'keep_current';
+export type Choices = Record<string, Decision>;
+export function extractionList(raw: string, key: string): Document[] {
+  const values = get(object(parse(raw), 'extraction response'), key);
+  if (!Array.isArray(values)) throw Error(`Invalid ${key} response`);
+  return values.map(value => object(value, key));
+}
+export function proposalSnapshot(raw: string): Document {
+  const result = object(parse(raw), 'proposal');
+  for (const key of ['revision', 'liveProfileRevision']) {
+    const revision = int(get(result, key));
+    if (revision === null || revision < 1n) throw Error('Invalid proposal revision');
+  }
+  if (!string(get(result, 'id'))) throw Error('Invalid proposal identity');
+  pendingPaths(result);
+  for (const key of ['candidate', 'currentValues', 'replacementScopes']) object(get(result, key), key);
+  return result;
+}
+export function pendingPaths(proposal: Document): string[] {
+  const paths = get(proposal, 'pendingPaths');
+  if (!Array.isArray(paths) || paths.some(path => !string(path)?.startsWith('/'))) throw Error('Invalid proposal paths');
+  return paths.map(path => string(path)!);
+}
+export function candidateValue(proposal: Document, pointer: string): Value {
+  let value = get(proposal, 'candidate');
+  for (const segment of pointer.slice(1).split('/')) {
+    const key = segment.replaceAll('~1', '/').replaceAll('~0', '~');
+    const container = object(value, 'candidate path');
+    if (!has(container, key)) throw Error('Candidate path is missing');
+    value = get(container, key);
+  }
+  return value;
+}
+export function replacementScope(proposal: Document, pointer: string): Document | null {
+  const scopes = object(get(proposal, 'replacementScopes'), 'replacement scopes');
+  return has(scopes, pointer) ? object(get(scopes, pointer), 'replacement scope') : null;
+}
+export function reapplyChoices(choices: Choices, latest: Document): Choices {
+  const pending = new Set(pendingPaths(latest));
+  return Object.fromEntries(Object.entries(choices).filter(([path]) => pending.has(path)));
+}
+export function reviewMutation(proposal: Document, choices: Choices, confirmed: string[]): string {
+  const decisions = new PythonObject<Value>(), confirmations = new PythonObject<Value>();
+  const pending = new Set(pendingPaths(proposal));
+  if (!Object.keys(choices).length) throw Error('Choose at least one decision.');
+  for (const [path, decision] of Object.entries(choices)) {
+    if (!pending.has(path) || !['use_extracted', 'keep_current'].includes(decision)) throw Error('Invalid review choice');
+    set(decisions, path, text(decision));
+    const scope = replacementScope(proposal, path);
+    if (decision === 'use_extracted' && scope) {
+      if (!confirmed.includes(path)) throw Error(`Confirm replacement for ${path}.`);
+      set(confirmations, path, get(scope, 'path'));
+    }
+  }
+  const body = new PythonObject<Value>();
+  set(body, 'decisions', decisions);
+  set(body, 'replacementConfirmations', confirmations);
+  set(body, 'expectedRevision', get(proposal, 'revision'));
+  set(body, 'expectedProfileRevision', get(proposal, 'liveProfileRevision'));
+  return serialize(body);
+}
+export function requestMutation(resume: Document, request?: Document, action?: string): string {
+  const body = new PythonObject<Value>();
+  if (request) set(body, 'expectedRevision', get(request, 'revision'));
+  else set(body, 'resumeId', get(resume, 'id'));
+  if (action !== 'cancel') set(body, 'expectedResumeRevision', get(resume, 'revision'));
+  return serialize(body);
+}

--- a/apps/companion/components/extraction-review.tsx
+++ b/apps/companion/components/extraction-review.tsx
@@ -1,0 +1,38 @@
+import { PythonObject } from '../../../src/contracts/python-object';
+import { get, keys, object, serialize, string } from '../../../src/contracts/workspace/values';
+import type { Value } from '../../../src/contracts/workspace/values';
+import { candidateValue, pendingPaths, replacementScope } from './extraction-model';
+import type { Choices, Decision, Document } from './extraction-model';
+
+function ValueDisplay({ value }: { value: Value }) {
+  if (value instanceof PythonObject) return <dl>{keys(value).map(key => <div key={key}>
+    <dt>{key}</dt><dd><ValueDisplay value={get(value, key)} /></dd>
+  </div>)}</dl>;
+  if (Array.isArray(value)) return value.length ? <ul>{value.map((item, index) => <li key={index}><ValueDisplay value={item} /></li>)}</ul> : <span>Empty list</span>;
+  return <span style={{ overflowWrap: 'anywhere', whiteSpace: 'pre-wrap' }}>{string(value) ?? (value === null ? 'No value' : serialize(value))}</span>;
+}
+export function ExtractionReview({ proposal, choices, confirmed, disabled, change, confirmReplacement }: {
+  proposal: Document; choices: Choices; confirmed: string[]; disabled: boolean;
+  change: (pointer: string, decision: Decision | '') => void;
+  confirmReplacement: (pointer: string, checked: boolean) => void;
+}) {
+  const current = object(get(proposal, 'currentValues'), 'current values');
+  return <fieldset disabled={disabled}><legend>Review extracted facts</legend>
+    {pendingPaths(proposal).map(pointer => {
+      const existing = object(get(current, pointer), 'current fact');
+      const scope = replacementScope(proposal, pointer);
+      return <fieldset key={pointer} style={{ minWidth: 0 }}><legend style={{ overflowWrap: 'anywhere' }}>{pointer}</legend>
+        <p>Current fact</p>{get(existing, 'exists') === true ? <ValueDisplay value={get(existing, 'value')} /> : <p>Not set</p>}
+        <p>Extracted fact</p><ValueDisplay value={candidateValue(proposal, pointer)} />
+        <label>Decision for {pointer}<select aria-label={`Decision for ${pointer}`} value={choices[pointer] ?? ''} onChange={event => change(pointer, event.target.value as Decision | '')}>
+          <option value="">Choose a decision</option><option value="keep_current">Keep current</option><option value="use_extracted">Use extracted</option>
+        </select></label>
+        {scope && choices[pointer] === 'use_extracted' && <div>
+          <p>This replaces the existing value at {string(get(scope, 'path'))}:</p><ValueDisplay value={get(scope, 'value')} />
+          <label><input type="checkbox" aria-label={`I confirm replacing ${string(get(scope, 'path'))} for ${pointer}.`} checked={confirmed.includes(pointer)} onChange={event => confirmReplacement(pointer, event.target.checked)} />
+            I confirm replacing {string(get(scope, 'path'))} for {pointer}.</label>
+        </div>}
+      </fieldset>;
+    })}
+  </fieldset>;
+}

--- a/config/migration/browser-native-answers-surfaces.json
+++ b/config/migration/browser-native-answers-surfaces.json
@@ -1,0 +1,203 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "browser:apps/companion/components/Answers.tsx:Answers",
+      "kind": "browser",
+      "export": "Answers",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/Answers.tsx"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/answer-fields.tsx:AnswerFields",
+      "kind": "browser",
+      "export": "AnswerFields",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/answer-fields.tsx"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/answer-model.ts:answerPath",
+      "kind": "browser",
+      "export": "answerPath",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/answer-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/answer-model.ts:answerSnapshot",
+      "kind": "browser",
+      "export": "answerSnapshot",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/answer-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/answer-model.ts:answerDraft",
+      "kind": "browser",
+      "export": "answerDraft",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/answer-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/answer-model.ts:answerPatch",
+      "kind": "browser",
+      "export": "answerPatch",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/answer-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/answer-model.ts:reapplyAnswer",
+      "kind": "browser",
+      "export": "reapplyAnswer",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/answer-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/answer-model.ts:answerMutation",
+      "kind": "browser",
+      "export": "answerMutation",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/answer-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/answer-model.ts:cloneAnswer",
+      "kind": "browser",
+      "export": "cloneAnswer",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/answer-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/browser-native-extractions-surfaces.json
+++ b/config/migration/browser-native-extractions-surfaces.json
@@ -2,16 +2,12 @@
   "schemaVersion": 1,
   "surfaces": [
     {
-      "id": "journal:resume-extraction-journal.json:operation:null",
-      "kind": "journal",
-      "path": "resume-extraction-journal.json",
-      "discriminator": "operation",
-      "value": null,
-      "node": "JOUR",
+      "id": "browser:apps/companion/components/Extractions.tsx:Extractions",
+      "kind": "browser",
+      "export": "Extractions",
+      "node": "UIF",
       "sources": [
-        "scripts/job_apply_store/domains/extractions/journal.py",
-        "src/store/native-jobs.ts",
-        "src/store/native-extraction-journal.ts"
+        "apps/companion/components/Extractions.tsx"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -28,16 +24,12 @@
       }
     },
     {
-      "id": "journal:resume-extraction-journal.json:operation.kind:create",
-      "kind": "journal",
-      "path": "resume-extraction-journal.json",
-      "discriminator": "operation.kind",
-      "value": "create",
-      "node": "JOUR",
+      "id": "browser:apps/companion/components/extraction-model.ts:extractionList",
+      "kind": "browser",
+      "export": "extractionList",
+      "node": "UIF",
       "sources": [
-        "scripts/job_apply_store/domains/extractions/journal.py",
-        "src/store/native-jobs.ts",
-        "src/store/native-extraction-journal.ts"
+        "apps/companion/components/extraction-model.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -54,16 +46,12 @@
       }
     },
     {
-      "id": "journal:resume-extraction-journal.json:operation.kind:review",
-      "kind": "journal",
-      "path": "resume-extraction-journal.json",
-      "discriminator": "operation.kind",
-      "value": "review",
-      "node": "JOUR",
+      "id": "browser:apps/companion/components/extraction-model.ts:proposalSnapshot",
+      "kind": "browser",
+      "export": "proposalSnapshot",
+      "node": "UIF",
       "sources": [
-        "scripts/job_apply_store/domains/extractions/journal.py",
-        "src/store/native-jobs.ts",
-        "src/store/native-extraction-journal.ts"
+        "apps/companion/components/extraction-model.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -80,16 +68,12 @@
       }
     },
     {
-      "id": "journal:resume-extraction-journal.json:operation.kind:request-create",
-      "kind": "journal",
-      "path": "resume-extraction-journal.json",
-      "discriminator": "operation.kind",
-      "value": "request-create",
-      "node": "JOUR",
+      "id": "browser:apps/companion/components/extraction-model.ts:pendingPaths",
+      "kind": "browser",
+      "export": "pendingPaths",
+      "node": "UIF",
       "sources": [
-        "scripts/job_apply_store/domains/extractions/journal.py",
-        "src/store/native-jobs.ts",
-        "src/store/native-extraction-journal.ts"
+        "apps/companion/components/extraction-model.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -106,16 +90,12 @@
       }
     },
     {
-      "id": "journal:resume-extraction-journal.json:operation.kind:request-close",
-      "kind": "journal",
-      "path": "resume-extraction-journal.json",
-      "discriminator": "operation.kind",
-      "value": "request-close",
-      "node": "JOUR",
+      "id": "browser:apps/companion/components/extraction-model.ts:candidateValue",
+      "kind": "browser",
+      "export": "candidateValue",
+      "node": "UIF",
       "sources": [
-        "scripts/job_apply_store/domains/extractions/journal.py",
-        "src/store/native-jobs.ts",
-        "src/store/native-extraction-journal.ts"
+        "apps/companion/components/extraction-model.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -132,16 +112,12 @@
       }
     },
     {
-      "id": "journal:resume-extraction-journal.json:operation.kind:request-retry",
-      "kind": "journal",
-      "path": "resume-extraction-journal.json",
-      "discriminator": "operation.kind",
-      "value": "request-retry",
-      "node": "JOUR",
+      "id": "browser:apps/companion/components/extraction-model.ts:replacementScope",
+      "kind": "browser",
+      "export": "replacementScope",
+      "node": "UIF",
       "sources": [
-        "scripts/job_apply_store/domains/extractions/journal.py",
-        "src/store/native-jobs.ts",
-        "src/store/native-extraction-journal.ts"
+        "apps/companion/components/extraction-model.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -158,16 +134,12 @@
       }
     },
     {
-      "id": "journal:resume-extraction-journal.json:operation.kind:request-complete",
-      "kind": "journal",
-      "path": "resume-extraction-journal.json",
-      "discriminator": "operation.kind",
-      "value": "request-complete",
-      "node": "JOUR",
+      "id": "browser:apps/companion/components/extraction-model.ts:reapplyChoices",
+      "kind": "browser",
+      "export": "reapplyChoices",
+      "node": "UIF",
       "sources": [
-        "scripts/job_apply_store/domains/extractions/journal.py",
-        "src/store/native-jobs.ts",
-        "src/store/native-extraction-journal.ts"
+        "apps/companion/components/extraction-model.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -184,16 +156,56 @@
       }
     },
     {
-      "id": "journal:resume-extraction-journal.json:operation.kind:resume-request-close",
-      "kind": "journal",
-      "path": "resume-extraction-journal.json",
-      "discriminator": "operation.kind",
-      "value": "resume-request-close",
-      "node": "JOUR",
+      "id": "browser:apps/companion/components/extraction-model.ts:reviewMutation",
+      "kind": "browser",
+      "export": "reviewMutation",
+      "node": "UIF",
       "sources": [
-        "scripts/job_apply_store/domains/extractions/journal.py",
-        "src/store/native-jobs.ts",
-        "src/store/native-extraction-journal.ts"
+        "apps/companion/components/extraction-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/extraction-model.ts:requestMutation",
+      "kind": "browser",
+      "export": "requestMutation",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/extraction-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/extraction-review.tsx:ExtractionReview",
+      "kind": "browser",
+      "export": "ExtractionReview",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/extraction-review.tsx"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/cli-native-answers-surfaces.json
+++ b/config/migration/cli-native-answers-surfaces.json
@@ -1,0 +1,239 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:answer-key",
+      "kind": "cli",
+      "command": "answer-key",
+      "node": "ANS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-answers.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:answer-find",
+      "kind": "cli",
+      "command": "answer-find",
+      "node": "ANS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-answers.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:answer-get",
+      "kind": "cli",
+      "command": "answer-get",
+      "node": "ANS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-answers.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:answer-reveal",
+      "kind": "cli",
+      "command": "answer-reveal",
+      "node": "ANS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-answers.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:answer-list",
+      "kind": "cli",
+      "command": "answer-list",
+      "node": "ANS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-answers.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:answer-put",
+      "kind": "cli",
+      "command": "answer-put",
+      "node": "ANS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-answers.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:answer-observe",
+      "kind": "cli",
+      "command": "answer-observe",
+      "node": "ANS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-answers.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:answer-update",
+      "kind": "cli",
+      "command": "answer-update",
+      "node": "ANS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-answers.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:answer-review",
+      "kind": "cli",
+      "command": "answer-review",
+      "node": "ANS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-answers.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/cli-native-extractions-surfaces.json
+++ b/config/migration/cli-native-extractions-surfaces.json
@@ -1,0 +1,291 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-extraction-request-create",
+      "kind": "cli",
+      "command": "resume-extraction-request-create",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-extractions.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts",
+        "src/workspace-core/extraction.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-extraction-request-get",
+      "kind": "cli",
+      "command": "resume-extraction-request-get",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-extractions.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts",
+        "src/workspace-core/extraction.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-extraction-request-list",
+      "kind": "cli",
+      "command": "resume-extraction-request-list",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-extractions.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts",
+        "src/workspace-core/extraction.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-extraction-request-cancel",
+      "kind": "cli",
+      "command": "resume-extraction-request-cancel",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-extractions.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts",
+        "src/workspace-core/extraction.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-extraction-request-fail",
+      "kind": "cli",
+      "command": "resume-extraction-request-fail",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-extractions.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts",
+        "src/workspace-core/extraction.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-extraction-request-retry",
+      "kind": "cli",
+      "command": "resume-extraction-request-retry",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-extractions.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts",
+        "src/workspace-core/extraction.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-extraction-request-complete",
+      "kind": "cli",
+      "command": "resume-extraction-request-complete",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-extractions.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts",
+        "src/workspace-core/extraction.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-proposal-create",
+      "kind": "cli",
+      "command": "resume-proposal-create",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-extractions.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts",
+        "src/workspace-core/extraction.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-proposal-get",
+      "kind": "cli",
+      "command": "resume-proposal-get",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-extractions.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts",
+        "src/workspace-core/extraction.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-proposal-list",
+      "kind": "cli",
+      "command": "resume-proposal-list",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-extractions.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts",
+        "src/workspace-core/extraction.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-proposal-review",
+      "kind": "cli",
+      "command": "resume-proposal-review",
+      "node": "RES",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-extractions.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts",
+        "src/workspace-core/extraction.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/document-01-surfaces.json
+++ b/config/migration/document-01-surfaces.json
@@ -54,7 +54,10 @@
       "artifact": "json",
       "node": "ANS",
       "sources": [
-        "scripts/job_apply_store/base.py"
+        "scripts/job_apply_store/base.py",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/document-01-surfaces.json
+++ b/config/migration/document-01-surfaces.json
@@ -129,7 +129,9 @@
       "artifact": "json",
       "node": "RES",
       "sources": [
-        "scripts/job_apply_store/base.py"
+        "scripts/job_apply_store/base.py",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -152,7 +154,9 @@
       "artifact": "json",
       "node": "RES",
       "sources": [
-        "scripts/job_apply_store/base.py"
+        "scripts/job_apply_store/base.py",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -175,7 +179,9 @@
       "artifact": "json",
       "node": "JOUR",
       "sources": [
-        "scripts/job_apply_store/base.py"
+        "scripts/job_apply_store/base.py",
+        "src/store/native-jobs.ts",
+        "src/store/native-extraction-journal.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-read-detail-surfaces.json
+++ b/config/migration/http-read-detail-surfaces.json
@@ -255,7 +255,10 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/extractions-http.ts",
+        "src/workspace-core/extraction.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-read-detail-surfaces.json
+++ b/config/migration/http-read-detail-surfaces.json
@@ -98,7 +98,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -152,7 +157,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-read-surfaces.json
+++ b/config/migration/http-read-surfaces.json
@@ -412,7 +412,10 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/extractions-http.ts",
+        "src/workspace-core/extraction.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -439,7 +442,10 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/extractions-http.ts",
+        "src/workspace-core/extraction.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-write-answers-02-surfaces.json
+++ b/config/migration/http-write-answers-02-surfaces.json
@@ -69,7 +69,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -125,7 +130,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -153,7 +163,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -265,7 +280,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -293,7 +313,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-write-answers-surfaces.json
+++ b/config/migration/http-write-answers-surfaces.json
@@ -13,7 +13,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -97,7 +102,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -125,7 +135,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -153,7 +168,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -209,7 +229,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -237,7 +262,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answers-http.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/answers.ts",
+        "src/workspace-core/answers.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-write-resumes-surfaces.json
+++ b/config/migration/http-write-resumes-surfaces.json
@@ -47,7 +47,10 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/extractions-http.ts",
+        "src/workspace-core/extraction.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -75,7 +78,10 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/extractions-http.ts",
+        "src/workspace-core/extraction.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -103,7 +109,10 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/extractions-http.ts",
+        "src/workspace-core/extraction.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -317,7 +326,10 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/extractions-http.ts",
+        "src/workspace-core/extraction.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -255,7 +255,7 @@
     },
     {
       "path": "source-catalog-native-answers.json",
-      "sha256": "a06c2a518e825df270d17373ab1580e4ece2fe5b482ebd0b1561afeb4a114b17"
+      "sha256": "926b5cbbc68d64cef6a1d3e73b988e2ea34e1a726d383c37b1d7b1b4ffd3d791"
     },
     {
       "path": "source-catalog-native-extractions.json",

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -38,6 +38,10 @@
       "sha256": "e012ca65fdf04343c960da5ce0a36e6a56d5b55f01074226c77bd35fcbe5408f"
     },
     {
+      "path": "browser-native-answers-surfaces.json",
+      "sha256": "deabe52901fe767c22222812550ad77e8d43f7376d690af6a41496a34056ce25"
+    },
+    {
       "path": "cli-01-surfaces.json",
       "sha256": "b05ac334f9949992f3497f79885033b970692cb798e831d4866d62050ce56841"
     },
@@ -70,6 +74,10 @@
       "sha256": "adcbc8737ec21bf25b4e0ea251fb2c7b34e577486f778e79aee43810fa946c07"
     },
     {
+      "path": "cli-native-answers-surfaces.json",
+      "sha256": "1f799e53cf30108c9b90e93170703bd9c5679680a7227ef68496965cf7e4ce7d"
+    },
+    {
       "path": "cli-native-facts-surfaces.json",
       "sha256": "b9710c5943613cea49bf1742e5aea7570220f3ef2db45e956ea4576adcbae223"
     },
@@ -87,7 +95,7 @@
     },
     {
       "path": "document-01-surfaces.json",
-      "sha256": "832cba04c3b722bbea66f242d3e2ce587e988732c8abcd7d0f3cd8f2cdf5f7de"
+      "sha256": "bd06142946295df5ee0ed4bf79c5a7b71c0adac91b96f91065f46f45af5a60fe"
     },
     {
       "path": "document-02-surfaces.json",
@@ -115,7 +123,7 @@
     },
     {
       "path": "http-read-detail-surfaces.json",
-      "sha256": "6b35b0079111a16eb7cc3b9a197c646467983d8d2e083b4d4d662dcefbc19bfc"
+      "sha256": "9b73db44d9cc03da30c284aa073af6587d035ab9d5bb4bbbf4df527c1593d68f"
     },
     {
       "path": "http-read-surfaces.json",
@@ -127,11 +135,11 @@
     },
     {
       "path": "http-write-answers-02-surfaces.json",
-      "sha256": "40aa2d382f575d8f363d3c98852adb2bc562ba9811e8148ac7c2dcbe8a96ef97"
+      "sha256": "68b243d60c99c87320d442629a2a5825fae7a469cf294539118c63eb93172ccc"
     },
     {
       "path": "http-write-answers-surfaces.json",
-      "sha256": "10ea3e206a02ae3dedb2f2ec2195f7df936b530cc3f9b2386463d5a7d2f9db36"
+      "sha256": "beb7a8d7d037c44ea637e7567aab712430b2a3126c3e95a5495cae1bda4c9b10"
     },
     {
       "path": "http-write-jobs-surfaces.json",
@@ -227,7 +235,7 @@
     },
     {
       "path": "source-catalog-g02-next.json",
-      "sha256": "dc5a2fedfd6cf2a532e623e9c2da77ba5b0c69f6b96af8fcd30d41a7a11dcda2"
+      "sha256": "b1820333e22a56cf3b312326734789a274209838b5a6d4c6e45170e3caebd772"
     },
     {
       "path": "source-catalog-m01.json",
@@ -238,12 +246,16 @@
       "sha256": "0b6ee35143f1ad4f49568ed3d9e15f1cfacf869476a50a151b4fea3fc6f29f41"
     },
     {
+      "path": "source-catalog-native-answers.json",
+      "sha256": "a06c2a518e825df270d17373ab1580e4ece2fe5b482ebd0b1561afeb4a114b17"
+    },
+    {
       "path": "source-catalog-native-facts.json",
       "sha256": "8a41ab419b7b46311658f0ec43e970c7cda36f6322aa8dba415c41ae9e6e6424"
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "9919e0c9935d3ea92654fef70c5f06c2502fac4d86967d45acc2424f1c0c893e"
+      "sha256": "ebfa93122c640353562cac434f0c030120d5ac8dabc5febae4a38ca013617806"
     },
     {
       "path": "source-catalog-native-resumes.json",

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -42,6 +42,10 @@
       "sha256": "deabe52901fe767c22222812550ad77e8d43f7376d690af6a41496a34056ce25"
     },
     {
+      "path": "browser-native-extractions-surfaces.json",
+      "sha256": "ac960232d6b5234f38fab48d567eabf436f72e291def557f9f52ab53cedee658"
+    },
+    {
       "path": "cli-01-surfaces.json",
       "sha256": "b05ac334f9949992f3497f79885033b970692cb798e831d4866d62050ce56841"
     },
@@ -78,6 +82,10 @@
       "sha256": "1f799e53cf30108c9b90e93170703bd9c5679680a7227ef68496965cf7e4ce7d"
     },
     {
+      "path": "cli-native-extractions-surfaces.json",
+      "sha256": "48b2da4e3573d28c16e3b8914b27ca34ae5379573e0214c5da84e034ee0f4801"
+    },
+    {
       "path": "cli-native-facts-surfaces.json",
       "sha256": "b9710c5943613cea49bf1742e5aea7570220f3ef2db45e956ea4576adcbae223"
     },
@@ -95,7 +103,7 @@
     },
     {
       "path": "document-01-surfaces.json",
-      "sha256": "bd06142946295df5ee0ed4bf79c5a7b71c0adac91b96f91065f46f45af5a60fe"
+      "sha256": "0bf1907dd70fdb9e76da995ba6522b979158baa763147c0c8890b21e9736d784"
     },
     {
       "path": "document-02-surfaces.json",
@@ -123,11 +131,11 @@
     },
     {
       "path": "http-read-detail-surfaces.json",
-      "sha256": "9b73db44d9cc03da30c284aa073af6587d035ab9d5bb4bbbf4df527c1593d68f"
+      "sha256": "dd8d077cbb24c86469471b48c86f2e1fc4e266b63d32a1ddc5fe071c4dad789e"
     },
     {
       "path": "http-read-surfaces.json",
-      "sha256": "91c59a29e0b3cad192438bbdeb11858abb377bab1e7cb9bb45cef54919a99a1a"
+      "sha256": "8bbc18ba8fbbb4064a46d4d6c981e91b038f6af88c1aa7c73bfa32da925d4397"
     },
     {
       "path": "http-write-accounts-surfaces.json",
@@ -151,7 +159,7 @@
     },
     {
       "path": "http-write-resumes-surfaces.json",
-      "sha256": "bd5d9621cdd4a79983c36c74517ebebdc69c1dc530bb1cc676e238680f6fabf6"
+      "sha256": "62274f8bdaf20fabf79a3988d41d134a3459452d2ba7eea5215d7a8feb7f36a8"
     },
     {
       "path": "http-write-surfaces.json",
@@ -163,7 +171,7 @@
     },
     {
       "path": "journal-02-surfaces.json",
-      "sha256": "1051479ffce514db1e766054102e7fc7a95188074052ea3ac4bed616178a8bb7"
+      "sha256": "91e0d6c0969a8d400e980d2f6723b15af49be60232299453dfca06307e77d5d8"
     },
     {
       "path": "journal-03-surfaces.json",
@@ -235,7 +243,7 @@
     },
     {
       "path": "source-catalog-g02-next.json",
-      "sha256": "b1820333e22a56cf3b312326734789a274209838b5a6d4c6e45170e3caebd772"
+      "sha256": "faf16f790ebda4d05c2a5b47335dfe26ef11b49e5d3788f6ba62d902a34fa39c"
     },
     {
       "path": "source-catalog-m01.json",
@@ -250,12 +258,16 @@
       "sha256": "a06c2a518e825df270d17373ab1580e4ece2fe5b482ebd0b1561afeb4a114b17"
     },
     {
+      "path": "source-catalog-native-extractions.json",
+      "sha256": "0ccd58b8d6e52a0f2818b43e8cd8d16dd39dc1f52898f3a61e42aa2ea77602f7"
+    },
+    {
       "path": "source-catalog-native-facts.json",
       "sha256": "8a41ab419b7b46311658f0ec43e970c7cda36f6322aa8dba415c41ae9e6e6424"
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "ebfa93122c640353562cac434f0c030120d5ac8dabc5febae4a38ca013617806"
+      "sha256": "bdb629946968ecb5e8239937c998d7d183770482e45cff2dd0ca2c77df11bfda"
     },
     {
       "path": "source-catalog-native-resumes.json",

--- a/config/migration/source-catalog-g02-next.json
+++ b/config/migration/source-catalog-g02-next.json
@@ -13,7 +13,7 @@
     },
     {
       "path": "apps/companion/components/Companion.tsx",
-      "sha256": "f36f98e97b467c2853244755bbc344d6d3372a5e6bff8f0560eb6bcd359bfa0b",
+      "sha256": "892a63d53e4a5d455f7cbf0d000f9eba1803fe2d46efcbb008ac51d85fdfb81c",
       "classification": "unreviewed"
     },
     {
@@ -38,7 +38,7 @@
     },
     {
       "path": "apps/companion/components/client.ts",
-      "sha256": "06fd7fce7cca30e855cf210a99d192206045b7a4d5c1681d2fe58d1b270fdd33",
+      "sha256": "b767b874663a38e0297ddae0183f7b155bd3a94da6f49593e1513ea419920730",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-g02-next.json
+++ b/config/migration/source-catalog-g02-next.json
@@ -13,7 +13,7 @@
     },
     {
       "path": "apps/companion/components/Companion.tsx",
-      "sha256": "bf9e06f2b21b57c64309eaa3ebaa209e7bec90dfa8624c13b3b65f8f63b6be59",
+      "sha256": "f36f98e97b467c2853244755bbc344d6d3372a5e6bff8f0560eb6bcd359bfa0b",
       "classification": "unreviewed"
     },
     {
@@ -38,7 +38,7 @@
     },
     {
       "path": "apps/companion/components/client.ts",
-      "sha256": "808fd59c56821aaaf2e479a6eff3c5aaaa5b364b73a3f1ccf4fe37eecee55b0c",
+      "sha256": "06fd7fce7cca30e855cf210a99d192206045b7a4d5c1681d2fe58d1b270fdd33",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-answers.json
+++ b/config/migration/source-catalog-native-answers.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "src/contracts/workspace/answers.ts",
+      "sha256": "efa837cb825230ba4ec40182443cb661a8a3a20f0c3d7b58363b8746f83cbe57",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/answers.ts",
+      "sha256": "55c741fc60a54d9a5b632c107f366018e17c48130b39b725c69688747574fb55",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/answers-http.ts",
+      "sha256": "9486b702290679d74d3a1e808c1aad0e45d2d02bf5f95d2cb1b9062ebcce89ab",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-answers.ts",
+      "sha256": "ab35fd27ee583021acb2900853f827e70ae73a8e1fc640979f8b35c06becae13",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/answers.js",
+      "sha256": "8b0881ce6bee817a6bd14f1eee77292af78a54b94c159669a512b612e1a9257b",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/answers.js",
+      "sha256": "aa00d9285feba7f2325a3955114c8daf8ced035ad0807fb8c58d01c9360f0490",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/answers-http.js",
+      "sha256": "42afc7942b54a494a2a58c134e7b94aed4f9d0d243bebd26cd09155a18e35242",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/cli/native-answers.js",
+      "sha256": "ac908afc5a9a856c4b11b6b18dfc5f49d68b343362d23a114257519cee44c34e",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/Answers.tsx",
+      "sha256": "0248f018d86c39a513ea10bbb5e7728c02e1db37f8af13f0663a05be54a52061",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/answer-fields.tsx",
+      "sha256": "1271ab64a41c45e1301665648936a1a2ca8b65ae1b1177d0009f992cf848433c",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/answer-model.ts",
+      "sha256": "078fc1a4b6b68a4dd22eb32b3d7bd294a40ad03f8a4cd014a50e5913a71d754f",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/config/migration/source-catalog-native-answers.json
+++ b/config/migration/source-catalog-native-answers.json
@@ -13,7 +13,7 @@
     },
     {
       "path": "src/workspace-core/answers-http.ts",
-      "sha256": "9486b702290679d74d3a1e808c1aad0e45d2d02bf5f95d2cb1b9062ebcce89ab",
+      "sha256": "64c69aabd1c08b43bfc1d3efeede132d660fa774e5682be9128bc6dee218509e",
       "classification": "unreviewed"
     },
     {
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/workspace-core/answers-http.js",
-      "sha256": "42afc7942b54a494a2a58c134e7b94aed4f9d0d243bebd26cd09155a18e35242",
+      "sha256": "95552854b484903cc58323b97744bcc7df1b34ac430cedb4db80a64c7c6d140d",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-extractions.json
+++ b/config/migration/source-catalog-native-extractions.json
@@ -1,0 +1,130 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "apps/companion/components/Extractions.tsx",
+      "sha256": "343bf8b6fe7cedebb5418591a09ccb1b880a60aae82238b7dec8b4bbc26ff68f",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/extraction-model.ts",
+      "sha256": "a2f7190011185bf6f582db04726b9563d738f4c5811dd251a540cf1f2d6e0f2e",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/extraction-review.tsx",
+      "sha256": "720a6bed5b9b4b5cefe8fb18ec77a0af559282f97317ea18a7bfec0c579511fc",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/cli/native-extractions.js",
+      "sha256": "4b3b1c21635df57f408adf8ccfab81e000d30fa8cee9c8c4982ad8dee6b15c4c",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/extraction-pointers.js",
+      "sha256": "bbbb452f611ccfcb3db7801c728defea44866b272f1ae977074c3868b2fffd5c",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/extraction-proposals.js",
+      "sha256": "38f707c38e3876bd3b4b8a44209d96155f0b803a7767afbb2805fe29c12961bb",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/extraction-requests.js",
+      "sha256": "1859106885d1ad5eb7a798f77ea56f54f1743fd02d80f66254b388606599fc4c",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/store/native-extraction-journal.js",
+      "sha256": "9b6f6aecad5cc89c4867677a16e8f77ce96dedde6fc94b898fac669962e57d57",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/extraction-context.js",
+      "sha256": "155bf4072ee6d2b08c582413d897a4ed7e67b31571ecedb13859845e7be7b5bb",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/extraction-proposal-state.js",
+      "sha256": "2d35f6ea0d6ae9ef9214eec5aba4bded5c6e4ab37e13add23409d4c115fd4304",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/extraction-proposals.js",
+      "sha256": "874fe07207fce34a9f424b19d45fe7b8969874082e2b85de33e79af20fb3f838",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/extraction-requests.js",
+      "sha256": "4a92fa78a3cd2a5b5024213378bb8dbaf0678d0564b17034edb16cb833495c04",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/extraction.js",
+      "sha256": "922b9ec9d06bde48a08c281ce6b8564198239a81461ca3ef78db915b2dd2352f",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/extractions-http.js",
+      "sha256": "1fb0d989426ef6b22e2c4a42572c29ae6caf9f265535e2e021b1f88bcbf1a525",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-extractions.ts",
+      "sha256": "55a12aa0d4da68928cd081704736f9b6d901c932644c7d58c679469544d8dec5",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/extraction-pointers.ts",
+      "sha256": "768e6fca6508951fb8bb78aad78beac630747286122ff6cbc7ff8612ef5302ef",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/extraction-proposals.ts",
+      "sha256": "d69810ed6c1a6e9bf4e183ff83279bd169ba5546ad1c05276a94d079d6658ae1",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/extraction-requests.ts",
+      "sha256": "101ce3f902c3f2909a4d3f64c051b7f1997e5793e2766281fdef038a8f032c99",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/store/native-extraction-journal.ts",
+      "sha256": "bd85393749b2ae808c41f3bb1b663767472257a8c3795cf661b10605f99635af",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/extraction-context.ts",
+      "sha256": "6ee6a2260e720405792f04ba3753d50118f7790f5131104a737fecb2a56fb242",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/extraction-proposal-state.ts",
+      "sha256": "de335577ffe68f0eeca01b188e3f9449cccce0c82d1c91fa9c98e41c8daa84b7",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/extraction-proposals.ts",
+      "sha256": "c968793feef658e6d17390de5bb7ee45d8debaea3768f22122aa0797136adde1",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/extraction-requests.ts",
+      "sha256": "86e2df274f03b8853b9dbe0646cd586f9edeeddce51c06463cbabc91123803d5",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/extraction.ts",
+      "sha256": "7867089f9480788e65b04a5ed1eb93f208ea88e10fd1af3f648022d12e910696",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/extractions-http.ts",
+      "sha256": "498816e52be4940fc840bd0aaed296ebee1fefa5ce6cd459d0fb540c5d65b075",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "8cadc6e6f01e20afce5c0b86798b9bc558c246fdc329084281a9722b46746aaf",
+      "sha256": "04f79fed4a8c4e7272f2f1c9443e486640cc2a871e29211e7393d92d685d7ad1",
       "classification": "unreviewed"
     },
     {
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "d615c660c4dfa746c43bfe3de8f71d3fc1b8d9d7022c4ac15453a718234d3209",
+      "sha256": "20750b73f1833ec8b74d0c61b38611ef626cae91284517642bd6142aae765b04",
       "classification": "unreviewed"
     },
     {
@@ -43,7 +43,7 @@
     },
     {
       "path": "runtime/workspace-core/jobs-http.js",
-      "sha256": "b54c16d83fa7440d8a66a53df7b6b2542ae09153157ac0dfdb9133d3e7b0e27e",
+      "sha256": "65b77677cc24c0d6f754bc89ce72b8e9b202e7e9fff21d3e7bf8823b092f94d4",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "63bc424ec003bd92cbe3c8ab8a64e27988b7ced5080c2ab63f4ec728a4fdc65c",
+      "sha256": "766ef6b79073d0d10fee17db11df1173269f27303a620b7856099797ab8c19bf",
       "classification": "unreviewed"
     },
     {
@@ -83,7 +83,7 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "d005b20201bf19fbffdf36c4d8ee08030ddd65728714e5df4a559aa477591e08",
+      "sha256": "4f15410a03158736638cac5831afb6f7cc0612f3b617e83f4a1d45dc6662596a",
       "classification": "unreviewed"
     },
     {
@@ -93,7 +93,7 @@
     },
     {
       "path": "src/workspace-core/jobs-http.ts",
-      "sha256": "3236e295cdf19b5e42f207c7e855a946678ded8aaddf098feaee61f93baa08d3",
+      "sha256": "612013d61812975dbd77819a4c1031b1b42c1f2413282a2aa5b9ed835e4a3501",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "6992347e011b548511a53ab4dde361cbebf08185c90cc235647dff1d9a0fc61f",
+      "sha256": "8cadc6e6f01e20afce5c0b86798b9bc558c246fdc329084281a9722b46746aaf",
       "classification": "unreviewed"
     },
     {
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "ca6492adc02592ba9c6b10a879a85117310cf15bed320c440323fd1799192f57",
+      "sha256": "d615c660c4dfa746c43bfe3de8f71d3fc1b8d9d7022c4ac15453a718234d3209",
       "classification": "unreviewed"
     },
     {
@@ -43,7 +43,7 @@
     },
     {
       "path": "runtime/workspace-core/jobs-http.js",
-      "sha256": "5a3b865192d62d1b429507f6077fbe71d57a9896c8587f624f0686b3880783c3",
+      "sha256": "b54c16d83fa7440d8a66a53df7b6b2542ae09153157ac0dfdb9133d3e7b0e27e",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "410df4f173a9a65c18384851d1938f405e71eee1229d7898fc8507fe275b74fc",
+      "sha256": "63bc424ec003bd92cbe3c8ab8a64e27988b7ced5080c2ab63f4ec728a4fdc65c",
       "classification": "unreviewed"
     },
     {
@@ -83,7 +83,7 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "2a21fb048a412e38869391bc9ce074ad1501779f21d8c31e14eacabf481c3459",
+      "sha256": "d005b20201bf19fbffdf36c4d8ee08030ddd65728714e5df4a559aa477591e08",
       "classification": "unreviewed"
     },
     {
@@ -93,7 +93,7 @@
     },
     {
       "path": "src/workspace-core/jobs-http.ts",
-      "sha256": "6f99dfc8d2bcf0594114bf71bd8304cf6c78fac3f9ae5d3b2a04108addbab266",
+      "sha256": "3236e295cdf19b5e42f207c7e855a946678ded8aaddf098feaee61f93baa08d3",
       "classification": "unreviewed"
     },
     {

--- a/docs/native-answers-fixture.md
+++ b/docs/native-answers-fixture.md
@@ -2,7 +2,7 @@
 
 This tranche provides lossless answer contracts, shared domain services, HTTP/CLI
 leaf adapters and a React editor. It is not a complete phase 8 migration or a
-live Store activation. Native fixture version 4 wires these services into the
+live Store activation. Native fixture version 5 wires these services into the
 shared Store lock, HTTP and CLI dispatch, and the Answers tab. Existing fixtures
 are rejected rather than upgraded; initialize a new isolated fixture using the
 [native fixture guide](native-jobs-fixture.md).

--- a/docs/native-answers-fixture.md
+++ b/docs/native-answers-fixture.md
@@ -1,0 +1,79 @@
+# Native Answers leaf tranche
+
+This tranche provides lossless answer contracts, shared domain services, HTTP/CLI
+leaf adapters and a React editor. It is not a complete phase 8 migration or a
+live Store activation. Native fixture version 4 wires these services into the
+shared Store lock, HTTP and CLI dispatch, and the Answers tab. Existing fixtures
+are rejected rather than upgraded; initialize a new isolated fixture using the
+[native fixture guide](native-jobs-fixture.md).
+
+## Repository integration
+
+`AnswersService` receives an `AnswerRepository` implementing:
+
+```ts
+answerTransaction<T>(operation: (
+  document: Document,
+  save: (document: Document) => Promise<void>,
+  references: ReadonlyMap<string, { sessions: bigint; history: bigint }>,
+) => Promise<T>): Promise<T>;
+```
+
+The repository owns cross-process locking, private-path validation, loading and
+atomic durable replacement of `answers.json`. It must hold the lock across the
+callback, supply a detached lossless document, validate before saving, and reject
+unsupported recovery journals without changing them. The domain validates all
+answer records and flattened redirects before reads or writes. Unknown record
+and metadata fields are preserved during edits.
+
+Reference counts must include sessions and history and resolve redirected keys.
+An empty map is safe only in fixtures that reject all unsupported session and
+history state. This leaf cannot assert real Store reference counts or writer
+exclusion on its own. Do not open an existing Python Store with these leaves.
+
+`answerHttp(repository, method, path, body)` returns a serialized response or
+`null` for unsupported routes. The parent owns authentication, body limits,
+error-to-status mapping and unsupported-route handling. Encoded `by-key` paths
+use UTF-8 base64url. Supported routes are query, put, observe, detail, update,
+explicit reveal and accept/decline. Semantic lookup and cleanup routes remain
+unsupported.
+
+`answerCommands` and `runAnswerCommand` provide answer-key, get, find, list, put,
+observe, update, reveal and review. The native parser recognizes the boolean
+flags `--remember-sensitive`, `--include-trashed`, `--trashed-only` and
+`--all-review-statuses`. Review uses the existing `--decision` option. Exact
+question/alias lookup is supported; semantic reuse authorization is not.
+
+## React integration
+
+Render `Answers` with `dirtyChanged` and an authenticated `AnswerClient` whose
+`answerRequest(path, method, body, signal)` returns raw response text. Use the
+existing bounded request transport in raw mode so integer and float tokens do
+not pass through ordinary JSON parsing.
+
+The leaf supports value-free search, status filters, selecting an answer,
+explicit sensitive reveal, ordinary labeled fields with lossless typed value editing, accept/decline, draft retention
+and selective reapply after loading a newer revision. Consent starts unchecked
+and resets after selection, save and conflict reapply. Unsupported merge,
+cleanup and pending application questions are identified in the UI. Creation is
+available through the service/CLI/HTTP; the leaf UI does not yet have a creation
+form. The native browser walkthrough covers editing, CLI conflicts and selective
+reapply, sensitive reveal and remember consent, pending review and saved reload.
+
+## Verification and remaining work
+
+Run `node --test tests_js/workspace_native_answers.test.mjs` after emitting the
+runtime. The focused suite includes an independent Python Store on a fresh
+separate temporary root, Unicode/numeric key checks, mutation/projection parity,
+privacy, stale revisions, collisions and HTTP/CLI validation. Its native domain
+repository is an isolated in-memory transaction fixture; it does not substitute
+for disk durability or cross-process integration. The companion
+`workspace_native_answers_integration.test.mjs` exercises real HTTP/CLI disk
+state, concurrent revisions, failed persistence, corrupt documents and rejected
+unsupported reference state. Existing native lock and atomic-write fault tests
+remain required; the domain tests alone do not certify crash recovery.
+
+Merge and cleanup commit require the coordinator journal plus reference/session
+rewrites. No single-document substitute is supplied. Full phase 8 acceptance
+also requires semantic matching/reuse policy, cleanup preview binding, complete
+React workflows, coordinator recovery and full release acceptance.

--- a/docs/native-extractions-fixture.md
+++ b/docs/native-extractions-fixture.md
@@ -1,0 +1,53 @@
+# Native extraction review
+
+The synthetic native workspace supports resume extraction requests, proposals,
+and review through shared TypeScript services. Create a fresh fixture using
+[the native launcher guide](native-jobs-fixture.md). Fixture version 5 adds
+`resume-extractions.json`, `resume-extraction-requests.json`, and
+`resume-extraction-journal.json`. Earlier fixtures must be recreated at a new
+path. Existing Python Stores remain unsupported.
+
+## Workflow
+
+Import a managed resume in Resumes, then open Resume extraction and choose it.
+Request extraction records work for an agent; it does not run a model or extract
+the file by itself. The native CLI exposes request get/list and complete/fail
+commands for the agent. The agent must supply candidate facts and the expected
+request and profile revisions. Direct proposal creation remains available.
+
+Missing facts can be filled automatically with resume provenance. Existing
+facts become pending comparisons. The review screen shows current and extracted
+values and lets the user keep the current value or use the extracted value.
+Replacing an existing ancestor, such as an array with a nested object, requires
+an explicit confirmation. Accepted values receive user provenance.
+
+The screen retains unsaved decisions after a failed save or refresh. Loading
+new comparisons requires explicit reapply, which clears replacement consent and
+drops decisions for fields already resolved. Stale proposals cannot be reviewed;
+request another extraction. Requests can be cancelled, and failed or stale
+requests can be retried. A retry creates a new request linked to the previous one.
+
+## CLI and recovery
+
+Use the native CLI with `--root` and `--native-lock` as in the launcher guide.
+Request commands use the prefix `resume-extraction-request-` and suffixes
+`create`, `get`, `list`, `cancel`, `fail`, `retry`, and `complete`. Proposal
+commands use `resume-proposal-create`, `get`, `list`, and `review`.
+
+Completion requires `--id`, `--input`, `--expected-request-revision`, and
+`--expected-profile-revision`. If another pending proposal exists, completion
+also requires its exact `--expected-pending-proposal-id`. Review requires
+`--id`, `--input`, `--expected-revision`, and `--expected-profile-revision`.
+The input contains `decisions` and, where needed, `replacementConfirmations`.
+Candidate creation and completion accept up to 2 MiB on stdin to accommodate
+JSON formatting and escapes; normalized candidates retain their 256 KiB limit.
+
+All native domains share the Store lock and replay extraction recovery before
+reading state. The extraction journal validates all destination documents
+before writing them. Resume replacement closes open requests as stale together
+with the new resume metadata, including recovery after an interrupted file
+installation. Metadata-only resume edits preserve content-bound requests.
+
+The focused extraction suites exercise domain contracts, HTTP/CLI integration,
+review models and interrupted persistence. This fixture does not activate a
+general Store writer, migrate live applicant data, or complete release acceptance.

--- a/docs/native-facts-fixture.md
+++ b/docs/native-facts-fixture.md
@@ -6,7 +6,7 @@ services between HTTP and the native CLI. The default launcher remains Python.
 No live Store is adopted, migrated or activated by this change.
 
 Create a new root using the [native fixture instructions](native-jobs-fixture.md).
-The fixture marker is now version 3 and initialization also creates
+The fixture marker is now version 4 and initialization also creates
 `fact-groups.json`. Version 1 and 2 disposable fixtures must be recreated at a new
 path; existing roots are never automatically upgraded. Profile replacement with
 revision zero cannot initialize or recover a missing profile in this mode.

--- a/docs/native-jobs-fixture.md
+++ b/docs/native-jobs-fixture.md
@@ -72,7 +72,12 @@ verify resume byte/metadata recovery, reject file swaps, kill a lock holder, and
 run a production Next/browser conflict-and-reload flow with managed resume import.
 No owner account, live Store, visible browser or plugin installation is used.
 
-Facts/profile and managed resumes are available in newly initialized version 3
+Facts/profile and managed resumes are available in newly initialized version 4
 synthetic fixtures. See [Facts/profile commands and limits](native-facts-fixture.md).
 Older version 1 and 2 fixtures must be recreated at a new path; they are not
 automatically upgraded.
+
+Version 4 also initializes `answers.json` for remembered-answer query, editing,
+review and explicit reveal through native HTTP/CLI and the Answers tab. It still
+rejects session/history and coordinator state; merge, cleanup and pending
+questions are unavailable. See [Answers scope](native-answers-fixture.md).

--- a/docs/native-jobs-fixture.md
+++ b/docs/native-jobs-fixture.md
@@ -72,12 +72,15 @@ verify resume byte/metadata recovery, reject file swaps, kill a lock holder, and
 run a production Next/browser conflict-and-reload flow with managed resume import.
 No owner account, live Store, visible browser or plugin installation is used.
 
-Facts/profile and managed resumes are available in newly initialized version 4
+Facts/profile and managed resumes are available in newly initialized version 5
 synthetic fixtures. See [Facts/profile commands and limits](native-facts-fixture.md).
-Older version 1 and 2 fixtures must be recreated at a new path; they are not
+Older fixtures must be recreated at a new path; they are not
 automatically upgraded.
 
-Version 4 also initializes `answers.json` for remembered-answer query, editing,
+Version 5 also initializes `answers.json` for remembered-answer query, editing,
 review and explicit reveal through native HTTP/CLI and the Answers tab. It still
 rejects session/history and coordinator state; merge, cleanup and pending
 questions are unavailable. See [Answers scope](native-answers-fixture.md).
+
+Extraction requests, proposals and review use the shared lock and extraction
+journal. See [Extraction workflow and limits](native-extractions-fixture.md).

--- a/runtime/cli/native-answers.js
+++ b/runtime/cli/native-answers.js
@@ -1,0 +1,56 @@
+import { answerKey } from '../contracts/workspace/answers.js';
+import { AnswersService } from '../workspace-core/answers.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { object, parse, set, text, JobsError } from '../contracts/workspace/values.js';
+export const answerCommands = {
+    'answer-key': ['--question', '--scope'], 'answer-find': ['--question', '--scope'],
+    'answer-get': ['--key', '--include-trashed'], 'answer-reveal': ['--key'],
+    'answer-list': ['--state', '--review-status', '--all-review-statuses', '--query', '--offset', '--limit', '--include-trashed', '--trashed-only'],
+    'answer-put': ['--input', '--expected-revision', '--remember-sensitive'],
+    'answer-observe': ['--input'],
+    'answer-update': ['--key', '--input', '--expected-revision', '--remember-sensitive'],
+    'answer-review': ['--key', '--decision', '--input', '--expected-revision', '--remember-sensitive'],
+};
+export async function runAnswerCommand(command, repository, options, payload) {
+    const service = new AnswersService(repository);
+    const required = (key) => {
+        const value = options.get(key);
+        if (!value)
+            throw new JobsError(`required option: ${key}`);
+        return value;
+    };
+    const revision = () => {
+        const value = required('--expected-revision');
+        if (!/^[0-9]+$/.test(value) || BigInt(value) < 1n)
+            throw new JobsError('expected revision must be a positive integer');
+        return BigInt(value);
+    };
+    const consent = options.has('--remember-sensitive');
+    switch (command) {
+        case 'answer-key': return set(emptyObject(), 'key', text(answerKey(required('--question'), object(parse(options.get('--scope') ?? '{}'), 'scope'))));
+        case 'answer-find': return service.find(required('--question'), object(parse(options.get('--scope') ?? '{}'), 'scope'));
+        case 'answer-get': return service.get(required('--key'), false, options.has('--include-trashed'));
+        case 'answer-reveal': {
+            const value = await service.get(required('--key'), true);
+            if (value === null)
+                throw new JobsError('answer does not exist');
+            return value;
+        }
+        case 'answer-list': {
+            if (options.has('--all-review-statuses') && options.has('--review-status'))
+                throw new JobsError('answer review filters are mutually exclusive');
+            return service.query({ query: options.get('--query') ?? '', state: options.get('--state') ?? null, reviewStatus: options.has('--all-review-statuses') ? null : options.get('--review-status') ?? 'accepted',
+                offset: Number(options.get('--offset') ?? '0'), limit: Number(options.get('--limit') ?? '50'), includeTrashed: options.has('--include-trashed'), trashedOnly: options.has('--trashed-only') });
+        }
+        case 'answer-put': return service.put(await payload(), consent, options.has('--expected-revision') ? revision() : null);
+        case 'answer-observe': return service.observe(await payload());
+        case 'answer-update': return service.update(required('--key'), await payload(), revision(), consent);
+        case 'answer-review': {
+            const status = required('--decision');
+            if (status !== 'accepted' && status !== 'declined')
+                throw new JobsError('answer review decision must be accepted or declined');
+            return service.update(required('--key'), options.has('--input') ? await payload() : emptyObject(), revision(), consent, status);
+        }
+        default: throw new JobsError('unsupported native answer command');
+    }
+}

--- a/runtime/cli/native-extractions.js
+++ b/runtime/cli/native-extractions.js
@@ -1,0 +1,44 @@
+import { ExtractionService } from '../workspace-core/extraction.js';
+import { JobsError } from '../contracts/workspace/values.js';
+export const extractionCommands = {
+    'resume-extraction-request-create': ['--resume-id', '--expected-resume-revision'],
+    'resume-extraction-request-get': ['--id'],
+    'resume-extraction-request-list': ['--resume-id', '--status'],
+    'resume-extraction-request-cancel': ['--id', '--expected-revision'],
+    'resume-extraction-request-fail': ['--id', '--reason', '--expected-revision'],
+    'resume-extraction-request-retry': ['--id', '--expected-revision', '--expected-resume-revision'],
+    'resume-extraction-request-complete': ['--id', '--input', '--expected-request-revision', '--expected-profile-revision', '--expected-pending-proposal-id'],
+    'resume-proposal-create': ['--resume-id', '--input', '--expected-resume-revision', '--expected-profile-revision', '--supersedes'],
+    'resume-proposal-get': ['--id'],
+    'resume-proposal-list': ['--resume-id', '--status', '--summary-only'],
+    'resume-proposal-review': ['--id', '--input', '--expected-revision', '--expected-profile-revision'],
+};
+export async function runExtractionCommand(command, repository, options, payload) {
+    const service = new ExtractionService(repository);
+    const required = (key) => {
+        const value = options.get(key);
+        if (!value)
+            throw new JobsError(`required option: ${key}`);
+        return value;
+    };
+    const revision = (key = '--expected-revision') => {
+        const value = required(key);
+        if (!/^[0-9]+$/.test(value) || BigInt(value) < 1n)
+            throw new JobsError(`${key} must be a positive integer`);
+        return BigInt(value);
+    };
+    switch (command) {
+        case 'resume-extraction-request-create': return service.createRequest(required('--resume-id'), revision('--expected-resume-revision'));
+        case 'resume-extraction-request-get': return service.getRequest(required('--id'));
+        case 'resume-extraction-request-list': return service.listRequests(options.get('--resume-id'), options.get('--status'));
+        case 'resume-extraction-request-cancel': return service.cancelRequest(required('--id'), revision());
+        case 'resume-extraction-request-fail': return service.failRequest(required('--id'), required('--reason'), revision());
+        case 'resume-extraction-request-retry': return service.retryRequest(required('--id'), revision(), revision('--expected-resume-revision'));
+        case 'resume-extraction-request-complete': return service.completeRequest(required('--id'), await payload(), revision('--expected-request-revision'), revision('--expected-profile-revision'), options.get('--expected-pending-proposal-id'));
+        case 'resume-proposal-create': return service.createProposal(required('--resume-id'), await payload(), revision('--expected-resume-revision'), revision('--expected-profile-revision'), options.get('--supersedes'));
+        case 'resume-proposal-get': return service.getProposal(required('--id'));
+        case 'resume-proposal-list': return service.listProposals(options.get('--resume-id'), options.get('--status'), options.has('--summary-only'));
+        case 'resume-proposal-review': return service.reviewProposal(required('--id'), await payload(), revision(), revision('--expected-profile-revision'));
+        default: throw new JobsError('unsupported native extraction command');
+    }
+}

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,5 +1,6 @@
 import { profileCommands, runProfileCommand } from "./native-profile.js";
 import { answerCommands, runAnswerCommand } from "./native-answers.js";
+import { extractionCommands, runExtractionCommand } from "./native-extractions.js";
 import { readFile } from "node:fs/promises";
 import { realpathSync } from "node:fs";
 import { basename } from "node:path";
@@ -23,7 +24,7 @@ export async function runJobsCli(args, input) {
         else {
             if (options.has(key))
                 throw new JobsError("duplicate CLI option");
-            if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses"].includes(key))
+            if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses", "--summary-only"].includes(key))
                 options.set(key, "true");
             else {
                 const value = args[++index];
@@ -36,6 +37,7 @@ export async function runJobsCli(args, input) {
     const fields = {
         ...profileCommands,
         ...answerCommands,
+        ...extractionCommands,
         "fixture-init": [], "job-create": ["--input", "--origin"], "job-get": ["--id", "--include-trashed"],
         "job-list": ["--status", "--include-trashed", "--trashed-only"],
         "job-update": ["--id", "--input", "--expected-revision", "--origin"],
@@ -64,12 +66,17 @@ export async function runJobsCli(args, input) {
     const resumes = new ResumeService(repository);
     const payload = async () => {
         const file = required("--input");
-        return parse(file === "-" ? await input() : await readFile(file, "utf8"));
+        // Extraction candidates permit 256 KiB after normalization. Allow JSON
+        // escaping and formatting overhead while keeping stdin bounded.
+        const limit = ["resume-proposal-create", "resume-extraction-request-complete"].includes(command) ? 2 * 1024 * 1024 : 65536;
+        return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
     };
     if (Object.hasOwn(profileCommands, command))
         return serialize(await runProfileCommand(command, repository, options, payload));
     if (Object.hasOwn(answerCommands, command))
         return serialize(await runAnswerCommand(command, repository, options, payload));
+    if (Object.hasOwn(extractionCommands, command))
+        return serialize(await runExtractionCommand(command, repository, options, payload));
     if (command === "resume-import") {
         const path = required("--path"), content = await new NativeResumeFiles(root).readPath(path);
         return serialize(await resumes.import(await payload(), basename(path), content, true));
@@ -106,13 +113,13 @@ export async function runJobsCli(args, input) {
 }
 if (process.argv[1] && pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url) {
     try {
-        const result = await runJobsCli(process.argv.slice(2), async () => {
+        const result = await runJobsCli(process.argv.slice(2), async (limit = 65536) => {
             const chunks = [];
             let size = 0;
             for await (const chunk of process.stdin) {
                 size += chunk.length;
-                if (size > 65536)
-                    throw new JobsError("input exceeds 64 KiB");
+                if (size > limit)
+                    throw new JobsError(`input exceeds ${limit / 1024} KiB`);
                 chunks.push(Buffer.from(chunk));
             }
             return Buffer.concat(chunks).toString("utf8");

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,4 +1,5 @@
 import { profileCommands, runProfileCommand } from "./native-profile.js";
+import { answerCommands, runAnswerCommand } from "./native-answers.js";
 import { readFile } from "node:fs/promises";
 import { realpathSync } from "node:fs";
 import { basename } from "node:path";
@@ -22,7 +23,7 @@ export async function runJobsCli(args, input) {
         else {
             if (options.has(key))
                 throw new JobsError("duplicate CLI option");
-            if (["--include-trashed", "--trashed-only", "--replace"].includes(key))
+            if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses"].includes(key))
                 options.set(key, "true");
             else {
                 const value = args[++index];
@@ -34,6 +35,7 @@ export async function runJobsCli(args, input) {
     }
     const fields = {
         ...profileCommands,
+        ...answerCommands,
         "fixture-init": [], "job-create": ["--input", "--origin"], "job-get": ["--id", "--include-trashed"],
         "job-list": ["--status", "--include-trashed", "--trashed-only"],
         "job-update": ["--id", "--input", "--expected-revision", "--origin"],
@@ -66,6 +68,8 @@ export async function runJobsCli(args, input) {
     };
     if (Object.hasOwn(profileCommands, command))
         return serialize(await runProfileCommand(command, repository, options, payload));
+    if (Object.hasOwn(answerCommands, command))
+        return serialize(await runAnswerCommand(command, repository, options, payload));
     if (command === "resume-import") {
         const path = required("--path"), content = await new NativeResumeFiles(root).readPath(path);
         return serialize(await resumes.import(await payload(), basename(path), content, true));

--- a/runtime/contracts/workspace/answers.js
+++ b/runtime/contracts/workspace/answers.js
@@ -1,0 +1,112 @@
+import { createHash } from 'node:crypto';
+import { PythonObject } from '../python-object.js';
+import { emptyObject } from './jobs.js';
+import { copy, get, has, int, integer, keys, object, same, serialize, set, string, text, JobsError } from './values.js';
+export const answerStates = new Set(['confirmed', 'inferred', 'missing', 'sensitive']);
+export const answerReviews = new Set(['accepted', 'pending', 'declined']);
+export const answerSensitivities = new Set(['none', 'personal', 'high']);
+export const answerPatchFields = new Set(['question', 'aliases', 'value', 'state', 'source', 'scope', 'fieldClass', 'sensitivity']);
+export const fallback = (record, key, value) => has(record, key) ? get(record, key) : value;
+export const answerRevision = (record) => int(fallback(record, 'revision', integer(1n)));
+export const sensitiveAnswer = (record) => string(get(record, 'state')) === 'sensitive' || string(fallback(record, 'sensitivity', text('none'))) !== 'none';
+const whitespace = /[\u0009-\u000d\u001c-\u0020\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+/u;
+export function normalizeAnswerQuestion(question) {
+    if (!question.split(whitespace).join(''))
+        throw new JobsError('question must be a non-empty string');
+    return question.normalize('NFKC').toLowerCase().replace(/[^\p{L}\p{N}_\u0009-\u000d\u001c-\u0020\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]/gu, ' ').split(whitespace).filter(Boolean).join(' ');
+}
+export function answerKey(question, scope = emptyObject()) {
+    const normalized = normalizeAnswerQuestion(question);
+    if (/[\uD800-\uDFFF]/u.test(normalized))
+        throw new JobsError('question contains invalid Unicode');
+    return `question.${createHash('sha256').update(`v1\0${normalized}\0${serialize(scope)}`).digest('hex')}`;
+}
+/** Scope identity treats booleans distinctly while preserving Python numeric equality. */
+export function sameAnswerScope(left, right) {
+    if (typeof left === 'boolean' || typeof right === 'boolean')
+        return left === right;
+    if (left instanceof PythonObject && right instanceof PythonObject) {
+        return left.size === right.size && left.entries().every(([key, value]) => right.has(key) && sameAnswerScope(value, right.get(key)));
+    }
+    if (Array.isArray(left) && Array.isArray(right)) {
+        return left.length === right.length && left.every((value, index) => sameAnswerScope(value, right[index]));
+    }
+    return same(left, right);
+}
+export function answerNames(record) {
+    const question = string(get(record, 'question'));
+    const aliases = fallback(record, 'aliases', []);
+    return [question, ...aliases.map(string)].filter((value) => value !== null && Boolean(value.split(whitespace).join(''))).map(normalizeAnswerQuestion);
+}
+export function normalizeAliases(value) {
+    if (!Array.isArray(value) || value.some(alias => string(alias) === null))
+        throw new JobsError('answer aliases must be strings');
+    return [...new Set(value.map(alias => normalizeAnswerQuestion(string(alias))).filter(Boolean))].map(text);
+}
+export function validateAnswer(key, value) {
+    const record = object(value, 'answer record');
+    if (string(get(record, 'key')) !== key)
+        throw new JobsError('answer record key does not match its index');
+    if (!answerStates.has(string(get(record, 'state'))))
+        throw new JobsError('answer record state is unsupported');
+    if (!answerReviews.has(string(fallback(record, 'reviewStatus', text('accepted')))))
+        throw new JobsError('answer record review status is unsupported');
+    if (!answerSensitivities.has(string(fallback(record, 'sensitivity', text('none')))))
+        throw new JobsError('answer record sensitivity is unsupported');
+    if (!/^[a-z][a-z0-9_]{0,63}$/.test(string(fallback(record, 'fieldClass', text('general'))) ?? ''))
+        throw new JobsError('answer record field class is invalid');
+    if (get(record, 'question') !== null && string(get(record, 'question')) === null)
+        throw new JobsError('answer record question must be a string');
+    const aliases = fallback(record, 'aliases', []);
+    if (!Array.isArray(aliases) || aliases.some(alias => string(alias) === null))
+        throw new JobsError('answer record aliases must be strings');
+    object(fallback(record, 'scope', emptyObject()), 'answer record scope');
+    const present = get(record, 'value') !== null;
+    if (string(get(record, 'state')) === 'confirmed' && !present)
+        throw new JobsError('confirmed answer record has no value');
+    if (string(get(record, 'state')) === 'missing' && present)
+        throw new JobsError('missing answer record contains a value');
+    if (present && sensitiveAnswer(record) && !string(get(record, 'rememberedWithConsentAt')))
+        throw new JobsError('sensitive answer record has no remember consent marker');
+    for (const field of ['source', 'confirmedAt', 'createdAt', 'updatedAt', 'rememberedWithConsentAt', 'deletedAt', 'observedAt', 'lastObservedAt', 'reviewedAt']) {
+        if (get(record, field) !== null && string(get(record, field)) === null)
+            throw new JobsError(`answer record ${field} must be a string`);
+    }
+    const revision = int(fallback(record, 'revision', integer(1n)));
+    if (revision === null || revision < 1n)
+        throw new JobsError('answer revision must be a positive integer');
+    const count = int(fallback(record, 'observationCount', integer(0n)));
+    if (count === null || count < 0n)
+        throw new JobsError('answer observation count must be a non-negative integer');
+    return record;
+}
+export function validateAnswers(value) {
+    const document = object(value, 'answers');
+    if (int(get(document, 'schemaVersion')) !== 1n)
+        throw new JobsError('answers version is unsupported');
+    const answers = object(get(document, 'answers'), 'answers.answers');
+    object(get(document, 'metadata'), 'answers.metadata');
+    for (const key of keys(answers)) {
+        if (!key)
+            throw new JobsError('answer index keys must be non-empty strings');
+        validateAnswer(key, get(answers, key));
+    }
+    const redirects = object(fallback(document, 'redirects', emptyObject()), 'answer redirects');
+    for (const key of keys(redirects)) {
+        const redirect = object(get(redirects, key), 'answer redirect');
+        const target = string(get(redirect, 'targetKey'));
+        if (!key || redirect.size !== 2 || !has(redirect, 'mergedAt') || !target || target === key || has(answers, key) || !has(answers, target) || has(redirects, target) || get(object(get(answers, target), 'answer'), 'deletedAt') !== null)
+            throw new JobsError('answer redirect is not flattened to an active answer');
+        if (!string(get(redirect, 'mergedAt')))
+            throw new JobsError('answer redirect timestamp is invalid');
+    }
+    return document;
+}
+export function answerView(record) {
+    const result = copy(record);
+    for (const [key, value] of [['revision', integer(1n)], ['createdAt', get(record, 'updatedAt')], ['deletedAt', null], ['reviewStatus', text('accepted')], ['observationCount', integer(0n)]]) {
+        if (!has(result, key))
+            set(result, key, value);
+    }
+    return result;
+}

--- a/runtime/contracts/workspace/extraction-pointers.js
+++ b/runtime/contracts/workspace/extraction-pointers.js
@@ -1,0 +1,80 @@
+import { PythonObject } from '../python-object.js';
+import { get, has, set, object, string, text, fromJSON, same, JobsError } from './values.js';
+import { emptyObject } from './jobs.js';
+export const segment = (key) => key.replaceAll('~', '~0').replaceAll('/', '~1');
+export function decodePointer(path) {
+    if (!path.startsWith('/') || path === '/')
+        throw new JobsError('proposal path is invalid');
+    return path.slice(1).split('/').map(part => {
+        if (!part || /~(?![01])/.test(part))
+            throw new JobsError('proposal path is invalid');
+        return part.replaceAll('~1', '/').replaceAll('~0', '~');
+    });
+}
+export function lookup(value, path) {
+    for (const key of decodePointer(path)) {
+        if (!(value instanceof PythonObject) || !has(value, key))
+            return [false, null];
+        value = get(value, key);
+    }
+    return [true, value];
+}
+export function baseline(document, path) {
+    const segments = decodePointer(path), ancestors = [];
+    let current = document, encoded = '';
+    for (const key of segments.slice(0, -1)) {
+        encoded += `/${segment(key)}`;
+        const exists = current instanceof PythonObject && has(current, key);
+        const value = exists ? get(current, key) : null;
+        const item = object(fromJSON({ path: encoded, exists }), 'ancestor');
+        if (exists && value instanceof PythonObject) {
+            set(item, 'container', true);
+            set(item, 'empty', value.size === 0);
+        }
+        else if (exists)
+            set(item, 'value', value);
+        ancestors.push(item);
+        current = value;
+    }
+    const [exists, value] = lookup(document, path);
+    const result = set(set(emptyObject(), 'exists', exists), 'ancestors', ancestors);
+    if (exists)
+        set(result, 'value', value);
+    return result;
+}
+export function setPointer(document, path, value, replace) {
+    const segments = decodePointer(path);
+    let current = document;
+    for (const key of segments.slice(0, -1)) {
+        let child = get(current, key);
+        if (!(child instanceof PythonObject)) {
+            if (child !== null && !replace)
+                throw new JobsError('proposal path conflicts with an existing fact');
+            child = emptyObject();
+            set(current, key, child);
+        }
+        current = child;
+    }
+    set(current, segments.at(-1), value);
+}
+export function replacementScope(item) {
+    for (const value of get(item, 'ancestors')) {
+        const ancestor = object(value, 'ancestor');
+        if (get(ancestor, 'exists') === true && get(ancestor, 'container') !== true)
+            return string(get(ancestor, 'path'));
+    }
+    return null;
+}
+export function equal(left, right) {
+    if (typeof left === 'boolean' || typeof right === 'boolean')
+        return left === right;
+    if (left instanceof PythonObject || right instanceof PythonObject) {
+        return left instanceof PythonObject && right instanceof PythonObject && left.size === right.size
+            && left.entries().every(([key, value]) => right.has(key) && equal(value, right.get(key)));
+    }
+    if (Array.isArray(left) || Array.isArray(right))
+        return Array.isArray(left) && Array.isArray(right)
+            && left.length === right.length && left.every((value, index) => equal(value, right[index]));
+    return same(left, right);
+}
+export function compareText(a, b) { return text(a).compare(text(b)); }

--- a/runtime/contracts/workspace/extraction-proposals.js
+++ b/runtime/contracts/workspace/extraction-proposals.js
@@ -1,0 +1,147 @@
+import { PythonObject } from '../python-object.js';
+import { get, has, int, keys, object, string, serialize, JobsError } from './values.js';
+import { safeId } from './jobs.js';
+import { contentRevision, exact } from './extraction-requests.js';
+import { compareText, decodePointer, segment } from './extraction-pointers.js';
+export const proposalStatuses = new Set(['pending', 'completed', 'superseded']);
+export const extractionDecisions = new Set(['use_extracted', 'keep_current']);
+export function validatedCandidate(value) {
+    const candidate = object(value, 'proposal candidate');
+    if (!candidate.size)
+        throw new JobsError('proposal candidate must not be empty');
+    function encodedSize(item) {
+        const value = string(item);
+        if (value !== null) {
+            if ([...value].some(char => char.codePointAt(0) >= 0xd800 && char.codePointAt(0) <= 0xdfff))
+                throw new JobsError('proposal candidate must contain JSON values');
+            return Buffer.byteLength(JSON.stringify(value));
+        }
+        if (item instanceof PythonObject)
+            return 2 + Math.max(0, item.size - 1) + item.entries().reduce((size, [key, child]) => size + encodedSize(key) + 1 + encodedSize(child), 0);
+        if (Array.isArray(item))
+            return 2 + Math.max(0, item.length - 1) + item.reduce((size, child) => size + encodedSize(child), 0);
+        if (item !== null && typeof item === 'object' && 'kind' in item && item.kind === 'float' && !Number.isFinite(item.value))
+            throw new JobsError('proposal candidate must contain JSON values');
+        return Buffer.byteLength(serialize(item));
+    }
+    const bytes = encodedSize(candidate);
+    const paths = [];
+    function visit(item, path, depth) {
+        if (depth > 12 || (string(item) !== null && Buffer.byteLength(string(item)) > 32768))
+            throw new JobsError('proposal candidate exceeds structural limits');
+        if (item === null)
+            throw new JobsError('proposal candidate values must not be null');
+        if (item instanceof PythonObject && item.size) {
+            for (const [key, child] of item.entries()) {
+                const name = string(key);
+                if (!name)
+                    throw new JobsError('proposal candidate keys must be non-empty strings');
+                visit(child, `${path}/${segment(name)}`, depth + 1);
+            }
+        }
+        else
+            paths.push(path);
+    }
+    visit(candidate, '', 0);
+    if (bytes > 262144 || paths.length > 512)
+        throw new JobsError('proposal candidate exceeds structural limits');
+    return [candidate, paths.sort(compareText)];
+}
+function paths(value) {
+    if (!Array.isArray(value) || value.some(item => string(item) === null))
+        throw new JobsError('resume proposal paths are invalid');
+    return value.map(item => string(item));
+}
+function validateBaseline(path, value) {
+    const segments = decodePointer(path), record = object(value, 'resume proposal baseline');
+    const ancestors = get(record, 'ancestors');
+    const invalid = () => { throw new JobsError('resume proposal baseline is invalid'); };
+    if (keys(record).some(key => !['exists', 'ancestors', 'value'].includes(key)) || typeof get(record, 'exists') !== 'boolean'
+        || !Array.isArray(ancestors) || get(record, 'exists') !== has(record, 'value') || ancestors.length !== segments.length - 1)
+        invalid();
+    let expected = '';
+    for (const [index, item] of ancestors.entries()) {
+        expected += `/${segment(segments[index])}`;
+        const ancestor = object(item, 'resume proposal ancestor baseline'), exists = get(ancestor, 'exists');
+        if (keys(ancestor).some(key => !['path', 'exists', 'container', 'empty', 'value'].includes(key))
+            || string(get(ancestor, 'path')) !== expected || typeof exists !== 'boolean')
+            invalid();
+        const count = Number(has(ancestor, 'container')) + Number(has(ancestor, 'value'));
+        if (exists ? count !== 1 : count !== 0)
+            invalid();
+        if (has(ancestor, 'container')) {
+            if (get(ancestor, 'container') !== true || typeof get(ancestor, 'empty') !== 'boolean')
+                invalid();
+        }
+        else if (has(ancestor, 'empty'))
+            invalid();
+    }
+}
+export function validateExtractionProposal(key, value) {
+    const record = object(value, 'resume proposal');
+    const allowed = ['id', 'resumeId', 'resumeRevision', 'resumeDigest', 'resumeContentRevision', 'profileRevision', 'resultProfileRevision', 'candidate', 'baselines', 'autoFilledPaths', 'pendingPaths', 'decisions', 'status', 'revision', 'createdAt', 'updatedAt', 'supersededBy'];
+    if (keys(record).some(key => !allowed.includes(key)) || string(get(record, 'id')) !== key)
+        throw new JobsError('resume proposal record is invalid');
+    safeId(key);
+    safeId(string(get(record, 'resumeId')));
+    for (const field of ['resumeRevision', 'profileRevision', 'resultProfileRevision', 'revision']) {
+        const revision = int(get(record, field));
+        if (revision === null || revision < 1n)
+            throw new JobsError('resume proposal revision is invalid');
+    }
+    if (!/^[0-9a-f]{64}$/.test(string(get(record, 'resumeDigest')) ?? ''))
+        throw new JobsError('resume proposal binding is invalid');
+    if (get(record, 'resumeContentRevision') !== null)
+        contentRevision(get(record, 'resumeContentRevision'));
+    const [, candidatePaths] = validatedCandidate(get(record, 'candidate'));
+    const baselines = object(get(record, 'baselines'), 'resume proposal baselines');
+    const auto = paths(get(record, 'autoFilledPaths')), pending = paths(get(record, 'pendingPaths')), all = [...auto, ...pending];
+    if (new Set(all).size !== all.length || all.some(path => !candidatePaths.includes(path))
+        || baselines.size !== candidatePaths.length || keys(baselines).some(path => !candidatePaths.includes(path)))
+        throw new JobsError('resume proposal paths are invalid');
+    for (const [path, item] of baselines.entries())
+        validateBaseline(string(path), item);
+    const decisions = object(get(record, 'decisions'), 'resume proposal decisions');
+    for (const [path, value] of decisions.entries()) {
+        decodePointer(string(path));
+        const decision = object(value, 'resume proposal decision');
+        exact(decision, ['decision', 'decidedAt'], 'resume proposal decision is invalid');
+        if (!extractionDecisions.has(string(get(decision, 'decision'))) || !string(get(decision, 'decidedAt')))
+            throw new JobsError('resume proposal decision is invalid');
+    }
+    const decisionPaths = keys(decisions), expected = candidatePaths.filter(path => !auto.includes(path));
+    if (decisionPaths.some(path => pending.includes(path)) || expected.length !== decisionPaths.length + pending.length
+        || [...decisionPaths, ...pending].some(path => !expected.includes(path)))
+        throw new JobsError('resume proposal decision paths are invalid');
+    const status = string(get(record, 'status'));
+    if (!proposalStatuses.has(status))
+        throw new JobsError('resume proposal status is invalid');
+    if (status === 'pending' && !pending.length)
+        throw new JobsError('pending resume proposal has no pending paths');
+    if (status === 'completed' && pending.length)
+        throw new JobsError('completed resume proposal has pending paths');
+    if (status === 'superseded')
+        safeId(string(get(record, 'supersededBy')));
+    else if (get(record, 'supersededBy') !== null)
+        throw new JobsError('resume proposal supersession is invalid');
+    for (const field of ['createdAt', 'updatedAt'])
+        if (!string(get(record, field)))
+            throw new JobsError('resume proposal timestamp is invalid');
+    return record;
+}
+export function validateExtractions(document) {
+    if (int(get(document, 'schemaVersion')) !== 1n)
+        throw new JobsError('resume proposals schema version is unsupported');
+    exact(document, ['schemaVersion', 'proposals', 'metadata'], 'resume proposal store contains unsupported fields');
+    object(get(document, 'metadata'), 'resume proposal metadata');
+    const seen = new Set();
+    for (const [key, value] of object(get(document, 'proposals'), 'resume proposals').entries()) {
+        const record = validateExtractionProposal(string(key), value), id = string(get(record, 'resumeId'));
+        if (string(get(record, 'status')) === 'pending') {
+            if (seen.has(id))
+                throw new JobsError('resume proposal store has multiple pending proposals');
+            seen.add(id);
+        }
+    }
+    return document;
+}

--- a/runtime/contracts/workspace/extraction-requests.js
+++ b/runtime/contracts/workspace/extraction-requests.js
@@ -1,0 +1,81 @@
+import { get, has, int, keys, object, string, JobsError } from './values.js';
+import { safeId } from './jobs.js';
+import { compareText } from './extraction-pointers.js';
+export const requestStatuses = new Set(['requested', 'completed', 'failed', 'stale', 'cancelled']);
+export const failureReasons = new Set(['content_unreadable', 'unsupported_resume', 'extraction_failed', 'candidate_invalid', 'interrupted']);
+export function contentRevision(value) {
+    if (!/^content_[A-Za-z0-9_-]{32,128}$/.test(string(value) ?? ''))
+        throw new JobsError('resume content revision is unverifiable');
+}
+export function exact(record, fields, message) {
+    if (record.size !== fields.length || keys(record).some(key => !fields.includes(key)))
+        throw new JobsError(message);
+}
+export function validateExtractionRequest(key, value) {
+    const record = object(value, 'resume extraction request');
+    exact(record, ['requestId', 'resumeId', 'resumeContentRevision', 'revision', 'status', 'createdAt', 'updatedAt', 'closedAt', 'proposalId', 'failureReason', 'supersedesRequestId'], 'resume extraction request is invalid');
+    if (string(get(record, 'requestId')) !== key)
+        throw new JobsError('resume extraction request is invalid');
+    safeId(key);
+    safeId(string(get(record, 'resumeId')));
+    contentRevision(get(record, 'resumeContentRevision'));
+    const revision = int(get(record, 'revision')), status = string(get(record, 'status'));
+    if (revision === null || revision < 1n)
+        throw new JobsError('resume extraction request revision is invalid');
+    if (!requestStatuses.has(status))
+        throw new JobsError('resume extraction request status is invalid');
+    for (const field of ['createdAt', 'updatedAt'])
+        if (!string(get(record, field)))
+            throw new JobsError('resume extraction request timestamp is invalid');
+    if ((status !== 'requested') !== Boolean(string(get(record, 'closedAt'))))
+        throw new JobsError('resume extraction request closure is invalid');
+    if (status === 'completed')
+        safeId(string(get(record, 'proposalId')));
+    else if (get(record, 'proposalId') !== null)
+        throw new JobsError('resume extraction request proposal is invalid');
+    if (status === 'failed' ? !failureReasons.has(string(get(record, 'failureReason'))) : get(record, 'failureReason') !== null)
+        throw new JobsError('resume extraction failure reason is invalid');
+    if (get(record, 'supersedesRequestId') !== null) {
+        if (safeId(string(get(record, 'supersedesRequestId'))) === key)
+            throw new JobsError('resume extraction supersession is invalid');
+    }
+    return record;
+}
+export function validateExtractionRequests(document) {
+    if (int(get(document, 'schemaVersion')) !== 1n)
+        throw new JobsError('resume extraction requests schema version is unsupported');
+    exact(document, ['schemaVersion', 'requests', 'metadata'], 'resume extraction request store contains unsupported fields');
+    const metadata = object(get(document, 'metadata'), 'request metadata');
+    exact(metadata, ['createdAt', 'updatedAt'], 'resume extraction request metadata is invalid');
+    for (const field of ['createdAt', 'updatedAt'])
+        if (!string(get(metadata, field)))
+            throw new JobsError('resume extraction request metadata is invalid');
+    const seen = new Set();
+    for (const [key, value] of object(get(document, 'requests'), 'resume extraction requests').entries()) {
+        const record = validateExtractionRequest(string(key), value), id = string(get(record, 'resumeId'));
+        if (string(get(record, 'status')) === 'requested') {
+            if (seen.has(id))
+                throw new JobsError('resume extraction request store has multiple open requests');
+            seen.add(id);
+        }
+    }
+    return document;
+}
+export function orderRequests(records, field = 'createdAt') {
+    const byId = new Map(records.map(record => [string(get(record, 'requestId')), record]));
+    function depth(record) {
+        const seen = new Set([string(get(record, 'requestId'))]);
+        let count = 0, current = record;
+        while (has(current, 'supersedesRequestId') && get(current, 'supersedesRequestId') !== null) {
+            const id = string(get(current, 'supersedesRequestId')), previous = byId.get(id);
+            if (seen.has(id) || !previous || string(get(previous, 'resumeId')) !== string(get(record, 'resumeId')))
+                break;
+            seen.add(id);
+            count++;
+            current = previous;
+        }
+        return count;
+    }
+    return records.sort((a, b) => compareText(string(get(a, field)), string(get(b, field))) || depth(a) - depth(b)
+        || compareText(string(get(a, 'requestId')), string(get(b, 'requestId'))));
+}

--- a/runtime/store/native-extraction-journal.js
+++ b/runtime/store/native-extraction-journal.js
@@ -1,0 +1,111 @@
+import { randomUUID } from 'node:crypto';
+import { validateProfile } from '../contracts/workspace/profile.js';
+import { validateResumeReferences } from '../contracts/workspace/resume-reference.js';
+import { validateExtractionRequests } from '../contracts/workspace/extraction-requests.js';
+import { validateExtractions } from '../contracts/workspace/extraction-proposals.js';
+import { safeId } from '../contracts/workspace/jobs.js';
+import { fromJSON, get, int, integer, keys, object, parse, serialize, set, string, text, JobsError } from '../contracts/workspace/values.js';
+const destinations = { profile: 'profile', proposals: 'resume-extractions', requests: 'resume-extraction-requests', resumes: 'resumes' };
+export const extractionJournalName = 'resume-extraction-journal';
+const kinds = new Set(['create', 'review', 'request-create', 'request-close', 'request-retry', 'request-complete', 'resume-request-close']);
+const legacy = ['kind', 'operationId', 'profileDocument', 'proposalsDocument'];
+const expanded = [...legacy, 'requestsDocument', 'resumesDocument'];
+export function validateExtractionResumes(document) {
+    if (int(get(document, 'schemaVersion')) !== 1n || document.size !== 3
+        || keys(document).some(key => !['schemaVersion', 'resumes', 'metadata'].includes(key))) {
+        throw new JobsError('resume proposal journal operation is invalid');
+    }
+    object(get(document, 'metadata'), 'resumes.metadata');
+    validateResumeReferences(object(get(document, 'resumes'), 'resumes.resumes'));
+    return document;
+}
+/** Validate every destination before the first write, including legacy journal shapes. */
+export function validateExtractionJournal(document) {
+    if (int(get(document, 'schemaVersion')) !== 1n || document.size !== 2
+        || keys(document).some(key => !['schemaVersion', 'operation'].includes(key))) {
+        throw new JobsError('invalid resume extraction journal');
+    }
+    if (get(document, 'operation') === null)
+        return document;
+    const operation = object(get(document, 'operation'), 'resume extraction journal operation');
+    const fields = keys(operation), kind = string(get(operation, 'kind'));
+    const isLegacy = fields.length === legacy.length && fields.every(key => legacy.includes(key));
+    if ((!isLegacy && (fields.length !== expanded.length || fields.some(key => !expanded.includes(key))))
+        || !kind || !kinds.has(kind) || isLegacy && !['create', 'review'].includes(kind)) {
+        throw new JobsError('resume proposal journal operation is invalid');
+    }
+    safeId(string(get(operation, 'operationId')));
+    for (const [key, validator] of Object.entries({ profile: validateProfile, proposals: validateExtractions,
+        requests: validateExtractionRequests, resumes: validateExtractionResumes })) {
+        const value = get(operation, `${key}Document`);
+        if (value !== null)
+            validator(object(value, `journal ${key}`));
+    }
+    return document;
+}
+export class NativeExtractionJournal {
+    read;
+    write;
+    constructor(read, write) {
+        this.read = read;
+        this.write = write;
+    }
+    async recover() {
+        const journal = validateExtractionJournal(await this.read());
+        await this.replay(journal);
+    }
+    async replay(journal) {
+        if (get(journal, 'operation') === null)
+            return;
+        const operation = object(get(journal, 'operation'), 'extraction operation');
+        for (const [key, destination] of Object.entries(destinations)) {
+            const value = get(operation, `${key}Document`);
+            if (value !== null)
+                await this.write(destination, object(value, `journal ${key}`));
+        }
+        await this.write(extractionJournalName, object(fromJSON({ schemaVersion: 1, operation: null }), 'journal'));
+    }
+    async commit(kind, updates) {
+        if (Object.keys(updates).some(key => !(key in destinations)))
+            throw new JobsError('unsupported extraction update');
+        const operation = object(fromJSON({ kind, operationId: `extraction-${randomUUID()}`,
+            profileDocument: null, proposalsDocument: null, requestsDocument: null, resumesDocument: null }), 'operation');
+        for (const [key, value] of Object.entries(updates))
+            if (value !== undefined)
+                set(operation, `${key}Document`, value);
+        const journal = object(fromJSON({ schemaVersion: 1, operation: null }), 'journal');
+        set(journal, 'operation', operation);
+        validateExtractionJournal(journal);
+        await this.write(extractionJournalName, journal);
+        await this.replay(journal);
+    }
+}
+/** Resume content replacement closes requests; metadata edits retain their content binding. */
+export function closeRequestsForResumes(requestDocument, resumeDocument) {
+    const requests = object(parse(serialize(requestDocument)), 'requests');
+    const records = object(get(resumeDocument, 'resumes'), 'resumes.resumes');
+    let changed = false;
+    const now = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+    for (const [, value] of object(get(requests, 'requests'), 'requests.requests').entries()) {
+        const request = object(value, 'request');
+        if (string(get(request, 'status')) !== 'requested')
+            continue;
+        const resume = get(records, string(get(request, 'resumeId')));
+        const record = resume === null ? null : object(resume, 'resume');
+        const status = record === null || get(record, 'deletedAt') !== null ? 'cancelled'
+            : string(get(record, 'contentRevision')) !== string(get(request, 'resumeContentRevision')) ? 'stale' : null;
+        if (status === null)
+            continue;
+        set(request, 'status', text(status));
+        set(request, 'revision', integer(int(get(request, 'revision')) + 1n));
+        set(request, 'closedAt', text(now));
+        set(request, 'updatedAt', text(now));
+        set(request, 'failureReason', null);
+        set(request, 'proposalId', null);
+        changed = true;
+    }
+    if (!changed)
+        return null;
+    set(object(get(requests, 'metadata'), 'requests.metadata'), 'updatedAt', text(now));
+    return validateExtractionRequests(requests);
+}

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -8,12 +8,15 @@ import { fromJSON, get, int, object, set, string, serialize, JobsError } from ".
 import { atomicWritePointJson } from "./point-persistence.js";
 import { withExclusiveFileLock } from "./exclusive-file-lock.js";
 import { NativeResumeFiles } from "./native-resume-files.js";
+import { NativeExtractionJournal, closeRequestsForResumes, extractionJournalName, validateExtractionResumes } from "./native-extraction-journal.js";
+import { validateExtractionRequests } from "../contracts/workspace/extraction-requests.js";
+import { validateExtractions } from "../contracts/workspace/extraction-proposals.js";
 import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
 import { validateAnswers } from "../contracts/workspace/answers.js";
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 };
-const marker = '{"mode":"native-jobs-fixture","version":4}\n';
-const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files"]);
+const marker = '{"mode":"native-jobs-fixture","version":5}\n';
+const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 };
 /** Creates a NEW synthetic root only. Never adopts or initializes an existing Store. */
@@ -30,6 +33,11 @@ export async function initializeJobsFixture(root) {
         await atomicWritePointJson(join(root, `${name}.json`), fromJSON(payload), options);
     }
     await atomicWritePointJson(join(root, `${journalName}.json`), fromJSON({ schemaVersion: 1, operation: null }), options);
+    for (const [name, key] of [["resume-extractions", "proposals"], ["resume-extraction-requests", "requests"]]) {
+        await atomicWritePointJson(join(root, `${name}.json`), fromJSON({ schemaVersion: 1, [key]: {},
+            metadata: { createdAt: now, updatedAt: now } }), options);
+    }
+    await atomicWritePointJson(join(root, `${extractionJournalName}.json`), fromJSON({ schemaVersion: 1, operation: null }), options);
     await mkdir(join(root, "resume-files"), { mode: 0o700 });
     await chmod(join(root, "resume-files"), 0o700);
     const lock = await open(join(root, ".store.lock"), "wx", 0o600);
@@ -101,10 +109,10 @@ export class NativeJobsRepository {
         object(get(value, "metadata"), `${name}.metadata`);
         return value;
     }
-    async journal() {
-        const value = object(parsePythonPointJsonBytes(await this.read(`${journalName}.json`), {
+    async journal(name = journalName) {
+        const value = object(parsePythonPointJsonBytes(await this.read(`${name}.json`), {
             diagnosticProfile: "3.12", intMaxStrDigits: 4300,
-        }), journalName);
+        }), name);
         if (int(get(value, "schemaVersion")) !== 1n)
             throw new JobsError("resume recovery schema version is unsupported");
         return value;
@@ -114,7 +122,23 @@ export class NativeJobsRepository {
         set(journal, "operation", operation);
         await this.write(join(this.root, `${journalName}.json`), journal, documentOptions);
     }
+    extractionJournal() {
+        return new NativeExtractionJournal(() => this.journal(extractionJournalName), (name, document) => this.write(join(this.root, `${name}.json`), document, documentOptions));
+    }
+    async saveResumes(document) {
+        validateExtractionResumes(document);
+        const requests = validateExtractionRequests(await this.document("resume-extraction-requests"));
+        const closed = closeRequestsForResumes(requests, document);
+        if (closed)
+            await this.extractionJournal().commit("resume-request-close", { requests: closed, resumes: document });
+        else
+            await this.write(join(this.root, "resumes.json"), document, documentOptions);
+    }
     async recoverResumes() {
+        // The extraction journal can contain the resume document intended by the file
+        // journal. Finish it first so subsequent file recovery never restores an older
+        // extraction snapshot over a newly installed resume. Validate before file I/O.
+        await this.extractionJournal().recover();
         const files = new NativeResumeFiles(this.root);
         const journal = await this.journal();
         if (journal.size !== 2)
@@ -122,8 +146,7 @@ export class NativeJobsRepository {
         let resumes = await this.document("resumes");
         const operation = get(journal, "operation");
         await files.recover(operation === null ? null : object(operation, "resume recovery operation"), resumes, async (document) => {
-            validateResumeReferences(object(get(document, "resumes"), "resumes.resumes"));
-            await this.write(join(this.root, "resumes.json"), document, documentOptions);
+            await this.saveResumes(document);
             resumes = document;
         }, async () => this.saveJournal(null));
         return resumes;
@@ -168,12 +191,21 @@ export class NativeJobsRepository {
             validateResumeReferences(object(get(document, "resumes"), "resumes.resumes"));
             return operation({ document, files,
                 save: async (value) => {
-                    validateResumeReferences(object(get(value, "resumes"), "resumes.resumes"));
-                    await this.write(join(this.root, "resumes.json"), value, documentOptions);
+                    await this.saveResumes(value);
                 },
                 saveJournal: async (value) => this.saveJournal(value),
             });
         }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
+    }
+    async extractionTransaction(operation) {
+        return this.transaction(async () => operation({
+            profile: validateProfile(await this.document("profile")),
+            resumes: validateExtractionResumes(await this.document("resumes")),
+            requests: validateExtractionRequests(await this.document("resume-extraction-requests")),
+            proposals: validateExtractions(await this.document("resume-extractions")),
+            files: new NativeResumeFiles(this.root),
+            commit: (kind, updates) => this.extractionJournal().commit(kind, updates),
+        }));
     }
     async profileTransaction(operation) {
         return this.transaction(async () => operation(validateProfile(await this.document("profile")), async (document) => {

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -10,9 +10,10 @@ import { withExclusiveFileLock } from "./exclusive-file-lock.js";
 import { NativeResumeFiles } from "./native-resume-files.js";
 import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
+import { validateAnswers } from "../contracts/workspace/answers.js";
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 };
-const marker = '{"mode":"native-jobs-fixture","version":3}\n';
-const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "resume-operation.json", "resume-files"]);
+const marker = '{"mode":"native-jobs-fixture","version":4}\n';
+const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 };
 /** Creates a NEW synthetic root only. Never adopts or initializes an existing Store. */
@@ -21,10 +22,11 @@ export async function initializeJobsFixture(root) {
         throw new JobsError("fixture root must be an absolute normalized path");
     await mkdir(root, { mode: 0o700 });
     const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
-    for (const name of ["jobs", "profile", "resumes", "fact-groups"]) {
+    for (const name of ["jobs", "profile", "resumes", "fact-groups", "answers"]) {
         const payload = name === "fact-groups" ? { schemaVersion: 1, groups: {}, metadata: { createdAt: now, updatedAt: now } }
-            : name === "profile" ? { schemaVersion: 1, profile: {}, metadata: { createdAt: now, updatedAt: now, revision: 1, factProvenance: {} } }
-                : { schemaVersion: 1, [name]: {}, metadata: { updatedAt: now } };
+            : name === "answers" ? { schemaVersion: 1, answers: {}, redirects: {}, metadata: { updatedAt: now } }
+                : name === "profile" ? { schemaVersion: 1, profile: {}, metadata: { createdAt: now, updatedAt: now, revision: 1, factProvenance: {} } }
+                    : { schemaVersion: 1, [name]: {}, metadata: { updatedAt: now } };
         await atomicWritePointJson(join(root, `${name}.json`), fromJSON(payload), options);
     }
     await atomicWritePointJson(join(root, `${journalName}.json`), fromJSON({ schemaVersion: 1, operation: null }), options);
@@ -184,6 +186,14 @@ export class NativeJobsRepository {
             validateGroups(document);
             await this.write(join(this.root, "fact-groups.json"), document, options);
         }));
+    }
+    async answerTransaction(operation) {
+        // transaction validates the closed fixture inventory under the shared lock.
+        // No session/history state can exist here, so reference counts are empty.
+        return this.transaction(async () => operation(validateAnswers(await this.document("answers")), async (document) => {
+            validateAnswers(document);
+            await this.write(join(this.root, "answers.json"), document, options);
+        }, new Map()));
     }
     async resumeSummaries() {
         // Reuse the lock and all root checks for projections too.

--- a/runtime/workspace-core/answers-http.js
+++ b/runtime/workspace-core/answers-http.js
@@ -22,7 +22,7 @@ function decodeKey(value) {
     if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1)
         throw new JobsError('encoded answer key is invalid');
     try {
-        const result = new TextDecoder('utf-8', { fatal: true }).decode(Buffer.from(value, 'base64url'));
+        const result = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(Buffer.from(value, 'base64url'));
         if (!result)
             throw new Error();
         return result;

--- a/runtime/workspace-core/answers-http.js
+++ b/runtime/workspace-core/answers-http.js
@@ -1,0 +1,111 @@
+import { AnswersService } from './answers.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { get, has, int, keys, object, parse, serialize, string, JobsError } from '../contracts/workspace/values.js';
+const response = (value) => ({ status: 200, body: serialize(value) });
+function fields(payload, allowed, required = []) {
+    if (keys(payload).some(key => !allowed.includes(key)) || required.some(key => !has(payload, key)))
+        throw new JobsError('answer body contains unsupported or missing fields');
+}
+function consent(payload) {
+    const value = has(payload, 'rememberSensitive') ? get(payload, 'rememberSensitive') : false;
+    if (typeof value !== 'boolean')
+        throw new JobsError('rememberSensitive must be a boolean');
+    return value;
+}
+function revision(payload) {
+    const value = int(get(payload, 'expectedRevision'));
+    if (value === null || value < 1n)
+        throw new JobsError('expectedRevision must be a positive integer');
+    return value;
+}
+function decodeKey(value) {
+    if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1)
+        throw new JobsError('encoded answer key is invalid');
+    try {
+        const result = new TextDecoder('utf-8', { fatal: true }).decode(Buffer.from(value, 'base64url'));
+        if (!result)
+            throw new Error();
+        return result;
+    }
+    catch {
+        throw new JobsError('encoded answer key is invalid');
+    }
+}
+export async function answerHttp(repository, method, path, body) {
+    if (!path.startsWith('/api/answers'))
+        return null;
+    if (['/api/answers/semantic', '/api/answers/cleanup-preview', '/api/answers/cleanup-approve'].includes(path))
+        return null;
+    const service = new AnswersService(repository);
+    if (method === 'POST' && path === '/api/answers/query') {
+        const payload = object(parse(body), 'body');
+        fields(payload, ['query', 'state', 'reviewStatus', 'includeTrashed', 'trashedOnly', 'offset', 'limit']);
+        const options = {};
+        for (const field of ['query', 'state', 'reviewStatus']) {
+            if (!has(payload, field))
+                continue;
+            const raw = get(payload, field), value = string(raw);
+            if (value === null && (raw !== null || field === 'query'))
+                throw new JobsError(`answer ${field} must be a string`);
+            if (field === 'query')
+                options.query = value;
+            else
+                options[field] = value;
+        }
+        for (const field of ['includeTrashed', 'trashedOnly']) {
+            if (!has(payload, field))
+                continue;
+            const value = get(payload, field);
+            if (typeof value !== 'boolean')
+                throw new JobsError('answer trash filters must be booleans');
+            options[field] = value;
+        }
+        for (const field of ['offset', 'limit']) {
+            if (!has(payload, field))
+                continue;
+            const value = int(get(payload, field));
+            if (value === null || value > BigInt(Number.MAX_SAFE_INTEGER))
+                throw new JobsError(`answer ${field} is invalid`);
+            options[field] = Number(value);
+        }
+        return response(await service.query(options));
+    }
+    if (method === 'POST' && path === '/api/answers') {
+        const payload = object(parse(body), 'body');
+        fields(payload, ['answer', 'expectedRevision', 'rememberSensitive'], ['answer']);
+        return response(await service.put(get(payload, 'answer'), consent(payload), has(payload, 'expectedRevision') ? revision(payload) : null));
+    }
+    if (method === 'POST' && path === '/api/answers/observe') {
+        const payload = object(parse(body), 'body');
+        fields(payload, ['answer'], ['answer']);
+        return response(await service.observe(get(payload, 'answer')));
+    }
+    const match = /^\/api\/answers\/(?:by-key\/([^/]+)|([^/]+))(?:\/(reveal|accept|decline))?$/.exec(path);
+    if (!match)
+        return null;
+    const key = match[1] ? decodeKey(match[1]) : decodeURIComponent(match[2]);
+    if (method === 'GET' && !match[3]) {
+        const answer = await service.get(key, false, true);
+        if (answer === null)
+            throw new JobsError('answer does not exist');
+        return response(answer);
+    }
+    if (method === 'PATCH' && !match[3]) {
+        const payload = object(parse(body), 'body');
+        fields(payload, ['patch', 'expectedRevision', 'rememberSensitive'], ['patch', 'expectedRevision']);
+        return response(await service.update(key, get(payload, 'patch'), revision(payload), consent(payload)));
+    }
+    if (method === 'POST' && match[3]) {
+        const payload = object(parse(body), 'body');
+        if (match[3] === 'reveal') {
+            fields(payload, []);
+            const revealed = await service.get(key, true);
+            if (revealed === null)
+                throw new JobsError('answer does not exist');
+            return response(revealed);
+        }
+        fields(payload, ['patch', 'expectedRevision', 'rememberSensitive'], ['expectedRevision']);
+        return response(await service.update(key, has(payload, 'patch') ? get(payload, 'patch') : emptyObject(), revision(payload), consent(payload), match[3] === 'accept' ? 'accepted' : 'declined'));
+    }
+    return null;
+}

--- a/runtime/workspace-core/answers.js
+++ b/runtime/workspace-core/answers.js
@@ -1,0 +1,267 @@
+import { answerKey, answerNames, answerPatchFields, answerRevision, answerReviews, answerStates, answerView, fallback, normalizeAliases, normalizeAnswerQuestion, sameAnswerScope, sensitiveAnswer, validateAnswer, validateAnswers } from '../contracts/workspace/answers.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { copy, get, has, int, integer, keys, object, same, set, string, text, JobsError } from '../contracts/workspace/values.js';
+export function answerProjection(record, references, detail = false, reveal = false) {
+    const view = answerView(record), result = emptyObject();
+    for (const key of keys(view))
+        if (key !== 'value')
+            set(result, key, get(view, key));
+    set(result, 'hasValue', get(view, 'value') !== null);
+    set(result, 'valueRedacted', sensitiveAnswer(view) && get(view, 'value') !== null);
+    const count = references.get(string(get(view, 'key'))) ?? { sessions: 0n, history: 0n };
+    const counts = set(set(emptyObject(), 'sessions', integer(count.sessions)), 'history', integer(count.history));
+    set(result, 'referenceCounts', set(counts, 'total', integer(count.sessions + count.history)));
+    if (detail && (!sensitiveAnswer(view) || reveal))
+        set(result, 'value', get(view, 'value'));
+    return result;
+}
+function canonical(document, key) {
+    const redirects = object(fallback(document, 'redirects', emptyObject()), 'redirects');
+    return has(redirects, key) ? string(get(object(get(redirects, key), 'redirect'), 'targetKey')) : key;
+}
+function collision(document, candidate, key) {
+    const names = answerNames(candidate), answers = object(get(document, 'answers'), 'answers');
+    const scope = object(fallback(candidate, 'scope', emptyObject()), 'scope');
+    for (const otherKey of keys(answers)) {
+        const other = object(get(answers, otherKey), 'answer');
+        if (otherKey !== key && sameAnswerScope(fallback(other, 'scope', emptyObject()), scope) && answerNames(other).some(name => names.includes(name)))
+            throw new JobsError('answer question or alias collides within scope');
+    }
+    for (const name of names) {
+        const retired = answerKey(name, scope);
+        if (canonical(document, retired) !== retired && canonical(document, retired) !== key)
+            throw new JobsError('answer question or alias is a retired redirect identity');
+    }
+}
+export class AnswersService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    get(key, reveal = false, includeTrashed = false) {
+        return this.repository.answerTransaction(async (raw, _save, references) => {
+            const document = validateAnswers(raw), resolved = canonical(document, key);
+            const answers = object(get(document, 'answers'), 'answers');
+            if (!has(answers, resolved))
+                return null;
+            const record = object(get(answers, resolved), 'answer');
+            if (get(record, 'deletedAt') !== null && !includeTrashed)
+                return null;
+            const result = answerProjection(record, references, true, reveal);
+            if (key !== resolved)
+                set(result, 'redirectedFrom', text(key));
+            return result;
+        });
+    }
+    find(question, scope = emptyObject()) {
+        const normalized = normalizeAnswerQuestion(question);
+        return this.repository.answerTransaction(async (raw, _save, references) => {
+            const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+            const eligible = (record) => get(record, 'deletedAt') === null
+                && string(fallback(record, 'reviewStatus', text('accepted'))) === 'accepted'
+                && sameAnswerScope(fallback(record, 'scope', emptyObject()), scope);
+            for (const key of keys(answers)) {
+                const record = object(get(answers, key), 'answer');
+                if (eligible(record) && answerNames(record).includes(normalized))
+                    return answerProjection(record, references, true);
+            }
+            const computed = answerKey(question, scope), resolved = canonical(document, computed);
+            if (!has(answers, resolved))
+                return null;
+            const record = object(get(answers, resolved), 'answer');
+            if (!eligible(record))
+                return null;
+            const result = answerProjection(record, references, true);
+            if (computed !== resolved)
+                set(result, 'redirectedFrom', text(computed));
+            return result;
+        });
+    }
+    query(options = {}) {
+        const { query = '', state = null, reviewStatus = 'accepted', includeTrashed = false, trashedOnly = false, offset = 0, limit = 50 } = options;
+        if (typeof query !== 'string')
+            throw new JobsError('answer query must be a string');
+        if (state !== null && !answerStates.has(state))
+            throw new JobsError('answer state is unsupported');
+        if (reviewStatus !== null && !answerReviews.has(reviewStatus))
+            throw new JobsError('answer review status is unsupported');
+        if (typeof includeTrashed !== 'boolean' || typeof trashedOnly !== 'boolean')
+            throw new JobsError('answer trash filters must be booleans');
+        if (trashedOnly && !includeTrashed)
+            throw new JobsError('trashed-only query requires include trashed');
+        if (!Number.isSafeInteger(offset) || offset < 0)
+            throw new JobsError('answer offset must be a non-negative integer');
+        if (!Number.isSafeInteger(limit) || limit < 1 || limit > 200)
+            throw new JobsError('answer limit must be between 1 and 200');
+        const needle = query.trim() ? normalizeAnswerQuestion(query) : '';
+        return this.repository.answerTransaction(async (raw, _save, references) => {
+            const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+            const records = keys(answers).map(key => object(get(answers, key), 'answer')).filter(record => {
+                const trashed = get(record, 'deletedAt') !== null;
+                return (includeTrashed || !trashed) && (!trashedOnly || trashed)
+                    && (state === null || string(get(record, 'state')) === state)
+                    && (reviewStatus === null || string(fallback(record, 'reviewStatus', text('accepted'))) === reviewStatus)
+                    && (!needle || answerNames(record).some(name => name.includes(needle)));
+            });
+            const compare = (a, b) => {
+                const left = Array.from(a, char => char.codePointAt(0)), right = Array.from(b, char => char.codePointAt(0));
+                for (let i = 0; i < Math.min(left.length, right.length); i++)
+                    if (left[i] !== right[i])
+                        return left[i] - right[i];
+                return left.length - right.length;
+            };
+            records.sort((a, b) => compare(string(get(a, 'question')) ?? '', string(get(b, 'question')) ?? '') || compare(string(get(a, 'key')), string(get(b, 'key'))));
+            const result = set(emptyObject(), 'items', records.slice(offset, offset + limit).map(record => answerProjection(record, references)));
+            set(result, 'total', integer(BigInt(records.length)));
+            set(result, 'offset', integer(BigInt(offset)));
+            set(result, 'limit', integer(BigInt(limit)));
+            return set(result, 'hasMore', offset + Math.min(limit, Math.max(0, records.length - offset)) < records.length);
+        });
+    }
+    update(key, value, revision, rememberSensitive = false, review = null) {
+        const patch = object(value, 'answer patch');
+        if ((!patch.size && review === null) || keys(patch).some(field => !answerPatchFields.has(field)))
+            throw new JobsError('answer patch contains unsupported fields');
+        if (!key)
+            throw new JobsError('answer key must be a non-empty string');
+        return this.repository.answerTransaction(async (raw, save, references) => {
+            const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+            if (!has(answers, key))
+                throw new JobsError('answer does not exist');
+            const current = object(get(answers, key), 'answer');
+            if (get(current, 'deletedAt') !== null)
+                throw new JobsError('answer does not exist');
+            if (answerRevision(current) !== revision)
+                throw new JobsError('answer revision conflict');
+            if (review !== null && string(fallback(current, 'reviewStatus', text('accepted'))) !== 'pending')
+                throw new JobsError('only pending answers can be reviewed');
+            const updated = copy(current), now = text(this.now());
+            for (const field of keys(patch))
+                set(updated, field, get(patch, field));
+            set(updated, 'aliases', normalizeAliases(fallback(updated, 'aliases', [])));
+            const state = string(get(updated, 'state'));
+            set(updated, 'sensitivity', fallback(updated, 'sensitivity', text(state === 'sensitive' ? 'high' : 'none')));
+            const changed = !same(get(updated, 'value'), get(current, 'value')) || !string(get(current, 'rememberedWithConsentAt'));
+            if (get(updated, 'value') !== null && sensitiveAnswer(updated)) {
+                if (changed && !rememberSensitive)
+                    throw new JobsError('sensitive answer value requires explicit remember consent');
+                if (changed)
+                    set(updated, 'rememberedWithConsentAt', now);
+            }
+            else
+                updated.delete(text('rememberedWithConsentAt'));
+            set(updated, 'revision', integer(revision + 1n));
+            set(updated, 'createdAt', get(current, 'createdAt') ?? get(current, 'updatedAt') ?? now);
+            set(updated, 'updatedAt', now);
+            set(updated, 'deletedAt', null);
+            set(updated, 'confirmedAt', state === 'confirmed' ? (state !== string(get(current, 'state')) || !same(get(updated, 'value'), get(current, 'value')) ? now : get(current, 'confirmedAt') ?? now) : null);
+            if (review !== null) {
+                set(updated, 'reviewStatus', text(review));
+                set(updated, 'reviewedAt', now);
+            }
+            await this.save(document, updated, key, save);
+            return answerProjection(updated, references, true);
+        });
+    }
+    put(value, rememberSensitive = false, revision = null) {
+        const incoming = object(value, 'answer'), scope = object(fallback(incoming, 'scope', emptyObject()), 'answer scope');
+        const question = string(get(incoming, 'question'));
+        if (get(incoming, 'key') !== null && string(get(incoming, 'key')) === null)
+            throw new JobsError('answer key must be a non-empty string');
+        const key = string(get(incoming, 'key')) ?? (question === null ? null : answerKey(question, scope));
+        if (!key || !key.trim())
+            throw new JobsError('answer requires a question or explicit key');
+        return this.repository.answerTransaction(async (raw, save, references) => {
+            const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+            if (canonical(document, key) !== key)
+                throw new JobsError('answer key was merged and cannot be resurrected');
+            const current = has(answers, key) ? object(get(answers, key), 'answer') : null;
+            if (current && get(current, 'deletedAt') !== null)
+                throw new JobsError('answer is trashed');
+            if (current && (revision === null || revision < 1n))
+                throw new JobsError('existing answer put requires expected revision');
+            if (current && answerRevision(current) !== revision)
+                throw new JobsError('answer revision conflict');
+            const requestedReview = string(fallback(incoming, 'reviewStatus', text('accepted')));
+            if (!answerReviews.has(requestedReview))
+                throw new JobsError('answer review status is unsupported');
+            if (!current && requestedReview !== 'accepted')
+                throw new JobsError('new answers created through put must have accepted review status');
+            const now = text(this.now()), updated = current ? copy(current) : emptyObject();
+            for (const field of ['question', 'value', 'state'])
+                set(updated, field, get(incoming, field));
+            set(updated, 'key', text(key));
+            set(updated, 'scope', scope);
+            set(updated, 'source', fallback(incoming, 'source', text('user')));
+            set(updated, 'aliases', normalizeAliases(fallback(incoming, 'aliases', [])));
+            set(updated, 'fieldClass', fallback(incoming, 'fieldClass', current ? fallback(current, 'fieldClass', text('general')) : text('general')));
+            set(updated, 'sensitivity', fallback(incoming, 'sensitivity', text(string(get(updated, 'state')) === 'sensitive' ? 'high' : 'none')));
+            set(updated, 'reviewStatus', current ? fallback(current, 'reviewStatus', text('accepted')) : text(requestedReview));
+            set(updated, 'createdAt', current ? get(current, 'createdAt') ?? now : now);
+            set(updated, 'updatedAt', now);
+            set(updated, 'deletedAt', null);
+            set(updated, 'revision', integer(current ? answerRevision(current) + 1n : 1n));
+            set(updated, 'observationCount', current ? fallback(current, 'observationCount', integer(0n)) : fallback(incoming, 'observationCount', integer(0n)));
+            if (!current)
+                for (const field of ['observedAt', 'lastObservedAt', 'reviewedAt'])
+                    if (has(incoming, field))
+                        set(updated, field, get(incoming, field));
+            set(updated, 'confirmedAt', string(get(updated, 'state')) === 'confirmed' ? get(incoming, 'confirmedAt') ?? now : get(incoming, 'confirmedAt'));
+            if (get(updated, 'value') !== null && sensitiveAnswer(updated)) {
+                if (!rememberSensitive)
+                    throw new JobsError('sensitive answer value requires explicit remember consent');
+                set(updated, 'rememberedWithConsentAt', now);
+            }
+            else
+                updated.delete(text('rememberedWithConsentAt'));
+            await this.save(document, updated, key, save);
+            return answerProjection(updated, references, true);
+        });
+    }
+    observe(value) {
+        const incoming = object(value, 'observed answer'), question = string(get(incoming, 'question'));
+        const scope = object(fallback(incoming, 'scope', emptyObject()), 'observed answer scope');
+        if (question === null)
+            throw new JobsError('observed answer requires question and object scope');
+        const state = string(fallback(incoming, 'state', text(get(incoming, 'value') === null ? 'missing' : 'inferred')));
+        if (!['missing', 'inferred'].includes(state))
+            throw new JobsError('observed answer state must be missing or inferred');
+        if (get(incoming, 'value') !== null && string(fallback(incoming, 'sensitivity', text('none'))) !== 'none')
+            throw new JobsError('sensitive observed values require review and fresh remember consent');
+        const normalized = normalizeAnswerQuestion(question);
+        return this.repository.answerTransaction(async (raw, save, references) => {
+            const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+            let key = keys(answers).find(key => {
+                const record = object(get(answers, key), 'answer');
+                return sameAnswerScope(fallback(record, 'scope', emptyObject()), scope) && answerNames(record).includes(normalized);
+            }) ?? canonical(document, answerKey(question, scope));
+            const current = has(answers, key) ? object(get(answers, key), 'answer') : null;
+            if (current && !sameAnswerScope(fallback(current, 'scope', emptyObject()), scope))
+                throw new JobsError('observed answer derived key is occupied by a different scope');
+            if (current && get(current, 'deletedAt') !== null)
+                throw new JobsError('observed answer is trashed');
+            const now = text(this.now()), updated = current ? copy(current) : emptyObject();
+            if (!current) {
+                for (const [field, item] of [['key', text(key)], ['question', text(question)], ['aliases', []], ['value', get(incoming, 'value')], ['state', text(state)], ['source', fallback(incoming, 'source', text('agent'))], ['scope', scope], ['fieldClass', fallback(incoming, 'fieldClass', text('general'))], ['sensitivity', fallback(incoming, 'sensitivity', text('none'))], ['reviewStatus', text('pending')], ['confirmedAt', null], ['createdAt', now], ['deletedAt', null]])
+                    set(updated, field, item);
+            }
+            set(updated, 'reviewStatus', fallback(updated, 'reviewStatus', text('accepted')));
+            set(updated, 'lastObservedAt', now);
+            set(updated, 'observedAt', get(updated, 'observedAt') ?? now);
+            set(updated, 'observationCount', integer((current ? int(fallback(current, 'observationCount', integer(0n))) : 0n) + 1n));
+            set(updated, 'revision', integer(current ? answerRevision(current) + 1n : 1n));
+            set(updated, 'updatedAt', now);
+            await this.save(document, updated, key, save);
+            return answerProjection(updated, references, true);
+        });
+    }
+    async save(document, record, key, save) {
+        validateAnswer(key, record);
+        collision(document, record, key);
+        const answers = set(copy(object(get(document, 'answers'), 'answers')), key, record);
+        const metadata = set(copy(object(get(document, 'metadata'), 'metadata')), 'updatedAt', get(record, 'updatedAt'));
+        await save(set(set(copy(document), 'answers', answers), 'metadata', metadata));
+    }
+}

--- a/runtime/workspace-core/extraction-context.js
+++ b/runtime/workspace-core/extraction-context.js
@@ -1,0 +1,71 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import { get, set, int, integer, object, string, text, fromJSON, JobsError } from '../contracts/workspace/values.js';
+export class ExtractionContext {
+    repository;
+    now;
+    id;
+    contentRevision;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'), id = (kind) => `${kind}-${randomUUID()}`, contentRevision = () => `content_${randomBytes(24).toString('base64url')}`) {
+        this.repository = repository;
+        this.now = now;
+        this.id = id;
+        this.contentRevision = contentRevision;
+    }
+}
+export const records = (document, key) => object(get(document, key), key);
+export const profileRevision = (document) => int(get(records(document, 'metadata'), 'revision')) ?? 1n;
+export function touch(document, now) { set(records(document, 'metadata'), 'updatedAt', text(now)); }
+export function revision(record, expected, message) {
+    if (int(get(record, 'revision')) !== expected)
+        throw new JobsError(message);
+}
+export async function readyResume(tx, id, expected) {
+    const value = get(records(tx.resumes, 'resumes'), id);
+    if (value === null || get(object(value, 'resume'), 'deletedAt') !== null)
+        throw new JobsError('resume does not exist');
+    const resume = object(value, 'resume');
+    if (string(get(resume, 'storageKind')) !== 'managed')
+        throw new JobsError('resume must be adopted before extraction');
+    if (expected !== undefined)
+        revision(resume, expected, 'resume revision conflict');
+    const observed = await tx.files.observation(resume);
+    if (!observed.exists || observed.digest !== string(get(resume, 'digest')))
+        throw new JobsError('resume file is not ready for extraction');
+    return resume;
+}
+export function closeRequest(document, id, expected, status, now, failure = null, proposal = null) {
+    const value = get(records(document, 'requests'), id);
+    if (value === null)
+        throw new JobsError('resume extraction request does not exist');
+    const current = object(value, 'request');
+    revision(current, expected, 'request revision conflict');
+    if (string(get(current, 'status')) !== 'requested')
+        throw new JobsError('resume extraction request is not open');
+    set(current, 'status', text(status));
+    set(current, 'failureReason', failure === null ? null : text(failure));
+    set(current, 'proposalId', proposal === null ? null : text(proposal));
+    set(current, 'revision', integer(expected + 1n));
+    set(current, 'updatedAt', text(now));
+    set(current, 'closedAt', text(now));
+    touch(document, now);
+    return current;
+}
+/** Called inside resume replacement recovery/commit, together with the new resume metadata. */
+export function staleOpenRequests(document, resumeId, now) {
+    let changed = false;
+    for (const [id, value] of records(document, 'requests').entries()) {
+        const record = object(value, 'request');
+        if (string(get(record, 'resumeId')) === resumeId && string(get(record, 'status')) === 'requested') {
+            closeRequest(document, string(id), int(get(record, 'revision')), 'stale', now);
+            changed = true;
+        }
+    }
+    return changed;
+}
+export function newRequest(context, resume, supersedes) {
+    const now = context.now();
+    const record = object(fromJSON({ requestId: context.id('request'), resumeId: string(get(resume, 'id')),
+        revision: 1, status: 'requested', createdAt: now, updatedAt: now, closedAt: null, proposalId: null,
+        failureReason: null, supersedesRequestId: supersedes }), 'request');
+    return set(record, 'resumeContentRevision', get(resume, 'contentRevision'));
+}

--- a/runtime/workspace-core/extraction-proposal-state.js
+++ b/runtime/workspace-core/extraction-proposal-state.js
@@ -1,0 +1,106 @@
+import { copy, get, set, int, integer, object, string, text, fromJSON, parse, serialize, JobsError } from '../contracts/workspace/values.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { validatedCandidate, validateExtractions } from '../contracts/workspace/extraction-proposals.js';
+import { baseline, lookup, setPointer } from '../contracts/workspace/extraction-pointers.js';
+import { provenanceAfter } from './profile-patch.js';
+import { records, profileRevision, touch } from './extraction-context.js';
+export function stampedProfile(document, profile, paths, source, now) {
+    const metadata = copy(records(document, 'metadata'));
+    const provenance = get(metadata, 'factProvenance') === null ? emptyObject() : records(metadata, 'factProvenance');
+    set(metadata, 'revision', integer(profileRevision(document) + 1n));
+    set(metadata, 'updatedAt', text(now));
+    set(metadata, 'factProvenance', provenanceAfter(provenance, paths, source, now, records(document, 'profile')));
+    return set(set(copy(document), 'profile', profile), 'metadata', metadata);
+}
+export function createProposalState(context, tx, resume, input, supersedes, bind) {
+    const [candidate, paths] = validatedCandidate(input), proposals = records(tx.proposals, 'proposals');
+    const pending = proposals.entries().map(([, value]) => object(value, 'proposal')).find(record => string(get(record, 'resumeId')) === string(get(resume, 'id')) && string(get(record, 'status')) === 'pending');
+    if (pending ? supersedes !== string(get(pending, 'id')) : supersedes !== null) {
+        throw new JobsError(pending ? 'pending proposal requires explicit supersession' : 'proposal to supersede does not exist');
+    }
+    const now = context.now(), id = context.id('proposal'), initialRevision = profileRevision(tx.profile);
+    const profile = object(parse(serialize(get(tx.profile, 'profile'))), 'profile');
+    const metadata = records(tx.profile, 'metadata'), provenance = get(metadata, 'factProvenance') === null ? emptyObject() : records(metadata, 'factProvenance');
+    const baselines = emptyObject(), auto = [], pendingPaths = [];
+    for (const path of paths)
+        set(baselines, path, baseline(records(tx.profile, 'profile'), path));
+    for (const path of paths) {
+        const item = records(baselines, path);
+        const ancestorsAllow = get(item, 'ancestors').every(value => {
+            const ancestor = object(value, 'ancestor');
+            return get(ancestor, 'exists') === false || get(ancestor, 'container') === true && get(ancestor, 'empty') === false
+                || ancestor.has(text('value')) && get(ancestor, 'value') === null;
+        });
+        const protectedPath = provenance.entries().some(([key, value]) => {
+            const name = string(key);
+            return string(get(object(value, 'provenance'), 'source')) === 'user' && (name === path || name.startsWith(`${path}/`) || path.startsWith(`${name}/`));
+        });
+        if ((get(item, 'exists') === false || get(item, 'value') === null) && ancestorsAllow && !protectedPath) {
+            setPointer(profile, path, lookup(candidate, path)[1], false);
+            auto.push(path);
+        }
+        else
+            pendingPaths.push(path);
+    }
+    if (auto.length)
+        tx.profile = stampedProfile(tx.profile, profile, auto, 'resume', now);
+    if (pending) {
+        set(pending, 'status', text('superseded'));
+        set(pending, 'supersededBy', text(id));
+        set(pending, 'revision', integer(int(get(pending, 'revision')) + 1n));
+        set(pending, 'updatedAt', text(now));
+    }
+    const proposal = object(fromJSON({ id, autoFilledPaths: auto, pendingPaths, decisions: {}, status: pendingPaths.length ? 'pending' : 'completed',
+        revision: 1, createdAt: now, updatedAt: now, supersededBy: null }), 'proposal');
+    set(proposal, 'resumeId', get(resume, 'id'));
+    set(proposal, 'resumeRevision', get(resume, 'revision'));
+    set(proposal, 'resumeDigest', get(resume, 'digest'));
+    set(proposal, 'profileRevision', integer(initialRevision));
+    set(proposal, 'resultProfileRevision', integer(profileRevision(tx.profile)));
+    set(proposal, 'candidate', candidate);
+    set(proposal, 'baselines', baselines);
+    if (bind)
+        set(proposal, 'resumeContentRevision', get(resume, 'contentRevision'));
+    set(proposals, id, proposal);
+    touch(tx.proposals, now);
+    validateExtractions(tx.proposals);
+    return proposal;
+}
+export async function staleReasons(tx, proposal) {
+    const value = get(records(tx.resumes, 'resumes'), string(get(proposal, 'resumeId')));
+    if (value === null)
+        return ['resume_deleted'];
+    const resume = object(value, 'resume'), reasons = [];
+    if (get(resume, 'deletedAt') !== null)
+        reasons.push('resume_trashed');
+    if (string(get(resume, 'storageKind')) !== 'managed')
+        return [...reasons, 'resume_not_managed'];
+    if (get(proposal, 'resumeContentRevision') !== null) {
+        if (string(get(resume, 'contentRevision')) !== string(get(proposal, 'resumeContentRevision')))
+            reasons.push('resume_content_revision_changed');
+    }
+    else {
+        if (int(get(resume, 'revision')) !== int(get(proposal, 'resumeRevision')))
+            reasons.push('resume_revision_changed');
+        if (string(get(resume, 'digest')) !== string(get(proposal, 'resumeDigest')))
+            reasons.push('resume_digest_changed');
+    }
+    const observed = await tx.files.observation(resume);
+    if (!observed.exists)
+        reasons.push('resume_file_missing');
+    else if (observed.digest !== string(get(resume, 'digest')))
+        reasons.push('resume_file_changed');
+    return reasons;
+}
+export async function proposalResult(tx, proposal) {
+    const reasons = await staleReasons(tx, proposal);
+    return set(set(copy(proposal), 'stale', reasons.length > 0), 'staleReasons', reasons.map(text));
+}
+export function proposalSummary(proposal, includeResume = true) {
+    const result = emptyObject();
+    for (const key of ['id', 'status', 'revision', ...(includeResume ? ['resumeId'] : [])])
+        set(result, key, get(proposal, key));
+    set(result, 'autoFilledCount', integer(BigInt(get(proposal, 'autoFilledPaths').length)));
+    set(result, 'pendingCount', integer(BigInt(get(proposal, 'pendingPaths').length)));
+    return result;
+}

--- a/runtime/workspace-core/extraction-proposals.js
+++ b/runtime/workspace-core/extraction-proposals.js
@@ -1,0 +1,128 @@
+import { copy, get, has, set, object, keys, string, text, integer, parse, serialize, JobsError } from '../contracts/workspace/values.js';
+import { safeId, emptyObject } from '../contracts/workspace/jobs.js';
+import { validatedCandidate, proposalStatuses, extractionDecisions, validateExtractions } from '../contracts/workspace/extraction-proposals.js';
+import { validateExtractionRequests } from '../contracts/workspace/extraction-requests.js';
+import { baseline, lookup, equal, replacementScope, setPointer, compareText } from '../contracts/workspace/extraction-pointers.js';
+import { ExtractionRequests } from './extraction-requests.js';
+import { records, profileRevision, readyResume, revision, closeRequest, touch } from './extraction-context.js';
+import { createProposalState, proposalResult, proposalSummary, staleReasons, stampedProfile } from './extraction-proposal-state.js';
+export class ExtractionProposals extends ExtractionRequests {
+    createProposal(resumeId, candidate, expectedResume, expectedProfile, supersedes = null) {
+        safeId(resumeId);
+        validatedCandidate(candidate);
+        return this.repository.extractionTransaction(async (tx) => {
+            const resume = await readyResume(tx, resumeId, expectedResume);
+            if (profileRevision(tx.profile) !== expectedProfile)
+                throw new JobsError('profile revision conflict');
+            const proposal = createProposalState(this, tx, resume, candidate, supersedes, false);
+            await tx.commit('create', { profile: tx.profile, proposals: tx.proposals });
+            return proposalResult(tx, proposal);
+        });
+    }
+    completeRequest(id, candidate, expectedRequest, expectedProfile, expectedPending = null) {
+        safeId(id);
+        if (expectedPending !== null)
+            safeId(expectedPending);
+        validatedCandidate(candidate);
+        return this.repository.extractionTransaction(async (tx) => {
+            const value = get(records(tx.requests, 'requests'), id);
+            if (value === null)
+                throw new JobsError('resume extraction request does not exist');
+            const request = object(value, 'request');
+            revision(request, expectedRequest, 'request revision conflict');
+            if (string(get(request, 'status')) !== 'requested')
+                throw new JobsError('resume extraction request is not open');
+            const resume = await readyResume(tx, string(get(request, 'resumeId')));
+            if (string(get(resume, 'contentRevision')) !== string(get(request, 'resumeContentRevision')))
+                throw new JobsError('resume content revision conflict');
+            if (profileRevision(tx.profile) !== expectedProfile)
+                throw new JobsError('profile revision conflict');
+            const proposal = createProposalState(this, tx, resume, candidate, expectedPending, true);
+            const completed = closeRequest(tx.requests, id, expectedRequest, 'completed', this.now(), null, string(get(proposal, 'id')));
+            validateExtractionRequests(tx.requests);
+            await tx.commit('request-complete', { profile: tx.profile, proposals: tx.proposals, requests: tx.requests });
+            return set(set(emptyObject(), 'request', completed), 'proposalSummary', proposalSummary(proposal, false));
+        });
+    }
+    getProposal(id) {
+        safeId(id);
+        return this.repository.extractionTransaction(async (tx) => {
+            const value = get(records(tx.proposals, 'proposals'), id);
+            return value === null ? null : proposalResult(tx, object(value, 'proposal'));
+        });
+    }
+    listProposals(resumeId, status, summaryOnly = false) {
+        if (resumeId !== undefined)
+            safeId(resumeId);
+        if (status !== undefined && !proposalStatuses.has(status))
+            throw new JobsError('resume proposal status is unsupported');
+        return this.repository.extractionTransaction(async (tx) => {
+            const selected = records(tx.proposals, 'proposals').entries().map(([, value]) => object(value, 'proposal'))
+                .filter(record => (resumeId === undefined || string(get(record, 'resumeId')) === resumeId)
+                && (status === undefined || string(get(record, 'status')) === status))
+                .sort((a, b) => compareText(string(get(a, 'createdAt')), string(get(b, 'createdAt'))) || compareText(string(get(a, 'id')), string(get(b, 'id'))));
+            return Promise.all(selected.map(record => summaryOnly ? proposalSummary(record) : proposalResult(tx, record)));
+        });
+    }
+    reviewProposal(id, input, expected, expectedProfile) {
+        safeId(id);
+        const review = object(input, 'proposal review'), choices = records(review, 'decisions');
+        const confirmations = has(review, 'replacementConfirmations') ? records(review, 'replacementConfirmations') : emptyObject();
+        if (!choices.size || keys(review).some(key => !['decisions', 'replacementConfirmations'].includes(key)))
+            throw new JobsError('proposal review must contain decisions');
+        if (choices.entries().some(([, value]) => !extractionDecisions.has(string(value))))
+            throw new JobsError('proposal review decision is unsupported');
+        return this.repository.extractionTransaction(async (tx) => {
+            const value = get(records(tx.proposals, 'proposals'), id);
+            if (value === null)
+                throw new JobsError('resume proposal does not exist');
+            const current = object(value, 'proposal');
+            revision(current, expected, 'resume proposal revision conflict');
+            if (string(get(current, 'status')) !== 'pending')
+                throw new JobsError('resume proposal is not pending');
+            if ((await staleReasons(tx, current)).length)
+                throw new JobsError('resume proposal is stale');
+            const pending = get(current, 'pendingPaths').map(item => string(item));
+            if (keys(choices).some(path => !pending.includes(path)))
+                throw new JobsError('proposal review path is not pending');
+            if (profileRevision(tx.profile) !== expectedProfile)
+                throw new JobsError('profile revision conflict');
+            const baselines = copy(records(current, 'baselines')), required = emptyObject();
+            for (const [key, choice] of choices.entries()) {
+                const path = string(key);
+                if (!equal(baseline(records(tx.profile, 'profile'), path), get(baselines, path)))
+                    throw new JobsError('proposal review baseline changed');
+                const replacement = replacementScope(records(baselines, path));
+                if (string(choice) === 'use_extracted' && replacement !== null)
+                    set(required, path, text(replacement));
+            }
+            if (!equal(confirmations, required))
+                throw new JobsError('proposal review replacement confirmation is required');
+            const now = this.now(), profile = object(parse(serialize(get(tx.profile, 'profile'))), 'profile'), accepted = [];
+            for (const [key, choice] of choices.entries())
+                if (string(choice) === 'use_extracted') {
+                    const path = string(key);
+                    setPointer(profile, path, lookup(get(current, 'candidate'), path)[1], true);
+                    accepted.push(path);
+                }
+            if (accepted.length)
+                tx.profile = stampedProfile(tx.profile, profile, accepted, 'user', now);
+            const remaining = pending.filter(path => !choices.has(text(path))), decisions = copy(records(current, 'decisions'));
+            for (const path of remaining)
+                set(baselines, path, baseline(profile, path));
+            for (const [key, choice] of choices.entries())
+                set(decisions, string(key), set(set(emptyObject(), 'decision', choice), 'decidedAt', text(now)));
+            set(current, 'pendingPaths', remaining.map(text));
+            set(current, 'baselines', baselines);
+            set(current, 'decisions', decisions);
+            set(current, 'status', text(remaining.length ? 'pending' : 'completed'));
+            set(current, 'resultProfileRevision', integer(profileRevision(tx.profile)));
+            set(current, 'revision', integer(expected + 1n));
+            set(current, 'updatedAt', text(now));
+            touch(tx.proposals, now);
+            validateExtractions(tx.proposals);
+            await tx.commit('review', { profile: tx.profile, proposals: tx.proposals });
+            return proposalResult(tx, current);
+        });
+    }
+}

--- a/runtime/workspace-core/extraction-requests.js
+++ b/runtime/workspace-core/extraction-requests.js
@@ -1,0 +1,85 @@
+import { get, set, object, string, text, integer, int, JobsError } from '../contracts/workspace/values.js';
+import { safeId } from '../contracts/workspace/jobs.js';
+import { failureReasons, requestStatuses, orderRequests, validateExtractionRequests } from '../contracts/workspace/extraction-requests.js';
+import { ExtractionContext, records, readyResume, revision, touch, closeRequest, newRequest } from './extraction-context.js';
+export class ExtractionRequests extends ExtractionContext {
+    createRequest(resumeId, expectedResumeRevision) {
+        safeId(resumeId);
+        return this.repository.extractionTransaction(async (tx) => {
+            const resume = await readyResume(tx, resumeId, expectedResumeRevision);
+            this.noOpen(tx.requests, resumeId);
+            const upgraded = get(resume, 'contentRevision') === null;
+            if (upgraded) {
+                set(resume, 'contentRevision', text(this.contentRevision()));
+                set(resume, 'revision', integer(int(get(resume, 'revision')) + 1n));
+                set(resume, 'updatedAt', text(this.now()));
+                touch(tx.resumes, this.now());
+            }
+            const request = newRequest(this, resume, null);
+            set(records(tx.requests, 'requests'), string(get(request, 'requestId')), request);
+            touch(tx.requests, string(get(request, 'updatedAt')));
+            validateExtractionRequests(tx.requests);
+            await tx.commit('request-create', { requests: tx.requests, ...(upgraded ? { resumes: tx.resumes } : {}) });
+            return request;
+        });
+    }
+    getRequest(id) {
+        safeId(id);
+        return this.repository.extractionTransaction(async (tx) => {
+            const value = get(records(tx.requests, 'requests'), id);
+            return value === null ? null : object(value, 'request');
+        });
+    }
+    listRequests(resumeId, status) {
+        if (resumeId !== undefined)
+            safeId(resumeId);
+        if (status !== undefined && !requestStatuses.has(status))
+            throw new JobsError('resume extraction request status is unsupported');
+        return this.repository.extractionTransaction(async (tx) => orderRequests(records(tx.requests, 'requests').entries()
+            .map(([, value]) => object(value, 'request')).filter(record => (resumeId === undefined || string(get(record, 'resumeId')) === resumeId)
+            && (status === undefined || string(get(record, 'status')) === status))));
+    }
+    cancelRequest(id, expected) { return this.close(id, expected, 'cancelled'); }
+    failRequest(id, reason, expected) {
+        if (!failureReasons.has(reason))
+            throw new JobsError('resume extraction failure reason is unsupported');
+        return this.close(id, expected, 'failed', reason);
+    }
+    close(id, expected, status, reason = null) {
+        safeId(id);
+        return this.repository.extractionTransaction(async (tx) => {
+            const result = closeRequest(tx.requests, id, expected, status, this.now(), reason);
+            validateExtractionRequests(tx.requests);
+            await tx.commit('request-close', { requests: tx.requests });
+            return result;
+        });
+    }
+    retryRequest(id, expected, expectedResumeRevision) {
+        safeId(id);
+        return this.repository.extractionTransaction(async (tx) => {
+            const value = get(records(tx.requests, 'requests'), id);
+            if (value === null)
+                throw new JobsError('resume extraction request does not exist');
+            const current = object(value, 'request');
+            revision(current, expected, 'request revision conflict');
+            if (!['failed', 'stale'].includes(string(get(current, 'status'))))
+                throw new JobsError('resume extraction request cannot be retried');
+            const resumeId = string(get(current, 'resumeId'));
+            const resume = await readyResume(tx, resumeId, expectedResumeRevision);
+            this.noOpen(tx.requests, resumeId);
+            const request = newRequest(this, resume, id);
+            set(records(tx.requests, 'requests'), string(get(request, 'requestId')), request);
+            touch(tx.requests, string(get(request, 'updatedAt')));
+            validateExtractionRequests(tx.requests);
+            await tx.commit('request-retry', { requests: tx.requests });
+            return request;
+        });
+    }
+    noOpen(document, resumeId) {
+        if (records(document, 'requests').entries().some(([, value]) => {
+            const record = object(value, 'request');
+            return string(get(record, 'resumeId')) === resumeId && string(get(record, 'status')) === 'requested';
+        }))
+            throw new JobsError('open extraction request already exists');
+    }
+}

--- a/runtime/workspace-core/extraction.js
+++ b/runtime/workspace-core/extraction.js
@@ -1,0 +1,2 @@
+export { ExtractionProposals as ExtractionService } from './extraction-proposals.js';
+export { staleOpenRequests } from './extraction-context.js';

--- a/runtime/workspace-core/extractions-http.js
+++ b/runtime/workspace-core/extractions-http.js
@@ -1,0 +1,98 @@
+import { ExtractionService } from './extraction.js';
+import { lookup, baseline, replacementScope } from '../contracts/workspace/extraction-pointers.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { get, has, int, integer, keys, object, parse, serialize, set, string, text, JobsError } from '../contracts/workspace/values.js';
+const response = (value) => ({ status: 200, body: serialize(value) });
+const envelope = (key, value) => set(emptyObject(), key, value);
+function project(record, fields) {
+    const result = emptyObject();
+    for (const field of fields)
+        if (has(record, field))
+            set(result, field, get(record, field));
+    return result;
+}
+export function publicExtractionRequest(record) {
+    return project(record, ['requestId', 'resumeId', 'revision', 'status', 'createdAt', 'updatedAt', 'closedAt', 'proposalId', 'failureReason', 'supersedesRequestId']);
+}
+export function publicProposalSummary(record) {
+    const result = project(record, ['id', 'resumeId', 'resumeRevision', 'profileRevision', 'resultProfileRevision', 'status', 'revision', 'createdAt', 'updatedAt', 'supersededBy', 'staleReasons']);
+    for (const [field, paths] of [['autoFilledCount', 'autoFilledPaths'], ['pendingCount', 'pendingPaths']]) {
+        const values = get(record, paths);
+        set(result, field, integer(BigInt(Array.isArray(values) ? values.length : 0)));
+    }
+    return result;
+}
+function fields(payload, allowed, required = allowed) {
+    if (keys(payload).some(key => !allowed.includes(key)) || required.some(key => !has(payload, key)))
+        throw new JobsError('extraction body contains unsupported or missing fields');
+}
+function revision(payload, key) {
+    const value = int(get(payload, key));
+    if (value === null || value < 1n)
+        throw new JobsError(`${key} must be a positive integer`);
+    return value;
+}
+async function detail(repository, id) {
+    return repository.extractionTransaction(async (transaction) => {
+        const service = new ExtractionService({ extractionTransaction: async (operation) => operation(transaction) });
+        const record = await service.getProposal(id);
+        if (!record)
+            throw new JobsError('resume proposal does not exist');
+        const result = publicProposalSummary(record);
+        const profile = object(get(transaction.profile, 'profile'), 'profile');
+        const metadata = object(get(transaction.profile, 'metadata'), 'profile metadata');
+        set(result, 'candidate', get(record, 'candidate'));
+        set(result, 'pendingPaths', get(record, 'pendingPaths'));
+        set(result, 'liveProfileRevision', has(metadata, 'revision') ? get(metadata, 'revision') : integer(1n));
+        const current = emptyObject(), replacements = emptyObject();
+        for (const raw of get(record, 'pendingPaths')) {
+            const pointer = string(raw);
+            const [exists, value] = lookup(profile, pointer);
+            const entry = set(emptyObject(), 'exists', exists);
+            set(entry, 'value', exists ? value : null);
+            set(current, pointer, entry);
+            const scope = replacementScope(baseline(profile, pointer));
+            if (scope !== null) {
+                const replacement = set(emptyObject(), 'path', text(scope));
+                set(replacement, 'value', lookup(profile, scope)[1]);
+                set(replacements, pointer, replacement);
+            }
+        }
+        set(result, 'currentValues', current);
+        set(result, 'replacementScopes', replacements);
+        return result;
+    });
+}
+export async function extractionHttp(repository, method, path, body) {
+    const service = new ExtractionService(repository);
+    if (method === 'GET' && path === '/api/resume-extraction-requests')
+        return response(envelope('requests', (await service.listRequests()).map(publicExtractionRequest)));
+    if (method === 'GET' && path === '/api/resume-proposals')
+        return response(envelope('proposals', (await service.listProposals()).map(publicProposalSummary)));
+    if (method === 'POST' && path === '/api/resume-extraction-requests') {
+        const payload = object(parse(body), 'body');
+        fields(payload, ['resumeId', 'expectedResumeRevision']);
+        const id = string(get(payload, 'resumeId'));
+        if (id === null)
+            throw new JobsError('resumeId must be a string');
+        return response(publicExtractionRequest(await service.createRequest(id, revision(payload, 'expectedResumeRevision'))));
+    }
+    const request = /^\/api\/resume-extraction-requests\/([^/]+)\/(cancel|retry)$/.exec(path);
+    if (method === 'POST' && request) {
+        const payload = object(parse(body), 'body'), id = decodeURIComponent(request[1]);
+        fields(payload, request[2] === 'cancel' ? ['expectedRevision'] : ['expectedRevision', 'expectedResumeRevision']);
+        const value = request[2] === 'cancel' ? await service.cancelRequest(id, revision(payload, 'expectedRevision'))
+            : await service.retryRequest(id, revision(payload, 'expectedRevision'), revision(payload, 'expectedResumeRevision'));
+        return response(publicExtractionRequest(value));
+    }
+    const proposal = /^\/api\/resume-proposals\/([^/]+)(?:\/(review))?$/.exec(path);
+    if (method === 'GET' && proposal && !proposal[2])
+        return response(await detail(repository, decodeURIComponent(proposal[1])));
+    if (method === 'POST' && proposal?.[2] === 'review') {
+        const payload = object(parse(body), 'body');
+        fields(payload, ['decisions', 'replacementConfirmations', 'expectedRevision', 'expectedProfileRevision'], ['decisions', 'expectedRevision', 'expectedProfileRevision']);
+        const decisions = project(payload, ['decisions', 'replacementConfirmations']);
+        return response(publicProposalSummary(await service.reviewProposal(decodeURIComponent(proposal[1]), decisions, revision(payload, 'expectedRevision'), revision(payload, 'expectedProfileRevision'))));
+    }
+    return null;
+}

--- a/runtime/workspace-core/jobs-http.js
+++ b/runtime/workspace-core/jobs-http.js
@@ -6,12 +6,16 @@ import { PythonObject } from "../contracts/python-object.js";
 import { ResumeService } from "./resumes.js";
 import { resumesHttp } from "./resumes-http.js";
 import { answerHttp } from "./answers-http.js";
+import { extractionHttp } from "./extractions-http.js";
 const response = (value, status = 200) => ({ status, body: serialize(value) });
 export const apiError = (status, code, message) => response(fromJSON({ error: { code, message } }), status);
 const envelope = (key, value) => set(emptyObject(), key, value);
 /** Transport-independent dispatch. Host/token/Origin/body bounds belong to the adapter. */
 export async function jobsHttp(service, repository, method, path, body = "") {
     try {
+        const extraction = await extractionHttp(repository, method, path, body);
+        if (extraction)
+            return extraction;
         const answers = await answerHttp(repository, method, path, body);
         if (answers)
             return answers;
@@ -63,12 +67,14 @@ export async function jobsHttp(service, repository, method, path, body = "") {
     catch (error) {
         if (error instanceof JobsError) {
             return error.message.includes("revision conflict") ? apiError(409, "revision_conflict", error.message)
-                : error.message.includes("content is too large") ? apiError(413, "request_error", error.message)
-                    : error.message === "managed resume content is unavailable" ? apiError(409, "content_unavailable", error.message)
-                        : error.message.includes("does not exist") ? apiError(404, "not_found", error.message)
-                            : error.message === "active job URL already exists" ? apiError(409, "duplicate_active_blocked", error.message)
-                                : ["resume id already exists", "resume file is already managed"].includes(error.message) ? apiError(409, "duplicate_resume_blocked", error.message)
-                                    : apiError(400, "store_rejected", error.message);
+                : error.message === "resume proposal is stale" ? apiError(409, "stale_conflict", error.message)
+                    : error.message === "proposal review baseline changed" ? apiError(409, "baseline_conflict", error.message)
+                        : error.message.includes("content is too large") ? apiError(413, "request_error", error.message)
+                            : error.message === "managed resume content is unavailable" ? apiError(409, "content_unavailable", error.message)
+                                : error.message.includes("does not exist") ? apiError(404, "not_found", error.message)
+                                    : error.message === "active job URL already exists" ? apiError(409, "duplicate_active_blocked", error.message)
+                                        : ["resume id already exists", "resume file is already managed"].includes(error.message) ? apiError(409, "duplicate_resume_blocked", error.message)
+                                            : apiError(400, "store_rejected", error.message);
         }
         if (error instanceof Error && ["JSONDecodeError", "ValueError"].includes(error.name)) {
             return apiError(400, "request_error", "body must be valid JSON");

--- a/runtime/workspace-core/jobs-http.js
+++ b/runtime/workspace-core/jobs-http.js
@@ -5,12 +5,16 @@ import { emptyObject } from "../contracts/workspace/jobs.js";
 import { PythonObject } from "../contracts/python-object.js";
 import { ResumeService } from "./resumes.js";
 import { resumesHttp } from "./resumes-http.js";
+import { answerHttp } from "./answers-http.js";
 const response = (value, status = 200) => ({ status, body: serialize(value) });
 export const apiError = (status, code, message) => response(fromJSON({ error: { code, message } }), status);
 const envelope = (key, value) => set(emptyObject(), key, value);
 /** Transport-independent dispatch. Host/token/Origin/body bounds belong to the adapter. */
 export async function jobsHttp(service, repository, method, path, body = "") {
     try {
+        const answers = await answerHttp(repository, method, path, body);
+        if (answers)
+            return answers;
         const resumes = await resumesHttp(new ResumeService(repository), method, path, body);
         if (resumes)
             return resumes;
@@ -54,7 +58,7 @@ export async function jobsHttp(service, repository, method, path, body = "") {
                 return apiError(400, "request_error", "expectedRevision must be a positive integer");
             return response(await service.update(decodeURIComponent(match[1]), get(payload, "patch"), revision));
         }
-        return apiError(501, "unsupported_native_workflow", "This synthetic native fixture supports Jobs and Facts/profile only.");
+        return apiError(501, "unsupported_native_workflow", "This workflow is not supported by the synthetic native workspace.");
     }
     catch (error) {
         if (error instanceof JobsError) {

--- a/src/cli/native-answers.ts
+++ b/src/cli/native-answers.ts
@@ -1,0 +1,54 @@
+import { answerKey } from '../contracts/workspace/answers.js';
+import { AnswersService } from '../workspace-core/answers.js';
+import type { AnswerRepository } from '../workspace-core/answers.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { object, parse, set, text, JobsError } from '../contracts/workspace/values.js';
+import type { Value } from '../contracts/workspace/values.js';
+
+export const answerCommands: Record<string, string[]> = {
+  'answer-key': ['--question', '--scope'], 'answer-find': ['--question', '--scope'],
+  'answer-get': ['--key', '--include-trashed'], 'answer-reveal': ['--key'],
+  'answer-list': ['--state', '--review-status', '--all-review-statuses', '--query', '--offset', '--limit', '--include-trashed', '--trashed-only'],
+  'answer-put': ['--input', '--expected-revision', '--remember-sensitive'],
+  'answer-observe': ['--input'],
+  'answer-update': ['--key', '--input', '--expected-revision', '--remember-sensitive'],
+  'answer-review': ['--key', '--decision', '--input', '--expected-revision', '--remember-sensitive'],
+};
+export async function runAnswerCommand(command: string, repository: AnswerRepository, options: Map<string, string>, payload: () => Promise<Value>): Promise<Value> {
+  const service = new AnswersService(repository);
+  const required = (key: string): string => {
+    const value = options.get(key);
+    if (!value) throw new JobsError(`required option: ${key}`);
+    return value;
+  };
+  const revision = (): bigint => {
+    const value = required('--expected-revision');
+    if (!/^[0-9]+$/.test(value) || BigInt(value) < 1n) throw new JobsError('expected revision must be a positive integer');
+    return BigInt(value);
+  };
+  const consent = options.has('--remember-sensitive');
+  switch (command) {
+    case 'answer-key': return set(emptyObject(), 'key', text(answerKey(required('--question'), object(parse(options.get('--scope') ?? '{}'), 'scope'))));
+    case 'answer-find': return service.find(required('--question'), object(parse(options.get('--scope') ?? '{}'), 'scope'));
+    case 'answer-get': return service.get(required('--key'), false, options.has('--include-trashed'));
+    case 'answer-reveal': {
+      const value = await service.get(required('--key'), true);
+      if (value === null) throw new JobsError('answer does not exist');
+      return value;
+    }
+    case 'answer-list': {
+      if (options.has('--all-review-statuses') && options.has('--review-status')) throw new JobsError('answer review filters are mutually exclusive');
+      return service.query({ query: options.get('--query') ?? '', state: options.get('--state') ?? null, reviewStatus: options.has('--all-review-statuses') ? null : options.get('--review-status') ?? 'accepted',
+        offset: Number(options.get('--offset') ?? '0'), limit: Number(options.get('--limit') ?? '50'), includeTrashed: options.has('--include-trashed'), trashedOnly: options.has('--trashed-only') });
+    }
+    case 'answer-put': return service.put(await payload(), consent, options.has('--expected-revision') ? revision() : null);
+    case 'answer-observe': return service.observe(await payload());
+    case 'answer-update': return service.update(required('--key'), await payload(), revision(), consent);
+    case 'answer-review': {
+      const status = required('--decision');
+      if (status !== 'accepted' && status !== 'declined') throw new JobsError('answer review decision must be accepted or declined');
+      return service.update(required('--key'), options.has('--input') ? await payload() : emptyObject(), revision(), consent, status);
+    }
+    default: throw new JobsError('unsupported native answer command');
+  }
+}

--- a/src/cli/native-extractions.ts
+++ b/src/cli/native-extractions.ts
@@ -1,0 +1,47 @@
+import { ExtractionService } from '../workspace-core/extraction.js';
+import type { ExtractionRepository } from '../workspace-core/extraction-context.js';
+import { JobsError } from '../contracts/workspace/values.js';
+import type { Value } from '../contracts/workspace/values.js';
+
+export const extractionCommands: Record<string, string[]> = {
+  'resume-extraction-request-create': ['--resume-id', '--expected-resume-revision'],
+  'resume-extraction-request-get': ['--id'],
+  'resume-extraction-request-list': ['--resume-id', '--status'],
+  'resume-extraction-request-cancel': ['--id', '--expected-revision'],
+  'resume-extraction-request-fail': ['--id', '--reason', '--expected-revision'],
+  'resume-extraction-request-retry': ['--id', '--expected-revision', '--expected-resume-revision'],
+  'resume-extraction-request-complete': ['--id', '--input', '--expected-request-revision', '--expected-profile-revision', '--expected-pending-proposal-id'],
+  'resume-proposal-create': ['--resume-id', '--input', '--expected-resume-revision', '--expected-profile-revision', '--supersedes'],
+  'resume-proposal-get': ['--id'],
+  'resume-proposal-list': ['--resume-id', '--status', '--summary-only'],
+  'resume-proposal-review': ['--id', '--input', '--expected-revision', '--expected-profile-revision'],
+};
+
+export async function runExtractionCommand(command: string, repository: ExtractionRepository,
+  options: Map<string, string>, payload: () => Promise<Value>): Promise<Value> {
+  const service = new ExtractionService(repository);
+  const required = (key: string): string => {
+    const value = options.get(key);
+    if (!value) throw new JobsError(`required option: ${key}`);
+    return value;
+  };
+  const revision = (key = '--expected-revision'): bigint => {
+    const value = required(key);
+    if (!/^[0-9]+$/.test(value) || BigInt(value) < 1n) throw new JobsError(`${key} must be a positive integer`);
+    return BigInt(value);
+  };
+  switch (command) {
+    case 'resume-extraction-request-create': return service.createRequest(required('--resume-id'), revision('--expected-resume-revision'));
+    case 'resume-extraction-request-get': return service.getRequest(required('--id'));
+    case 'resume-extraction-request-list': return service.listRequests(options.get('--resume-id'), options.get('--status'));
+    case 'resume-extraction-request-cancel': return service.cancelRequest(required('--id'), revision());
+    case 'resume-extraction-request-fail': return service.failRequest(required('--id'), required('--reason'), revision());
+    case 'resume-extraction-request-retry': return service.retryRequest(required('--id'), revision(), revision('--expected-resume-revision'));
+    case 'resume-extraction-request-complete': return service.completeRequest(required('--id'), await payload(), revision('--expected-request-revision'), revision('--expected-profile-revision'), options.get('--expected-pending-proposal-id'));
+    case 'resume-proposal-create': return service.createProposal(required('--resume-id'), await payload(), revision('--expected-resume-revision'), revision('--expected-profile-revision'), options.get('--supersedes'));
+    case 'resume-proposal-get': return service.getProposal(required('--id'));
+    case 'resume-proposal-list': return service.listProposals(options.get('--resume-id'), options.get('--status'), options.has('--summary-only'));
+    case 'resume-proposal-review': return service.reviewProposal(required('--id'), await payload(), revision(), revision('--expected-profile-revision'));
+    default: throw new JobsError('unsupported native extraction command');
+  }
+}

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,5 +1,6 @@
 import { profileCommands, runProfileCommand } from "./native-profile.js";
 import { answerCommands, runAnswerCommand } from "./native-answers.js";
+import { extractionCommands, runExtractionCommand } from "./native-extractions.js";
 import { readFile } from "node:fs/promises";
 import { realpathSync } from "node:fs";
 import { basename } from "node:path";
@@ -11,7 +12,7 @@ import { parse, serialize, JobsError } from "../contracts/workspace/values.js";
 import { ResumeService } from "../workspace-core/resumes.js";
 import { NativeResumeFiles } from "../store/native-resume-files.js";
 
-export async function runJobsCli(args: string[], input: () => Promise<string>): Promise<string> {
+export async function runJobsCli(args: string[], input: (limit?: number) => Promise<string>): Promise<string> {
   const options = new Map<string, string>();
   let command: string | undefined;
   for (let index = 0; index < args.length; index++) {
@@ -21,7 +22,7 @@ export async function runJobsCli(args: string[], input: () => Promise<string>): 
       command = key;
     } else {
       if (options.has(key)) throw new JobsError("duplicate CLI option");
-      if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses"].includes(key)) options.set(key, "true");
+      if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses", "--summary-only"].includes(key)) options.set(key, "true");
       else {
         const value = args[++index];
         if (!value || value.startsWith("--")) throw new JobsError("missing CLI option value");
@@ -32,6 +33,7 @@ export async function runJobsCli(args: string[], input: () => Promise<string>): 
   const fields: Record<string, string[]> = {
     ...profileCommands,
     ...answerCommands,
+    ...extractionCommands,
     "fixture-init": [], "job-create": ["--input", "--origin"], "job-get": ["--id", "--include-trashed"],
     "job-list": ["--status", "--include-trashed", "--trashed-only"],
     "job-update": ["--id", "--input", "--expected-revision", "--origin"],
@@ -56,10 +58,14 @@ export async function runJobsCli(args: string[], input: () => Promise<string>): 
   const resumes = new ResumeService(repository);
   const payload = async () => {
     const file = required("--input");
-    return parse(file === "-" ? await input() : await readFile(file, "utf8"));
+    // Extraction candidates permit 256 KiB after normalization. Allow JSON
+    // escaping and formatting overhead while keeping stdin bounded.
+    const limit = ["resume-proposal-create", "resume-extraction-request-complete"].includes(command!) ? 2 * 1024 * 1024 : 65536;
+    return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
   };
   if (Object.hasOwn(profileCommands, command!)) return serialize(await runProfileCommand(command!, repository, options, payload));
   if (Object.hasOwn(answerCommands, command!)) return serialize(await runAnswerCommand(command!, repository, options, payload));
+  if (Object.hasOwn(extractionCommands, command!)) return serialize(await runExtractionCommand(command!, repository, options, payload));
   if (command === "resume-import") {
     const path = required("--path"), content = await new NativeResumeFiles(root).readPath(path);
     return serialize(await resumes.import(await payload(), basename(path), content, true));
@@ -87,12 +93,12 @@ export async function runJobsCli(args: string[], input: () => Promise<string>): 
 
 if (process.argv[1] && pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url) {
   try {
-    const result = await runJobsCli(process.argv.slice(2), async () => {
+    const result = await runJobsCli(process.argv.slice(2), async (limit = 65536) => {
       const chunks: Buffer[] = [];
       let size = 0;
       for await (const chunk of process.stdin) {
         size += chunk.length;
-        if (size > 65536) throw new JobsError("input exceeds 64 KiB");
+        if (size > limit) throw new JobsError(`input exceeds ${limit / 1024} KiB`);
         chunks.push(Buffer.from(chunk));
       }
       return Buffer.concat(chunks).toString("utf8");

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,4 +1,5 @@
 import { profileCommands, runProfileCommand } from "./native-profile.js";
+import { answerCommands, runAnswerCommand } from "./native-answers.js";
 import { readFile } from "node:fs/promises";
 import { realpathSync } from "node:fs";
 import { basename } from "node:path";
@@ -20,7 +21,7 @@ export async function runJobsCli(args: string[], input: () => Promise<string>): 
       command = key;
     } else {
       if (options.has(key)) throw new JobsError("duplicate CLI option");
-      if (["--include-trashed", "--trashed-only", "--replace"].includes(key)) options.set(key, "true");
+      if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses"].includes(key)) options.set(key, "true");
       else {
         const value = args[++index];
         if (!value || value.startsWith("--")) throw new JobsError("missing CLI option value");
@@ -30,6 +31,7 @@ export async function runJobsCli(args: string[], input: () => Promise<string>): 
   }
   const fields: Record<string, string[]> = {
     ...profileCommands,
+    ...answerCommands,
     "fixture-init": [], "job-create": ["--input", "--origin"], "job-get": ["--id", "--include-trashed"],
     "job-list": ["--status", "--include-trashed", "--trashed-only"],
     "job-update": ["--id", "--input", "--expected-revision", "--origin"],
@@ -57,6 +59,7 @@ export async function runJobsCli(args: string[], input: () => Promise<string>): 
     return parse(file === "-" ? await input() : await readFile(file, "utf8"));
   };
   if (Object.hasOwn(profileCommands, command!)) return serialize(await runProfileCommand(command!, repository, options, payload));
+  if (Object.hasOwn(answerCommands, command!)) return serialize(await runAnswerCommand(command!, repository, options, payload));
   if (command === "resume-import") {
     const path = required("--path"), content = await new NativeResumeFiles(root).readPath(path);
     return serialize(await resumes.import(await payload(), basename(path), content, true));

--- a/src/contracts/workspace/answers.ts
+++ b/src/contracts/workspace/answers.ts
@@ -1,0 +1,93 @@
+import { createHash } from 'node:crypto';
+import { PythonObject } from '../python-object.js';
+import { emptyObject } from './jobs.js';
+import { copy, get, has, int, integer, keys, object, same, serialize, set, string, text, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+
+export const answerStates = new Set(['confirmed', 'inferred', 'missing', 'sensitive']);
+export const answerReviews = new Set(['accepted', 'pending', 'declined']);
+export const answerSensitivities = new Set(['none', 'personal', 'high']);
+export const answerPatchFields = new Set(['question', 'aliases', 'value', 'state', 'source', 'scope', 'fieldClass', 'sensitivity']);
+export const fallback = (record: Document, key: string, value: Value): Value => has(record, key) ? get(record, key) : value;
+export const answerRevision = (record: Document): bigint => int(fallback(record, 'revision', integer(1n)))!;
+export const sensitiveAnswer = (record: Document): boolean => string(get(record, 'state')) === 'sensitive' || string(fallback(record, 'sensitivity', text('none'))) !== 'none';
+const whitespace = /[\u0009-\u000d\u001c-\u0020\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+/u;
+export function normalizeAnswerQuestion(question: string): string {
+  if (!question.split(whitespace).join('')) throw new JobsError('question must be a non-empty string');
+  return question.normalize('NFKC').toLowerCase().replace(/[^\p{L}\p{N}_\u0009-\u000d\u001c-\u0020\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]/gu, ' ').split(whitespace).filter(Boolean).join(' ');
+}
+export function answerKey(question: string, scope: Document = emptyObject()): string {
+  const normalized = normalizeAnswerQuestion(question);
+  if (/[\uD800-\uDFFF]/u.test(normalized)) throw new JobsError('question contains invalid Unicode');
+  return `question.${createHash('sha256').update(`v1\0${normalized}\0${serialize(scope)}`).digest('hex')}`;
+}
+/** Scope identity treats booleans distinctly while preserving Python numeric equality. */
+export function sameAnswerScope(left: Value, right: Value): boolean {
+  if (typeof left === 'boolean' || typeof right === 'boolean') return left === right;
+  if (left instanceof PythonObject && right instanceof PythonObject) {
+    return left.size === right.size && left.entries().every(([key, value]) =>
+      right.has(key) && sameAnswerScope(value, right.get(key)!));
+  }
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return left.length === right.length && left.every((value, index) => sameAnswerScope(value, right[index]!));
+  }
+  return same(left, right);
+}
+export function answerNames(record: Document): string[] {
+  const question = string(get(record, 'question'));
+  const aliases = fallback(record, 'aliases', []) as Value[];
+  return [question, ...aliases.map(string)].filter((value): value is string => value !== null && Boolean(value.split(whitespace).join(''))).map(normalizeAnswerQuestion);
+}
+export function normalizeAliases(value: Value): Value[] {
+  if (!Array.isArray(value) || value.some(alias => string(alias) === null)) throw new JobsError('answer aliases must be strings');
+  return [...new Set(value.map(alias => normalizeAnswerQuestion(string(alias)!)).filter(Boolean))].map(text);
+}
+export function validateAnswer(key: string, value: Value): Document {
+  const record = object(value, 'answer record');
+  if (string(get(record, 'key')) !== key) throw new JobsError('answer record key does not match its index');
+  if (!answerStates.has(string(get(record, 'state'))!)) throw new JobsError('answer record state is unsupported');
+  if (!answerReviews.has(string(fallback(record, 'reviewStatus', text('accepted')))!)) throw new JobsError('answer record review status is unsupported');
+  if (!answerSensitivities.has(string(fallback(record, 'sensitivity', text('none')))!)) throw new JobsError('answer record sensitivity is unsupported');
+  if (!/^[a-z][a-z0-9_]{0,63}$/.test(string(fallback(record, 'fieldClass', text('general'))) ?? '')) throw new JobsError('answer record field class is invalid');
+  if (get(record, 'question') !== null && string(get(record, 'question')) === null) throw new JobsError('answer record question must be a string');
+  const aliases = fallback(record, 'aliases', []);
+  if (!Array.isArray(aliases) || aliases.some(alias => string(alias) === null)) throw new JobsError('answer record aliases must be strings');
+  object(fallback(record, 'scope', emptyObject()), 'answer record scope');
+  const present = get(record, 'value') !== null;
+  if (string(get(record, 'state')) === 'confirmed' && !present) throw new JobsError('confirmed answer record has no value');
+  if (string(get(record, 'state')) === 'missing' && present) throw new JobsError('missing answer record contains a value');
+  if (present && sensitiveAnswer(record) && !string(get(record, 'rememberedWithConsentAt'))) throw new JobsError('sensitive answer record has no remember consent marker');
+  for (const field of ['source', 'confirmedAt', 'createdAt', 'updatedAt', 'rememberedWithConsentAt', 'deletedAt', 'observedAt', 'lastObservedAt', 'reviewedAt']) {
+    if (get(record, field) !== null && string(get(record, field)) === null) throw new JobsError(`answer record ${field} must be a string`);
+  }
+  const revision = int(fallback(record, 'revision', integer(1n)));
+  if (revision === null || revision < 1n) throw new JobsError('answer revision must be a positive integer');
+  const count = int(fallback(record, 'observationCount', integer(0n)));
+  if (count === null || count < 0n) throw new JobsError('answer observation count must be a non-negative integer');
+  return record;
+}
+export function validateAnswers(value: Value): Document {
+  const document = object(value, 'answers');
+  if (int(get(document, 'schemaVersion')) !== 1n) throw new JobsError('answers version is unsupported');
+  const answers = object(get(document, 'answers'), 'answers.answers');
+  object(get(document, 'metadata'), 'answers.metadata');
+  for (const key of keys(answers)) {
+    if (!key) throw new JobsError('answer index keys must be non-empty strings');
+    validateAnswer(key, get(answers, key));
+  }
+  const redirects = object(fallback(document, 'redirects', emptyObject()), 'answer redirects');
+  for (const key of keys(redirects)) {
+    const redirect = object(get(redirects, key), 'answer redirect');
+    const target = string(get(redirect, 'targetKey'));
+    if (!key || redirect.size !== 2 || !has(redirect, 'mergedAt') || !target || target === key || has(answers, key) || !has(answers, target) || has(redirects, target) || get(object(get(answers, target), 'answer'), 'deletedAt') !== null) throw new JobsError('answer redirect is not flattened to an active answer');
+    if (!string(get(redirect, 'mergedAt'))) throw new JobsError('answer redirect timestamp is invalid');
+  }
+  return document;
+}
+export function answerView(record: Document): Document {
+  const result = copy(record);
+  for (const [key, value] of [['revision', integer(1n)], ['createdAt', get(record, 'updatedAt')], ['deletedAt', null], ['reviewStatus', text('accepted')], ['observationCount', integer(0n)]] as [string, Value][]) {
+    if (!has(result, key)) set(result, key, value);
+  }
+  return result;
+}

--- a/src/contracts/workspace/extraction-pointers.ts
+++ b/src/contracts/workspace/extraction-pointers.ts
@@ -1,0 +1,72 @@
+import { PythonObject } from '../python-object.js';
+import { get, has, set, object, string, text, fromJSON, same, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+import { emptyObject } from './jobs.js';
+
+export const segment = (key: string): string => key.replaceAll('~', '~0').replaceAll('/', '~1');
+export function decodePointer(path: string): string[] {
+  if (!path.startsWith('/') || path === '/') throw new JobsError('proposal path is invalid');
+  return path.slice(1).split('/').map(part => {
+    if (!part || /~(?![01])/.test(part)) throw new JobsError('proposal path is invalid');
+    return part.replaceAll('~1', '/').replaceAll('~0', '~');
+  });
+}
+export function lookup(value: Value, path: string): [boolean, Value] {
+  for (const key of decodePointer(path)) {
+    if (!(value instanceof PythonObject) || !has(value, key)) return [false, null];
+    value = get(value, key);
+  }
+  return [true, value];
+}
+export function baseline(document: Document, path: string): Document {
+  const segments = decodePointer(path), ancestors: Value[] = [];
+  let current: Value = document, encoded = '';
+  for (const key of segments.slice(0, -1)) {
+    encoded += `/${segment(key)}`;
+    const exists: boolean = current instanceof PythonObject && has(current, key);
+    const value: Value = exists ? get(current as Document, key) : null;
+    const item = object(fromJSON({ path: encoded, exists }), 'ancestor');
+    if (exists && value instanceof PythonObject) {
+      set(item, 'container', true);
+      set(item, 'empty', value.size === 0);
+    } else if (exists) set(item, 'value', value);
+    ancestors.push(item);
+    current = value;
+  }
+  const [exists, value] = lookup(document, path);
+  const result = set(set(emptyObject(), 'exists', exists), 'ancestors', ancestors);
+  if (exists) set(result, 'value', value);
+  return result;
+}
+export function setPointer(document: Document, path: string, value: Value, replace: boolean): void {
+  const segments = decodePointer(path);
+  let current = document;
+  for (const key of segments.slice(0, -1)) {
+    let child = get(current, key);
+    if (!(child instanceof PythonObject)) {
+      if (child !== null && !replace) throw new JobsError('proposal path conflicts with an existing fact');
+      child = emptyObject();
+      set(current, key, child);
+    }
+    current = child;
+  }
+  set(current, segments.at(-1)!, value);
+}
+export function replacementScope(item: Document): string | null {
+  for (const value of get(item, 'ancestors') as Value[]) {
+    const ancestor = object(value, 'ancestor');
+    if (get(ancestor, 'exists') === true && get(ancestor, 'container') !== true) return string(get(ancestor, 'path'));
+  }
+  return null;
+}
+export function equal(left: Value, right: Value): boolean {
+  if (typeof left === 'boolean' || typeof right === 'boolean') return left === right;
+  if (left instanceof PythonObject || right instanceof PythonObject) {
+    return left instanceof PythonObject && right instanceof PythonObject && left.size === right.size
+      && left.entries().every(([key, value]) => right.has(key) && equal(value, right.get(key)!));
+  }
+  if (Array.isArray(left) || Array.isArray(right)) return Array.isArray(left) && Array.isArray(right)
+    && left.length === right.length && left.every((value, index) => equal(value, right[index]!));
+  return same(left, right);
+}
+export function compareText(a: string, b: string): number { return text(a).compare(text(b)); }

--- a/src/contracts/workspace/extraction-proposals.ts
+++ b/src/contracts/workspace/extraction-proposals.ts
@@ -1,0 +1,113 @@
+import { PythonObject } from '../python-object.js';
+import { get, has, int, keys, object, string, serialize, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+import { safeId } from './jobs.js';
+import { contentRevision, exact } from './extraction-requests.js';
+import { compareText, decodePointer, segment } from './extraction-pointers.js';
+export const proposalStatuses = new Set(['pending','completed','superseded']);
+export const extractionDecisions = new Set(['use_extracted','keep_current']);
+export function validatedCandidate(value: Value): [Document, string[]] {
+  const candidate = object(value, 'proposal candidate');
+  if (!candidate.size) throw new JobsError('proposal candidate must not be empty');
+  function encodedSize(item: Value): number {
+    const value = string(item);
+    if (value !== null) {
+      if ([...value].some(char => char.codePointAt(0)! >= 0xd800 && char.codePointAt(0)! <= 0xdfff)) throw new JobsError('proposal candidate must contain JSON values');
+      return Buffer.byteLength(JSON.stringify(value));
+    }
+    if (item instanceof PythonObject) return 2 + Math.max(0,item.size-1) + item.entries().reduce((size,[key,child]) => size + encodedSize(key) + 1 + encodedSize(child),0);
+    if (Array.isArray(item)) return 2 + Math.max(0,item.length-1) + item.reduce<number>((size,child) => size + encodedSize(child),0);
+    if (item !== null && typeof item === 'object' && 'kind' in item && item.kind === 'float' && !Number.isFinite(item.value)) throw new JobsError('proposal candidate must contain JSON values');
+    return Buffer.byteLength(serialize(item));
+  }
+  const bytes = encodedSize(candidate);
+  const paths: string[] = [];
+  function visit(item: Value, path: string, depth: number): void {
+    if (depth > 12 || (string(item) !== null && Buffer.byteLength(string(item)!) > 32768)) throw new JobsError('proposal candidate exceeds structural limits');
+    if (item === null) throw new JobsError('proposal candidate values must not be null');
+    if (item instanceof PythonObject && item.size) {
+      for (const [key, child] of item.entries()) {
+        const name = string(key)!;
+        if (!name) throw new JobsError('proposal candidate keys must be non-empty strings');
+        visit(child, `${path}/${segment(name)}`, depth + 1);
+      }
+    } else paths.push(path);
+  }
+  visit(candidate, '', 0);
+  if (bytes > 262144 || paths.length > 512) throw new JobsError('proposal candidate exceeds structural limits');
+  return [candidate, paths.sort(compareText)];
+}
+function paths(value: Value): string[] {
+  if (!Array.isArray(value) || value.some(item => string(item) === null)) throw new JobsError('resume proposal paths are invalid');
+  return value.map(item => string(item)!);
+}
+function validateBaseline(path: string, value: Value): void {
+  const segments = decodePointer(path), record = object(value, 'resume proposal baseline');
+  const ancestors = get(record, 'ancestors');
+  const invalid = (): never => { throw new JobsError('resume proposal baseline is invalid'); };
+  if (keys(record).some(key => !['exists','ancestors','value'].includes(key)) || typeof get(record,'exists') !== 'boolean'
+    || !Array.isArray(ancestors) || get(record,'exists') !== has(record,'value') || ancestors.length !== segments.length-1) invalid();
+  let expected = '';
+  for (const [index, item] of (ancestors as Value[]).entries()) {
+    expected += `/${segment(segments[index]!)}`;
+    const ancestor = object(item,'resume proposal ancestor baseline'), exists = get(ancestor,'exists');
+    if (keys(ancestor).some(key => !['path','exists','container','empty','value'].includes(key))
+      || string(get(ancestor,'path')) !== expected || typeof exists !== 'boolean') invalid();
+    const count = Number(has(ancestor,'container')) + Number(has(ancestor,'value'));
+    if (exists ? count !== 1 : count !== 0) invalid();
+    if (has(ancestor,'container')) {
+      if (get(ancestor,'container') !== true || typeof get(ancestor,'empty') !== 'boolean') invalid();
+    } else if (has(ancestor,'empty')) invalid();
+  }
+}
+export function validateExtractionProposal(key: string, value: Value): Document {
+  const record = object(value,'resume proposal');
+  const allowed = ['id','resumeId','resumeRevision','resumeDigest','resumeContentRevision','profileRevision','resultProfileRevision','candidate','baselines','autoFilledPaths','pendingPaths','decisions','status','revision','createdAt','updatedAt','supersededBy'];
+  if (keys(record).some(key => !allowed.includes(key)) || string(get(record,'id')) !== key) throw new JobsError('resume proposal record is invalid');
+  safeId(key);
+  safeId(string(get(record,'resumeId')));
+  for (const field of ['resumeRevision','profileRevision','resultProfileRevision','revision']) {
+    const revision = int(get(record,field));
+    if (revision === null || revision < 1n) throw new JobsError('resume proposal revision is invalid');
+  }
+  if (!/^[0-9a-f]{64}$/.test(string(get(record,'resumeDigest')) ?? '')) throw new JobsError('resume proposal binding is invalid');
+  if (get(record,'resumeContentRevision') !== null) contentRevision(get(record,'resumeContentRevision'));
+  const [, candidatePaths] = validatedCandidate(get(record,'candidate'));
+  const baselines = object(get(record,'baselines'),'resume proposal baselines');
+  const auto = paths(get(record,'autoFilledPaths')), pending = paths(get(record,'pendingPaths')), all = [...auto,...pending];
+  if (new Set(all).size !== all.length || all.some(path => !candidatePaths.includes(path))
+    || baselines.size !== candidatePaths.length || keys(baselines).some(path => !candidatePaths.includes(path))) throw new JobsError('resume proposal paths are invalid');
+  for (const [path,item] of baselines.entries()) validateBaseline(string(path)!,item);
+  const decisions = object(get(record,'decisions'),'resume proposal decisions');
+  for (const [path,value] of decisions.entries()) {
+    decodePointer(string(path)!);
+    const decision = object(value,'resume proposal decision');
+    exact(decision,['decision','decidedAt'],'resume proposal decision is invalid');
+    if (!extractionDecisions.has(string(get(decision,'decision'))!) || !string(get(decision,'decidedAt'))) throw new JobsError('resume proposal decision is invalid');
+  }
+  const decisionPaths = keys(decisions), expected = candidatePaths.filter(path => !auto.includes(path));
+  if (decisionPaths.some(path => pending.includes(path)) || expected.length !== decisionPaths.length+pending.length
+    || [...decisionPaths,...pending].some(path => !expected.includes(path))) throw new JobsError('resume proposal decision paths are invalid');
+  const status = string(get(record,'status'))!;
+  if (!proposalStatuses.has(status)) throw new JobsError('resume proposal status is invalid');
+  if (status === 'pending' && !pending.length) throw new JobsError('pending resume proposal has no pending paths');
+  if (status === 'completed' && pending.length) throw new JobsError('completed resume proposal has pending paths');
+  if (status === 'superseded') safeId(string(get(record,'supersededBy')));
+  else if (get(record,'supersededBy') !== null) throw new JobsError('resume proposal supersession is invalid');
+  for (const field of ['createdAt','updatedAt']) if (!string(get(record,field))) throw new JobsError('resume proposal timestamp is invalid');
+  return record;
+}
+export function validateExtractions(document: Document): Document {
+  if (int(get(document,'schemaVersion')) !== 1n) throw new JobsError('resume proposals schema version is unsupported');
+  exact(document,['schemaVersion','proposals','metadata'],'resume proposal store contains unsupported fields');
+  object(get(document,'metadata'),'resume proposal metadata');
+  const seen = new Set<string>();
+  for (const [key,value] of object(get(document,'proposals'),'resume proposals').entries()) {
+    const record = validateExtractionProposal(string(key)!,value), id = string(get(record,'resumeId'))!;
+    if (string(get(record,'status')) === 'pending') {
+      if (seen.has(id)) throw new JobsError('resume proposal store has multiple pending proposals');
+      seen.add(id);
+    }
+  }
+  return document;
+}

--- a/src/contracts/workspace/extraction-requests.ts
+++ b/src/contracts/workspace/extraction-requests.ts
@@ -1,0 +1,65 @@
+import { get, has, int, keys, object, string, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+import { safeId } from './jobs.js';
+import { compareText } from './extraction-pointers.js';
+export const requestStatuses = new Set(['requested', 'completed', 'failed', 'stale', 'cancelled']);
+export const failureReasons = new Set(['content_unreadable', 'unsupported_resume', 'extraction_failed', 'candidate_invalid', 'interrupted']);
+export function contentRevision(value: Value): void {
+  if (!/^content_[A-Za-z0-9_-]{32,128}$/.test(string(value) ?? '')) throw new JobsError('resume content revision is unverifiable');
+}
+export function exact(record: Document, fields: string[], message: string): void {
+  if (record.size !== fields.length || keys(record).some(key => !fields.includes(key))) throw new JobsError(message);
+}
+export function validateExtractionRequest(key: string, value: Value): Document {
+  const record = object(value, 'resume extraction request');
+  exact(record, ['requestId','resumeId','resumeContentRevision','revision','status','createdAt','updatedAt','closedAt','proposalId','failureReason','supersedesRequestId'], 'resume extraction request is invalid');
+  if (string(get(record, 'requestId')) !== key) throw new JobsError('resume extraction request is invalid');
+  safeId(key);
+  safeId(string(get(record, 'resumeId')));
+  contentRevision(get(record, 'resumeContentRevision'));
+  const revision = int(get(record, 'revision')), status = string(get(record, 'status'))!;
+  if (revision === null || revision < 1n) throw new JobsError('resume extraction request revision is invalid');
+  if (!requestStatuses.has(status)) throw new JobsError('resume extraction request status is invalid');
+  for (const field of ['createdAt','updatedAt']) if (!string(get(record, field))) throw new JobsError('resume extraction request timestamp is invalid');
+  if ((status !== 'requested') !== Boolean(string(get(record, 'closedAt')))) throw new JobsError('resume extraction request closure is invalid');
+  if (status === 'completed') safeId(string(get(record, 'proposalId')));
+  else if (get(record, 'proposalId') !== null) throw new JobsError('resume extraction request proposal is invalid');
+  if (status === 'failed' ? !failureReasons.has(string(get(record, 'failureReason'))!) : get(record, 'failureReason') !== null) throw new JobsError('resume extraction failure reason is invalid');
+  if (get(record, 'supersedesRequestId') !== null) {
+    if (safeId(string(get(record, 'supersedesRequestId'))) === key) throw new JobsError('resume extraction supersession is invalid');
+  }
+  return record;
+}
+export function validateExtractionRequests(document: Document): Document {
+  if (int(get(document, 'schemaVersion')) !== 1n) throw new JobsError('resume extraction requests schema version is unsupported');
+  exact(document, ['schemaVersion','requests','metadata'], 'resume extraction request store contains unsupported fields');
+  const metadata = object(get(document, 'metadata'), 'request metadata');
+  exact(metadata, ['createdAt','updatedAt'], 'resume extraction request metadata is invalid');
+  for (const field of ['createdAt','updatedAt']) if (!string(get(metadata, field))) throw new JobsError('resume extraction request metadata is invalid');
+  const seen = new Set<string>();
+  for (const [key, value] of object(get(document, 'requests'), 'resume extraction requests').entries()) {
+    const record = validateExtractionRequest(string(key)!, value), id = string(get(record, 'resumeId'))!;
+    if (string(get(record, 'status')) === 'requested') {
+      if (seen.has(id)) throw new JobsError('resume extraction request store has multiple open requests');
+      seen.add(id);
+    }
+  }
+  return document;
+}
+export function orderRequests(records: Document[], field = 'createdAt'): Document[] {
+  const byId = new Map(records.map(record => [string(get(record, 'requestId')), record]));
+  function depth(record: Document): number {
+    const seen = new Set([string(get(record, 'requestId'))]);
+    let count = 0, current = record;
+    while (has(current, 'supersedesRequestId') && get(current, 'supersedesRequestId') !== null) {
+      const id = string(get(current, 'supersedesRequestId')), previous = byId.get(id);
+      if (seen.has(id) || !previous || string(get(previous, 'resumeId')) !== string(get(record, 'resumeId'))) break;
+      seen.add(id);
+      count++;
+      current = previous;
+    }
+    return count;
+  }
+  return records.sort((a,b) => compareText(string(get(a, field))!, string(get(b, field))!) || depth(a)-depth(b)
+    || compareText(string(get(a, 'requestId'))!, string(get(b, 'requestId'))!));
+}

--- a/src/store/native-extraction-journal.ts
+++ b/src/store/native-extraction-journal.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from 'node:crypto';
+import { validateProfile } from '../contracts/workspace/profile.js';
+import { validateResumeReferences } from '../contracts/workspace/resume-reference.js';
+import { validateExtractionRequests } from '../contracts/workspace/extraction-requests.js';
+import { validateExtractions } from '../contracts/workspace/extraction-proposals.js';
+import { safeId } from '../contracts/workspace/jobs.js';
+import { fromJSON, get, int, integer, keys, object, parse, serialize, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document } from '../contracts/workspace/values.js';
+
+export type ExtractionUpdates = { profile?: Document; proposals?: Document; requests?: Document; resumes?: Document };
+const destinations = { profile: 'profile', proposals: 'resume-extractions', requests: 'resume-extraction-requests', resumes: 'resumes' } as const;
+export const extractionJournalName = 'resume-extraction-journal';
+const kinds = new Set(['create', 'review', 'request-create', 'request-close', 'request-retry', 'request-complete', 'resume-request-close']);
+const legacy = ['kind', 'operationId', 'profileDocument', 'proposalsDocument'];
+const expanded = [...legacy, 'requestsDocument', 'resumesDocument'];
+
+export function validateExtractionResumes(document: Document): Document {
+  if (int(get(document, 'schemaVersion')) !== 1n || document.size !== 3
+    || keys(document).some(key => !['schemaVersion', 'resumes', 'metadata'].includes(key))) {
+    throw new JobsError('resume proposal journal operation is invalid');
+  }
+  object(get(document, 'metadata'), 'resumes.metadata');
+  validateResumeReferences(object(get(document, 'resumes'), 'resumes.resumes'));
+  return document;
+}
+
+/** Validate every destination before the first write, including legacy journal shapes. */
+export function validateExtractionJournal(document: Document): Document {
+  if (int(get(document, 'schemaVersion')) !== 1n || document.size !== 2
+    || keys(document).some(key => !['schemaVersion', 'operation'].includes(key))) {
+    throw new JobsError('invalid resume extraction journal');
+  }
+  if (get(document, 'operation') === null) return document;
+  const operation = object(get(document, 'operation'), 'resume extraction journal operation');
+  const fields = keys(operation), kind = string(get(operation, 'kind'));
+  const isLegacy = fields.length === legacy.length && fields.every(key => legacy.includes(key));
+  if ((!isLegacy && (fields.length !== expanded.length || fields.some(key => !expanded.includes(key))))
+    || !kind || !kinds.has(kind) || isLegacy && !['create', 'review'].includes(kind)) {
+    throw new JobsError('resume proposal journal operation is invalid');
+  }
+  safeId(string(get(operation, 'operationId')));
+  for (const [key, validator] of Object.entries({ profile: validateProfile, proposals: validateExtractions,
+    requests: validateExtractionRequests, resumes: validateExtractionResumes })) {
+    const value = get(operation, `${key}Document`);
+    if (value !== null) validator(object(value, `journal ${key}`));
+  }
+  return document;
+}
+
+export class NativeExtractionJournal {
+  constructor(private readonly read: () => Promise<Document>,
+    private readonly write: (name: string, document: Document) => Promise<void>) {}
+
+  async recover(): Promise<void> {
+    const journal = validateExtractionJournal(await this.read());
+    await this.replay(journal);
+  }
+
+  private async replay(journal: Document): Promise<void> {
+    if (get(journal, 'operation') === null) return;
+    const operation = object(get(journal, 'operation'), 'extraction operation');
+    for (const [key, destination] of Object.entries(destinations)) {
+      const value = get(operation, `${key}Document`);
+      if (value !== null) await this.write(destination, object(value, `journal ${key}`));
+    }
+    await this.write(extractionJournalName, object(fromJSON({ schemaVersion: 1, operation: null }), 'journal'));
+  }
+
+  async commit(kind: string, updates: ExtractionUpdates): Promise<void> {
+    if (Object.keys(updates).some(key => !(key in destinations))) throw new JobsError('unsupported extraction update');
+    const operation = object(fromJSON({ kind, operationId: `extraction-${randomUUID()}`,
+      profileDocument: null, proposalsDocument: null, requestsDocument: null, resumesDocument: null }), 'operation');
+    for (const [key, value] of Object.entries(updates)) if (value !== undefined) set(operation, `${key}Document`, value);
+    const journal = object(fromJSON({ schemaVersion: 1, operation: null }), 'journal');
+    set(journal, 'operation', operation);
+    validateExtractionJournal(journal);
+    await this.write(extractionJournalName, journal);
+    await this.replay(journal);
+  }
+}
+
+/** Resume content replacement closes requests; metadata edits retain their content binding. */
+export function closeRequestsForResumes(requestDocument: Document, resumeDocument: Document): Document | null {
+  const requests = object(parse(serialize(requestDocument)), 'requests');
+  const records = object(get(resumeDocument, 'resumes'), 'resumes.resumes');
+  let changed = false;
+  const now = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+  for (const [, value] of object(get(requests, 'requests'), 'requests.requests').entries()) {
+    const request = object(value, 'request');
+    if (string(get(request, 'status')) !== 'requested') continue;
+    const resume = get(records, string(get(request, 'resumeId'))!);
+    const record = resume === null ? null : object(resume, 'resume');
+    const status = record === null || get(record, 'deletedAt') !== null ? 'cancelled'
+      : string(get(record, 'contentRevision')) !== string(get(request, 'resumeContentRevision')) ? 'stale' : null;
+    if (status === null) continue;
+    set(request, 'status', text(status));
+    set(request, 'revision', integer(int(get(request, 'revision'))! + 1n));
+    set(request, 'closedAt', text(now));
+    set(request, 'updatedAt', text(now));
+    set(request, 'failureReason', null);
+    set(request, 'proposalId', null);
+    changed = true;
+  }
+  if (!changed) return null;
+  set(object(get(requests, 'metadata'), 'requests.metadata'), 'updatedAt', text(now));
+  return validateExtractionRequests(requests);
+}

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -14,10 +14,12 @@ import { NativeResumeFiles } from "./native-resume-files.js";
 
 import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
+import { validateAnswers } from "../contracts/workspace/answers.js";
+import type { AnswerReferenceCounts } from "../workspace-core/answers.js";
 
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
-const marker = '{"mode":"native-jobs-fixture","version":3}\n';
-const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "resume-operation.json", "resume-files"]);
+const marker = '{"mode":"native-jobs-fixture","version":4}\n';
+const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
 
@@ -33,8 +35,9 @@ export async function initializeJobsFixture(root: string): Promise<void> {
   if (!isAbsolute(root) || root !== resolve(root)) throw new JobsError("fixture root must be an absolute normalized path");
   await mkdir(root, { mode: 0o700 });
   const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
-  for (const name of ["jobs", "profile", "resumes", "fact-groups"]) {
+  for (const name of ["jobs", "profile", "resumes", "fact-groups", "answers"]) {
     const payload = name === "fact-groups" ? { schemaVersion: 1, groups: {}, metadata: { createdAt: now, updatedAt: now } }
+      : name === "answers" ? { schemaVersion: 1, answers: {}, redirects: {}, metadata: { updatedAt: now } }
       : name === "profile" ? { schemaVersion: 1, profile: {}, metadata: { createdAt: now, updatedAt: now, revision: 1, factProvenance: {} } }
       : { schemaVersion: 1, [name]: {}, metadata: { updatedAt: now } };
     await atomicWritePointJson(join(root, `${name}.json`), fromJSON(payload), options);
@@ -182,6 +185,15 @@ export class NativeJobsRepository implements JobsRepository {
       validateGroups(document);
       await this.write(join(this.root, "fact-groups.json"), document, options);
     }));
+  }
+
+  async answerTransaction<T>(operation: (document: Document, save: (document: Document) => Promise<void>, references: AnswerReferenceCounts) => Promise<T>): Promise<T> {
+    // transaction validates the closed fixture inventory under the shared lock.
+    // No session/history state can exist here, so reference counts are empty.
+    return this.transaction(async () => operation(validateAnswers(await this.document("answers")), async document => {
+      validateAnswers(document);
+      await this.write(join(this.root, "answers.json"), document, options);
+    }, new Map()));
   }
 
   async resumeSummaries(): Promise<Value[]> {

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -11,6 +11,10 @@ import { atomicWritePointJson } from "./point-persistence.js";
 import { withExclusiveFileLock } from "./exclusive-file-lock.js";
 import type { PosixFlockProvider } from "./posix-flock.js";
 import { NativeResumeFiles } from "./native-resume-files.js";
+import { NativeExtractionJournal, closeRequestsForResumes, extractionJournalName, validateExtractionResumes } from "./native-extraction-journal.js";
+import { validateExtractionRequests } from "../contracts/workspace/extraction-requests.js";
+import { validateExtractions } from "../contracts/workspace/extraction-proposals.js";
+import type { ExtractionTransaction } from "../workspace-core/extraction-context.js";
 
 import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
@@ -18,8 +22,8 @@ import { validateAnswers } from "../contracts/workspace/answers.js";
 import type { AnswerReferenceCounts } from "../workspace-core/answers.js";
 
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
-const marker = '{"mode":"native-jobs-fixture","version":4}\n';
-const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files"]);
+const marker = '{"mode":"native-jobs-fixture","version":5}\n';
+const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
 
@@ -43,6 +47,11 @@ export async function initializeJobsFixture(root: string): Promise<void> {
     await atomicWritePointJson(join(root, `${name}.json`), fromJSON(payload), options);
   }
   await atomicWritePointJson(join(root, `${journalName}.json`), fromJSON({ schemaVersion: 1, operation: null }), options);
+  for (const [name, key] of [["resume-extractions", "proposals"], ["resume-extraction-requests", "requests"]]) {
+    await atomicWritePointJson(join(root, `${name}.json`), fromJSON({ schemaVersion: 1, [key!]: {},
+      metadata: { createdAt: now, updatedAt: now } }), options);
+  }
+  await atomicWritePointJson(join(root, `${extractionJournalName}.json`), fromJSON({ schemaVersion: 1, operation: null }), options);
   await mkdir(join(root, "resume-files"), { mode: 0o700 });
   await chmod(join(root, "resume-files"), 0o700);
   const lock = await open(join(root, ".store.lock"), "wx", 0o600);
@@ -97,10 +106,10 @@ export class NativeJobsRepository implements JobsRepository {
     return value;
   }
 
-  private async journal(): Promise<Document> {
-    const value = object(parsePythonPointJsonBytes(await this.read(`${journalName}.json`), {
+  private async journal(name = journalName): Promise<Document> {
+    const value = object(parsePythonPointJsonBytes(await this.read(`${name}.json`), {
       diagnosticProfile: "3.12", intMaxStrDigits: 4300,
-    }), journalName);
+    }), name);
     if (int(get(value, "schemaVersion")) !== 1n) throw new JobsError("resume recovery schema version is unsupported");
     return value;
   }
@@ -111,7 +120,24 @@ export class NativeJobsRepository implements JobsRepository {
     await this.write(join(this.root, `${journalName}.json`), journal, documentOptions);
   }
 
+  private extractionJournal(): NativeExtractionJournal {
+    return new NativeExtractionJournal(() => this.journal(extractionJournalName),
+      (name, document) => this.write(join(this.root, `${name}.json`), document, documentOptions));
+  }
+
+  private async saveResumes(document: Document): Promise<void> {
+    validateExtractionResumes(document);
+    const requests = validateExtractionRequests(await this.document("resume-extraction-requests"));
+    const closed = closeRequestsForResumes(requests, document);
+    if (closed) await this.extractionJournal().commit("resume-request-close", { requests: closed, resumes: document });
+    else await this.write(join(this.root, "resumes.json"), document, documentOptions);
+  }
+
   private async recoverResumes(): Promise<Document> {
+    // The extraction journal can contain the resume document intended by the file
+    // journal. Finish it first so subsequent file recovery never restores an older
+    // extraction snapshot over a newly installed resume. Validate before file I/O.
+    await this.extractionJournal().recover();
     const files = new NativeResumeFiles(this.root);
     const journal = await this.journal();
     if (journal.size !== 2) throw new JobsError("invalid resume recovery journal");
@@ -119,8 +145,7 @@ export class NativeJobsRepository implements JobsRepository {
     const operation = get(journal, "operation");
     await files.recover(operation === null ? null : object(operation, "resume recovery operation"), resumes,
       async document => {
-        validateResumeReferences(object(get(document, "resumes"), "resumes.resumes"));
-        await this.write(join(this.root, "resumes.json"), document, documentOptions);
+        await this.saveResumes(document);
         resumes = document;
       }, async () => this.saveJournal(null));
     return resumes;
@@ -165,12 +190,22 @@ export class NativeJobsRepository implements JobsRepository {
       validateResumeReferences(object(get(document, "resumes"), "resumes.resumes"));
       return operation({ document, files,
         save: async value => {
-          validateResumeReferences(object(get(value, "resumes"), "resumes.resumes"));
-          await this.write(join(this.root, "resumes.json"), value, documentOptions);
+          await this.saveResumes(value);
         },
         saveJournal: async value => this.saveJournal(value),
       });
     }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
+  }
+
+  async extractionTransaction<T>(operation: (transaction: ExtractionTransaction) => Promise<T>): Promise<T> {
+    return this.transaction(async () => operation({
+      profile: validateProfile(await this.document("profile")),
+      resumes: validateExtractionResumes(await this.document("resumes")),
+      requests: validateExtractionRequests(await this.document("resume-extraction-requests")),
+      proposals: validateExtractions(await this.document("resume-extractions")),
+      files: new NativeResumeFiles(this.root),
+      commit: (kind, updates) => this.extractionJournal().commit(kind, updates),
+    }));
   }
 
   async profileTransaction<T>(operation: (document: Document, save: (document: Document) => Promise<void>) => Promise<T>): Promise<T> {

--- a/src/workspace-core/answers-http.ts
+++ b/src/workspace-core/answers-http.ts
@@ -21,7 +21,7 @@ function revision(payload: Document): bigint {
 function decodeKey(value: string): string {
   if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1) throw new JobsError('encoded answer key is invalid');
   try {
-    const result = new TextDecoder('utf-8', { fatal: true }).decode(Buffer.from(value, 'base64url'));
+    const result = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(Buffer.from(value, 'base64url'));
     if (!result) throw new Error();
     return result;
   } catch { throw new JobsError('encoded answer key is invalid'); }

--- a/src/workspace-core/answers-http.ts
+++ b/src/workspace-core/answers-http.ts
@@ -1,0 +1,93 @@
+import { AnswersService } from './answers.js';
+import type { AnswerQuery, AnswerRepository } from './answers.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { get, has, int, keys, object, parse, serialize, string, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+
+const response = (value: Value) => ({ status: 200, body: serialize(value) });
+function fields(payload: Document, allowed: string[], required: string[] = []): void {
+  if (keys(payload).some(key => !allowed.includes(key)) || required.some(key => !has(payload, key))) throw new JobsError('answer body contains unsupported or missing fields');
+}
+function consent(payload: Document): boolean {
+  const value = has(payload, 'rememberSensitive') ? get(payload, 'rememberSensitive') : false;
+  if (typeof value !== 'boolean') throw new JobsError('rememberSensitive must be a boolean');
+  return value;
+}
+function revision(payload: Document): bigint {
+  const value = int(get(payload, 'expectedRevision'));
+  if (value === null || value < 1n) throw new JobsError('expectedRevision must be a positive integer');
+  return value;
+}
+function decodeKey(value: string): string {
+  if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1) throw new JobsError('encoded answer key is invalid');
+  try {
+    const result = new TextDecoder('utf-8', { fatal: true }).decode(Buffer.from(value, 'base64url'));
+    if (!result) throw new Error();
+    return result;
+  } catch { throw new JobsError('encoded answer key is invalid'); }
+}
+export async function answerHttp(repository: AnswerRepository, method: string, path: string, body: string): Promise<{ status: number; body: string } | null> {
+  if (!path.startsWith('/api/answers')) return null;
+  if (['/api/answers/semantic', '/api/answers/cleanup-preview', '/api/answers/cleanup-approve'].includes(path)) return null;
+  const service = new AnswersService(repository);
+  if (method === 'POST' && path === '/api/answers/query') {
+    const payload = object(parse(body), 'body');
+    fields(payload, ['query', 'state', 'reviewStatus', 'includeTrashed', 'trashedOnly', 'offset', 'limit']);
+    const options: AnswerQuery = {};
+    for (const field of ['query', 'state', 'reviewStatus'] as const) {
+      if (!has(payload, field)) continue;
+      const raw = get(payload, field), value = string(raw);
+      if (value === null && (raw !== null || field === 'query')) throw new JobsError(`answer ${field} must be a string`);
+      if (field === 'query') options.query = value!;
+      else options[field] = value;
+    }
+    for (const field of ['includeTrashed', 'trashedOnly'] as const) {
+      if (!has(payload, field)) continue;
+      const value = get(payload, field);
+      if (typeof value !== 'boolean') throw new JobsError('answer trash filters must be booleans');
+      options[field] = value;
+    }
+    for (const field of ['offset', 'limit'] as const) {
+      if (!has(payload, field)) continue;
+      const value = int(get(payload, field));
+      if (value === null || value > BigInt(Number.MAX_SAFE_INTEGER)) throw new JobsError(`answer ${field} is invalid`);
+      options[field] = Number(value);
+    }
+    return response(await service.query(options));
+  }
+  if (method === 'POST' && path === '/api/answers') {
+    const payload = object(parse(body), 'body');
+    fields(payload, ['answer', 'expectedRevision', 'rememberSensitive'], ['answer']);
+    return response(await service.put(get(payload, 'answer'), consent(payload), has(payload, 'expectedRevision') ? revision(payload) : null));
+  }
+  if (method === 'POST' && path === '/api/answers/observe') {
+    const payload = object(parse(body), 'body');
+    fields(payload, ['answer'], ['answer']);
+    return response(await service.observe(get(payload, 'answer')));
+  }
+  const match = /^\/api\/answers\/(?:by-key\/([^/]+)|([^/]+))(?:\/(reveal|accept|decline))?$/.exec(path);
+  if (!match) return null;
+  const key = match[1] ? decodeKey(match[1]) : decodeURIComponent(match[2]!);
+  if (method === 'GET' && !match[3]) {
+    const answer = await service.get(key, false, true);
+    if (answer === null) throw new JobsError('answer does not exist');
+    return response(answer);
+  }
+  if (method === 'PATCH' && !match[3]) {
+    const payload = object(parse(body), 'body');
+    fields(payload, ['patch', 'expectedRevision', 'rememberSensitive'], ['patch', 'expectedRevision']);
+    return response(await service.update(key, get(payload, 'patch'), revision(payload), consent(payload)));
+  }
+  if (method === 'POST' && match[3]) {
+    const payload = object(parse(body), 'body');
+    if (match[3] === 'reveal') {
+      fields(payload, []);
+      const revealed = await service.get(key, true);
+      if (revealed === null) throw new JobsError('answer does not exist');
+      return response(revealed);
+    }
+    fields(payload, ['patch', 'expectedRevision', 'rememberSensitive'], ['expectedRevision']);
+    return response(await service.update(key, has(payload, 'patch') ? get(payload, 'patch') : emptyObject(), revision(payload), consent(payload), match[3] === 'accept' ? 'accepted' : 'declined'));
+  }
+  return null;
+}

--- a/src/workspace-core/answers.ts
+++ b/src/workspace-core/answers.ts
@@ -1,0 +1,220 @@
+import { answerKey, answerNames, answerPatchFields, answerRevision, answerReviews, answerStates, answerView, fallback, normalizeAliases, normalizeAnswerQuestion, sameAnswerScope, sensitiveAnswer, validateAnswer, validateAnswers } from '../contracts/workspace/answers.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { copy, get, has, int, integer, keys, object, same, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+
+export interface AnswerReferences { sessions: bigint; history: bigint }
+export type AnswerReferenceCounts = ReadonlyMap<string, AnswerReferences>;
+export interface AnswerRepository {
+  answerTransaction<T>(operation: (document: Document, save: (document: Document) => Promise<void>, references: AnswerReferenceCounts) => Promise<T>): Promise<T>;
+}
+export interface AnswerQuery {
+  query?: string; state?: string | null; reviewStatus?: string | null;
+  includeTrashed?: boolean; trashedOnly?: boolean; offset?: number; limit?: number;
+}
+export function answerProjection(record: Document, references: AnswerReferenceCounts, detail = false, reveal = false): Document {
+  const view = answerView(record), result = emptyObject();
+  for (const key of keys(view)) if (key !== 'value') set(result, key, get(view, key));
+  set(result, 'hasValue', get(view, 'value') !== null);
+  set(result, 'valueRedacted', sensitiveAnswer(view) && get(view, 'value') !== null);
+  const count = references.get(string(get(view, 'key'))!) ?? { sessions: 0n, history: 0n };
+  const counts = set(set(emptyObject(), 'sessions', integer(count.sessions)), 'history', integer(count.history));
+  set(result, 'referenceCounts', set(counts, 'total', integer(count.sessions + count.history)));
+  if (detail && (!sensitiveAnswer(view) || reveal)) set(result, 'value', get(view, 'value'));
+  return result;
+}
+function canonical(document: Document, key: string): string {
+  const redirects = object(fallback(document, 'redirects', emptyObject()), 'redirects');
+  return has(redirects, key) ? string(get(object(get(redirects, key), 'redirect'), 'targetKey'))! : key;
+}
+function collision(document: Document, candidate: Document, key: string): void {
+  const names = answerNames(candidate), answers = object(get(document, 'answers'), 'answers');
+  const scope = object(fallback(candidate, 'scope', emptyObject()), 'scope');
+  for (const otherKey of keys(answers)) {
+    const other = object(get(answers, otherKey), 'answer');
+    if (otherKey !== key && sameAnswerScope(fallback(other, 'scope', emptyObject()), scope) && answerNames(other).some(name => names.includes(name))) throw new JobsError('answer question or alias collides within scope');
+  }
+  for (const name of names) {
+    const retired = answerKey(name, scope);
+    if (canonical(document, retired) !== retired && canonical(document, retired) !== key) throw new JobsError('answer question or alias is a retired redirect identity');
+  }
+}
+export class AnswersService {
+  constructor(readonly repository: AnswerRepository, private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+  get(key: string, reveal = false, includeTrashed = false): Promise<Value> {
+    return this.repository.answerTransaction(async (raw, _save, references) => {
+      const document = validateAnswers(raw), resolved = canonical(document, key);
+      const answers = object(get(document, 'answers'), 'answers');
+      if (!has(answers, resolved)) return null;
+      const record = object(get(answers, resolved), 'answer');
+      if (get(record, 'deletedAt') !== null && !includeTrashed) return null;
+      const result = answerProjection(record, references, true, reveal);
+      if (key !== resolved) set(result, 'redirectedFrom', text(key));
+      return result;
+    });
+  }
+  find(question: string, scope: Document = emptyObject()): Promise<Value> {
+    const normalized = normalizeAnswerQuestion(question);
+    return this.repository.answerTransaction(async (raw, _save, references) => {
+      const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+      const eligible = (record: Document): boolean => get(record, 'deletedAt') === null
+        && string(fallback(record, 'reviewStatus', text('accepted'))) === 'accepted'
+        && sameAnswerScope(fallback(record, 'scope', emptyObject()), scope);
+      for (const key of keys(answers)) {
+        const record = object(get(answers, key), 'answer');
+        if (eligible(record) && answerNames(record).includes(normalized)) return answerProjection(record, references, true);
+      }
+      const computed = answerKey(question, scope), resolved = canonical(document, computed);
+      if (!has(answers, resolved)) return null;
+      const record = object(get(answers, resolved), 'answer');
+      if (!eligible(record)) return null;
+      const result = answerProjection(record, references, true);
+      if (computed !== resolved) set(result, 'redirectedFrom', text(computed));
+      return result;
+    });
+  }
+  query(options: AnswerQuery = {}): Promise<Document> {
+    const { query = '', state = null, reviewStatus = 'accepted', includeTrashed = false, trashedOnly = false, offset = 0, limit = 50 } = options;
+    if (typeof query !== 'string') throw new JobsError('answer query must be a string');
+    if (state !== null && !answerStates.has(state)) throw new JobsError('answer state is unsupported');
+    if (reviewStatus !== null && !answerReviews.has(reviewStatus)) throw new JobsError('answer review status is unsupported');
+    if (typeof includeTrashed !== 'boolean' || typeof trashedOnly !== 'boolean') throw new JobsError('answer trash filters must be booleans');
+    if (trashedOnly && !includeTrashed) throw new JobsError('trashed-only query requires include trashed');
+    if (!Number.isSafeInteger(offset) || offset < 0) throw new JobsError('answer offset must be a non-negative integer');
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 200) throw new JobsError('answer limit must be between 1 and 200');
+    const needle = query.trim() ? normalizeAnswerQuestion(query) : '';
+    return this.repository.answerTransaction(async (raw, _save, references) => {
+      const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+      const records = keys(answers).map(key => object(get(answers, key), 'answer')).filter(record => {
+        const trashed = get(record, 'deletedAt') !== null;
+        return (includeTrashed || !trashed) && (!trashedOnly || trashed)
+          && (state === null || string(get(record, 'state')) === state)
+          && (reviewStatus === null || string(fallback(record, 'reviewStatus', text('accepted'))) === reviewStatus)
+          && (!needle || answerNames(record).some(name => name.includes(needle)));
+      });
+      const compare = (a: string, b: string): number => {
+        const left = Array.from(a, char => char.codePointAt(0)!), right = Array.from(b, char => char.codePointAt(0)!);
+        for (let i = 0; i < Math.min(left.length, right.length); i++) if (left[i] !== right[i]) return left[i]! - right[i]!;
+        return left.length - right.length;
+      };
+      records.sort((a, b) => compare(string(get(a, 'question')) ?? '', string(get(b, 'question')) ?? '') || compare(string(get(a, 'key'))!, string(get(b, 'key'))!));
+      const result = set(emptyObject(), 'items', records.slice(offset, offset + limit).map(record => answerProjection(record, references)));
+      set(result, 'total', integer(BigInt(records.length)));
+      set(result, 'offset', integer(BigInt(offset)));
+      set(result, 'limit', integer(BigInt(limit)));
+      return set(result, 'hasMore', offset + Math.min(limit, Math.max(0, records.length - offset)) < records.length);
+    });
+  }
+  update(key: string, value: Value, revision: bigint, rememberSensitive = false, review: 'accepted' | 'declined' | null = null): Promise<Document> {
+    const patch = object(value, 'answer patch');
+    if ((!patch.size && review === null) || keys(patch).some(field => !answerPatchFields.has(field))) throw new JobsError('answer patch contains unsupported fields');
+    if (!key) throw new JobsError('answer key must be a non-empty string');
+    return this.repository.answerTransaction(async (raw, save, references) => {
+      const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+      if (!has(answers, key)) throw new JobsError('answer does not exist');
+      const current = object(get(answers, key), 'answer');
+      if (get(current, 'deletedAt') !== null) throw new JobsError('answer does not exist');
+      if (answerRevision(current) !== revision) throw new JobsError('answer revision conflict');
+      if (review !== null && string(fallback(current, 'reviewStatus', text('accepted'))) !== 'pending') throw new JobsError('only pending answers can be reviewed');
+      const updated = copy(current), now = text(this.now());
+      for (const field of keys(patch)) set(updated, field, get(patch, field));
+      set(updated, 'aliases', normalizeAliases(fallback(updated, 'aliases', [])));
+      const state = string(get(updated, 'state'));
+      set(updated, 'sensitivity', fallback(updated, 'sensitivity', text(state === 'sensitive' ? 'high' : 'none')));
+      const changed = !same(get(updated, 'value'), get(current, 'value')) || !string(get(current, 'rememberedWithConsentAt'));
+      if (get(updated, 'value') !== null && sensitiveAnswer(updated)) {
+        if (changed && !rememberSensitive) throw new JobsError('sensitive answer value requires explicit remember consent');
+        if (changed) set(updated, 'rememberedWithConsentAt', now);
+      } else updated.delete(text('rememberedWithConsentAt'));
+      set(updated, 'revision', integer(revision + 1n));
+      set(updated, 'createdAt', get(current, 'createdAt') ?? get(current, 'updatedAt') ?? now);
+      set(updated, 'updatedAt', now);
+      set(updated, 'deletedAt', null);
+      set(updated, 'confirmedAt', state === 'confirmed' ? (state !== string(get(current, 'state')) || !same(get(updated, 'value'), get(current, 'value')) ? now : get(current, 'confirmedAt') ?? now) : null);
+      if (review !== null) {
+        set(updated, 'reviewStatus', text(review));
+        set(updated, 'reviewedAt', now);
+      }
+      await this.save(document, updated, key, save);
+      return answerProjection(updated, references, true);
+    });
+  }
+  put(value: Value, rememberSensitive = false, revision: bigint | null = null): Promise<Document> {
+    const incoming = object(value, 'answer'), scope = object(fallback(incoming, 'scope', emptyObject()), 'answer scope');
+    const question = string(get(incoming, 'question'));
+    if (get(incoming, 'key') !== null && string(get(incoming, 'key')) === null) throw new JobsError('answer key must be a non-empty string');
+    const key = string(get(incoming, 'key')) ?? (question === null ? null : answerKey(question, scope));
+    if (!key || !key.trim()) throw new JobsError('answer requires a question or explicit key');
+    return this.repository.answerTransaction(async (raw, save, references) => {
+      const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+      if (canonical(document, key) !== key) throw new JobsError('answer key was merged and cannot be resurrected');
+      const current = has(answers, key) ? object(get(answers, key), 'answer') : null;
+      if (current && get(current, 'deletedAt') !== null) throw new JobsError('answer is trashed');
+      if (current && (revision === null || revision < 1n)) throw new JobsError('existing answer put requires expected revision');
+      if (current && answerRevision(current) !== revision) throw new JobsError('answer revision conflict');
+      const requestedReview = string(fallback(incoming, 'reviewStatus', text('accepted')));
+      if (!answerReviews.has(requestedReview!)) throw new JobsError('answer review status is unsupported');
+      if (!current && requestedReview !== 'accepted') throw new JobsError('new answers created through put must have accepted review status');
+      const now = text(this.now()), updated = current ? copy(current) : emptyObject();
+      for (const field of ['question', 'value', 'state']) set(updated, field, get(incoming, field));
+      set(updated, 'key', text(key));
+      set(updated, 'scope', scope);
+      set(updated, 'source', fallback(incoming, 'source', text('user')));
+      set(updated, 'aliases', normalizeAliases(fallback(incoming, 'aliases', [])));
+      set(updated, 'fieldClass', fallback(incoming, 'fieldClass', current ? fallback(current, 'fieldClass', text('general')) : text('general')));
+      set(updated, 'sensitivity', fallback(incoming, 'sensitivity', text(string(get(updated, 'state')) === 'sensitive' ? 'high' : 'none')));
+      set(updated, 'reviewStatus', current ? fallback(current, 'reviewStatus', text('accepted')) : text(requestedReview!));
+      set(updated, 'createdAt', current ? get(current, 'createdAt') ?? now : now);
+      set(updated, 'updatedAt', now);
+      set(updated, 'deletedAt', null);
+      set(updated, 'revision', integer(current ? answerRevision(current) + 1n : 1n));
+      set(updated, 'observationCount', current ? fallback(current, 'observationCount', integer(0n)) : fallback(incoming, 'observationCount', integer(0n)));
+      if (!current) for (const field of ['observedAt', 'lastObservedAt', 'reviewedAt']) if (has(incoming, field)) set(updated, field, get(incoming, field));
+      set(updated, 'confirmedAt', string(get(updated, 'state')) === 'confirmed' ? get(incoming, 'confirmedAt') ?? now : get(incoming, 'confirmedAt'));
+      if (get(updated, 'value') !== null && sensitiveAnswer(updated)) {
+        if (!rememberSensitive) throw new JobsError('sensitive answer value requires explicit remember consent');
+        set(updated, 'rememberedWithConsentAt', now);
+      } else updated.delete(text('rememberedWithConsentAt'));
+      await this.save(document, updated, key, save);
+      return answerProjection(updated, references, true);
+    });
+  }
+  observe(value: Value): Promise<Document> {
+    const incoming = object(value, 'observed answer'), question = string(get(incoming, 'question'));
+    const scope = object(fallback(incoming, 'scope', emptyObject()), 'observed answer scope');
+    if (question === null) throw new JobsError('observed answer requires question and object scope');
+    const state = string(fallback(incoming, 'state', text(get(incoming, 'value') === null ? 'missing' : 'inferred')));
+    if (!['missing', 'inferred'].includes(state!)) throw new JobsError('observed answer state must be missing or inferred');
+    if (get(incoming, 'value') !== null && string(fallback(incoming, 'sensitivity', text('none'))) !== 'none') throw new JobsError('sensitive observed values require review and fresh remember consent');
+    const normalized = normalizeAnswerQuestion(question);
+    return this.repository.answerTransaction(async (raw, save, references) => {
+      const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+      let key = keys(answers).find(key => {
+        const record = object(get(answers, key), 'answer');
+        return sameAnswerScope(fallback(record, 'scope', emptyObject()), scope) && answerNames(record).includes(normalized);
+      }) ?? canonical(document, answerKey(question, scope));
+      const current = has(answers, key) ? object(get(answers, key), 'answer') : null;
+      if (current && !sameAnswerScope(fallback(current, 'scope', emptyObject()), scope)) throw new JobsError('observed answer derived key is occupied by a different scope');
+      if (current && get(current, 'deletedAt') !== null) throw new JobsError('observed answer is trashed');
+      const now = text(this.now()), updated = current ? copy(current) : emptyObject();
+      if (!current) {
+        for (const [field, item] of [['key', text(key)], ['question', text(question)], ['aliases', []], ['value', get(incoming, 'value')], ['state', text(state!)], ['source', fallback(incoming, 'source', text('agent'))], ['scope', scope], ['fieldClass', fallback(incoming, 'fieldClass', text('general'))], ['sensitivity', fallback(incoming, 'sensitivity', text('none'))], ['reviewStatus', text('pending')], ['confirmedAt', null], ['createdAt', now], ['deletedAt', null]] as [string, Value][]) set(updated, field, item);
+      }
+      set(updated, 'reviewStatus', fallback(updated, 'reviewStatus', text('accepted')));
+      set(updated, 'lastObservedAt', now);
+      set(updated, 'observedAt', get(updated, 'observedAt') ?? now);
+      set(updated, 'observationCount', integer((current ? int(fallback(current, 'observationCount', integer(0n)))! : 0n) + 1n));
+      set(updated, 'revision', integer(current ? answerRevision(current) + 1n : 1n));
+      set(updated, 'updatedAt', now);
+      await this.save(document, updated, key, save);
+      return answerProjection(updated, references, true);
+    });
+  }
+  private async save(document: Document, record: Document, key: string, save: (document: Document) => Promise<void>): Promise<void> {
+    validateAnswer(key, record);
+    collision(document, record, key);
+    const answers = set(copy(object(get(document, 'answers'), 'answers')), key, record);
+    const metadata = set(copy(object(get(document, 'metadata'), 'metadata')), 'updatedAt', get(record, 'updatedAt'));
+    await save(set(set(copy(document), 'answers', answers), 'metadata', metadata));
+  }
+}

--- a/src/workspace-core/extraction-context.ts
+++ b/src/workspace-core/extraction-context.ts
@@ -1,0 +1,70 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import { get, set, int, integer, object, string, text, fromJSON, JobsError } from '../contracts/workspace/values.js';
+import type { Document } from '../contracts/workspace/values.js';
+import type { NativeResumeFiles } from '../store/native-resume-files.js';
+export interface ExtractionUpdates { profile?: Document; resumes?: Document; requests?: Document; proposals?: Document }
+export interface ExtractionTransaction {
+  profile: Document; resumes: Document; requests: Document; proposals: Document;
+  files: NativeResumeFiles;
+  commit(kind: string, updates: ExtractionUpdates): Promise<void>;
+}
+export interface ExtractionRepository {
+  extractionTransaction<T>(operation: (transaction: ExtractionTransaction) => Promise<T>): Promise<T>;
+}
+export class ExtractionContext {
+  constructor(readonly repository: ExtractionRepository,
+    readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    readonly id = (kind: string) => `${kind}-${randomUUID()}`,
+    readonly contentRevision = () => `content_${randomBytes(24).toString('base64url')}`) {}
+}
+export const records = (document: Document, key: string): Document => object(get(document,key),key);
+export const profileRevision = (document: Document): bigint => int(get(records(document,'metadata'),'revision')) ?? 1n;
+export function touch(document: Document, now: string): void { set(records(document,'metadata'),'updatedAt',text(now)); }
+export function revision(record: Document, expected: bigint, message: string): void {
+  if (int(get(record,'revision')) !== expected) throw new JobsError(message);
+}
+export async function readyResume(tx: ExtractionTransaction, id: string, expected?: bigint): Promise<Document> {
+  const value = get(records(tx.resumes,'resumes'),id);
+  if (value === null || get(object(value,'resume'),'deletedAt') !== null) throw new JobsError('resume does not exist');
+  const resume = object(value,'resume');
+  if (string(get(resume,'storageKind')) !== 'managed') throw new JobsError('resume must be adopted before extraction');
+  if (expected !== undefined) revision(resume,expected,'resume revision conflict');
+  const observed = await tx.files.observation(resume);
+  if (!observed.exists || observed.digest !== string(get(resume,'digest'))) throw new JobsError('resume file is not ready for extraction');
+  return resume;
+}
+export function closeRequest(document: Document, id: string, expected: bigint, status: string, now: string,
+  failure: string | null = null, proposal: string | null = null): Document {
+  const value = get(records(document,'requests'),id);
+  if (value === null) throw new JobsError('resume extraction request does not exist');
+  const current = object(value,'request');
+  revision(current,expected,'request revision conflict');
+  if (string(get(current,'status')) !== 'requested') throw new JobsError('resume extraction request is not open');
+  set(current,'status',text(status));
+  set(current,'failureReason',failure === null ? null : text(failure));
+  set(current,'proposalId',proposal === null ? null : text(proposal));
+  set(current,'revision',integer(expected+1n));
+  set(current,'updatedAt',text(now));
+  set(current,'closedAt',text(now));
+  touch(document,now);
+  return current;
+}
+/** Called inside resume replacement recovery/commit, together with the new resume metadata. */
+export function staleOpenRequests(document: Document, resumeId: string, now: string): boolean {
+  let changed = false;
+  for (const [id,value] of records(document,'requests').entries()) {
+    const record = object(value,'request');
+    if (string(get(record,'resumeId')) === resumeId && string(get(record,'status')) === 'requested') {
+      closeRequest(document,string(id)!,int(get(record,'revision'))!,'stale',now);
+      changed = true;
+    }
+  }
+  return changed;
+}
+export function newRequest(context: ExtractionContext, resume: Document, supersedes: string | null): Document {
+  const now = context.now();
+  const record = object(fromJSON({ requestId: context.id('request'), resumeId: string(get(resume,'id')),
+    revision: 1, status:'requested', createdAt:now, updatedAt:now, closedAt:null, proposalId:null,
+    failureReason:null, supersedesRequestId:supersedes }),'request');
+  return set(record,'resumeContentRevision',get(resume,'contentRevision'));
+}

--- a/src/workspace-core/extraction-proposal-state.ts
+++ b/src/workspace-core/extraction-proposal-state.ts
@@ -1,0 +1,95 @@
+import { copy, get, set, int, integer, object, string, text, fromJSON, parse, serialize, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { validatedCandidate, validateExtractions } from '../contracts/workspace/extraction-proposals.js';
+import { baseline, lookup, setPointer } from '../contracts/workspace/extraction-pointers.js';
+import { provenanceAfter } from './profile-patch.js';
+import { records, profileRevision, touch } from './extraction-context.js';
+import type { ExtractionContext, ExtractionTransaction } from './extraction-context.js';
+export function stampedProfile(document: Document, profile: Document, paths: string[], source: string, now: string): Document {
+  const metadata = copy(records(document,'metadata'));
+  const provenance = get(metadata,'factProvenance') === null ? emptyObject() : records(metadata,'factProvenance');
+  set(metadata,'revision',integer(profileRevision(document)+1n));
+  set(metadata,'updatedAt',text(now));
+  set(metadata,'factProvenance',provenanceAfter(provenance,paths,source,now,records(document,'profile')));
+  return set(set(copy(document),'profile',profile),'metadata',metadata);
+}
+export function createProposalState(context: ExtractionContext, tx: ExtractionTransaction, resume: Document,
+  input: Value, supersedes: string | null, bind: boolean): Document {
+  const [candidate,paths] = validatedCandidate(input), proposals = records(tx.proposals,'proposals');
+  const pending = proposals.entries().map(([,value]) => object(value,'proposal')).find(record =>
+    string(get(record,'resumeId')) === string(get(resume,'id')) && string(get(record,'status')) === 'pending');
+  if (pending ? supersedes !== string(get(pending,'id')) : supersedes !== null) {
+    throw new JobsError(pending ? 'pending proposal requires explicit supersession' : 'proposal to supersede does not exist');
+  }
+  const now = context.now(), id = context.id('proposal'), initialRevision = profileRevision(tx.profile);
+  const profile = object(parse(serialize(get(tx.profile,'profile'))),'profile');
+  const metadata = records(tx.profile,'metadata'), provenance = get(metadata,'factProvenance') === null ? emptyObject() : records(metadata,'factProvenance');
+  const baselines = emptyObject(), auto: string[] = [], pendingPaths: string[] = [];
+  for (const path of paths) set(baselines,path,baseline(records(tx.profile,'profile'),path));
+  for (const path of paths) {
+    const item = records(baselines,path);
+    const ancestorsAllow = (get(item,'ancestors') as Value[]).every(value => {
+      const ancestor = object(value,'ancestor');
+      return get(ancestor,'exists') === false || get(ancestor,'container') === true && get(ancestor,'empty') === false
+        || ancestor.has(text('value')) && get(ancestor,'value') === null;
+    });
+    const protectedPath = provenance.entries().some(([key,value]) => {
+      const name = string(key)!;
+      return string(get(object(value,'provenance'),'source')) === 'user' && (name === path || name.startsWith(`${path}/`) || path.startsWith(`${name}/`));
+    });
+    if ((get(item,'exists') === false || get(item,'value') === null) && ancestorsAllow && !protectedPath) {
+      setPointer(profile,path,lookup(candidate,path)[1],false);
+      auto.push(path);
+    } else pendingPaths.push(path);
+  }
+  if (auto.length) tx.profile = stampedProfile(tx.profile,profile,auto,'resume',now);
+  if (pending) {
+    set(pending,'status',text('superseded'));
+    set(pending,'supersededBy',text(id));
+    set(pending,'revision',integer(int(get(pending,'revision'))!+1n));
+    set(pending,'updatedAt',text(now));
+  }
+  const proposal = object(fromJSON({ id, autoFilledPaths:auto, pendingPaths, decisions:{}, status:pendingPaths.length ? 'pending':'completed',
+    revision:1, createdAt:now, updatedAt:now, supersededBy:null }),'proposal');
+  set(proposal,'resumeId',get(resume,'id'));
+  set(proposal,'resumeRevision',get(resume,'revision'));
+  set(proposal,'resumeDigest',get(resume,'digest'));
+  set(proposal,'profileRevision',integer(initialRevision));
+  set(proposal,'resultProfileRevision',integer(profileRevision(tx.profile)));
+  set(proposal,'candidate',candidate);
+  set(proposal,'baselines',baselines);
+  if (bind) set(proposal,'resumeContentRevision',get(resume,'contentRevision'));
+  set(proposals,id,proposal);
+  touch(tx.proposals,now);
+  validateExtractions(tx.proposals);
+  return proposal;
+}
+export async function staleReasons(tx: ExtractionTransaction, proposal: Document): Promise<string[]> {
+  const value = get(records(tx.resumes,'resumes'),string(get(proposal,'resumeId'))!);
+  if (value === null) return ['resume_deleted'];
+  const resume = object(value,'resume'), reasons: string[] = [];
+  if (get(resume,'deletedAt') !== null) reasons.push('resume_trashed');
+  if (string(get(resume,'storageKind')) !== 'managed') return [...reasons,'resume_not_managed'];
+  if (get(proposal,'resumeContentRevision') !== null) {
+    if (string(get(resume,'contentRevision')) !== string(get(proposal,'resumeContentRevision'))) reasons.push('resume_content_revision_changed');
+  } else {
+    if (int(get(resume,'revision')) !== int(get(proposal,'resumeRevision'))) reasons.push('resume_revision_changed');
+    if (string(get(resume,'digest')) !== string(get(proposal,'resumeDigest'))) reasons.push('resume_digest_changed');
+  }
+  const observed = await tx.files.observation(resume);
+  if (!observed.exists) reasons.push('resume_file_missing');
+  else if (observed.digest !== string(get(resume,'digest'))) reasons.push('resume_file_changed');
+  return reasons;
+}
+export async function proposalResult(tx: ExtractionTransaction, proposal: Document): Promise<Document> {
+  const reasons = await staleReasons(tx,proposal);
+  return set(set(copy(proposal),'stale',reasons.length > 0),'staleReasons',reasons.map(text));
+}
+export function proposalSummary(proposal: Document, includeResume = true): Document {
+  const result = emptyObject();
+  for (const key of ['id','status','revision',...(includeResume ? ['resumeId']:[])]) set(result,key,get(proposal,key));
+  set(result,'autoFilledCount',integer(BigInt((get(proposal,'autoFilledPaths') as Value[]).length)));
+  set(result,'pendingCount',integer(BigInt((get(proposal,'pendingPaths') as Value[]).length)));
+  return result;
+}

--- a/src/workspace-core/extraction-proposals.ts
+++ b/src/workspace-core/extraction-proposals.ts
@@ -1,0 +1,107 @@
+import { copy, get, has, set, object, keys, string, text, integer, parse, serialize, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import { safeId, emptyObject } from '../contracts/workspace/jobs.js';
+import { validatedCandidate, proposalStatuses, extractionDecisions, validateExtractions } from '../contracts/workspace/extraction-proposals.js';
+import { validateExtractionRequests } from '../contracts/workspace/extraction-requests.js';
+import { baseline, lookup, equal, replacementScope, setPointer, compareText } from '../contracts/workspace/extraction-pointers.js';
+import { ExtractionRequests } from './extraction-requests.js';
+import { records, profileRevision, readyResume, revision, closeRequest, touch } from './extraction-context.js';
+import { createProposalState, proposalResult, proposalSummary, staleReasons, stampedProfile } from './extraction-proposal-state.js';
+export class ExtractionProposals extends ExtractionRequests {
+  createProposal(resumeId: string, candidate: Value, expectedResume: bigint, expectedProfile: bigint, supersedes: string | null = null): Promise<Document> {
+    safeId(resumeId);
+    validatedCandidate(candidate);
+    return this.repository.extractionTransaction(async tx => {
+      const resume = await readyResume(tx,resumeId,expectedResume);
+      if (profileRevision(tx.profile) !== expectedProfile) throw new JobsError('profile revision conflict');
+      const proposal = createProposalState(this,tx,resume,candidate,supersedes,false);
+      await tx.commit('create',{profile:tx.profile,proposals:tx.proposals});
+      return proposalResult(tx,proposal);
+    });
+  }
+  completeRequest(id: string, candidate: Value, expectedRequest: bigint, expectedProfile: bigint, expectedPending: string | null = null): Promise<Document> {
+    safeId(id);
+    if (expectedPending !== null) safeId(expectedPending);
+    validatedCandidate(candidate);
+    return this.repository.extractionTransaction(async tx => {
+      const value = get(records(tx.requests,'requests'),id);
+      if (value === null) throw new JobsError('resume extraction request does not exist');
+      const request = object(value,'request');
+      revision(request,expectedRequest,'request revision conflict');
+      if (string(get(request,'status')) !== 'requested') throw new JobsError('resume extraction request is not open');
+      const resume = await readyResume(tx,string(get(request,'resumeId'))!);
+      if (string(get(resume,'contentRevision')) !== string(get(request,'resumeContentRevision'))) throw new JobsError('resume content revision conflict');
+      if (profileRevision(tx.profile) !== expectedProfile) throw new JobsError('profile revision conflict');
+      const proposal = createProposalState(this,tx,resume,candidate,expectedPending,true);
+      const completed = closeRequest(tx.requests,id,expectedRequest,'completed',this.now(),null,string(get(proposal,'id')));
+      validateExtractionRequests(tx.requests);
+      await tx.commit('request-complete',{profile:tx.profile,proposals:tx.proposals,requests:tx.requests});
+      return set(set(emptyObject(),'request',completed),'proposalSummary',proposalSummary(proposal,false));
+    });
+  }
+  getProposal(id: string): Promise<Document | null> {
+    safeId(id);
+    return this.repository.extractionTransaction(async tx => {
+      const value = get(records(tx.proposals,'proposals'),id);
+      return value === null ? null : proposalResult(tx,object(value,'proposal'));
+    });
+  }
+  listProposals(resumeId?: string, status?: string, summaryOnly = false): Promise<Document[]> {
+    if (resumeId !== undefined) safeId(resumeId);
+    if (status !== undefined && !proposalStatuses.has(status)) throw new JobsError('resume proposal status is unsupported');
+    return this.repository.extractionTransaction(async tx => {
+      const selected = records(tx.proposals,'proposals').entries().map(([,value]) => object(value,'proposal'))
+        .filter(record => (resumeId === undefined || string(get(record,'resumeId')) === resumeId)
+          && (status === undefined || string(get(record,'status')) === status))
+        .sort((a,b) => compareText(string(get(a,'createdAt'))!,string(get(b,'createdAt'))!) || compareText(string(get(a,'id'))!,string(get(b,'id'))!));
+      return Promise.all(selected.map(record => summaryOnly ? proposalSummary(record) : proposalResult(tx,record)));
+    });
+  }
+  reviewProposal(id: string, input: Value, expected: bigint, expectedProfile: bigint): Promise<Document> {
+    safeId(id);
+    const review = object(input,'proposal review'), choices = records(review,'decisions');
+    const confirmations = has(review,'replacementConfirmations') ? records(review,'replacementConfirmations') : emptyObject();
+    if (!choices.size || keys(review).some(key => !['decisions','replacementConfirmations'].includes(key))) throw new JobsError('proposal review must contain decisions');
+    if (choices.entries().some(([,value]) => !extractionDecisions.has(string(value)!))) throw new JobsError('proposal review decision is unsupported');
+    return this.repository.extractionTransaction(async tx => {
+      const value = get(records(tx.proposals,'proposals'),id);
+      if (value === null) throw new JobsError('resume proposal does not exist');
+      const current = object(value,'proposal');
+      revision(current,expected,'resume proposal revision conflict');
+      if (string(get(current,'status')) !== 'pending') throw new JobsError('resume proposal is not pending');
+      if ((await staleReasons(tx,current)).length) throw new JobsError('resume proposal is stale');
+      const pending = (get(current,'pendingPaths') as Value[]).map(item => string(item)!);
+      if (keys(choices).some(path => !pending.includes(path))) throw new JobsError('proposal review path is not pending');
+      if (profileRevision(tx.profile) !== expectedProfile) throw new JobsError('profile revision conflict');
+      const baselines = copy(records(current,'baselines')), required = emptyObject();
+      for (const [key,choice] of choices.entries()) {
+        const path = string(key)!;
+        if (!equal(baseline(records(tx.profile,'profile'),path),get(baselines,path))) throw new JobsError('proposal review baseline changed');
+        const replacement = replacementScope(records(baselines,path));
+        if (string(choice) === 'use_extracted' && replacement !== null) set(required,path,text(replacement));
+      }
+      if (!equal(confirmations,required)) throw new JobsError('proposal review replacement confirmation is required');
+      const now = this.now(), profile = object(parse(serialize(get(tx.profile,'profile'))),'profile'), accepted: string[] = [];
+      for (const [key,choice] of choices.entries()) if (string(choice) === 'use_extracted') {
+        const path = string(key)!;
+        setPointer(profile,path,lookup(get(current,'candidate'),path)[1],true);
+        accepted.push(path);
+      }
+      if (accepted.length) tx.profile = stampedProfile(tx.profile,profile,accepted,'user',now);
+      const remaining = pending.filter(path => !choices.has(text(path))), decisions = copy(records(current,'decisions'));
+      for (const path of remaining) set(baselines,path,baseline(profile,path));
+      for (const [key,choice] of choices.entries()) set(decisions,string(key)!,set(set(emptyObject(),'decision',choice),'decidedAt',text(now)));
+      set(current,'pendingPaths',remaining.map(text));
+      set(current,'baselines',baselines);
+      set(current,'decisions',decisions);
+      set(current,'status',text(remaining.length ? 'pending':'completed'));
+      set(current,'resultProfileRevision',integer(profileRevision(tx.profile)));
+      set(current,'revision',integer(expected+1n));
+      set(current,'updatedAt',text(now));
+      touch(tx.proposals,now);
+      validateExtractions(tx.proposals);
+      await tx.commit('review',{profile:tx.profile,proposals:tx.proposals});
+      return proposalResult(tx,current);
+    });
+  }
+}

--- a/src/workspace-core/extraction-requests.ts
+++ b/src/workspace-core/extraction-requests.ts
@@ -1,0 +1,80 @@
+import { get, set, object, string, text, integer, int, JobsError } from '../contracts/workspace/values.js';
+import type { Document } from '../contracts/workspace/values.js';
+import { safeId } from '../contracts/workspace/jobs.js';
+import { failureReasons, requestStatuses, orderRequests, validateExtractionRequests } from '../contracts/workspace/extraction-requests.js';
+import { ExtractionContext, records, readyResume, revision, touch, closeRequest, newRequest } from './extraction-context.js';
+export class ExtractionRequests extends ExtractionContext {
+  createRequest(resumeId: string, expectedResumeRevision: bigint): Promise<Document> {
+    safeId(resumeId);
+    return this.repository.extractionTransaction(async tx => {
+      const resume = await readyResume(tx,resumeId,expectedResumeRevision);
+      this.noOpen(tx.requests,resumeId);
+      const upgraded = get(resume,'contentRevision') === null;
+      if (upgraded) {
+        set(resume,'contentRevision',text(this.contentRevision()));
+        set(resume,'revision',integer(int(get(resume,'revision'))!+1n));
+        set(resume,'updatedAt',text(this.now()));
+        touch(tx.resumes,this.now());
+      }
+      const request = newRequest(this,resume,null);
+      set(records(tx.requests,'requests'),string(get(request,'requestId'))!,request);
+      touch(tx.requests,string(get(request,'updatedAt'))!);
+      validateExtractionRequests(tx.requests);
+      await tx.commit('request-create',{ requests:tx.requests, ...(upgraded ? {resumes:tx.resumes} : {}) });
+      return request;
+    });
+  }
+  getRequest(id: string): Promise<Document | null> {
+    safeId(id);
+    return this.repository.extractionTransaction(async tx => {
+      const value = get(records(tx.requests,'requests'),id);
+      return value === null ? null : object(value,'request');
+    });
+  }
+  listRequests(resumeId?: string, status?: string): Promise<Document[]> {
+    if (resumeId !== undefined) safeId(resumeId);
+    if (status !== undefined && !requestStatuses.has(status)) throw new JobsError('resume extraction request status is unsupported');
+    return this.repository.extractionTransaction(async tx => orderRequests(records(tx.requests,'requests').entries()
+      .map(([,value]) => object(value,'request')).filter(record => (resumeId === undefined || string(get(record,'resumeId')) === resumeId)
+        && (status === undefined || string(get(record,'status')) === status))));
+  }
+  cancelRequest(id: string, expected: bigint): Promise<Document> { return this.close(id,expected,'cancelled'); }
+  failRequest(id: string, reason: string, expected: bigint): Promise<Document> {
+    if (!failureReasons.has(reason)) throw new JobsError('resume extraction failure reason is unsupported');
+    return this.close(id,expected,'failed',reason);
+  }
+  private close(id: string, expected: bigint, status: string, reason: string | null = null): Promise<Document> {
+    safeId(id);
+    return this.repository.extractionTransaction(async tx => {
+      const result = closeRequest(tx.requests,id,expected,status,this.now(),reason);
+      validateExtractionRequests(tx.requests);
+      await tx.commit('request-close',{ requests:tx.requests });
+      return result;
+    });
+  }
+  retryRequest(id: string, expected: bigint, expectedResumeRevision: bigint): Promise<Document> {
+    safeId(id);
+    return this.repository.extractionTransaction(async tx => {
+      const value = get(records(tx.requests,'requests'),id);
+      if (value === null) throw new JobsError('resume extraction request does not exist');
+      const current = object(value,'request');
+      revision(current,expected,'request revision conflict');
+      if (!['failed','stale'].includes(string(get(current,'status'))!)) throw new JobsError('resume extraction request cannot be retried');
+      const resumeId = string(get(current,'resumeId'))!;
+      const resume = await readyResume(tx,resumeId,expectedResumeRevision);
+      this.noOpen(tx.requests,resumeId);
+      const request = newRequest(this,resume,id);
+      set(records(tx.requests,'requests'),string(get(request,'requestId'))!,request);
+      touch(tx.requests,string(get(request,'updatedAt'))!);
+      validateExtractionRequests(tx.requests);
+      await tx.commit('request-retry',{requests:tx.requests});
+      return request;
+    });
+  }
+  private noOpen(document: Document, resumeId: string): void {
+    if (records(document,'requests').entries().some(([,value]) => {
+      const record = object(value,'request');
+      return string(get(record,'resumeId')) === resumeId && string(get(record,'status')) === 'requested';
+    })) throw new JobsError('open extraction request already exists');
+  }
+}

--- a/src/workspace-core/extraction.ts
+++ b/src/workspace-core/extraction.ts
@@ -1,0 +1,3 @@
+export { ExtractionProposals as ExtractionService } from './extraction-proposals.js';
+export { staleOpenRequests } from './extraction-context.js';
+export type { ExtractionRepository, ExtractionTransaction, ExtractionUpdates } from './extraction-context.js';

--- a/src/workspace-core/extractions-http.ts
+++ b/src/workspace-core/extractions-http.ts
@@ -1,0 +1,93 @@
+import { ExtractionService } from './extraction.js';
+import type { ExtractionRepository } from './extraction-context.js';
+import { lookup, baseline, replacementScope } from '../contracts/workspace/extraction-pointers.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { get, has, int, integer, keys, object, parse, serialize, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import type { ApiResult } from './jobs-http.js';
+
+const response = (value: Value): ApiResult => ({ status: 200, body: serialize(value) });
+const envelope = (key: string, value: Value) => set(emptyObject(), key, value);
+function project(record: Document, fields: string[]): Document {
+  const result = emptyObject();
+  for (const field of fields) if (has(record, field)) set(result, field, get(record, field));
+  return result;
+}
+export function publicExtractionRequest(record: Document): Document {
+  return project(record, ['requestId', 'resumeId', 'revision', 'status', 'createdAt', 'updatedAt', 'closedAt', 'proposalId', 'failureReason', 'supersedesRequestId']);
+}
+export function publicProposalSummary(record: Document): Document {
+  const result = project(record, ['id', 'resumeId', 'resumeRevision', 'profileRevision', 'resultProfileRevision', 'status', 'revision', 'createdAt', 'updatedAt', 'supersededBy', 'staleReasons']);
+  for (const [field, paths] of [['autoFilledCount', 'autoFilledPaths'], ['pendingCount', 'pendingPaths']]) {
+    const values = get(record, paths!);
+    set(result, field!, integer(BigInt(Array.isArray(values) ? values.length : 0)));
+  }
+  return result;
+}
+function fields(payload: Document, allowed: string[], required = allowed): void {
+  if (keys(payload).some(key => !allowed.includes(key)) || required.some(key => !has(payload, key))) throw new JobsError('extraction body contains unsupported or missing fields');
+}
+function revision(payload: Document, key: string): bigint {
+  const value = int(get(payload, key));
+  if (value === null || value < 1n) throw new JobsError(`${key} must be a positive integer`);
+  return value;
+}
+async function detail(repository: ExtractionRepository, id: string): Promise<Document> {
+  return repository.extractionTransaction(async transaction => {
+    const service = new ExtractionService({ extractionTransaction: async operation => operation(transaction) });
+    const record = await service.getProposal(id);
+    if (!record) throw new JobsError('resume proposal does not exist');
+    const result = publicProposalSummary(record);
+    const profile = object(get(transaction.profile, 'profile'), 'profile');
+    const metadata = object(get(transaction.profile, 'metadata'), 'profile metadata');
+    set(result, 'candidate', get(record, 'candidate'));
+    set(result, 'pendingPaths', get(record, 'pendingPaths'));
+    set(result, 'liveProfileRevision', has(metadata, 'revision') ? get(metadata, 'revision') : integer(1n));
+    const current = emptyObject(), replacements = emptyObject();
+    for (const raw of get(record, 'pendingPaths') as Value[]) {
+      const pointer = string(raw)!;
+      const [exists, value] = lookup(profile, pointer);
+      const entry = set(emptyObject(), 'exists', exists);
+      set(entry, 'value', exists ? value : null);
+      set(current, pointer, entry);
+      const scope = replacementScope(baseline(profile, pointer));
+      if (scope !== null) {
+        const replacement = set(emptyObject(), 'path', text(scope));
+        set(replacement, 'value', lookup(profile, scope)[1]);
+        set(replacements, pointer, replacement);
+      }
+    }
+    set(result, 'currentValues', current);
+    set(result, 'replacementScopes', replacements);
+    return result;
+  });
+}
+export async function extractionHttp(repository: ExtractionRepository, method: string, path: string, body: string): Promise<ApiResult | null> {
+  const service = new ExtractionService(repository);
+  if (method === 'GET' && path === '/api/resume-extraction-requests') return response(envelope('requests', (await service.listRequests()).map(publicExtractionRequest)));
+  if (method === 'GET' && path === '/api/resume-proposals') return response(envelope('proposals', (await service.listProposals()).map(publicProposalSummary)));
+  if (method === 'POST' && path === '/api/resume-extraction-requests') {
+    const payload = object(parse(body), 'body');
+    fields(payload, ['resumeId', 'expectedResumeRevision']);
+    const id = string(get(payload, 'resumeId'));
+    if (id === null) throw new JobsError('resumeId must be a string');
+    return response(publicExtractionRequest(await service.createRequest(id, revision(payload, 'expectedResumeRevision'))));
+  }
+  const request = /^\/api\/resume-extraction-requests\/([^/]+)\/(cancel|retry)$/.exec(path);
+  if (method === 'POST' && request) {
+    const payload = object(parse(body), 'body'), id = decodeURIComponent(request[1]!);
+    fields(payload, request[2] === 'cancel' ? ['expectedRevision'] : ['expectedRevision', 'expectedResumeRevision']);
+    const value = request[2] === 'cancel' ? await service.cancelRequest(id, revision(payload, 'expectedRevision'))
+      : await service.retryRequest(id, revision(payload, 'expectedRevision'), revision(payload, 'expectedResumeRevision'));
+    return response(publicExtractionRequest(value));
+  }
+  const proposal = /^\/api\/resume-proposals\/([^/]+)(?:\/(review))?$/.exec(path);
+  if (method === 'GET' && proposal && !proposal[2]) return response(await detail(repository, decodeURIComponent(proposal[1]!)));
+  if (method === 'POST' && proposal?.[2] === 'review') {
+    const payload = object(parse(body), 'body');
+    fields(payload, ['decisions', 'replacementConfirmations', 'expectedRevision', 'expectedProfileRevision'], ['decisions', 'expectedRevision', 'expectedProfileRevision']);
+    const decisions = project(payload, ['decisions', 'replacementConfirmations']);
+    return response(publicProposalSummary(await service.reviewProposal(decodeURIComponent(proposal[1]!), decisions, revision(payload, 'expectedRevision'), revision(payload, 'expectedProfileRevision'))));
+  }
+  return null;
+}

--- a/src/workspace-core/jobs-http.ts
+++ b/src/workspace-core/jobs-http.ts
@@ -9,6 +9,7 @@ import { PythonObject } from "../contracts/python-object.js";
 import { ResumeService } from "./resumes.js";
 import { resumesHttp } from "./resumes-http.js";
 import { answerHttp } from "./answers-http.js";
+import { extractionHttp } from "./extractions-http.js";
 
 export type ApiResult = { status: number; body: string | Buffer; contentType?: string; disposition?: string };
 const response = (value: Value, status = 200): ApiResult => ({ status, body: serialize(value) });
@@ -20,6 +21,8 @@ const envelope = (key: string, value: Value): Value => set(emptyObject(), key, v
 export async function jobsHttp(service: JobsService, repository: NativeJobsRepository,
   method: string, path: string, body = ""): Promise<ApiResult> {
   try {
+    const extraction = await extractionHttp(repository, method, path, body);
+    if (extraction) return extraction;
     const answers = await answerHttp(repository, method, path, body);
     if (answers) return answers;
     const resumes = await resumesHttp(new ResumeService(repository), method, path, body);
@@ -65,6 +68,8 @@ export async function jobsHttp(service: JobsService, repository: NativeJobsRepos
   } catch (error) {
     if (error instanceof JobsError) {
       return error.message.includes("revision conflict") ? apiError(409, "revision_conflict", error.message)
+        : error.message === "resume proposal is stale" ? apiError(409, "stale_conflict", error.message)
+        : error.message === "proposal review baseline changed" ? apiError(409, "baseline_conflict", error.message)
         : error.message.includes("content is too large") ? apiError(413, "request_error", error.message)
         : error.message === "managed resume content is unavailable" ? apiError(409, "content_unavailable", error.message)
         : error.message.includes("does not exist") ? apiError(404, "not_found", error.message)

--- a/src/workspace-core/jobs-http.ts
+++ b/src/workspace-core/jobs-http.ts
@@ -8,6 +8,7 @@ import { emptyObject } from "../contracts/workspace/jobs.js";
 import { PythonObject } from "../contracts/python-object.js";
 import { ResumeService } from "./resumes.js";
 import { resumesHttp } from "./resumes-http.js";
+import { answerHttp } from "./answers-http.js";
 
 export type ApiResult = { status: number; body: string | Buffer; contentType?: string; disposition?: string };
 const response = (value: Value, status = 200): ApiResult => ({ status, body: serialize(value) });
@@ -19,6 +20,8 @@ const envelope = (key: string, value: Value): Value => set(emptyObject(), key, v
 export async function jobsHttp(service: JobsService, repository: NativeJobsRepository,
   method: string, path: string, body = ""): Promise<ApiResult> {
   try {
+    const answers = await answerHttp(repository, method, path, body);
+    if (answers) return answers;
     const resumes = await resumesHttp(new ResumeService(repository), method, path, body);
     if (resumes) return resumes;
     const facts = await profileHttp(repository, method, path, body);
@@ -58,7 +61,7 @@ export async function jobsHttp(service: JobsService, repository: NativeJobsRepos
       if (revision === null || revision < 1n) return apiError(400, "request_error", "expectedRevision must be a positive integer");
       return response(await service.update(decodeURIComponent(match[1]!), get(payload, "patch"), revision));
     }
-    return apiError(501, "unsupported_native_workflow", "This synthetic native fixture supports Jobs and Facts/profile only.");
+    return apiError(501, "unsupported_native_workflow", "This workflow is not supported by the synthetic native workspace.");
   } catch (error) {
     if (error instanceof JobsError) {
       return error.message.includes("revision conflict") ? apiError(409, "revision_conflict", error.message)

--- a/tests_js/workspace_native_answers.test.mjs
+++ b/tests_js/workspace_native_answers.test.mjs
@@ -116,3 +116,21 @@ test('HTTP missing answer details fail explicitly for direct and encoded identit
     await assert.rejects(answerHttp(repository, 'GET', path, ''), /answer does not exist/);
   }
 });
+
+test('encoded answer keys preserve a leading BOM and never select or update its unprefixed peer', async () => {
+  const { service, repository } = fixture();
+  for (const [key, question, value] of [['x', 'Unprefixed question?', 'unprefixed'], ['\ufeffx', 'Prefixed question?', 'prefixed']]) {
+    await service.put(fromJSON({ key, question, state: 'confirmed', value }));
+  }
+  const path = '/api/answers/by-key/' + Buffer.from('\ufeffx').toString('base64url');
+  const selected = JSON.parse((await answerHttp(repository, 'GET', path, '')).body);
+  assert.equal(selected.key, '\ufeffx');
+  assert.equal(selected.value, 'prefixed');
+  const updated = JSON.parse((await answerHttp(repository, 'PATCH', path,
+    JSON.stringify({ patch: { value: 'updated-prefixed' }, expectedRevision: 1 }))).body);
+  assert.equal(updated.key, '\ufeffx');
+  assert.equal(updated.revision, 2);
+  assert.equal(plain(await service.get('x')).value, 'unprefixed');
+  assert.equal(plain(await service.get('x')).revision, 1);
+  assert.equal(plain(await service.get('\ufeffx')).value, 'updated-prefixed');
+});

--- a/tests_js/workspace_native_answers.test.mjs
+++ b/tests_js/workspace_native_answers.test.mjs
@@ -1,0 +1,118 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AnswersService } from '../runtime/workspace-core/answers.js';
+import { answerHttp } from '../runtime/workspace-core/answers-http.js';
+import { runAnswerCommand } from '../runtime/cli/native-answers.js';
+import { answerKey, normalizeAnswerQuestion } from '../runtime/contracts/workspace/answers.js';
+import { parse, serialize, fromJSON, get, object, set, text } from '../runtime/contracts/workspace/values.js';
+const fixed = '2026-09-09T12:00:00Z';
+const plain = value => JSON.parse(serialize(value));
+function fixture() {
+  let document = fromJSON({ schemaVersion: 1, answers: {}, metadata: { updatedAt: fixed }, redirects: {} });
+  let writes = 0;
+  const repository = { async answerTransaction(operation) {
+    return operation(parse(serialize(document)), async next => { document = parse(serialize(next)); writes++; }, new Map());
+  } };
+  return { repository, service: new AnswersService(repository, () => fixed), document: () => document, writes: () => writes };
+}
+test('answer identity matches independent Python Unicode/numeric scope oracle', () => {
+  const inputs = [
+    ['ＦＵＬＬ width?  Straße', '{}'], ['What\u0085now\u001c?', '{"salary":9007199254740993,"float":1.0}'],
+    ['Greek ΣΟΣ', '{"😀":1,"é":"é"}'], ['a\ufeffb', '{}'], ['日本語 Ⅳ ²?', '{"null":null,"flag":true}'],
+  ];
+  const script = `import sys,json\nsys.path.insert(0,'scripts')\nfrom job_apply_store.normalization import answer_key,normalize_question\nprint(json.dumps([[normalize_question(q),answer_key(q,json.loads(scope))] for q,scope in json.loads(sys.argv[1])]))`;
+  const expected = JSON.parse(execFileSync('python3', ['-c', script, JSON.stringify(inputs)], { encoding: 'utf8' }));
+  assert.deepEqual(inputs.map(([question, scope]) => [normalizeAnswerQuestion(question), answerKey(question, object(parse(scope), 'scope'))]), expected);
+});
+test('put, observe, review, edit and query agree with independent Python Store', () => {
+  const root = mkdtempSync(join(tmpdir(), 'native-answer-oracle-'));
+  try {
+    const script = `import sys,json,importlib.util\nfrom pathlib import Path\nsys.path.insert(0,'scripts')\nspec=importlib.util.spec_from_file_location('answer_reference','scripts/job-apply-store.py')\nm=importlib.util.module_from_spec(spec);spec.loader.exec_module(m)\nm.utc_now=lambda:'${fixed}'\ns=m.Store(Path(sys.argv[1]));s.initialize()\na=s.put_answer({'key':'plain','question':'Favorite color?','state':'confirmed','value':'blue'})\nb=s.observe_answer({'question':'Preferred editor?','value':'vim'})\nc=s.review_answer(b['key'],'accepted',1)\nd=s.update_answer('plain',{'value':'green'},1)\nprint(json.dumps([a,b,c,d,s.query_answers(),s.get_answer('plain')]))`;
+    const expected = JSON.parse(execFileSync('python3', ['-c', script, join(root, 'python')], { encoding: 'utf8' }));
+    const { service } = fixture();
+    return (async () => {
+      const a = await service.put(fromJSON({ key: 'plain', question: 'Favorite color?', state: 'confirmed', value: 'blue' }));
+      const b = await service.observe(fromJSON({ question: 'Preferred editor?', value: 'vim' }));
+      const c = await service.update(plain(b).key, fromJSON({}), 1n, false, 'accepted');
+      const d = await service.update('plain', fromJSON({ value: 'green' }), 1n);
+      assert.deepEqual([a,b,c,d,await service.query(),await service.get('plain')].map(plain), expected);
+    })();
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+test('sensitive values require consent and stay out of every incidental projection', async () => {
+  const { service, writes } = fixture();
+  const answer = fromJSON({ key: 'secret', question: 'Private answer?', state: 'sensitive', value: 'private-test-value' });
+  await assert.rejects(service.put(answer), /remember consent/);
+  assert.equal(writes(), 0);
+  const saved = await service.put(answer, true);
+  assert.equal(plain(saved).value, undefined);
+  assert.equal(plain(await service.get('secret')).value, undefined);
+  assert.ok(!serialize(await service.query()).includes('private-test-value'));
+  assert.equal(plain(await service.get('secret', true)).value, 'private-test-value');
+  await service.update('secret', fromJSON({ question: 'Updated private answer?' }), 1n);
+  await assert.rejects(service.update('secret', fromJSON({ value: 'new-private-test-value' }), 2n), /remember consent/);
+  assert.equal(writes(), 2);
+});
+test('revision/collision/review rejection leaves canonical bytes unchanged and unknown data lossless', async () => {
+  const f = fixture();
+  await f.service.put(parse('{"key":"a","question":"How many?","state":"confirmed","value":9007199254740993,"scope":{"number":1.0}}'));
+  const before = serialize(f.document());
+  await assert.rejects(f.service.update('a', fromJSON({ value: 'stale' }), 9n), /revision conflict/);
+  await assert.rejects(f.service.update('a', fromJSON({}), 1n, false, 'accepted'), /pending/);
+  assert.equal(serialize(f.document()), before);
+  await assert.rejects(f.service.put(parse('{"key":"b","question":"How many!","state":"confirmed","value":1,"scope":{"number":1}}')), /collides/);
+  assert.equal(serialize(f.document()), before);
+  assert.match(before, /9007199254740993/);
+  assert.match(before, /1\.0/);
+  const answers = object(get(f.document(), 'answers'), 'answers');
+  set(object(get(answers, 'a'), 'answer'), 'opaque', parse('{"huge":9007199254740995}'));
+  await f.service.update('a', fromJSON({ source: 'user' }), 1n);
+  assert.match(serialize(f.document()), /9007199254740995/);
+});
+test('HTTP and CLI share validation, explicit reveal and revision boundaries', async () => {
+  const { repository } = fixture();
+  const input = fromJSON({ key: 'a/b λ', question: 'Transport?', state: 'sensitive', value: 'secret' });
+  await runAnswerCommand('answer-put', repository, new Map([['--remember-sensitive', '']]), async () => input);
+  const path = `/api/answers/by-key/${Buffer.from('a/b λ').toString('base64url')}`;
+  assert.equal(JSON.parse((await answerHttp(repository, 'GET', path, '')).body).value, undefined);
+  assert.equal(JSON.parse((await answerHttp(repository, 'POST', `${path}/reveal`, '{}')).body).value, 'secret');
+  await assert.rejects(answerHttp(repository, 'POST', `${path}/reveal`, '{"extra":true}'), /unsupported/);
+  await assert.rejects(answerHttp(repository, 'PATCH', path, '{"patch":{"source":"user"},"expectedRevision":false}'), /positive integer/);
+  await assert.rejects(answerHttp(repository, 'POST', '/api/answers', '{"answer":{},"rememberSensitive":"yes"}'), /boolean/);
+  assert.equal(await answerHttp(repository, 'POST', `${path}/merge`, '{}'), null);
+  assert.equal(await answerHttp(repository, 'POST', '/api/answers/cleanup-approve', '{}'), null);
+});
+test('exact matching respects alias, scope, accepted review and pending retries', async () => {
+  const { service } = fixture();
+  await service.put(fromJSON({ key: 'canonical', question: 'Preferred location?', aliases: ['Work city'], state: 'confirmed', value: 'Remote', scope: { region: 1 } }));
+  assert.equal(plain(await service.find('WORK CITY!', fromJSON({ region: 1 }))).key, 'canonical');
+  assert.equal(await service.find('Work city', fromJSON({ region: 2 })), null);
+  const observed = plain(await service.observe(fromJSON({ question: 'Favorite editor?', value: 'vim' })));
+  assert.equal(await service.find('Favorite editor?'), null);
+  await service.update(observed.key, fromJSON({}), 1n, false, 'accepted');
+  await assert.rejects(service.update(observed.key, fromJSON({}), 1n, false, 'accepted'), /revision conflict/);
+  await assert.rejects(service.update(observed.key, fromJSON({}), 2n, false, 'accepted'), /pending/);
+  assert.equal(plain(await service.find('Favorite editor?')).value, 'vim');
+});
+test('scope identity separates booleans from numbers recursively but equates integer and float', async () => {
+  const { service } = fixture();
+  for (const [key, scope] of [['bool', '{"nested":[{"flag":true}]}'], ['num', '{"nested":[{"flag":1}]}']]) {
+    await service.put(parse(`{"key":"${key}","question":"Same question?","state":"confirmed","value":"${key}","scope":${scope}}`));
+  }
+  assert.equal(plain(await service.find('Same question?', parse('{"nested":[{"flag":true}]}'))).key, 'bool');
+  assert.equal(plain(await service.find('Same question?', parse('{"nested":[{"flag":1.0}]}'))).key, 'num');
+  await assert.rejects(service.put(parse('{"key":"float","question":"Same question?","state":"confirmed","value":1,"scope":{"nested":[{"flag":1.0}]}}')), /collides/);
+  const observed = plain(await service.observe(parse('{"question":"Same question?","scope":{"nested":[{"flag":true}]}}')));
+  assert.equal(observed.key, 'bool');
+  assert.equal(plain(await service.get('num')).revision, 1);
+});
+test('HTTP missing answer details fail explicitly for direct and encoded identities', async () => {
+  const { repository } = fixture();
+  for (const path of ['/api/answers/missing', `/api/answers/by-key/${Buffer.from('missing').toString('base64url')}`]) {
+    await assert.rejects(answerHttp(repository, 'GET', path, ''), /answer does not exist/);
+  }
+});

--- a/tests_js/workspace_native_answers_browser_support.mjs
+++ b/tests_js/workspace_native_answers_browser_support.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const execute = promisify(execFile);
+
+export async function nativeAnswersBrowser(page, root, fixture, buildRoot) {
+    const input = join(fixture.root, 'answer-browser-input.json');
+    async function cli(command, body, args = []) {
+        await writeFile(input, body);
+        return JSON.parse((await execute(process.execPath, [join(buildRoot, 'runtime/cli/native-jobs.js'),
+            '--root', root, '--native-lock', fixture.receipt.artifact, command, '--input', input, ...args],
+        { env: { PATH: '' } })).stdout);
+    }
+    const stored = async key => JSON.parse(await readFile(join(root, 'answers.json'), 'utf8')).answers[key];
+    await cli('answer-put', '{"key":"browser-answer","question":"Preferred work location?","state":"confirmed","value":"Remote","scope":{"exact":9007199254740993,"decimal":1.0}}');
+    await cli('answer-put', '{"key":"private-answer","question":"Private remembered answer?","state":"sensitive","value":"synthetic-private-value"}', ['--remember-sensitive']);
+    const pending = await cli('answer-observe', '{"question":"Suggested answer?","value":"Suggested value"}');
+    await page.getByRole('button', { name: 'Answers', exact: true }).click();
+    await page.getByRole('button', { name: 'Preferred work location?', exact: true }).click();
+    await page.getByLabel('Answer value', { exact: true }).fill('My answer draft');
+    await cli('answer-update', '{"source":"concurrent-client"}', ['--key', 'browser-answer', '--expected-revision', '1']);
+    await page.getByRole('button', { name: 'Save answer', exact: true }).click();
+    await page.getByRole('button', { name: 'Reapply my changes', exact: true }).waitFor();
+    assert.equal(await page.getByLabel('Answer value', { exact: true }).inputValue(), 'My answer draft');
+    await page.getByRole('button', { name: 'Reapply my changes', exact: true }).click();
+    assert.equal(await page.getByLabel('Source', { exact: true }).inputValue(), 'concurrent-client');
+    await page.getByRole('button', { name: 'Save answer', exact: true }).click();
+    await page.getByText('Answer saved.', { exact: true }).waitFor();
+    assert.equal((await stored('browser-answer')).value, 'My answer draft');
+    assert.equal((await stored('browser-answer')).source, 'concurrent-client');
+    const bytes = await readFile(join(root, 'answers.json'), 'utf8');
+    assert.match(bytes, /9007199254740993/);
+    assert.match(bytes, /"decimal":\s*1\.0/);
+
+    await page.getByRole('button', { name: 'Private remembered answer?', exact: true }).click();
+    await page.getByRole('button', { name: 'Replace hidden answer', exact: true }).waitFor();
+    assert.equal(await page.getByLabel('Answer value', { exact: true }).count(), 0);
+    assert.equal(await page.getByRole('button', { name: 'Replace hidden answer', exact: true }).isDisabled(), true);
+    await page.getByRole('button', { name: 'Reveal sensitive value', exact: true }).click();
+    await page.getByLabel('Answer value', { exact: true }).waitFor();
+    assert.equal(await page.getByLabel('Answer value', { exact: true }).inputValue(), 'synthetic-private-value');
+    await page.getByLabel('Answer value', { exact: true }).fill('changed-private-value');
+    await page.getByRole('button', { name: 'Save answer', exact: true }).click();
+    await page.getByRole('alert').filter({ hasText: /remember consent/ }).waitFor();
+    assert.equal((await stored('private-answer')).value, 'synthetic-private-value');
+    await page.getByRole('button', { name: 'Reapply my changes', exact: true }).click();
+    await page.getByLabel('I consent to remembering the sensitive value in this edit.').check();
+    await page.getByRole('button', { name: 'Save answer', exact: true }).click();
+    await page.getByText('Answer saved.', { exact: true }).waitFor();
+    assert.equal((await stored('private-answer')).value, 'changed-private-value');
+    assert.equal(await page.getByLabel('Answer value', { exact: true }).count(), 0);
+
+    await page.getByLabel('Review status', { exact: true }).selectOption('pending');
+    await page.getByRole('button', { name: 'Search answers', exact: true }).click();
+    await page.getByRole('button', { name: 'Suggested answer?', exact: true }).click();
+    await page.getByRole('button', { name: 'Accept answer', exact: true }).click();
+    await page.getByText('Answer saved.', { exact: true }).waitFor();
+    assert.equal((await stored(pending.key)).reviewStatus, 'accepted');
+
+    await page.reload();
+    await page.getByRole('button', { name: 'Answers', exact: true }).click();
+    await page.getByRole('button', { name: 'Preferred work location?', exact: true }).click();
+    assert.equal(await page.getByLabel('Answer value', { exact: true }).inputValue(), 'My answer draft');
+    await page.setViewportSize({ width: 390, height: 844 });
+    assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1));
+    return { persistedEdits: true, cliConflictReapply: true, losslessScope: true, explicitSensitiveConsent: true, review: true, reload: true, narrow: true };
+}

--- a/tests_js/workspace_native_answers_integration.test.mjs
+++ b/tests_js/workspace_native_answers_integration.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile, realpath, writeFile, unlink } from 'node:fs/promises';
+import { join, basename } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { loadPosixFlockProvider } from '../runtime/store/posix-flock.js';
+import { NativeJobsRepository, initializeJobsFixture } from '../runtime/store/native-jobs.js';
+import { atomicWritePointJson } from '../runtime/store/point-persistence.js';
+import { AnswersService } from '../runtime/workspace-core/answers.js';
+import { JobsService } from '../runtime/workspace-core/jobs.js';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { fromJSON, serialize } from '../runtime/contracts/workspace/values.js';
+
+const execute = promisify(execFile);
+
+test('native answers share locked durable state across HTTP and Python-free CLI', { timeout: 60000 }, async t => {
+    const fixture = await nativeFixture();
+    try {
+        const root = join(await realpath(fixture.root), 'answers');
+        await initializeJobsFixture(root);
+        const provider = loadPosixFlockProvider(fixture.receipt.artifact);
+        const repository = new NativeJobsRepository(root, provider);
+        const service = new AnswersService(repository);
+        const jobs = new JobsService(repository);
+        const path = join(root, 'answers.json');
+        const cli = async args => execute(process.execPath, [join(process.cwd(), 'runtime/cli/native-jobs.js'),
+            '--root', root, '--native-lock', fixture.receipt.artifact, ...args], { env: { PATH: '' } });
+        await t.test('HTTP creation and CLI editing persist and missing details return 404', async () => {
+            const result = await jobsHttp(jobs, repository, 'POST', '/api/answers', JSON.stringify({ answer: {
+                key: 'shared', question: 'Preferred location?', state: 'confirmed', value: 'Remote'
+            } }));
+            assert.equal(result.status, 200);
+            const patch = join(fixture.root, 'answer-patch.json');
+            await writeFile(patch, '{"value":"Hybrid"}');
+            const updated = JSON.parse((await cli(['answer-update', '--key', 'shared', '--expected-revision', '1', '--input', patch])).stdout);
+            assert.equal(updated.revision, 2);
+            assert.equal(JSON.parse(serialize(await new AnswersService(new NativeJobsRepository(root, provider)).get('shared'))).value, 'Hybrid');
+            assert.equal(JSON.parse(await readFile(path, 'utf8')).answers.shared.value, 'Hybrid');
+            assert.equal((await jobsHttp(jobs, repository, 'GET', '/api/answers/by-key/bWlzc2luZw')).status, 404);
+        });
+        await t.test('concurrent CLI writers admit one expected revision', async () => {
+            const patch = join(fixture.root, 'answer-concurrent.json');
+            await writeFile(patch, '{"value":"Concurrent"}');
+            const results = await Promise.allSettled(Array.from({ length: 4 }, () => cli([
+                'answer-update', '--key', 'shared', '--expected-revision', '2', '--input', patch
+            ])));
+            assert.equal(results.filter(result => result.status === 'fulfilled').length, 1);
+            for (const result of results.filter(result => result.status === 'rejected')) assert.match(result.reason.stderr, /revision conflict/);
+            assert.equal(JSON.parse(await readFile(path, 'utf8')).answers.shared.revision, 3);
+        });
+        await t.test('failed persistence and invalid documents leave canonical bytes unchanged', async () => {
+            const before = await readFile(path);
+            const failing = new NativeJobsRepository(root, provider, async (file, ...args) => {
+                if (basename(file) === 'answers.json') throw Error('injected answer write failure');
+                return atomicWritePointJson(file, ...args);
+            });
+            await assert.rejects(new AnswersService(failing).update('shared', fromJSON({ value: 'Not saved' }), 3n), /injected answer write failure/);
+            assert.deepEqual(await readFile(path), before);
+            const corrupted = Buffer.from('{"schemaVersion":1,"answers":[],"metadata":{}}');
+            await writeFile(path, corrupted);
+            await assert.rejects(service.query(), /object/);
+            assert.deepEqual(await readFile(path), corrupted);
+            await writeFile(path, before);
+        });
+        await t.test('unsupported reference state is rejected before assuming empty counts', async () => {
+            const before = await readFile(path);
+            await writeFile(join(root, 'history.jsonl'), '', { mode: 0o600 });
+            await assert.rejects(service.query(), /unsupported state/);
+            assert.deepEqual(await readFile(path), before);
+            await unlink(join(root, 'history.jsonl'));
+        });
+        await t.test('sensitive HTTP and CLI output is redacted until explicit reveal', async () => {
+            await service.put(fromJSON({ key: 'private', question: 'Private fixture?', state: 'sensitive', value: 'synthetic-sensitive' }), true);
+            const response = await jobsHttp(jobs, repository, 'GET', '/api/answers/private');
+            assert.equal(response.status, 200);
+            assert.equal(response.body.includes('synthetic-sensitive'), false);
+            assert.equal((await cli(['answer-list'])).stdout.includes('synthetic-sensitive'), false);
+            const reveal = await jobsHttp(jobs, repository, 'POST', '/api/answers/private/reveal', '{}');
+            assert.equal(JSON.parse(reveal.body).value, 'synthetic-sensitive');
+        });
+    } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_answers_model.test.mjs
+++ b/tests_js/workspace_native_answers_model.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import ts from 'typescript';
+import { parse, serialize, object, get, set, text, copy, has } from '../runtime/contracts/workspace/values.js';
+
+const source = await readFile(new URL('../apps/companion/components/answer-model.ts', import.meta.url), 'utf8');
+const emitted = ts.transpileModule(source, { compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022 } }).outputText
+  .replaceAll('../../../src/contracts/python-object', new URL('../runtime/contracts/python-object.js', import.meta.url).href)
+  .replaceAll('../../../src/contracts/workspace/values', new URL('../runtime/contracts/workspace/values.js', import.meta.url).href);
+const model = await import(`data:text/javascript;base64,${Buffer.from(emitted).toString('base64')}`);
+const record = raw => object(parse(raw), 'answer');
+
+test('ordinary field edits retain hidden values as absent and preserve untouched rich values', () => {
+  const base = record('{"key":"a","revision":1,"question":"Question","state":"sensitive","valueRedacted":true,"scope":{"huge":9007199254740993,"float":1.0},"aliases":["Alias"]}');
+  const draft = model.answerDraft(base);
+  assert.equal(has(draft, 'value'), false);
+  const next = set(copy(draft), 'question', text('Revised question'));
+  const body = model.answerMutation(base, next, false);
+  assert.deepEqual(JSON.parse(body).patch, { question: 'Revised question' });
+  assert.equal(get(next, 'scope'), get(draft, 'scope'));
+  assert.match(serialize(get(next, 'scope')), /9007199254740993/);
+  assert.match(serialize(get(next, 'scope')), /1\.0/);
+  assert.equal(has(object(get(record(body), 'patch'), 'patch'), 'value'), false);
+});
+
+test('selective reapply retains remote untouched value and local field changes', () => {
+  const base = record('{"key":"a","revision":1,"question":"Question","value":9007199254740993,"state":"confirmed","scope":{"remote":"before"}}');
+  const draft = set(model.answerDraft(base), 'question', text('Local question'));
+  const latest = record('{"key":"a","revision":2,"question":"Remote question","value":9007199254740995,"state":"confirmed","scope":{"remote":"after"}}');
+  const reapplied = model.reapplyAnswer(base, draft, latest);
+  assert.equal(serialize(get(reapplied, 'value')), '9007199254740995');
+  const mutation = model.answerMutation(latest, reapplied, false);
+  assert.deepEqual(JSON.parse(mutation), { expectedRevision: 2, patch: { question: 'Local question' }, rememberSensitive: false });
+});
+
+test('intentional hidden value replacement is isolated in a consent-bearing mutation', () => {
+  const base = record('{"key":"a","revision":7,"question":"Question","state":"sensitive","valueRedacted":true}');
+  const draft = set(model.answerDraft(base), 'value', text('Replacement'));
+  assert.deepEqual(JSON.parse(model.answerMutation(base, draft, true)), {
+    expectedRevision: 7, patch: { value: 'Replacement' }, rememberSensitive: true,
+  });
+});
+test('field type changes remain intentional edits including boolean-to-number scope changes', () => {
+  const base = record('{"key":"a","revision":1,"scope":{"flag":true},"value":1}');
+  const draft = model.answerDraft(base);
+  set(draft, 'scope', parse('{"flag":1}'));
+  set(draft, 'value', parse('1.0'));
+  const body = model.answerMutation(base, draft, false);
+  assert.deepEqual(JSON.parse(body).patch.scope, { flag: 1 });
+  assert.match(body, /"value":1\.0/);
+});

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,6 +1,7 @@
 import { nativeFactsBrowser } from './workspace_native_facts_browser_support.mjs';
 import { resumeDraftBrowser } from './workspace_native_resumes_browser_support.mjs';
 import { nativeAnswersBrowser } from './workspace_native_answers_browser_support.mjs';
+import { nativeExtractionsBrowser } from './workspace_native_extractions_browser_support.mjs';
 import assert from 'node:assert/strict';
 import { chromium } from 'playwright';
 import { spawn, execFile } from 'node:child_process';
@@ -96,11 +97,12 @@ export async function nativeJobsBrowser(buildRoot) {
     assert.equal(await readFile(join(root, 'resume-files', browserResume.managedFile), 'utf8'), 'updated browser resume');
     await resumeDraftBrowser(page, root, fixture, buildRoot, browserResume.id);
     const answers = await nativeAnswersBrowser(page, root, fixture, buildRoot);
+    const extractions = await nativeExtractionsBrowser(page, root, fixture, buildRoot);
     const token = new URLSearchParams(new URL(startup.url).hash.slice(1)).get('token');
     const unsupported = await fetch(startup.origin + '/api/overview', { headers: { Authorization: `Bearer ${token}` } });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { facts, answers, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     if (browser) await browser.close();
     if (child && child.exitCode === null && child.signalCode === null) {

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,5 +1,6 @@
 import { nativeFactsBrowser } from './workspace_native_facts_browser_support.mjs';
 import { resumeDraftBrowser } from './workspace_native_resumes_browser_support.mjs';
+import { nativeAnswersBrowser } from './workspace_native_answers_browser_support.mjs';
 import assert from 'node:assert/strict';
 import { chromium } from 'playwright';
 import { spawn, execFile } from 'node:child_process';
@@ -94,11 +95,12 @@ export async function nativeJobsBrowser(buildRoot) {
     assert.equal(browserResume.label, 'Browser resume updated');
     assert.equal(await readFile(join(root, 'resume-files', browserResume.managedFile), 'utf8'), 'updated browser resume');
     await resumeDraftBrowser(page, root, fixture, buildRoot, browserResume.id);
+    const answers = await nativeAnswersBrowser(page, root, fixture, buildRoot);
     const token = new URLSearchParams(new URL(startup.url).hash.slice(1)).get('token');
     const unsupported = await fetch(startup.origin + '/api/overview', { headers: { Authorization: `Bearer ${token}` } });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { facts, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { facts, answers, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     if (browser) await browser.close();
     if (child && child.exitCode === null && child.signalCode === null) {

--- a/tests_js/workspace_native_extraction_domain.test.mjs
+++ b/tests_js/workspace_native_extraction_domain.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ExtractionService, staleOpenRequests } from '../runtime/workspace-core/extraction.js';
+import { parse, serialize, fromJSON, get, set, object, text, integer } from '../runtime/contracts/workspace/values.js';
+import { validateExtractionRequests } from '../runtime/contracts/workspace/extraction-requests.js';
+import { validatedCandidate, validateExtractions } from '../runtime/contracts/workspace/extraction-proposals.js';
+const json = value => JSON.parse(serialize(value));
+const now = '2026-09-09T00:00:00Z';
+function fixture(profile = {}, provenance = {}) {
+  let sequence = 0;
+  let state = {
+    profile:fromJSON({schemaVersion:1,profile,metadata:{revision:1,updatedAt:now,factProvenance:provenance}}),
+    resumes:fromJSON({schemaVersion:1,resumes:{r:{id:'r',storageKind:'managed',digest:'a'.repeat(64),contentRevision:`content_${'a'.repeat(32)}`,revision:1,deletedAt:null}},metadata:{updatedAt:now}}),
+    requests:fromJSON({schemaVersion:1,requests:{},metadata:{createdAt:now,updatedAt:now}}),
+    proposals:fromJSON({schemaVersion:1,proposals:{},metadata:{createdAt:now,updatedAt:now}}),
+  };
+  const repository = {async extractionTransaction(operation) {
+    const detached = Object.fromEntries(Object.entries(state).map(([key,value])=>[key,parse(serialize(value))]));
+    return operation({...detached,files:{observation:async()=>({exists:true,digest:'a'.repeat(64)})},
+      commit:async(kind,updates)=>{void kind; validateExtractionRequests(updates.requests ?? state.requests);validateExtractions(updates.proposals ?? state.proposals);state={...state,...updates};}});
+  }};
+  return {service:new ExtractionService(repository,()=>now,kind=>`${kind}-${++sequence}`),state:()=>state,
+    resume:()=>object(get(object(get(state.resumes,'resumes'),'resumes'),'r'),'r')};
+}
+test('request completion tolerates metadata revisions and binds content identity; duplicate completion denied',async()=>{
+  const f=fixture(),request=json(await f.service.createRequest('r',1n));
+  set(f.resume(),'revision',integer(2n));
+  const result=json(await f.service.completeRequest(request.requestId,fromJSON({name:'Alice'}),1n,1n));
+  assert.equal(result.request.status,'completed');
+  assert.equal(json(f.state().profile).profile.name,'Alice');
+  assert.equal(json(f.state().profile).metadata.factProvenance['/name'].source,'resume');
+  await assert.rejects(f.service.completeRequest(request.requestId,fromJSON({name:'Bob'}),2n,2n),/not open/);
+  set(f.resume(),'revision',integer(3n));
+  assert.equal(json(await f.service.getProposal(result.proposalSummary.id)).stale,false);
+  set(f.resume(),'contentRevision',text(`content_${'b'.repeat(32)}`));
+  assert.deepEqual(json(await f.service.getProposal(result.proposalSummary.id)).staleReasons,['resume_content_revision_changed']);
+});
+test('cancel, fail, retry ordering and replacement closure',async()=>{
+  const f=fixture(),request=json(await f.service.createRequest('r',1n));
+  await assert.rejects(f.service.createRequest('r',1n),/open extraction/);
+  await f.service.failRequest(request.requestId,'interrupted',1n);
+  const retry=json(await f.service.retryRequest(request.requestId,2n,1n));
+  assert.equal(retry.supersedesRequestId,request.requestId);
+  assert.deepEqual((await f.service.listRequests()).map(v=>json(v).requestId),[request.requestId,retry.requestId]);
+  assert.equal(staleOpenRequests(f.state().requests,'r',now),true);
+  assert.equal(json(await f.service.getRequest(retry.requestId)).status,'stale');
+  const third=json(await f.service.retryRequest(retry.requestId,2n,1n));
+  await f.service.cancelRequest(third.requestId,1n);
+  await assert.rejects(f.service.retryRequest(third.requestId,2n,1n),/cannot be retried/);
+});
+test('explicit supersession, user provenance, replacements and partial review',async()=>{
+  const f=fixture({name:'Existing',section:'old'},{'/name':{source:'user',updatedAt:now}});
+  const candidate=fromJSON({name:'Extracted',section:{a:1,b:2}});
+  const p=json(await f.service.createProposal('r',candidate,1n,1n));
+  await assert.rejects(f.service.createProposal('r',candidate,1n,1n),/explicit supersession/);
+  const next=json(await f.service.createProposal('r',candidate,1n,1n,p.id));
+  assert.equal(json(await f.service.getProposal(p.id)).status,'superseded');
+  await assert.rejects(f.service.reviewProposal(next.id,fromJSON({decisions:{'/section/a':'use_extracted'}}),1n,1n),/replacement confirmation/);
+  let reviewed=json(await f.service.reviewProposal(next.id,fromJSON({decisions:{'/section/a':'use_extracted'},replacementConfirmations:{'/section/a':'/section'}}),1n,1n));
+  assert.deepEqual(reviewed.pendingPaths,['/name','/section/b']);
+  reviewed=json(await f.service.reviewProposal(next.id,fromJSON({decisions:{'/name':'keep_current','/section/b':'use_extracted'}}),2n,2n));
+  assert.equal(reviewed.status,'completed');
+  assert.deepEqual(json(f.state().profile).profile,{name:'Existing',section:{a:1,b:2}});
+  assert.equal(json(f.state().profile).metadata.factProvenance['/section/b'].source,'user');
+});
+test('boolean baseline change is not equal to integer and failed review is atomic',async()=>{
+  const f=fixture({flag:true}),p=json(await f.service.createProposal('r',fromJSON({flag:false}),1n,1n));
+  set(object(get(f.state().profile,'profile'),'profile'),'flag',integer(1n));
+  await assert.rejects(f.service.reviewProposal(p.id,fromJSON({decisions:{'/flag':'keep_current'}}),1n,1n),/baseline changed/);
+  assert.equal(json(await f.service.getProposal(p.id)).revision,1);
+});
+test('candidate limits preserve arrays as atomic leaves and use UTF-8 size',()=>{
+  assert.deepEqual(validatedCandidate(fromJSON({x:[null,{a:null}]}))[1],['/x']);
+  assert.throws(()=>validatedCandidate(fromJSON({x:null})),/must not be null/);
+  assert.throws(()=>validatedCandidate(fromJSON({x:'a'.repeat(32769)})),/structural limits/);
+  assert.doesNotThrow(()=>validatedCandidate(fromJSON(Object.fromEntries(Array.from({length:8},(_,i)=>[`x${i}`,'é'.repeat(15000)])))));
+  assert.throws(()=>validatedCandidate(fromJSON(Object.fromEntries(Array.from({length:513},(_,i)=>[`x${i}`,i])))),/structural limits/);
+});
+
+test('Python differential candidate and leaf baseline parity on synthetic values',async()=>{
+  const {spawnSync}=await import('node:child_process');
+  const {baseline}=await import('../runtime/contracts/workspace/extraction-pointers.js');
+  const fixtures=[
+    {profile:{section:'old'},candidate:{section:{a:1,b:2}}},
+    {profile:{section:{},flag:true},candidate:{section:{x:[]},flag:false}},
+    {profile:{section:null},candidate:{section:{'a/b':{'x~y':'é'}}}},
+    {profile:{},candidate:{values:[null,{nested:null}]}},
+  ];
+  const python=spawnSync('python3',['-c',String.raw`
+import json,sys
+sys.path.insert(0,'scripts')
+from job_apply_store.normalization import _pointer_baseline
+from job_apply_store.validation.extraction import _validated_candidate
+result=[]
+for fixture in json.load(sys.stdin):
+ candidate,paths=_validated_candidate(fixture['candidate'])
+ result.append({'paths':paths,'baselines':{path:_pointer_baseline(fixture['profile'],path) for path in paths}})
+print(json.dumps(result))
+`],{cwd:new URL('..',import.meta.url),input:JSON.stringify(fixtures),encoding:'utf8'});
+  assert.equal(python.status,0,python.stderr);
+  const native=fixtures.map(fixture=>{
+    const [,paths]=validatedCandidate(fromJSON(fixture.candidate));
+    return {paths,baselines:Object.fromEntries(paths.map(path=>[path,json(baseline(fromJSON(fixture.profile),path))]))};
+  });
+  assert.deepEqual(native,JSON.parse(python.stdout));
+});

--- a/tests_js/workspace_native_extraction_kill.test.mjs
+++ b/tests_js/workspace_native_extraction_kill.test.mjs
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { realpath, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { child, nativeFixture } from './exclusive_file_lock_support.mjs';
+import { loadPosixFlockProvider } from '../runtime/store/posix-flock.js';
+import { initializeJobsFixture, NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { ResumeService } from '../runtime/workspace-core/resumes.js';
+import { ExtractionService } from '../runtime/workspace-core/extraction.js';
+import { fromJSON, serialize } from '../runtime/contracts/workspace/values.js';
+
+const moduleUrl = path => new URL(`../runtime/${path}.js`, import.meta.url).href;
+const imports = `
+import { basename, join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { NativeJobsRepository } from ${JSON.stringify(moduleUrl('store/native-jobs'))};
+import { loadPosixFlockProvider } from ${JSON.stringify(moduleUrl('store/posix-flock'))};
+import { atomicWritePointJson } from ${JSON.stringify(moduleUrl('store/point-persistence'))};
+import { ExtractionService } from ${JSON.stringify(moduleUrl('workspace-core/extraction'))};
+import { fromJSON, get, serialize } from ${JSON.stringify(moduleUrl('contracts/workspace/values'))};
+const [root, addon, boundary] = process.argv.slice(1);
+`;
+const writerScript = imports + `
+let intended;
+const repository = new NativeJobsRepository(root, loadPosixFlockProvider(addon), async (path, document, options) => {
+  const name = basename(path);
+  if (name === 'resume-extraction-journal.json' && get(document, 'operation') !== null) {
+    intended = JSON.parse(serialize(get(document, 'operation')));
+  }
+  await atomicWritePointJson(path, document, options);
+  const checkpoint = name === 'resume-extraction-journal.json'
+    ? get(document, 'operation') === null ? 'clear' : 'journal' : name;
+  if (checkpoint === boundary) {
+    console.log(JSON.stringify({ intended }));
+    console.log('durable-boundary');
+    await new Promise(() => { setInterval(() => {}, 1000); });
+  }
+});
+await new ExtractionService(repository, () => '2026-09-09T12:00:00Z', kind => kind + '-completed')
+  .completeRequest('request-pending', fromJSON({ name: 'Synthetic applicant', location: 'Remote' }), 1n, 1n);
+throw Error('Writer unexpectedly passed its kill boundary');
+`;
+const recoveryScript = imports + `
+const repository = new NativeJobsRepository(root, loadPosixFlockProvider(addon));
+await repository.transaction(async () => {});
+const documents = {};
+for (const name of ['profile', 'resume-extractions', 'resume-extraction-requests', 'resume-extraction-journal']) {
+  documents[name] = JSON.parse(await readFile(join(root, name + '.json'), 'utf8'));
+}
+console.log(JSON.stringify(documents));
+`;
+
+test('SIGKILL at each durable completion boundary recovers one coherent extraction transaction', { timeout: 60000 }, async t => {
+  const fixture = await nativeFixture();
+  try {
+    const directory = await realpath(fixture.root);
+    const provider = loadPosixFlockProvider(fixture.receipt.artifact);
+    const boundaries = ['journal', 'profile.json', 'resume-extractions.json', 'resume-extraction-requests.json', 'clear'];
+    for (const boundary of boundaries) {
+      await t.test(boundary, async () => {
+        const root = join(directory, boundary);
+        await initializeJobsFixture(root);
+        const repository = new NativeJobsRepository(root, provider);
+        await new ResumeService(repository).import(fromJSON({ id: 'source', label: 'Synthetic source' }), 'source.txt', Buffer.from('Synthetic applicant'));
+        await new ExtractionService(repository, () => '2026-09-09T12:00:00Z', () => 'request-pending').createRequest('source', 1n);
+        const writer = child(writerScript, [root, fixture.receipt.artifact, boundary]);
+        let intended;
+        try {
+          await writer.line('durable-boundary');
+          intended = JSON.parse(writer.lines.find(line => line.startsWith('{'))).intended;
+          assert.equal(intended.kind, 'request-complete');
+          assert.equal(writer.process.kill('SIGKILL'), true);
+          assert.deepEqual(await writer.exited, { code: null, signal: 'SIGKILL' });
+        } finally { await writer.stop(); }
+        const restarted = child(recoveryScript, [root, fixture.receipt.artifact]);
+        let recovered;
+        try {
+          await restarted.success();
+          recovered = JSON.parse(restarted.lines.find(line => line.startsWith('{')));
+        } finally { await restarted.stop(); }
+        assert.deepEqual(recovered.profile, intended.profileDocument);
+        assert.deepEqual(recovered['resume-extractions'], intended.proposalsDocument);
+        assert.deepEqual(recovered['resume-extraction-requests'], intended.requestsDocument);
+        assert.deepEqual(recovered['resume-extraction-journal'], { schemaVersion: 1, operation: null });
+        assert.deepEqual(recovered.profile.profile, { name: 'Synthetic applicant', location: 'Remote' });
+        assert.equal(recovered.profile.metadata.revision, 2);
+        for (const path of ['/name', '/location']) {
+          assert.deepEqual(recovered.profile.metadata.factProvenance[path], { source: 'resume', updatedAt: '2026-09-09T12:00:00Z' });
+        }
+        const request = recovered['resume-extraction-requests'].requests['request-pending'];
+        assert.equal(request.status, 'completed');
+        assert.equal(request.revision, 2);
+        const proposal = recovered['resume-extractions'].proposals[request.proposalId];
+        assert.equal(proposal.status, 'completed');
+        assert.equal(proposal.resultProfileRevision, recovered.profile.metadata.revision);
+        assert.equal(proposal.resumeContentRevision, request.resumeContentRevision);
+        // A second restart is idempotent and does not advance profile/request revisions.
+        await new NativeJobsRepository(root, provider).transaction(async () => {});
+        for (const [name, document] of Object.entries(recovered)) {
+          assert.deepEqual(JSON.parse(await readFile(join(root, `${name}.json`), 'utf8')), document);
+        }
+      });
+    }
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_extraction_model.test.mjs
+++ b/tests_js/workspace_native_extraction_model.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import ts from 'typescript';
+import { parse, serialize, object } from '../runtime/contracts/workspace/values.js';
+
+const source = await readFile(new URL('../apps/companion/components/extraction-model.ts', import.meta.url), 'utf8');
+const emitted = ts.transpileModule(source, { compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022 } }).outputText
+  .replaceAll('../../../src/contracts/python-object', new URL('../runtime/contracts/python-object.js', import.meta.url).href)
+  .replaceAll('../../../src/contracts/workspace/values', new URL('../runtime/contracts/workspace/values.js', import.meta.url).href);
+const model = await import(`data:text/javascript;base64,${Buffer.from(emitted).toString('base64')}`);
+const record = raw => object(parse(raw), 'record');
+const proposal = model.proposalSnapshot(`{
+  "id":"proposal-one", "revision":9007199254740993, "liveProfileRevision":9007199254740995,
+  "candidate":{"contact":{"name":"New"},"a/b":{"~key":9007199254740997}},
+  "pendingPaths":["/contact/name","/a~1b/~0key"],
+  "currentValues":{"/contact/name":{"exists":false,"value":null},"/a~1b/~0key":{"exists":true,"value":1}},
+  "replacementScopes":{"/contact/name":{"path":"/contact","value":"Old contact"}}
+}`);
+
+test('candidate pointer traversal unescapes segments without rounding extracted numbers', () => {
+  assert.equal(serialize(model.candidateValue(proposal, '/a~1b/~0key')), '9007199254740997');
+  assert.throws(() => model.candidateValue(proposal, '/missing'), /missing/);
+});
+
+test('review retains exact proposal and profile revisions and requires replacement consent', () => {
+  assert.throws(() => model.reviewMutation(proposal, { '/contact/name': 'use_extracted' }, []), /Confirm replacement/);
+  const body = model.reviewMutation(proposal, { '/contact/name': 'use_extracted', '/a~1b/~0key': 'keep_current' }, ['/contact/name']);
+  assert.match(body, /"expectedRevision":9007199254740993/);
+  assert.match(body, /"expectedProfileRevision":9007199254740995/);
+  assert.deepEqual(JSON.parse(body).replacementConfirmations, { '/contact/name': '/contact' });
+  assert.deepEqual(JSON.parse(model.reviewMutation(proposal, { '/contact/name': 'keep_current' }, ['/contact/name'])).replacementConfirmations, {});
+});
+
+test('reapply drops resolved choices while retaining only still pending decisions', () => {
+  const latest = record('{"pendingPaths":["/a~1b/~0key"]}');
+  assert.deepEqual(model.reapplyChoices({ '/contact/name': 'use_extracted', '/a~1b/~0key': 'keep_current' }, latest), { '/a~1b/~0key': 'keep_current' });
+  assert.throws(() => model.reviewMutation(proposal, { '/gone': 'keep_current' }, []), /Invalid review/);
+  assert.throws(() => model.reviewMutation(proposal, {}, []), /at least one/);
+});
+
+test('request, cancel and retry serialize only their exact revision contracts', () => {
+  const resume = record('{"id":"resume-one","revision":9007199254740993}');
+  const request = record('{"requestId":"request-one","revision":9007199254740995}');
+  assert.equal(model.requestMutation(resume), '{"expectedResumeRevision":9007199254740993,"resumeId":"resume-one"}');
+  assert.equal(model.requestMutation(resume, request, 'cancel'), '{"expectedRevision":9007199254740995}');
+  assert.equal(model.requestMutation(resume, request, 'retry'), '{"expectedResumeRevision":9007199254740993,"expectedRevision":9007199254740995}');
+});
+
+test('malformed proposals and list responses fail before displaying a review', () => {
+  assert.throws(() => model.proposalSnapshot('{"id":"p","revision":true,"liveProfileRevision":1}'), /revision/);
+  assert.throws(() => model.extractionList('{"requests":{}}', 'requests'), /Invalid requests/);
+});

--- a/tests_js/workspace_native_extraction_recovery.test.mjs
+++ b/tests_js/workspace_native_extraction_recovery.test.mjs
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile, realpath, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { loadPosixFlockProvider } from '../runtime/store/posix-flock.js';
+import { NativeJobsRepository, initializeJobsFixture } from '../runtime/store/native-jobs.js';
+import { atomicWritePointJson } from '../runtime/store/point-persistence.js';
+import { NativeExtractionJournal } from '../runtime/store/native-extraction-journal.js';
+import { ResumeService } from '../runtime/workspace-core/resumes.js';
+import { fromJSON, get, object, serialize, set, text } from '../runtime/contracts/workspace/values.js';
+
+const plain = value => JSON.parse(serialize(value));
+const now = '2026-09-09T12:00:00Z';
+const requestDocument = contentRevision => fromJSON({ schemaVersion: 1, requests: {
+  'request-one': { requestId: 'request-one', resumeId: 'resume-one', resumeContentRevision: contentRevision,
+    revision: 1, status: 'requested', createdAt: now, updatedAt: now, closedAt: null,
+    proposalId: null, failureReason: null, supersedesRequestId: null }
+}, metadata: { createdAt: now, updatedAt: now } });
+const json = async (root, name) => JSON.parse(await readFile(join(root, `${name}.json`), 'utf8'));
+
+async function seeded(base, provider, name) {
+  const root = join(base, name);
+  await initializeJobsFixture(root);
+  const repository = new NativeJobsRepository(root, provider);
+  const resumes = new ResumeService(repository, () => now, () => 'resume-one', () => `content_${'a'.repeat(32)}`);
+  const resume = plain(await resumes.import(fromJSON({ id: 'resume-one', label: 'Fixture' }), 'resume.txt', Buffer.from('old bytes')));
+  await repository.extractionTransaction(tx => tx.commit('request-create', { requests: requestDocument(resume.contentRevision) }));
+  return { root, repository, resumes };
+}
+
+test('extraction journals validate the whole transaction and roll forward every write interruption', async () => {
+  const proposals = fromJSON({ schemaVersion: 1, proposals: {}, metadata: { createdAt: now, updatedAt: now } });
+  const profile = fromJSON({ schemaVersion: 1, profile: { fixture: 'recovered' }, metadata: { revision: 2, createdAt: now, updatedAt: now, factProvenance: {} } });
+  const resumes = fromJSON({ schemaVersion: 1, resumes: {}, metadata: { updatedAt: now } });
+  const requests = fromJSON({ schemaVersion: 1, requests: {}, metadata: { createdAt: now, updatedAt: now } });
+  for (let failAt = 1; failAt <= 6; failAt++) {
+    const disk = new Map([['resume-extraction-journal', fromJSON({ schemaVersion: 1, operation: null })]]);
+    let count = 0;
+    const journal = new NativeExtractionJournal(async () => disk.get('resume-extraction-journal'), async (name, document) => {
+      disk.set(name, fromJSON(plain(document)));
+      if (++count === failAt) throw Error('crash after durable write');
+    });
+    await assert.rejects(journal.commit('request-complete', { profile, proposals, requests, resumes }), /crash/);
+    const recovery = new NativeExtractionJournal(async () => disk.get('resume-extraction-journal'), async (name, document) => { disk.set(name, document); });
+    await recovery.recover();
+    assert.deepEqual(plain(disk.get('profile')), plain(profile));
+    assert.deepEqual(plain(disk.get('resume-extraction-requests')), plain(requests));
+    assert.deepEqual(plain(disk.get('resumes')), plain(resumes));
+    assert.equal(plain(disk.get('resume-extraction-journal')).operation, null);
+    await recovery.recover();
+  }
+  const malformed = fromJSON({ schemaVersion: 1, operation: { kind: 'request-complete', operationId: 'extraction-one',
+    profileDocument: plain(profile), proposalsDocument: null, requestsDocument: { invalid: true }, resumesDocument: null } });
+  let writes = 0;
+  await assert.rejects(new NativeExtractionJournal(async () => malformed, async () => { writes++; }).recover());
+  assert.equal(writes, 0, 'valid earlier destination must not be written before later invalid destination is checked');
+  const legacy = fromJSON({ schemaVersion: 1, operation: { kind: 'review', operationId: 'extraction-legacy',
+    profileDocument: plain(profile), proposalsDocument: plain(proposals) } });
+  const replayed = [];
+  await new NativeExtractionJournal(async () => legacy, async name => { replayed.push(name); }).recover();
+  assert.deepEqual(replayed, ['profile', 'resume-extractions', 'resume-extraction-journal']);
+  const invalidCases = [
+    { schemaVersion: 1, operation: null, extra: true },
+    { schemaVersion: 1, operation: { ...plain(legacy).operation, kind: 'request-create' } },
+    { schemaVersion: 1, operation: { ...plain(legacy).operation, operationId: '../escape' } },
+    { schemaVersion: 1, operation: { ...plain(legacy).operation, requestsDocument: null } },
+  ];
+  for (const value of invalidCases) {
+    await assert.rejects(new NativeExtractionJournal(async () => fromJSON(value), async () => { writes++; }).recover());
+  }
+  assert.equal(writes, 0);
+
+});
+
+test('resume replacement and extraction closure recover together under the shared Store lock', { timeout: 60000 }, async t => {
+  const fixture = await nativeFixture();
+  try {
+    const base = await realpath(fixture.root);
+    const provider = loadPosixFlockProvider(fixture.receipt.artifact);
+    for (const target of ['resume-extraction-journal.json', 'resume-extraction-requests.json', 'resumes.json']) {
+      await t.test(`recover replacement interrupted at ${target}`, async () => {
+        const { root } = await seeded(base, provider, target.replaceAll('.', '-'));
+        let failed = false;
+        const failing = new NativeJobsRepository(root, provider, async (file, ...args) => {
+          await atomicWritePointJson(file, ...args);
+          if (!failed && basename(file) === target) { failed = true; throw Error('injected crash'); }
+        });
+        const service = new ResumeService(failing, () => now, () => 'unused', () => `content_${'b'.repeat(32)}`);
+        await assert.rejects(service.replace('resume-one', 'next.txt', Buffer.from('new bytes'), 1n), /injected crash/);
+        const restarted = new NativeJobsRepository(root, provider);
+        // A Jobs read must recover extraction and resume file journals too.
+        await restarted.transaction(async () => {});
+        const request = (await json(root, 'resume-extraction-requests')).requests['request-one'];
+        assert.equal(request.status, 'stale');
+        assert.equal(request.revision, 2);
+        assert.equal((await json(root, 'resumes')).resumes['resume-one'].contentRevision, `content_${'b'.repeat(32)}`);
+        assert.equal(await readFile(join(root, 'resume-files/resume-one.txt'), 'utf8'), 'new bytes');
+        assert.equal((await json(root, 'resume-extraction-journal')).operation, null);
+        assert.equal((await json(root, 'resume-operation')).operation, null);
+        await restarted.transaction(async () => {});
+        assert.equal((await json(root, 'resume-extraction-requests')).requests['request-one'].revision, 2);
+      });
+    }
+    await t.test('metadata changes retain requests and trash cancels them', async () => {
+      const { root, repository, resumes } = await seeded(base, provider, 'metadata');
+      await resumes.update('resume-one', fromJSON({ label: 'Renamed' }), 1n);
+      assert.equal((await json(root, 'resume-extraction-requests')).requests['request-one'].status, 'requested');
+      await repository.resumeTransaction(async tx => {
+        const resume = object(get(object(get(tx.document, 'resumes'), 'resumes'), 'resume-one'), 'resume');
+        set(resume, 'deletedAt', text(now));
+        await tx.save(tx.document);
+      });
+      assert.equal((await json(root, 'resume-extraction-requests')).requests['request-one'].status, 'cancelled');
+    });
+    await t.test('malformed extraction journal blocks every read before resume recovery side effects', async () => {
+      const { root, repository } = await seeded(base, provider, 'invalid');
+      const bytes = await readFile(join(root, 'resumes.json'));
+      const malformed = JSON.stringify({ schemaVersion: 1, operation: { kind: 'request-complete', operationId: 'extraction-one',
+        profileDocument: null, proposalsDocument: null, requestsDocument: { invalid: true }, resumesDocument: null } });
+      await writeFile(join(root, 'resume-extraction-journal.json'), malformed);
+      const staged = join(root, 'resume-files/.native-11111111-1111-1111-1111-111111111111.tmp');
+      await writeFile(staged, 'untouched staging', { mode: 0o600 });
+      for (const call of [() => repository.transaction(async () => {}), () => repository.resumeTransaction(async () => {}),
+        () => repository.profileTransaction(async () => {}), () => repository.groupsTransaction(async () => {}),
+        () => repository.answerTransaction(async () => {}), () => repository.extractionTransaction(async () => {})]) {
+        await assert.rejects(call());
+      }
+      assert.deepEqual(await readFile(join(root, 'resumes.json')), bytes);
+      assert.equal(await readFile(staged, 'utf8'), 'untouched staging');
+      assert.equal(await readFile(join(root, 'resume-extraction-journal.json'), 'utf8'), malformed);
+    });
+    await t.test('transactions serialize detached profile updates', async () => {
+      const { repository } = await seeded(base, provider, 'concurrent');
+      await Promise.all(Array.from({ length: 5 }, (_, index) => repository.extractionTransaction(async tx => {
+        set(object(get(tx.profile, 'profile'), 'profile'), `writer${index}`, text('saved'));
+        await tx.commit('review', { profile: tx.profile });
+      })));
+      await repository.extractionTransaction(async tx => assert.equal(object(get(tx.profile, 'profile'), 'profile').size, 5));
+    });
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_extractions.test.mjs
+++ b/tests_js/workspace_native_extractions.test.mjs
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { realpath, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { loadPosixFlockProvider } from '../runtime/store/posix-flock.js';
+import { NativeJobsRepository, initializeJobsFixture } from '../runtime/store/native-jobs.js';
+import { ResumeService } from '../runtime/workspace-core/resumes.js';
+import { JobsService } from '../runtime/workspace-core/jobs.js';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { runJobsCli } from '../runtime/cli/native-jobs.js';
+import { fromJSON, serialize } from '../runtime/contracts/workspace/values.js';
+
+test('HTTP review and CLI extraction share durable revisions and browser-safe projections', { timeout: 60000 }, async () => {
+  const fixture = await nativeFixture();
+  try {
+    const root = join(await realpath(fixture.root), 'extraction-http');
+    await initializeJobsFixture(root);
+    const repository = new NativeJobsRepository(root, loadPosixFlockProvider(fixture.receipt.artifact));
+    const jobs = new JobsService(repository);
+    const http = async (method, path, body) => {
+      const result = await jobsHttp(jobs, repository, method, path, body === undefined ? '' : JSON.stringify(body));
+      return { status: result.status, value: JSON.parse(result.body) };
+    };
+    const cli = async (command, options = [], input = {}) => JSON.parse(await runJobsCli([
+      command, '--root', root, '--native-lock', fixture.receipt.artifact, ...options,
+    ], async () => JSON.stringify(input)));
+    const resume = JSON.parse(serialize(await new ResumeService(repository).import(fromJSON({ id: 'source', label: 'Source' }), 'source.txt', Buffer.from('Synthetic resume'))));
+    await http('PATCH', '/api/profile', { expectedRevision: 1, patch: { name: 'Current', employer: ['Existing employer'] } });
+    const created = await http('POST', '/api/resume-extraction-requests', { resumeId: 'source', expectedResumeRevision: resume.revision });
+    assert.equal(created.status, 200);
+    assert.equal(created.value.resumeContentRevision, undefined);
+    const requestId = created.value.requestId;
+    const completed = await cli('resume-extraction-request-complete', ['--id', requestId, '--expected-request-revision', '1', '--expected-profile-revision', '2', '--input', '-'], { name: 'Extracted', location: 'Remote', employer: { title: 'Engineer' } });
+    assert.equal(completed.request.status, 'completed');
+    const proposalId = completed.proposalSummary.id;
+    const detail = await http('GET', `/api/resume-proposals/${proposalId}`);
+    assert.equal(detail.status, 200);
+    assert.equal(detail.value.resumeDigest, undefined);
+    assert.equal(detail.value.resumeContentRevision, undefined);
+    assert.equal(detail.value.autoFilledCount, 1);
+    assert.deepEqual(detail.value.currentValues['/name'], { exists: true, value: 'Current' });
+    assert.deepEqual(detail.value.replacementScopes['/employer/title'], { path: '/employer', value: ['Existing employer'] });
+    const body = { expectedRevision: detail.value.revision, expectedProfileRevision: detail.value.liveProfileRevision,
+      decisions: { '/name': 'keep_current', '/employer/title': 'use_extracted' } };
+    assert.equal((await http('POST', `/api/resume-proposals/${proposalId}/review`, body)).status, 400);
+    const accepted = await http('POST', `/api/resume-proposals/${proposalId}/review`, { ...body, replacementConfirmations: { '/employer/title': '/employer' } });
+    assert.equal(accepted.status, 200);
+    assert.equal(accepted.value.status, 'completed');
+    assert.equal((await http('POST', `/api/resume-proposals/${proposalId}/review`, body)).status, 409);
+    const profile = JSON.parse(await readFile(join(root, 'profile.json'), 'utf8'));
+    assert.equal(profile.profile.name, 'Current');
+    assert.equal(profile.profile.employer.title, 'Engineer');
+    assert.equal(profile.metadata.factProvenance['/location'].source, 'resume');
+    assert.equal(profile.metadata.factProvenance['/employer/title'].source, 'user');
+    assert.equal((await http('GET', '/api/resume-proposals/missing')).status, 404);
+    assert.equal((await http('POST', '/api/resume-extraction-requests', { resumeId: 'source', expectedResumeRevision: true })).status, 400);
+    await assert.rejects(cli('resume-extraction-request-complete', ['--id', requestId, '--expected-request-revision', '1', '--expected-profile-revision', '4', '--input', '-'], { value: 'duplicate' }), /revision conflict|not open/);
+    const restarted = await cli('resume-proposal-get', ['--id', proposalId]);
+    assert.equal(restarted.status, 'completed');
+    const request2 = await cli('resume-extraction-request-create', ['--resume-id', 'source', '--expected-resume-revision', String(resume.revision)]);
+    await new ResumeService(repository).replace('source', 'new.txt', Buffer.from('Changed synthetic resume'), BigInt(resume.revision));
+    assert.equal((await cli('resume-extraction-request-get', ['--id', request2.requestId])).status, 'stale');
+    assert.equal((await cli('resume-proposal-get', ['--id', proposalId])).stale, true);
+    const conflict = await cli('resume-proposal-create', ['--resume-id', 'source', '--expected-resume-revision', '2', '--expected-profile-revision', '4', '--input', '-'], { name: 'Next name' });
+    assert.equal((await http('PATCH', '/api/profile', { expectedRevision: 4, patch: { name: 'New current name' } })).status, 200);
+    const review = { expectedRevision: conflict.revision, expectedProfileRevision: 5, decisions: { '/name': 'use_extracted' } };
+    const baselineConflict = await http('POST', `/api/resume-proposals/${conflict.id}/review`, review);
+    assert.equal(baselineConflict.status, 409);
+    assert.equal(baselineConflict.value.error.code, 'baseline_conflict');
+    await new ResumeService(repository).replace('source', 'again.txt', Buffer.from('Another synthetic resume'), 2n);
+    const staleConflict = await http('POST', `/api/resume-proposals/${conflict.id}/review`, review);
+    assert.equal(staleConflict.status, 409);
+    assert.equal(staleConflict.value.error.code, 'stale_conflict');
+    await new ResumeService(repository).import(fromJSON({ id: 'large', label: 'Large candidate' }), 'large.txt', Buffer.from('Large candidate synthetic source'));
+    const largeInput = JSON.stringify({ largeA: 'a'.repeat(30000), largeB: 'b'.repeat(30000), largeC: 'c'.repeat(30000) });
+    const stdin = args => {
+      const result = spawnSync(process.execPath, ['runtime/cli/native-jobs.js', '--root', root,
+        '--native-lock', fixture.receipt.artifact, ...args, '--input', '-'], { input: largeInput, encoding: 'utf8', env: { PATH: '' } });
+      assert.equal(result.status, 0, result.stderr);
+      return JSON.parse(result.stdout);
+    };
+    assert.equal(stdin(['resume-proposal-create', '--resume-id', 'large', '--expected-resume-revision', '1', '--expected-profile-revision', '5']).status, 'completed');
+    const largeRequest = await cli('resume-extraction-request-create', ['--resume-id', 'large', '--expected-resume-revision', '1']);
+    assert.equal(stdin(['resume-extraction-request-complete', '--id', largeRequest.requestId, '--expected-request-revision', '1', '--expected-profile-revision', '6']).request.status, 'completed');
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_extractions_browser_support.mjs
+++ b/tests_js/workspace_native_extractions_browser_support.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+const execute = promisify(execFile);
+
+export async function nativeExtractionsBrowser(page, root, fixture, buildRoot) {
+  const input = join(fixture.root, 'extraction-browser-input.json');
+  const document = async name => JSON.parse(await readFile(join(root, `${name}.json`), 'utf8'));
+  async function cli(command, args = [], body) {
+    if (body !== undefined) { await writeFile(input, JSON.stringify(body)); args = [...args, '--input', input]; }
+    return JSON.parse((await execute(process.execPath, [join(buildRoot, 'runtime/cli/native-jobs.js'),
+      '--root', root, '--native-lock', fixture.receipt.artifact, command, ...args], { env: { PATH: '' } })).stdout);
+  }
+  const resume = Object.values((await document('resumes')).resumes)[0];
+  let profile = await document('profile');
+  await cli('profile-patch', ['--source', 'user', '--expected-revision', String(profile.metadata.revision)], { employer: ['Existing employer'] });
+  await page.getByRole('button', { name: 'Resume extraction', exact: true }).click();
+  await page.getByLabel('Resume to extract').selectOption(resume.id);
+  await page.getByRole('button', { name: 'Request extraction', exact: true }).click();
+  await page.getByRole('button', { name: 'Cancel extraction', exact: true }).waitFor();
+  await page.getByRole('button', { name: 'Cancel extraction', exact: true }).click();
+  await page.getByText('Extraction request cancelled.', { exact: true }).waitFor();
+  await page.getByRole('button', { name: 'Request extraction', exact: true }).click();
+  await page.getByRole('button', { name: 'Cancel extraction', exact: true }).waitFor();
+  const request = Object.values((await document('resume-extraction-requests')).requests).find(item => item.status === 'requested');
+  profile = await document('profile');
+  const result = await cli('resume-extraction-request-complete', ['--id', request.requestId,
+    '--expected-request-revision', '1', '--expected-profile-revision', String(profile.metadata.revision)],
+  { firstName: 'Extracted name', employer: { title: 'Engineer' }, extractedCity: 'Remote' });
+  await page.getByRole('button', { name: 'Refresh extraction status', exact: true }).click();
+  await page.getByRole('button', { name: 'Review extraction result', exact: true }).click();
+  try { await page.getByLabel('Decision for /firstName', { exact: true }).selectOption('keep_current', { timeout: 5000 }); }
+  catch (error) { throw Error(error.message + '\n' + await page.locator('body').innerText()); }
+  await page.getByLabel('Decision for /employer/title', { exact: true }).selectOption('use_extracted');
+  await page.getByRole('button', { name: 'Save review decisions', exact: true }).click();
+  await page.getByRole('alert').filter({ hasText: /Confirm replacement/ }).waitFor();
+  await page.getByLabel('I confirm replacing /employer for /employer/title.').check();
+  profile = await document('profile');
+  await cli('profile-patch', ['--source', 'user', '--expected-revision', String(profile.metadata.revision)], { concurrentNote: 'Keep this' });
+  await page.getByRole('button', { name: 'Save review decisions', exact: true }).click();
+  await page.getByRole('button', { name: 'Reapply my decisions', exact: true }).waitFor();
+  assert.equal(await page.getByLabel('Decision for /employer/title', { exact: true }).inputValue(), 'use_extracted');
+  await page.getByRole('button', { name: 'Reapply my decisions', exact: true }).click();
+  assert.equal(await page.getByLabel('I confirm replacing /employer for /employer/title.').isChecked(), false);
+  await page.getByLabel('I confirm replacing /employer for /employer/title.').check();
+  await page.getByRole('button', { name: 'Save review decisions', exact: true }).click();
+  await page.getByText('Review decisions saved.', { exact: true }).waitFor();
+  await page.getByText('This proposal is complete. No further review is needed.', { exact: true }).waitFor();
+  profile = await document('profile');
+  assert.equal(profile.profile.employer.title, 'Engineer');
+  assert.equal(profile.profile.concurrentNote, 'Keep this');
+  assert.equal(profile.metadata.factProvenance['/extractedCity'].source, 'resume');
+  assert.equal(profile.metadata.factProvenance['/employer/title'].source, 'user');
+  assert.equal((await document('resume-extractions')).proposals[result.proposalSummary.id].status, 'completed');
+  await page.setViewportSize({ width: 390, height: 844 });
+  assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1));
+  return { requestCancel: true, cliCompletion: true, replacementConsent: true, conflictReapply: true, provenance: true, narrow: true };
+}

--- a/tests_js/workspace_next_security_support.mjs
+++ b/tests_js/workspace_next_security_support.mjs
@@ -18,8 +18,10 @@ export async function nextSecurity() {
             if (/\.tsx?$/.test(name)) components.set(`apps/companion/components/${name}`,
                 await readFile(join(componentDirectory, name), 'utf8'));
         }
-        const surfaces = JSON.parse(await readFile(join(root,
-            'config/migration/browser-g02-next-surfaces.json'), 'utf8')).surfaces;
+        const catalogs = ['browser-g02-next-surfaces.json', 'browser-native-answers-surfaces.json',
+            'browser-native-extractions-surfaces.json'];
+        const surfaces = (await Promise.all(catalogs.map(async name =>
+            JSON.parse(await readFile(join(root, 'config/migration', name), 'utf8')).surfaces))).flat();
         assert.deepEqual(checkBrowserBindings(discoverNextBrowserExports(components), surfaces), []);
         const example = 'apps/companion/components/example.tsx';
         assert.deepEqual(discoverNextBrowserExports(new Map([[example,


### PR DESCRIPTION
Adds remembered-answer editing/review and resume extraction request/proposal review to the native synthetic workspace. HTTP and CLI share revision, consent and recovery rules; React preserves drafts and requires explicit review before applying extracted facts.

Depends on the managed resume library PR. New synthetic fixtures initialize the required Answer/extraction documents and journals. Existing Stores are not adopted, and live Python/native mixed writers remain unsupported.

Validation includes independent Python contract comparisons, real-disk HTTP/CLI and concurrency checks, SIGKILL recovery, production browser workflows, focused independent review and normal repository commit/push gates. Final commit `1db8ac72fca21cf415a0008e1a131225554e2b33` passed the 27-suite deep and normal push gates, [Validate Plugin](https://github.com/neonwatty/job-apply-plugin/actions/runs/34431131020), and [Release Validation attempt 2](https://github.com/neonwatty/job-apply-plugin/actions/runs/34431133872/attempts/2).

Final review fix: preserve leading Unicode BOMs in encoded answer keys. A GET/PATCH regression proves the intended record is accessed while its unprefixed peer remains unchanged; malformed UTF-8 still fails before Store access.

Release attempt 1 failed in the unchanged legacy task-flow oracle at `first_acquisition`. The independent package job passed on the same commit, and Release passed unchanged on retry. The original log is retained; no product fix or proven timing diagnosis is claimed.
