### PR TITLE
Add native active claims and durable application handoffs

### DIFF
--- a/apps/companion/components/Claims.tsx
+++ b/apps/companion/components/Claims.tsx
@@ -11,14 +11,15 @@ function claimValue(value: unknown): Claim | null {
         expiresAt: String(value.expiresAt), expired: value.expired };
 }
 
-export function Claims({ client, jobs, disabled, changed, activityChanged }: {
+export function Claims({ client, jobs, disabled, changed, activityChanged, navigationChanged }: {
     client: Client; jobs: Job[]; disabled: boolean; changed: () => void;
-    activityChanged: (active: boolean) => void;
+    activityChanged: (active: boolean) => void; navigationChanged: (dirty: boolean) => void;
 }) {
     const [claim, setClaim] = useState<Claim | null>(null);
     const [selected, setSelected] = useState<Job | null>(null);
     const [owner, setOwner] = useState('Companion owner');
     const [busy, setBusy] = useState(false);
+    const [writing, setWriting] = useState(false);
     const [loaded, setLoaded] = useState(false);
     const [error, setError] = useState('');
     const [notice, setNotice] = useState('');
@@ -65,13 +66,14 @@ export function Claims({ client, jobs, disabled, changed, activityChanged }: {
         return () => { alive.current = false; pending.current?.abort(); pending.current = null; credential.current = null; };
     }, [client]);
     useEffect(() => { activityChanged(owned || busy); return () => activityChanged(false); }, [owned, busy, activityChanged]);
+    useEffect(() => { navigationChanged(owned || writing); return () => navigationChanged(false); }, [owned, writing, navigationChanged]);
     async function action(kind: 'select' | 'acquire' | 'recover' | 'heartbeat' | 'handoff') {
         if (pending.current) return;
         const held = credential.current;
         const current = kind === 'heartbeat' || kind === 'handoff' ? held?.job : selected;
         if (!current && kind !== 'recover') return;
         if (kind === 'select' && !confirm(`Select ${String(current!.role || current!.id)} for application work at revision ${current!.revision}?`)) return;
-        const controller = new AbortController(); pending.current = controller; setBusy(true); setError(''); setNotice('');
+        const controller = new AbortController(); pending.current = controller; setBusy(true); setWriting(true); setError(''); setNotice('');
         try {
             const body = kind === 'select' ? { jobId: current!.id, expectedRevision: current!.revision, ownerConfirmed: true }
                 : kind === 'acquire' ? { jobId: current!.id, expectedRevision: current!.revision, ownerLabel: owner }
@@ -106,7 +108,7 @@ export function Claims({ client, jobs, disabled, changed, activityChanged }: {
         } finally {
             if (pending.current === controller) {
                 pending.current = null;
-                if (alive.current) setBusy(false);
+                if (alive.current) { setBusy(false); setWriting(false); }
             }
         }
     }

--- a/apps/companion/components/Claims.tsx
+++ b/apps/companion/components/Claims.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useRef, useState } from 'react';
+import { type Client } from './client';
+import { job as decodeJob, object, type Job } from './contracts';
+
+type Claim = { claimId: string; jobId: string; ownerLabel: string; expiresAt: string; expired: boolean };
+function claimValue(value: unknown): Claim | null {
+    if (value === null) return null;
+    if (!object(value) || !['claimId', 'jobId', 'ownerLabel', 'expiresAt'].every(key => typeof value[key] === 'string')
+        || typeof value.expired !== 'boolean') throw Error('Invalid claim status');
+    return { claimId: String(value.claimId), jobId: String(value.jobId), ownerLabel: String(value.ownerLabel),
+        expiresAt: String(value.expiresAt), expired: value.expired };
+}
+
+export function Claims({ client, jobs, disabled, changed, activityChanged }: {
+    client: Client; jobs: Job[]; disabled: boolean; changed: () => void;
+    activityChanged: (active: boolean) => void;
+}) {
+    const [claim, setClaim] = useState<Claim | null>(null);
+    const [selected, setSelected] = useState<Job | null>(null);
+    const [owner, setOwner] = useState('Companion owner');
+    const [busy, setBusy] = useState(false);
+    const [loaded, setLoaded] = useState(false);
+    const [error, setError] = useState('');
+    const [notice, setNotice] = useState('');
+    const [owned, setOwned] = useState(false);
+    const [heartbeatSeconds, setHeartbeatSeconds] = useState(60);
+    const credential = useRef<{ token: string; job: Job; claimId: string } | null>(null);
+    const alive = useRef(false);
+    const pending = useRef<AbortController | null>(null);
+    async function request(path: string, body: unknown, signal: AbortSignal) {
+        const raw = await client.extractionRequest('/api/claims' + path, body === undefined ? 'GET' : 'POST',
+            body === undefined ? undefined : JSON.stringify(body), signal);
+        const value: unknown = JSON.parse(raw);
+        if (!object(value)) throw Error('Invalid claim response');
+        return value;
+    }
+    function acceptStatus(next: Claim | null) {
+        setClaim(next);
+        if (credential.current && (!next || next.claimId !== credential.current.claimId || next.jobId !== credential.current.job.id)) {
+            credential.current = null;
+            setOwned(false);
+        }
+    }
+    async function refresh() {
+        if (pending.current) return;
+        const controller = new AbortController(); pending.current = controller; setBusy(true);
+        try {
+            const value = await request('', undefined, controller.signal);
+            if (!alive.current || controller.signal.aborted) return;
+            acceptStatus(claimValue(value.claim));
+            if (typeof value.heartbeatSeconds === 'number' && value.heartbeatSeconds >= 1)
+                setHeartbeatSeconds(value.heartbeatSeconds);
+            setLoaded(true); setError('');
+        } catch {
+            if (alive.current && !controller.signal.aborted) setError('Unable to refresh active application status. Try again.');
+        } finally {
+            if (pending.current === controller) {
+                pending.current = null;
+                if (alive.current) setBusy(false);
+            }
+        }
+    }
+    useEffect(() => {
+        alive.current = true; void refresh();
+        return () => { alive.current = false; pending.current?.abort(); pending.current = null; credential.current = null; };
+    }, [client]);
+    useEffect(() => { activityChanged(owned || busy); return () => activityChanged(false); }, [owned, busy, activityChanged]);
+    async function action(kind: 'select' | 'acquire' | 'recover' | 'heartbeat' | 'handoff') {
+        if (pending.current) return;
+        const held = credential.current;
+        const current = kind === 'heartbeat' || kind === 'handoff' ? held?.job : selected;
+        if (!current && kind !== 'recover') return;
+        if (kind === 'select' && !confirm(`Select ${String(current!.role || current!.id)} for application work at revision ${current!.revision}?`)) return;
+        const controller = new AbortController(); pending.current = controller; setBusy(true); setError(''); setNotice('');
+        try {
+            const body = kind === 'select' ? { jobId: current!.id, expectedRevision: current!.revision, ownerConfirmed: true }
+                : kind === 'acquire' ? { jobId: current!.id, expectedRevision: current!.revision, ownerLabel: owner }
+                : kind === 'recover' ? { jobId: claim!.jobId, ownerLabel: owner }
+                : kind === 'heartbeat' ? { jobId: current!.id, token: held!.token }
+                : { jobId: current!.id, token: held!.token, expectedRevision: current!.revision, status: 'needs_info',
+                    session: { status: 'active', attemptRevision: current!.revision,
+                        blockers: [{ type: 'information', code: 'owner-input-required' }] } };
+            const value = await request('/' + kind, body, controller.signal);
+            if (!alive.current || controller.signal.aborted) return;
+            if (kind === 'acquire' || kind === 'recover') {
+                const nextClaim = claimValue(value.claim), nextJob = decodeJob(value.job);
+                if (!nextClaim || typeof value.token !== 'string' || !value.token) throw Error('Invalid acquisition');
+                credential.current = { token: value.token, job: nextJob, claimId: nextClaim.claimId };
+                setClaim(nextClaim); setOwned(true); setSelected(nextJob);
+                setNotice('Application work acquired. You can return it for owner input below.');
+            } else if (kind === 'select') {
+                // Select returns a public job summary. Load the full canonical record before acquisition.
+                const nextJob = await client.job(current!.id, controller.signal);
+                if (!alive.current || controller.signal.aborted) return;
+                setSelected(nextJob);
+                setNotice('Job selected. Acquisition checks readiness again.');
+            } else if (kind === 'heartbeat') {
+                acceptStatus(claimValue(value.claim));
+            } else {
+                credential.current = null; setOwned(false); setClaim(null); setSelected(null);
+                setNotice('Application returned for owner input.');
+            }
+            if (kind !== 'heartbeat') changed();
+        } catch {
+            if (alive.current && !controller.signal.aborted) setError('Action was not confirmed. Refresh status and the selected job before retrying; your job draft is preserved.');
+        } finally {
+            if (pending.current === controller) {
+                pending.current = null;
+                if (alive.current) setBusy(false);
+            }
+        }
+    }
+    useEffect(() => {
+        if (!owned || claim?.expired) return;
+        const timer = setInterval(() => { void action('heartbeat'); }, heartbeatSeconds * 1000);
+        return () => clearInterval(timer);
+    }, [owned, heartbeatSeconds, client, claim?.expired]);
+    async function choose(id: string) {
+        if (pending.current) return;
+        setSelected(jobs.find(item => item.id === id) ?? null); setError(''); setNotice('');
+    }
+    const blocked = disabled || busy || !loaded;
+    return <section aria-label="Active application">
+        <h2>Active application</h2>
+        <p>Only one application can be claimed at a time. Final submission remains yours.</p>
+        <button disabled={busy} onClick={() => void refresh()}>Refresh application status</button>
+        {error && <p role="alert">{error}</p>}
+        {notice && <p role="status">{notice}</p>}
+        {loaded && !claim && <p>No active application claim.</p>}
+        {claim && <p>Claimed job: {claim.jobId}. Owner: {claim.ownerLabel}. {claim.expired ? 'Expired' : 'Lease expires'}: {claim.expiresAt}.</p>}
+        {claim && !owned && !claim.expired && <p>This view does not hold the claim credential. After reload or navigation, wait for expiry, refresh status, and explicitly recover the same job.</p>}
+        {owned && <p>This view renews the claim automatically. Keep it open until you hand off; leaving loses its credential.</p>}
+        <label>Claim owner label<input value={owner} onChange={event => setOwner(event.target.value)} disabled={busy || owned} /></label>
+        {!claim && <>
+            <label>Job for application work<select aria-label="Job for application work" style={{ maxWidth: '100%' }} value={selected?.id ?? ''} disabled={blocked} onChange={event => void choose(event.target.value)}>
+                <option value="">Choose a job…</option>
+                {jobs.map(item => <option key={item.id} value={item.id}>{String(item.role || item.url)} · {item.status} · revision {item.revision}</option>)}
+            </select></label>
+            {selected && <p>Selected revision {selected.revision}. Refresh the jobs list and choose again after a conflict.</p>}
+            <button disabled={blocked || !selected} onClick={() => void action('select')}>Select this job</button>{' '}
+            <button disabled={blocked || selected?.status !== 'ready' || !owner.trim()} onClick={() => void action('acquire')}>Acquire application work</button>
+        </>}
+        {claim?.expired && <button disabled={blocked || !owner.trim()} onClick={() => void action('recover')}>Recover expired application</button>}
+        {owned && !claim?.expired && <button disabled={blocked} onClick={() => void action('handoff')}>Return for owner input</button>}
+    </section>;
+}

--- a/apps/companion/components/Companion.tsx
+++ b/apps/companion/components/Companion.tsx
@@ -111,7 +111,7 @@ export default function Companion() {
         </section>:boot?.status==='ready'&&client? (tab==='overview'? <Overview
             client={client}
             openJobs={() => navigate('jobs')}
-            legacyHref={legacyHref} />:tab==='facts'?<Facts client={client} dirtyChanged={dirtyChanged}/>:tab==='resumes'?<Resumes client={client} dirtyChanged={dirtyChanged}/>:tab==='extractions'?<Extractions client={client} dirtyChanged={dirtyChanged}/>:tab==='answers'?<Answers client={client} dirtyChanged={dirtyChanged}/>:<Jobs client={client} dirtyChanged={dirtyChanged} />):!error&&<p>Loading workspace…
+            legacyHref={legacyHref} />:tab==='facts'?<Facts client={client} dirtyChanged={dirtyChanged}/>:tab==='resumes'?<Resumes client={client} dirtyChanged={dirtyChanged}/>:tab==='extractions'?<Extractions client={client} dirtyChanged={dirtyChanged}/>:tab==='answers'?<Answers client={client} dirtyChanged={dirtyChanged}/>:<Jobs client={client} dirtyChanged={dirtyChanged} claimsEnabled={nativeFixture} />):!error&&<p>Loading workspace…
             </p>}
     </main>;
 }

--- a/apps/companion/components/Jobs.tsx
+++ b/apps/companion/components/Jobs.tsx
@@ -15,6 +15,7 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false }: {
     const [editor, setEditor] = useState<Editor | null>(null);
     const [busy, setBusy] = useState(false);
     const [claimsActive, setClaimsActive] = useState(false);
+    const [claimsDirty, setClaimsDirty] = useState(false);
     const [loading, setLoading] = useState(true);
     const [loadError, setLoadError] = useState('');
     const [error, setError] = useState('');
@@ -61,9 +62,9 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false }: {
         };
     }, [client]);
     useEffect(() => {
-        dirtyChanged(Boolean(editor?.dirty.size) || busy || claimsActive);
+        dirtyChanged(Boolean(editor?.dirty.size) || busy || claimsDirty);
         return () => dirtyChanged(false);
-    }, [editor, busy, claimsActive, dirtyChanged]);
+    }, [editor, busy, claimsDirty, dirtyChanged]);
 
     function open(job: Job | null) {
         if (mutation.current || claimsActive) return;
@@ -167,7 +168,7 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false }: {
             ? <p>No jobs match these filters. <button onClick={() => { setQuery(''); setStatus(''); }}>Clear filters</button></p>
             : <p>No jobs yet. Capture a job to get started.</p>)}
         {claimsEnabled && <Claims client={client} jobs={allJobs} disabled={busy || loading || Boolean(editor?.dirty.size)}
-            activityChanged={setClaimsActive} changed={() => { void refresh(); }} />}
+            activityChanged={setClaimsActive} navigationChanged={setClaimsDirty} changed={() => { void refresh(); }} />}
         {editor && <JobEditor editor={editor} resumes={data?.resumes ?? []} busy={busy || claimsActive} error={error}
             change={(fields: Partial<JobFields>) => setEditor(current => current ? edit(current, fields) : current)}
             close={close} save={() => void save()}

--- a/apps/companion/components/Jobs.tsx
+++ b/apps/companion/components/Jobs.tsx
@@ -4,14 +4,17 @@ import { ApiError, type Client } from './client';
 import type { Job, JobFields, WorkspaceState } from './contracts';
 import { edit, observe, openEditor, reapply, type Editor } from './job-editor-state';
 import { JobEditor } from './JobEditor';
+import { Claims } from './Claims';
 
-export function Jobs({ client, dirtyChanged }: {
+export function Jobs({ client, dirtyChanged, claimsEnabled = false }: {
     client: Client;
+    claimsEnabled?: boolean;
     dirtyChanged: (dirty: boolean) => void;
 }) {
     const [data, setData] = useState<WorkspaceState | null>(null);
     const [editor, setEditor] = useState<Editor | null>(null);
     const [busy, setBusy] = useState(false);
+    const [claimsActive, setClaimsActive] = useState(false);
     const [loading, setLoading] = useState(true);
     const [loadError, setLoadError] = useState('');
     const [error, setError] = useState('');
@@ -58,12 +61,13 @@ export function Jobs({ client, dirtyChanged }: {
         };
     }, [client]);
     useEffect(() => {
-        dirtyChanged(Boolean(editor?.dirty.size) || busy);
+        dirtyChanged(Boolean(editor?.dirty.size) || busy || claimsActive);
         return () => dirtyChanged(false);
-    }, [editor, busy, dirtyChanged]);
+    }, [editor, busy, claimsActive, dirtyChanged]);
 
     function open(job: Job | null) {
-        if (mutation.current) return;
+        if (mutation.current || claimsActive) return;
+        if (editor?.dirty.size && !confirm('Discard unsaved job changes?')) return;
         generation.current++;
         setError('');
         setNotice('');
@@ -162,7 +166,9 @@ export function Jobs({ client, dirtyChanged }: {
         {data && !loading && !loadError && !jobs.length && (allJobs.length
             ? <p>No jobs match these filters. <button onClick={() => { setQuery(''); setStatus(''); }}>Clear filters</button></p>
             : <p>No jobs yet. Capture a job to get started.</p>)}
-        {editor && <JobEditor editor={editor} resumes={data?.resumes ?? []} busy={busy} error={error}
+        {claimsEnabled && <Claims client={client} jobs={allJobs} disabled={busy || loading || Boolean(editor?.dirty.size)}
+            activityChanged={setClaimsActive} changed={() => { void refresh(); }} />}
+        {editor && <JobEditor editor={editor} resumes={data?.resumes ?? []} busy={busy || claimsActive} error={error}
             change={(fields: Partial<JobFields>) => setEditor(current => current ? edit(current, fields) : current)}
             close={close} save={() => void save()}
             refresh={() => {

--- a/apps/companion/components/Jobs.tsx
+++ b/apps/companion/components/Jobs.tsx
@@ -140,7 +140,7 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false }: {
             <div><p className="eyebrow">Your pipeline</p><h1>Jobs</h1></div>
             <div>
                 <button disabled={busy} onClick={() => void refresh()}>Refresh</button>{' '}
-                <button className="primary" data-job-create disabled={busy} onClick={() => open(null)}>New job</button>
+                <button className="primary" data-job-create disabled={busy || claimsActive} onClick={() => open(null)}>New job</button>
             </div>
         </header>
         <p role="status">{loading ? (data ? 'Refreshing jobs…' : 'Loading jobs…') : notice}</p>
@@ -157,7 +157,7 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false }: {
             </select></label>
         </div>
         <div className="job-list">
-            {jobs.map(job => <button className="job-card" key={job.id} onClick={() => open(job)}>
+            {jobs.map(job => <button className="job-card" disabled={busy || claimsActive} key={job.id} onClick={() => open(job)}>
                 <strong>{String(job.role || job.url)}</strong>
                 <span>{String(job.company || '')} · {String(job.location || '')}</span>
                 <small>{job.status.replaceAll('_', ' ')} · revision {job.revision}</small>

--- a/apps/companion/server/routes.ts
+++ b/apps/companion/server/routes.ts
@@ -1,5 +1,13 @@
 // Explicit Companion API allowlist; no caller-selected upstream destinations.
 export const apiRoutes = [
+  ["GET","/api/claims"],
+  ["POST","/api/claims/select"],
+  ["POST","/api/claims/acquire"],
+  ["POST","/api/claims/heartbeat"],
+  ["POST","/api/claims/recover"],
+  ["POST","/api/claims/progress"],
+  ["POST","/api/claims/handoff"],
+
   [
     "GET",
     "/api/account-operation"

--- a/config/migration/browser-native-answers-surfaces.json
+++ b/config/migration/browser-native-answers-surfaces.json
@@ -440,6 +440,28 @@
         "recovery": "unverified",
         "platform": "unverified"
       }
+    },
+    {
+      "id": "browser:apps/companion/components/Claims.tsx:Claims",
+      "kind": "browser",
+      "export": "Claims",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/Claims.tsx"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
     }
   ]
 }

--- a/config/migration/cli-native-claims-surfaces.json
+++ b/config/migration/cli-native-claims-surfaces.json
@@ -1,0 +1,180 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:task-select",
+      "kind": "cli",
+      "command": "task-select",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-claims.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:job-acquire",
+      "kind": "cli",
+      "command": "job-acquire",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-claims.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:claim-status",
+      "kind": "cli",
+      "command": "claim-status",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-claims.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:claim-heartbeat",
+      "kind": "cli",
+      "command": "claim-heartbeat",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-claims.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:claim-recover",
+      "kind": "cli",
+      "command": "claim-recover",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-claims.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:claim-progress",
+      "kind": "cli",
+      "command": "claim-progress",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-claims.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:claim-handoff",
+      "kind": "cli",
+      "command": "claim-handoff",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-claims.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/http-native-claims-surfaces.json
+++ b/config/migration/http-native-claims-surfaces.json
@@ -1,0 +1,194 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "http:GET:/api/claims",
+      "kind": "http",
+      "method": "GET",
+      "path": "/api/claims",
+      "node": "SESS",
+      "sources": [
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/claims-http.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "http:POST:/api/claims/select",
+      "kind": "http",
+      "method": "POST",
+      "path": "/api/claims/select",
+      "node": "SESS",
+      "sources": [
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/claims-http.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "http:POST:/api/claims/acquire",
+      "kind": "http",
+      "method": "POST",
+      "path": "/api/claims/acquire",
+      "node": "SESS",
+      "sources": [
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/claims-http.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "http:POST:/api/claims/heartbeat",
+      "kind": "http",
+      "method": "POST",
+      "path": "/api/claims/heartbeat",
+      "node": "SESS",
+      "sources": [
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/claims-http.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "http:POST:/api/claims/recover",
+      "kind": "http",
+      "method": "POST",
+      "path": "/api/claims/recover",
+      "node": "SESS",
+      "sources": [
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/claims-http.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "http:POST:/api/claims/progress",
+      "kind": "http",
+      "method": "POST",
+      "path": "/api/claims/progress",
+      "node": "SESS",
+      "sources": [
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/claims-http.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "http:POST:/api/claims/handoff",
+      "kind": "http",
+      "method": "POST",
+      "path": "/api/claims/handoff",
+      "node": "SESS",
+      "sources": [
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/claims-http.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/journal-01-surfaces.json
+++ b/config/migration/journal-01-surfaces.json
@@ -99,7 +99,10 @@
       "value": "acquire",
       "node": "JOUR",
       "sources": [
-        "scripts/job_apply_store/domains/coordinator/persistence.py"
+        "scripts/job_apply_store/domains/coordinator/persistence.py",
+        "src/store/native-claim-journal.ts",
+        "src/store/native-jobs.ts",
+        "src/workspace-core/claims.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -147,7 +150,10 @@
       "value": "recover",
       "node": "JOUR",
       "sources": [
-        "scripts/job_apply_store/domains/coordinator/persistence.py"
+        "scripts/job_apply_store/domains/coordinator/persistence.py",
+        "src/store/native-claim-journal.ts",
+        "src/store/native-jobs.ts",
+        "src/workspace-core/claims.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -171,7 +177,10 @@
       "value": "handoff",
       "node": "JOUR",
       "sources": [
-        "scripts/job_apply_store/domains/coordinator/persistence.py"
+        "scripts/job_apply_store/domains/coordinator/persistence.py",
+        "src/store/native-claim-journal.ts",
+        "src/store/native-jobs.ts",
+        "src/workspace-core/claims.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -251,7 +251,7 @@
     },
     {
       "path": "source-catalog-g02-next.json",
-      "sha256": "5c368e49cd8e75b4fa3bfde3e238be208543f342552ba38de724c66b72d14bf1"
+      "sha256": "821097bba1c91450dd91a5d5062a8b20b734e51e855b0596bb38121802374a24"
     },
     {
       "path": "source-catalog-m01.json",
@@ -279,7 +279,7 @@
     },
     {
       "path": "source-catalog-native-claims.json",
-      "sha256": "2dab7fc38adfff4d4fea18d84314a12b53dd58c6cfec58e4e8fd44167cbe84c1"
+      "sha256": "73d0eb2f6bd8509745ad5771e00663128979acc63ef25525187ab2c11cfc76be"
     },
     {
       "path": "source-catalog-native-extractions.json",

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -39,7 +39,7 @@
     },
     {
       "path": "browser-native-answers-surfaces.json",
-      "sha256": "cc0772c27c2b5cf296d0fb73d243f32b4bfbde961f1a29a37e4b41f541dc79c7"
+      "sha256": "78b0da7541ea8313da77a80f845ce161605f38075490f73dc5bcef3a7fe06e3d"
     },
     {
       "path": "browser-native-extractions-surfaces.json",
@@ -80,6 +80,10 @@
     {
       "path": "cli-native-answers-surfaces.json",
       "sha256": "bbb71b096d75f3cb7f33cf946859f0163b66d431c2b5c5c3597ddd69a9df88c9"
+    },
+    {
+      "path": "cli-native-claims-surfaces.json",
+      "sha256": "09810dd8553247c6a265c27a2c12790313c8b5db5b372723d7e84a31f6dd1b99"
     },
     {
       "path": "cli-native-extractions-surfaces.json",
@@ -130,6 +134,10 @@
       "sha256": "db3834520f0400a2ceb19b0192cdccbe04c8f4aca3a9e950ba51b0093da908d0"
     },
     {
+      "path": "http-native-claims-surfaces.json",
+      "sha256": "3f1f986998a1824d6c8d99a4bef9f9969ad931cec2768cec84a78579defa6d20"
+    },
+    {
       "path": "http-read-detail-surfaces.json",
       "sha256": "dd8d077cbb24c86469471b48c86f2e1fc4e266b63d32a1ddc5fe071c4dad789e"
     },
@@ -167,7 +175,7 @@
     },
     {
       "path": "journal-01-surfaces.json",
-      "sha256": "62143ea52b6c8adbe62c9810f8edaa6f367321d2a4ac4324946772a433bb1741"
+      "sha256": "4035b629e5d5223e9ec9e449012393ee960c0139e10ec7a0043584530715ffa5"
     },
     {
       "path": "journal-02-surfaces.json",
@@ -243,7 +251,7 @@
     },
     {
       "path": "source-catalog-g02-next.json",
-      "sha256": "6d1d673e6b95dc51ce95c7fd89ffda572ea3018b8e7dac0f672722d4580d80ba"
+      "sha256": "48818c2da075ecb5fe3433316fae3ecdc472563909a89458ab737f8500378d2d"
     },
     {
       "path": "source-catalog-m01.json",
@@ -270,6 +278,10 @@
       "sha256": "d53992f00a314edaf8745531ec9f4c3bda984be79663009f46c39e16be3dda42"
     },
     {
+      "path": "source-catalog-native-claims.json",
+      "sha256": "2dab7fc38adfff4d4fea18d84314a12b53dd58c6cfec58e4e8fd44167cbe84c1"
+    },
+    {
       "path": "source-catalog-native-extractions.json",
       "sha256": "0ccd58b8d6e52a0f2818b43e8cd8d16dd39dc1f52898f3a61e42aa2ea77602f7"
     },
@@ -279,11 +291,11 @@
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "11ed40f696ab7f22ad0408ba9088c950ec8361112f9dd5f642a12aa81ac43682"
+      "sha256": "d0653eae3e3a109e5adf7d5ea49f7b5445cd7791cf721397062b607651e62649"
     },
     {
       "path": "source-catalog-native-pending-answers.json",
-      "sha256": "c84db8c21807b6646ce92f8b985094bda927c07ea0423066370ea63cfbfa0179"
+      "sha256": "ee5ef37a557f1275b2a954c5d88ca6bceac66891ecd01d4b3128542f43453719"
     },
     {
       "path": "source-catalog-native-resumes.json",

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -251,7 +251,7 @@
     },
     {
       "path": "source-catalog-g02-next.json",
-      "sha256": "48818c2da075ecb5fe3433316fae3ecdc472563909a89458ab737f8500378d2d"
+      "sha256": "5c368e49cd8e75b4fa3bfde3e238be208543f342552ba38de724c66b72d14bf1"
     },
     {
       "path": "source-catalog-m01.json",

--- a/config/migration/source-catalog-g02-next.json
+++ b/config/migration/source-catalog-g02-next.json
@@ -23,7 +23,7 @@
     },
     {
       "path": "apps/companion/components/Jobs.tsx",
-      "sha256": "ac1038245a2a07b011bac2d4107e17fc456f23d9ae69044cf984dc3c1f4050a7",
+      "sha256": "f8000e675a83ac34542157827fd68120f8d2d9b69b1c8b2bac76655afe660134",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-g02-next.json
+++ b/config/migration/source-catalog-g02-next.json
@@ -23,7 +23,7 @@
     },
     {
       "path": "apps/companion/components/Jobs.tsx",
-      "sha256": "f8000e675a83ac34542157827fd68120f8d2d9b69b1c8b2bac76655afe660134",
+      "sha256": "878a91279d498b798d165060d8af33e65237e6b9df441624b8b447f2e0aa35fb",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-g02-next.json
+++ b/config/migration/source-catalog-g02-next.json
@@ -13,7 +13,7 @@
     },
     {
       "path": "apps/companion/components/Companion.tsx",
-      "sha256": "892a63d53e4a5d455f7cbf0d000f9eba1803fe2d46efcbb008ac51d85fdfb81c",
+      "sha256": "4b724f74163ce3b799c8aecf371b29795d2d6cc9b0a424699f161112cb143f26",
       "classification": "unreviewed"
     },
     {
@@ -23,7 +23,7 @@
     },
     {
       "path": "apps/companion/components/Jobs.tsx",
-      "sha256": "94c5ee26574327f56f21609c973d4fabd6840039215038245d78bfa24e35b5b0",
+      "sha256": "ac1038245a2a07b011bac2d4107e17fc456f23d9ae69044cf984dc3c1f4050a7",
       "classification": "unreviewed"
     },
     {
@@ -103,7 +103,7 @@
     },
     {
       "path": "apps/companion/server/routes.ts",
-      "sha256": "693dd3413975e75b1a7b4d012049d5964a4a990e47f5c778968ebb99cf912a7d",
+      "sha256": "a5b8a3807b9c981db027c5be7a2a37dc8038628c636289553e1e64eb35fb3381",
       "classification": "unreviewed"
     }
   ]

--- a/config/migration/source-catalog-native-claims.json
+++ b/config/migration/source-catalog-native-claims.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "apps/companion/components/Claims.tsx",
+      "sha256": "e90e4a7fecf8b3d1c96d3ffedb81c6dcc4441e5050a1e4eeb7f0005851e2287a",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/cli/native-claims.js",
+      "sha256": "5d4117f694fa82ec850cb47c99fafc3a56770f5abf492646173571be39ece480",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/claim-session-pending.js",
+      "sha256": "4e15261c3a7c3409fb8e6ca40dc0b9c3d53a7b11f5e439d6d437793559206dd1",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/claim-session-readiness.js",
+      "sha256": "28c1eb237316ab5973c5d32f3fbd5e4e2fcae33c8b438b0827fcf9b36827b81d",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/claim-session.js",
+      "sha256": "8256ff9744553af208fe42f3047a9609b1d3271ede20b8b69a6936452d28f4fc",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/claim-time.js",
+      "sha256": "3640ca406a04d2e1b52569dd78a474655fa73250f84488273bdb6b7197135a2f",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/claims.js",
+      "sha256": "024b46b581df51421375f6ab579e443be7b636aa7044978326669d11c140c234",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/store/native-claim-history.js",
+      "sha256": "deeae329578287e30829ddef79119936badc7e6ddab2fba9fd689b09999a2a10",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/store/native-claim-journal.js",
+      "sha256": "6f6158c76d6c03dc2d90b50d72ee8577802d1fcd651a04b1c03bcb003e0021dc",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/claims-http.js",
+      "sha256": "43795b75d117e586dfe5192472a0b91340ce1829be9276ebc0ba12fa2d6b459d",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/claims.js",
+      "sha256": "23f6d734e07f794f727a344065ba17b9d0a07aae828b1a4f5131d7deb9e14800",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-claims.ts",
+      "sha256": "ba9441b0bb68942779f8506b8985a54e73999c7d8ddbe4200a00ba61ab02af93",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/claim-session-pending.ts",
+      "sha256": "5506e45e1c23f90c9ad9ff0bdca39be2e1bf429dd903ef700c7a330508fab75d",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/claim-session-readiness.ts",
+      "sha256": "896e19e01f29e8a2ebb932e7fb0e1c35a3502bbb36a8f8ae1a8852408048ba93",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/claim-session.ts",
+      "sha256": "8b58e628987ce16009165d54f505f79c9ccc32fee0192f960ae5c30d77da3ea7",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/claim-time.ts",
+      "sha256": "c2fa084134be640199da70ade39471cc88abc3724f3456973903c446205b13c2",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/claims.ts",
+      "sha256": "032f6184fb3194f15bc698f27353b9149e7a32fab7dffad633f32bf24ceec7b8",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/store/native-claim-history.ts",
+      "sha256": "fe1b877b48f361cf424c195aab17f5cda5be0d9722a260397eb78efaebb4232a",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/store/native-claim-journal.ts",
+      "sha256": "f174f3f8a16a84111f0bca4ce3b7b6f73e66c9c12f3de3b66c167211ca4b4392",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/claims-http.ts",
+      "sha256": "dad301002abfb44e0acb2a6fe5fc3c2ff0a78ae4ca525c80e2d4ec31eeb34ec1",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/claims.ts",
+      "sha256": "6406a6e80d27e891cccfcd069851c681d6a1dd5868517ecf19c73ee28da693f8",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/config/migration/source-catalog-native-claims.json
+++ b/config/migration/source-catalog-native-claims.json
@@ -3,7 +3,7 @@
   "sources": [
     {
       "path": "apps/companion/components/Claims.tsx",
-      "sha256": "e90e4a7fecf8b3d1c96d3ffedb81c6dcc4441e5050a1e4eeb7f0005851e2287a",
+      "sha256": "55250cd607e692c495889b468ba945b984739c30ddaa73f237d3eac19f2a3e1d",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "ffcd239e1a3875a5aec06aecee7492ce074a353e7e5e1e5476f191f6e25dba6d",
+      "sha256": "2581263768a3c6ddaa3695741022e60644e55b467641bb4dd5b55ee330b8f373",
       "classification": "unreviewed"
     },
     {
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "b7effe376daab5f5a311e05fbda117982befd858a9e1f9e67709bf3dc3361318",
+      "sha256": "236bfd38aa565990c00768622f91843d644c642498093e3d8618727a329d2a9c",
       "classification": "unreviewed"
     },
     {
@@ -43,12 +43,12 @@
     },
     {
       "path": "runtime/workspace-core/jobs-http.js",
-      "sha256": "91717441552f4de2a7e56cc4cf9c5a243f94d0980ca3e2687f6381743e2dfabd",
+      "sha256": "b4fa069710a1ca246fd588a8d1e09026369dac37aa28a8ce4ceecafc42bf7dcf",
       "classification": "unreviewed"
     },
     {
       "path": "runtime/workspace-core/jobs.js",
-      "sha256": "4e92884264ed9ee6e5466bcce9efb1e7746c089af832dfab3be50896f5c8fdb0",
+      "sha256": "b4a35755dc22dbedc554de0c62685f6a4b3c0dc554a1819655c63a35b8a7f951",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "b1043c16d9d68184ffc9af915627bd898975f27cd12183fb3b7ef0b3be50588a",
+      "sha256": "e878b9280a23f361fffbc339722e40abdbc780dc4d69f29e2b1ac74e8b68b14c",
       "classification": "unreviewed"
     },
     {
@@ -83,7 +83,7 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "8341141545fa2a3b8d660d76a2e12a6216384f2cc65e2ad9235f7c59bd8774c7",
+      "sha256": "a59815f1f00d44d48ca965646d2489deb26adef78af7d6bc8f089f3a0a9616c7",
       "classification": "unreviewed"
     },
     {
@@ -93,12 +93,12 @@
     },
     {
       "path": "src/workspace-core/jobs-http.ts",
-      "sha256": "4e26895df0d483c5affa93468fc7e630579925693ccf2b2b94f6cfaf7534312c",
+      "sha256": "c1c629da3b4ffecd5eb418d3a2f3886addb97671673a1065347faca4302cfa85",
       "classification": "unreviewed"
     },
     {
       "path": "src/workspace-core/jobs.ts",
-      "sha256": "db3e520063460c0f855754f0304f15e981b14c1113b1d45d87a2c589e4892f74",
+      "sha256": "035c5ff4d589e9e2a2a0bdaac57c43d48f475420ab84389535bd762b9ab4c593",
       "classification": "unreviewed"
     }
   ]

--- a/config/migration/source-catalog-native-pending-answers.json
+++ b/config/migration/source-catalog-native-pending-answers.json
@@ -43,7 +43,7 @@
     },
     {
       "path": "runtime/workspace-core/pending-answers.js",
-      "sha256": "565ced08c4a7350f30fe81af2449dbac4968066f0f6c8c44be6a4253e9981607",
+      "sha256": "acc340232db1b941681d4037263f1fff3e8e9ad70da24f26de8ba7b6a4f932cf",
       "classification": "unreviewed"
     },
     {
@@ -78,7 +78,7 @@
     },
     {
       "path": "src/workspace-core/pending-answers.ts",
-      "sha256": "ad6913418d2fc324041ddb0e5f0518965b1ce96d1f1e0ddd6bc2567d59d75d4e",
+      "sha256": "41dcf5668b466ce8d24085b1dc287a0ae676570f226b44fa801dc8df948717fb",
       "classification": "unreviewed"
     }
   ]

--- a/docs/native-answers-fixture.md
+++ b/docs/native-answers-fixture.md
@@ -118,15 +118,16 @@ requires a separate confirmation for each proposed merge.
 
 ## Durable merge and approval
 
-Fixture v7 includes private `sessions/*.json`, `applications.jsonl`, `coordinator.json`
+Fixture v8 includes private `sessions/*.json`, `applications.jsonl`, `coordinator.json`
 and `coordinator-journal.json`. New synthetic roots start with an idle coordinator;
-active claims and journal kinds other than `answer_merge` and
-`answer_resolution` are rejected. Existing
+[active claims](native-claims-fixture.md) and their acquisition, recovery and
+handoff journals are supported. Answer merges and pending-answer resolution
+require an idle coordinator. Existing
 fixtures and live Stores are not upgraded or adopted.
 
 `AnswerMergeService` uses `answerMergeTransaction` to hold the shared lock across
 preview validation, revision/collision checks, session projection and journal
-commit. Every domain entry point replays pending merges and resolutions before reading state.
+commit. Every domain entry point replays pending merges, resolutions and claim journals before reading state.
 The journal retains the Python `answer_merge` operation shape. Replay writes
 answers, affected sessions, the idle coordinator, then clears the journal.
 Interrupted replay resumes without increasing the winner revision twice.

--- a/docs/native-claims-fixture.md
+++ b/docs/native-claims-fixture.md
@@ -1,0 +1,55 @@
+# Native active-claim fixture
+
+New v8 synthetic roots support selection, acquisition, public status, heartbeat,
+expired-claim recovery, progress and durable handoff. Follow the setup in
+[native Jobs](native-jobs-fixture.md); existing fixtures and live Stores are not
+adopted or upgraded. The native implementation uses no Python subprocess.
+
+## Companion
+
+In Jobs, confirm selection after the profile and resume preflight succeeds,
+then acquire the ready job. The page keeps its bearer credential in memory and
+heartbeats every 60 seconds. The lease lasts 300 seconds. Public status contains
+no credential or persisted token hash. Reloading loses the credential; wait for
+expiry and explicitly recover the named job. Recovery rotates the credential
+without increasing the job revision. Returning a job for owner input writes a
+session, records history and releases the claim.
+
+## CLI and HTTP
+
+Use `node runtime/cli/native-jobs.js --root ROOT --native-lock ADDON COMMAND`
+with these command arguments:
+
+| Command | Arguments |
+| --- | --- |
+| `task-select` | `--id ID --expected-revision N --owner-confirmed` |
+| `job-acquire` | `--id ID --owner LABEL --expected-revision N` |
+| `claim-status` | none |
+| `claim-heartbeat` | `--id ID --token TOKEN` |
+| `claim-recover` | `--id ID --owner LABEL` |
+| `claim-progress` | `--id ID --token TOKEN --input SESSION_JSON` |
+| `claim-handoff` | `--id ID --token TOKEN --status STATUS --input SESSION_JSON --expected-revision N` |
+
+Only acquisition and recovery return a new bearer token. Session input accepts
+stdin with `--input -`. Progress and handoff use the existing Python-compatible
+session packet contract. Handoff accepts `needs_info` or `awaiting_review`;
+review handoff recomputes readiness against current answers, approvals, attempt
+revision and trusted fixture evidence. It does not submit an application.
+
+The authenticated native HTTP adapter exposes `GET /api/claims` and POST routes
+under `/api/claims/`: `select`, `acquire`, `heartbeat`, `recover`, `progress` and
+`handoff`. They share the CLI service and Store lock. Selection takes
+`ownerConfirmed: true`; writes use `jobId`, applicable `expectedRevision`,
+`ownerLabel`, `token`, `session` and `status` fields.
+
+## Persistence and boundaries
+
+Acquisition, recovery and handoff use the coordinator journal and append durable
+application history. Replay validates identities and event collisions before
+writing documents, repairs an interrupted final history append and avoids duplicate
+events and revision increments. All domain entry points recover pending journals.
+
+Ordinary edits cannot change a claimed job; unrelated jobs remain editable.
+Answer merge and pending-answer resolution require an idle coordinator, including
+when they concern a different job. Complete the handoff first. Reviewed restart,
+broader attention projections and live Store activation remain separate work.

--- a/docs/native-jobs-fixture.md
+++ b/docs/native-jobs-fixture.md
@@ -9,7 +9,8 @@ including URL deduplication, revisions and human/agent provenance. Resume
 selection validates the shared registry. Managed resume import, list, get,
 metadata update, file replacement, legacy adoption, default selection, integrity
 check, content read and resolution are available through the same Store lock.
-Facts/profile operations are also available; see the linked guide below. Other
+Facts/profile operations and [active claims](native-claims-fixture.md) are also
+available. Other
 workflows return `unsupported_native_workflow`; they never fall back to Python.
 
 ## Run against a new synthetic root
@@ -55,7 +56,7 @@ lossless numeric/text codec; browser editing requires safe integer revisions.
 
 Only the initialized fixture inventory is permitted: the readiness marker, Store
 lock, Jobs, profile, fact-groups, answers, resume registry/files and extraction
-documents/journals, private sessions/history and idle coordinator/journal. Resume replacement writes a durable intent before installing bytes;
+documents/journals, private sessions/history and coordinator/journal. Resume replacement writes a durable intent before installing bytes;
 the next locked operation rolls that exact record forward after interruption and
 clears owned staging files. Unknown state, symlinks, hard links, permissive files
 and mismatched recovery identities are rejected. Keep the failed fixture for

--- a/runtime/cli/native-claims.js
+++ b/runtime/cli/native-claims.js
@@ -1,0 +1,39 @@
+import { ClaimsService } from '../workspace-core/claims.js';
+import { object, text, JobsError } from '../contracts/workspace/values.js';
+export const claimCommands = {
+    'task-select': ['--id', '--expected-revision', '--owner-confirmed'],
+    'job-acquire': ['--id', '--owner', '--expected-revision'], 'claim-status': [],
+    'claim-heartbeat': ['--id', '--token'], 'claim-recover': ['--id', '--owner'],
+    'claim-progress': ['--id', '--token', '--input'],
+    'claim-handoff': ['--id', '--token', '--status', '--input', '--expected-revision'],
+};
+export async function runClaimCommand(command, repository, options, payload) {
+    const service = new ClaimsService(repository);
+    const required = (key) => {
+        const value = options.get(key);
+        if (!value)
+            throw new JobsError(`required option: ${key}`);
+        return value;
+    };
+    const revision = () => {
+        const value = required('--expected-revision');
+        if (!/^[+-]?[0-9]+$/.test(value))
+            throw new JobsError('expected revision must be an integer');
+        return BigInt(value);
+    };
+    if (command === 'claim-status')
+        return service.status();
+    const id = required('--id');
+    if (command === 'task-select')
+        return service.select(id, revision(), options.has('--owner-confirmed'));
+    if (command === 'job-acquire')
+        return service.acquire(id, text(required('--owner')), revision());
+    if (command === 'claim-recover')
+        return service.recover(id, text(required('--owner')));
+    const token = text(required('--token'));
+    if (command === 'claim-heartbeat')
+        return service.heartbeat(id, token);
+    if (command === 'claim-progress')
+        return service.progress(id, token, object(await payload(), 'session'));
+    return service.handoff(id, token, required('--status'), object(await payload(), 'session'), revision());
+}

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,3 +1,4 @@
+import { claimCommands, runClaimCommand } from './native-claims.js';
 import { pendingAnswerCommands, runPendingAnswerCommand } from './native-pending-answers.js';
 import { profileCommands, runProfileCommand } from "./native-profile.js";
 import { answerCommands, runAnswerCommand } from "./native-answers.js";
@@ -36,6 +37,7 @@ export async function runJobsCli(args, input) {
         }
     }
     const fields = {
+        ...claimCommands,
         ...pendingAnswerCommands,
         ...profileCommands,
         ...answerCommands,
@@ -73,6 +75,8 @@ export async function runJobsCli(args, input) {
         const limit = ["resume-proposal-create", "resume-extraction-request-complete"].includes(command) ? 2 * 1024 * 1024 : 65536;
         return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
     };
+    if (Object.hasOwn(claimCommands, command))
+        return serialize(await runClaimCommand(command, repository, options, payload));
     if (Object.hasOwn(pendingAnswerCommands, command))
         return serialize(await runPendingAnswerCommand(command, repository, options));
     if (Object.hasOwn(profileCommands, command))

--- a/runtime/contracts/workspace/claim-session-pending.js
+++ b/runtime/contracts/workspace/claim-session-pending.js
@@ -1,0 +1,126 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { answerRevision, fallback } from './answers.js';
+import { rankCandidates } from './answer-match-scoring.js';
+import { canonicalJson } from './canonical-json.js';
+import { casefold } from './casefold.js';
+import { strip } from './job-url.js';
+import { fields, requireCondition as check } from './answer-session-fields.js';
+import { copy, get, object, parse, same, serialize, set, string, text, truth, integer, JobsError } from './values.js';
+const empty = () => object(parse('{}'), 'object');
+const clone = (value) => parse(serialize(value));
+export function claimSessionObject(value, label) {
+    try {
+        return object(value, label);
+    }
+    catch {
+        throw new JobsError(`${label} must be a JSON object`);
+    }
+}
+export function canonicalClaimAnswer(answers, key) {
+    const redirect = get(object(fallback(answers, 'redirects', empty()), 'redirects'), key);
+    return redirect === null ? key : string(get(object(redirect, 'redirect'), 'targetKey'));
+}
+function answerRecord(answers, key) {
+    const identity = string(key);
+    if (!identity)
+        return null;
+    const value = get(object(get(answers, 'answers'), 'answers'), canonicalClaimAnswer(answers, identity));
+    if (value === null)
+        return null;
+    const record = object(value, 'answer');
+    return get(record, 'deletedAt') === null ? record : null;
+}
+function identity(field) {
+    const result = copy(field);
+    for (const name of ['reference', 'matchConfidence', 'matchReasonCodes', 'matchAnswerRevision'])
+        result.delete(text(name));
+    return canonicalJson(result);
+}
+function candidate(answer) {
+    const result = empty();
+    for (const name of ['question', 'state'])
+        set(result, name, get(answer, name));
+    set(result, 'answerKey', get(answer, 'key'));
+    set(result, 'aliases', fallback(answer, 'aliases', []).filter(value => string(value) !== null && Boolean(strip(string(value)))));
+    set(result, 'scope', fallback(answer, 'scope', empty()));
+    set(result, 'fieldClass', fallback(answer, 'fieldClass', text('general')));
+    set(result, 'sensitivity', fallback(answer, 'sensitivity', text('none')));
+    set(result, 'recordStatus', text(get(answer, 'deletedAt') === null ? 'active' : 'deleted'));
+    set(result, 'reviewStatus', fallback(answer, 'reviewStatus', text('accepted')));
+    return set(result, 'valueState', text(get(answer, 'value') !== null ? 'seen' : 'missing'));
+}
+export function buildClaimPending(incoming, existing, ats, answers) {
+    const raw = fallback(incoming, 'pendingFields', []);
+    check(Array.isArray(raw), 'session pendingFields must be a list');
+    const reusable = new Map();
+    for (const value of existing ? fallback(existing, 'pendingFields', []) : []) {
+        const field = object(value, 'pending field'), key = identity(field);
+        reusable.set(key, [...reusable.get(key) ?? [], string(get(field, 'reference'))]);
+    }
+    return raw.map(value => {
+        const field = claimSessionObject(value, 'pending field');
+        check(fields(field, ['question', 'state', 'answerKey', 'sensitive', 'fieldClass', 'scope', 'matchConfidence', 'matchReasonCodes']), 'pending field contains unsupported fields');
+        const result = object(clone(field), 'pending field');
+        const question = string(get(result, 'question'));
+        result.delete(text('question'));
+        if (question !== null && strip(question)) {
+            const normalized = casefold(question.split(/[\u0009-\u000d\u001c-\u0020\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+/u).filter(Boolean).join(' '));
+            set(result, 'questionFingerprint', text(createHash('sha256').update(text(normalized).encodeUtf8()).digest('hex')));
+        }
+        const scope = get(result, 'scope') ?? (string(ats) ? set(empty(), 'ats', ats) : empty());
+        result.delete(text('scope'));
+        let scopeObject;
+        try {
+            scopeObject = object(scope, 'pending field scope');
+        }
+        catch {
+            throw new JobsError('pending field scope must be a JSON object');
+        }
+        if (truth(scopeObject)) {
+            try {
+                set(result, 'scopeFingerprint', text(createHash('sha256').update(canonicalJson(scopeObject)).digest('hex')));
+            }
+            catch {
+                throw new JobsError('pending field scope is invalid');
+            }
+        }
+        result.delete(text('matchConfidence'));
+        result.delete(text('matchReasonCodes'));
+        const answer = answerRecord(answers, get(result, 'answerKey'));
+        if (answer !== null && string(get(answer, 'question')) !== null && strip(string(get(answer, 'question'))) && question !== null && strip(question)) {
+            try {
+                const sensitivity = fallback(answer, 'sensitivity', text('none'));
+                const match = rankCandidates({ question: text(question), scope: scopeObject, fieldClass: fallback(result, 'fieldClass', text('general')),
+                    sensitivity: string(sensitivity) !== 'none' ? sensitivity : text(get(result, 'sensitive') === true || string(get(result, 'state')) === 'sensitive' ? 'high' : 'none'),
+                    candidates: [candidate(answer)], limit: integer(1n) })[0];
+                set(result, 'matchConfidence', get(match, 'confidenceBand'));
+                set(result, 'matchReasonCodes', get(match, 'reasonCodes'));
+            }
+            catch {
+                throw new JobsError('pending field semantic match is invalid');
+            }
+        }
+        else if (answer !== null) {
+            set(result, 'matchConfidence', text('none'));
+            set(result, 'matchReasonCodes', [text('no_semantic_match')]);
+        }
+        if (answer !== null)
+            set(result, 'matchAnswerRevision', integer(answerRevision(answer)));
+        const references = reusable.get(identity(result));
+        return set(result, 'reference', text(references?.shift() ?? `pending_${randomUUID().replaceAll('-', '')}`));
+    });
+}
+export function currentClaimApprovals(existing, pending, answers, attempt) {
+    if (existing === null || !same(get(existing, 'attemptRevision'), attempt))
+        return [];
+    return fallback(existing, 'approvals', []).filter(value => {
+        const approval = object(value, 'approval');
+        const field = pending.find(item => same(get(item, 'reference'), get(approval, 'reference')));
+        const fieldKey = field ? string(get(field, 'answerKey')) : null, approvalKey = string(get(approval, 'answerKey'));
+        if (fieldKey === null || approvalKey === null)
+            return false;
+        const resolved = canonicalClaimAnswer(answers, fieldKey), answer = answerRecord(answers, text(resolved));
+        return resolved === canonicalClaimAnswer(answers, approvalKey) && answer !== null && get(answer, 'deletedAt') === null
+            && same(integer(answerRevision(answer)), get(approval, 'answerRevision'));
+    }).map(clone);
+}

--- a/runtime/contracts/workspace/claim-session-readiness.js
+++ b/runtime/contracts/workspace/claim-session-readiness.js
@@ -1,0 +1,136 @@
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { canonicalJson } from './canonical-json.js';
+import { fields, matches, member, positive, requireCondition as check } from './answer-session-fields.js';
+import { get, object, parse, same, set, string, integer, fromJSON, JobsError } from './values.js';
+const kindByRole = { textbox: 'text', combobox: 'selection', radiogroup: 'selection', checkbox: 'toggle', file: 'upload' };
+const digest = (value) => createHash('sha256').update(canonicalJson(value)).digest('hex');
+function controlsOf(fixture) {
+    const steps = get(fixture, 'steps');
+    check(Array.isArray(steps), 'invalid fixture steps');
+    return steps.flatMap(step => {
+        const controls = get(object(step, 'step'), 'controls');
+        check(Array.isArray(controls), 'invalid fixture controls');
+        return controls.map(item => object(item, 'control'));
+    });
+}
+function validateObservation(observation, fixture, controls) {
+    check(fields(observation, ['schemaVersion', 'platformFamily', 'observationRevision', 'adapterState', 'uploadCapability', 'controls', 'validationErrorControlIds', 'finalControlState'], true), 'invalid observation fields');
+    check(positive(get(observation, 'schemaVersion')) && same(get(observation, 'schemaVersion'), integer(1n)), 'invalid observation version');
+    check(same(get(observation, 'platformFamily'), get(fixture, 'platformFamily')) && positive(get(observation, 'observationRevision')), 'invalid observation identity');
+    check(member(get(observation, 'adapterState'), ['accessible', 'inaccessible']), 'invalid adapter state');
+    check(member(get(observation, 'uploadCapability'), ['available', 'external-runtime-unavailable', 'not-required']), 'invalid upload capability');
+    check(member(get(observation, 'finalControlState'), ['available', 'unavailable', 'inaccessible', 'activated']), 'invalid final state');
+    const raw = get(observation, 'controls');
+    check(Array.isArray(raw), 'invalid controls');
+    const observed = raw.map(item => object(item, 'observed control'));
+    const known = new Map(controls.map(item => [string(get(item, 'id')), item]));
+    const seen = new Set();
+    for (const item of observed) {
+        check(fields(item, ['controlId', 'kind', 'state', 'observationRevision'], true), 'invalid observed control fields');
+        const id = string(get(item, 'controlId'));
+        check(id !== null && known.has(id) && !seen.has(id), 'invalid observed identity');
+        seen.add(id);
+        const kind = kindByRole[string(get(known.get(id), 'role'))];
+        check(kind !== undefined && string(get(item, 'kind')) === kind, 'invalid control kind');
+        check(member(get(item, 'state'), [kind === 'upload' ? 'accepted' : 'complete', 'missing', 'rejected', 'unresolved', 'inaccessible']), 'invalid control state');
+        check(positive(get(item, 'observationRevision')), 'invalid control revision');
+    }
+    const errors = get(observation, 'validationErrorControlIds');
+    check(Array.isArray(errors), 'invalid validation errors');
+    const ids = errors.map(string);
+    check(ids.every(id => id !== null && known.has(id)) && new Set(ids).size === ids.length, 'invalid validation identities');
+    check(ids.every((id, index) => index === 0 || ids[index - 1] < id), 'unsorted validation identities');
+    return observed;
+}
+/** Recompute only from an exact bundled fixture and closed, current observation input. */
+export function recomputeClaimReadiness(raw, attempt, ats) {
+    let packet;
+    try {
+        packet = object(raw, 'readiness input');
+    }
+    catch {
+        throw new JobsError('readiness input must be a JSON object');
+    }
+    check(fields(packet, ['attemptRevision', 'evidenceKind', 'fixture', 'observation', 'expectedObservationRevision', 'formManifest'], true), 'readiness input contains unsupported fields');
+    check(same(get(packet, 'attemptRevision'), attempt), 'readiness input is not bound to the current attempt');
+    check(member(get(packet, 'evidenceKind'), ['agent_attested_current_attempt', 'repository_replay']), 'readiness evidence kind is unsupported');
+    try {
+        const fixture = object(get(packet, 'fixture'), 'readiness fixture');
+        check(matches(get(fixture, 'id'), /^[a-z0-9][a-z0-9-]{0,127}$/u), 'invalid fixture id');
+        const trusted = parse(readFileSync(new URL(`../../../qa/fixtures/${string(get(fixture, 'id'))}/fixture.json`, import.meta.url), 'utf8'));
+        check(canonicalJson(fixture) === canonicalJson(trusted), 'fixture differs from bundled definition');
+        check(!string(ats) || same(get(fixture, 'platformFamily'), ats), 'fixture ATS mismatch');
+        const controls = controlsOf(fixture), required = controls.filter(item => get(item, 'required') === true);
+        check(required.length > 0, 'fixture has no required control');
+        const revision = get(packet, 'expectedObservationRevision');
+        check(positive(revision), 'invalid expected revision');
+        const ids = required.map(item => string(get(item, 'id'))).sort();
+        const fingerprint = `sha256:${digest(fromJSON({ platformFamily: string(get(fixture, 'platformFamily')), requiredControlIds: ids }))}`;
+        const manifest = object(fromJSON({ schemaVersion: 1, platformFamily: string(get(fixture, 'platformFamily')), requiredControlIds: ids, controlSetFingerprint: fingerprint, complete: true }), 'manifest');
+        set(manifest, 'observationRevision', revision);
+        check(same(get(packet, 'formManifest'), manifest), 'form manifest mismatch');
+        const observation = object(get(packet, 'observation'), 'observation');
+        const observed = validateObservation(observation, fixture, controls);
+        const byId = new Map(observed.map(item => [string(get(item, 'controlId')), item]));
+        const missing = required.filter(item => !byId.has(string(get(item, 'id'))));
+        const present = required.flatMap(item => {
+            const value = byId.get(string(get(item, 'id')));
+            return value ? [value] : [];
+        });
+        const stale = present.filter(item => !same(get(item, 'observationRevision'), revision));
+        const incomplete = present.filter(item => string(get(item, 'state')) !== (string(get(item, 'kind')) === 'upload' ? 'accepted' : 'complete'));
+        const requiredUploads = new Set(required.filter(item => string(get(item, 'role')) === 'file').map(item => string(get(item, 'id'))));
+        const missingUpload = missing.some(item => requiredUploads.has(string(get(item, 'id')))) || incomplete.some(item => string(get(item, 'kind')) === 'upload' && string(get(item, 'state')) === 'missing');
+        const assertions = {
+            'observation-current': same(get(observation, 'observationRevision'), revision) && stale.length === 0,
+            'adapter-accessible': string(get(observation, 'adapterState')) === 'accessible',
+            'required-controls-complete': missing.length + stale.length + incomplete.length === 0,
+            'required-uploads-accepted': !missing.some(item => requiredUploads.has(string(get(item, 'id')))) && ![...stale, ...incomplete].some(item => requiredUploads.has(string(get(item, 'controlId')))),
+            'validation-clear': get(observation, 'validationErrorControlIds').length === 0,
+            'final-control-available': string(get(observation, 'finalControlState')) === 'available',
+            'final-action-untouched': string(get(observation, 'finalControlState')) !== 'activated',
+        };
+        const blockers = new Set();
+        if (!assertions['observation-current'])
+            blockers.add('readiness-evidence-stale');
+        if (!assertions['adapter-accessible'])
+            blockers.add('form-observation-inaccessible');
+        if (missing.length)
+            blockers.add('required-control-evidence-missing');
+        if (missingUpload)
+            blockers.add('required-upload-missing');
+        for (const item of incomplete) {
+            const state = string(get(item, 'state')), upload = string(get(item, 'kind')) === 'upload';
+            if (state === 'rejected')
+                blockers.add(upload ? 'required-upload-rejected' : 'required-control-rejected');
+            else if (state === 'unresolved')
+                blockers.add('required-control-unresolved');
+            else if (state === 'inaccessible')
+                blockers.add('required-control-inaccessible');
+            else if (state === 'missing' && !upload)
+                blockers.add('required-control-incomplete');
+        }
+        if (!assertions['validation-clear'])
+            blockers.add('validation-error-present');
+        const final = string(get(observation, 'finalControlState'));
+        if (final === 'activated')
+            blockers.add('final-action-activated');
+        else if (final === 'inaccessible')
+            blockers.add('final-control-inaccessible');
+        else if (final === 'unavailable')
+            blockers.add('final-control-unavailable');
+        const fallback = missingUpload && string(get(observation, 'uploadCapability')) === 'external-runtime-unavailable' ? 'owner-upload-required' : null;
+        if (fallback)
+            blockers.add('external-upload-capability-unavailable');
+        const result = object(fromJSON({ status: Object.values(assertions).every(Boolean) ? 'ready' : 'blocked',
+            assertions: Object.fromEntries(Object.entries(assertions).map(([key, passed]) => [key, passed ? 'passed' : 'failed'])),
+            blockerCodes: [...blockers].sort(), fallbackCode: fallback, controlSetFingerprint: fingerprint, requiredControlCount: ids.length }), 'readiness');
+        set(result, 'attemptRevision', attempt);
+        set(result, 'observationRevision', get(observation, 'observationRevision'));
+        return set(result, 'evidenceKind', get(packet, 'evidenceKind'));
+    }
+    catch {
+        throw new JobsError('readiness evidence is invalid');
+    }
+}

--- a/runtime/contracts/workspace/claim-session.js
+++ b/runtime/contracts/workspace/claim-session.js
@@ -1,0 +1,118 @@
+import { fallback } from './answers.js';
+import { canonicalJson } from './canonical-json.js';
+import { safeAnswerSessionId, validateAnswerSession } from './answer-session-validation.js';
+import { agentCodes, fields, member, requireCondition as check } from './answer-session-fields.js';
+import { buildClaimPending, currentClaimApprovals, claimSessionObject } from './claim-session-pending.js';
+import { recomputeClaimReadiness } from './claim-session-readiness.js';
+import { get, has, object, parse, same, serialize, set, string, text, truth, fromJSON } from './values.js';
+const clone = (value) => parse(serialize(value));
+function blockerType(code) {
+    if (code.includes('upload'))
+        return 'upload';
+    if (code.includes('validation'))
+        return 'validation';
+    if (code.includes('final'))
+        return 'final_action';
+    if (code.includes('inaccessible') || code === 'owner-upload-required')
+        return 'browser_handoff';
+    return 'readiness';
+}
+const agentTypes = Object.fromEntries(agentCodes.map(code => [code, code === 'consent-required' ? 'owner_review' : code === 'owner-input-required' ? 'information' : 'browser_handoff']));
+export function buildClaimSession(applicationId, incoming, context) {
+    check(fields(incoming, ['applicationId', 'status', 'ats', 'company', 'role', 'url', 'step', 'answerKeys', 'pendingFields', 'createdAt', 'updatedAt', 'attemptRevision', 'readinessInput', 'blockers', 'browserHandoff']), 'session contains unsupported fields');
+    safeAnswerSessionId(text(applicationId));
+    check(same(fallback(incoming, 'applicationId', text(applicationId)), text(applicationId)), 'session application id does not match path');
+    const attempt = fallback(incoming, 'attemptRevision', context.attemptRevision);
+    check(context.attemptRevision === null || same(attempt, context.attemptRevision), 'session is not bound to the current attempt');
+    const status = fallback(incoming, 'status', text('active'));
+    check(member(status, ['active', 'review', 'completed', 'abandoned']), 'session status is unsupported');
+    const answerKeys = fallback(incoming, 'answerKeys', []);
+    check(Array.isArray(answerKeys) && answerKeys.every(item => string(item) !== null), 'session answerKeys must be strings');
+    const existing = context.existing;
+    if (existing) {
+        validateAnswerSession(existing);
+        check(string(get(existing, 'applicationId')) === applicationId, 'session application id does not match path');
+    }
+    const pending = buildClaimPending(incoming, existing, context.ats, context.answers);
+    let readiness = null;
+    if (has(incoming, 'readinessInput')) {
+        check(attempt !== null, 'readiness requires a current attempt revision');
+        readiness = recomputeClaimReadiness(get(incoming, 'readinessInput'), attempt, context.ats);
+    }
+    else if (existing !== null && same(get(existing, 'attemptRevision'), attempt))
+        readiness = clone(get(existing, 'readiness'));
+    const blockers = pending.map(field => {
+        const sensitive = get(field, 'sensitive') === true || string(get(field, 'state')) === 'sensitive';
+        const result = object(fromJSON({ type: 'information', code: sensitive ? 'sensitive-answer-required' : 'answer-required', sensitivity: sensitive ? 'high' : 'none' }), 'blocker');
+        set(result, 'reference', get(field, 'reference'));
+        if (has(field, 'fieldClass'))
+            set(result, 'fieldClass', get(field, 'fieldClass'));
+        return result;
+    });
+    if (readiness !== null) {
+        const report = object(readiness, 'readiness');
+        for (const code of get(report, 'blockerCodes'))
+            blockers.push(object(fromJSON({ type: blockerType(string(code)), code: string(code) }), 'blocker'));
+        if (get(report, 'fallbackCode') !== null)
+            blockers.push(object(fromJSON({ type: 'browser_handoff', code: string(get(report, 'fallbackCode')) }), 'blocker'));
+    }
+    const supplied = fallback(incoming, 'blockers', []);
+    check(Array.isArray(supplied), 'session blockers must be a list');
+    for (const item of supplied) {
+        const blocker = claimSessionObject(item, 'session blocker');
+        check(fields(blocker, ['type', 'code'], true), 'agent blockers must contain only closed type and code');
+        const code = string(get(blocker, 'code'));
+        check(code !== null && Object.hasOwn(agentTypes, code) && string(get(blocker, 'type')) === agentTypes[code], 'session blocker is invalid');
+        blockers.push(object(clone(blocker), 'blocker'));
+    }
+    const unique = [...new Map(blockers.map(item => [canonicalJson(item), item])).values()];
+    const browserReasons = [...agentCodes, 'none', 'owner-upload-required', 'final-review-required', 'form-observation-inaccessible', 'required-control-inaccessible'];
+    const browserBlockers = unique.filter(item => string(get(item, 'type')) === 'browser_handoff' && browserReasons.includes(string(get(item, 'code'))));
+    let handoff = get(incoming, 'browserHandoff');
+    if (handoff === null) {
+        const fallbackCode = readiness === null ? null : get(object(readiness, 'readiness'), 'fallbackCode');
+        const reason = fallbackCode !== null ? string(fallbackCode) : browserBlockers.length ? string(get(browserBlockers[0], 'code')) : null;
+        handoff = fromJSON({ state: reason !== null ? 'required' : string(status) === 'review' ? 'ready_for_owner' : 'not_required',
+            reasonCode: reason ?? (string(status) === 'review' ? 'final-review-required' : 'none'), revision: 1 });
+    }
+    else {
+        handoff = clone(handoff);
+        check(fields(claimSessionObject(handoff, 'browser handoff'), ['state', 'reasonCode', 'revision'], true), 'browser handoff contains unsupported fields');
+    }
+    check(browserBlockers.length === 0 || string(get(object(handoff, 'browser handoff'), 'state')) === 'required', 'browser handoff contradicts browser blockers');
+    let created = get(incoming, 'createdAt');
+    if (!truth(created) && existing)
+        created = get(existing, 'createdAt');
+    const session = object(fromJSON({ schemaVersion: 1, applicationId, createdAt: context.now, updatedAt: context.now }), 'session');
+    for (const name of ['status', 'step'])
+        if (has(incoming, name))
+            set(session, name, clone(get(incoming, name)));
+    set(session, 'ats', clone(context.ats));
+    set(session, 'status', status);
+    set(session, 'answerKeys', clone(answerKeys));
+    set(session, 'pendingFields', pending);
+    set(session, 'attemptRevision', attempt);
+    set(session, 'readiness', readiness);
+    set(session, 'blockers', unique);
+    set(session, 'browserHandoff', handoff);
+    set(session, 'approvals', currentClaimApprovals(existing, pending, context.answers, attempt));
+    if (truth(created))
+        set(session, 'createdAt', created);
+    return validateAnswerSession(session);
+}
+export function validateClaimHandoff(session, incoming, target, attemptRevision) {
+    check(['needs_info', 'awaiting_review'].includes(target), 'claimed handoff status is unsupported');
+    check(string(get(session, 'status')) === (target === 'needs_info' ? 'active' : 'review'), 'handoff session status does not match job status');
+    if (target !== 'awaiting_review')
+        return;
+    check(has(incoming, 'readinessInput'), 'awaiting_review requires fresh current live readiness input');
+    const readiness = get(session, 'readiness');
+    const complete = readiness !== null && (() => {
+        const report = object(readiness, 'readiness');
+        return same(get(report, 'attemptRevision'), attemptRevision) && string(get(report, 'evidenceKind')) === 'agent_attested_current_attempt'
+            && string(get(report, 'status')) === 'ready' && !truth(get(report, 'blockerCodes'))
+            && object(get(report, 'assertions'), 'assertions').entries().every(([, value]) => string(value) === 'passed');
+    })();
+    check(complete && !truth(get(session, 'pendingFields')) && !truth(get(session, 'blockers'))
+        && same(get(session, 'browserHandoff'), fromJSON({ state: 'ready_for_owner', reasonCode: 'final-review-required', revision: 1 })), 'awaiting_review requires complete current agent-attested readiness');
+}

--- a/runtime/contracts/workspace/claim-time.js
+++ b/runtime/contracts/workspace/claim-time.js
@@ -1,0 +1,71 @@
+import { JobsError } from './values.js';
+function invalid() { throw new JobsError('coordinator timestamp is invalid'); }
+function overflow() {
+    const error = new RangeError('date value out of range');
+    error.name = 'OverflowError';
+    throw error;
+}
+const dayMicros = 86400000000n;
+function midnight(year, month, day) {
+    const date = new Date(0);
+    date.setUTCFullYear(year, month - 1, day);
+    date.setUTCHours(0, 0, 0, 0);
+    if (year < 1 || year > 9999 || date.getUTCFullYear() !== year
+        || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day)
+        invalid();
+    return BigInt(date.getTime()) * 1000n;
+}
+function clock(value, offset) {
+    const match = /^(\d{2})(?:(:?)(\d{2})(?:\2(\d{2}))?)?(?:[.,](\d+))?$/.exec(value);
+    if (!match)
+        invalid();
+    const hour = Number(match[1]), minute = Number(match[3] ?? 0), second = Number(match[4] ?? 0);
+    if (!offset && (hour > 23 || minute > 59 || second > 59))
+        invalid();
+    const integral = BigInt(hour * 3600 + minute * 60 + second) * 1000000n;
+    // CPython treats any all-zero integral UTC offset as UTC, ignoring fractions.
+    if (offset && integral === 0n)
+        return 0n;
+    return integral + BigInt((match[5] ?? '').slice(0, 6).padEnd(6, '0'));
+}
+/** Python's aware ISO calendar/week dates, offsets and truncated microseconds. */
+export function claimTime(value) {
+    const input = value.replaceAll('Z', '+00:00');
+    const date = /^(\d{4})(?:(-?)(\d{2})\2(\d{2})|(-?)W(\d{2})(?:\5([1-7]))?)/.exec(input);
+    if (!date)
+        invalid();
+    const year = Number(date[1]);
+    let epoch;
+    if (date[3])
+        epoch = midnight(year, Number(date[3]), Number(date[4]));
+    else {
+        const week = Number(date[6]), day = Number(date[7] ?? 1);
+        const jan4 = midnight(year, 1, 4);
+        const weekday = (new Date(Number(jan4 / 1000n)).getUTCDay() + 6) % 7;
+        epoch = jan4 + BigInt((week - 1) * 7 + day - 1 - weekday) * dayMicros;
+        const thursday = new Date(Number((epoch + BigInt(4 - day) * dayMicros) / 1000n));
+        if (week < 1 || week > 53 || thursday.getUTCFullYear() !== year)
+            invalid();
+    }
+    const suffix = input.slice(date[0].length);
+    if (!suffix)
+        invalid();
+    const rest = Array.from(suffix).slice(1).join('');
+    const zone = /([+-])([^+-]+)$/.exec(rest);
+    if (!zone)
+        invalid();
+    const local = clock(rest.slice(0, zone.index), false);
+    const offset = clock(zone[2], true);
+    if (offset >= dayMicros)
+        invalid();
+    const result = epoch + local - (zone[1] === '-' ? -offset : offset);
+    if (result < midnight(1, 1, 1) || result >= midnight(9999, 12, 31) + dayMicros)
+        overflow();
+    return result;
+}
+export function claimTimeString(micros) {
+    if (micros < midnight(1, 1, 1) || micros >= midnight(9999, 12, 31) + dayMicros)
+        overflow();
+    const milliseconds = micros >= 0n ? micros / 1000n : (micros - 999n) / 1000n;
+    return new Date(Number(milliseconds)).toISOString().replace(/\.\d{3}Z$/, 'Z');
+}

--- a/runtime/contracts/workspace/claims.js
+++ b/runtime/contracts/workspace/claims.js
@@ -1,0 +1,102 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
+import { PythonObject } from '../python-object.js';
+import { PythonText } from '../python-text.js';
+import { safeAnswerSessionId } from './answer-session-validation.js';
+import { strip } from './job-url.js';
+import { claimTime, claimTimeString } from './claim-time.js';
+import { copy, fromJSON, get, has, int, keys, object, set, string, text, JobsError } from './values.js';
+export const claimLeaseSeconds = 300;
+export const claimHeartbeatSeconds = 60;
+export function validateCoordinator(value) {
+    if (!(value instanceof PythonObject))
+        throw new JobsError('coordinator must be a JSON object');
+    const document = value;
+    const version = int(get(document, 'schemaVersion'));
+    if (version === null)
+        throw new JobsError('coordinator has no valid schemaVersion');
+    if (version > 1n)
+        throw new JobsError(`coordinator uses unsupported future schemaVersion ${version}`);
+    if (version !== 1n)
+        throw new JobsError(`coordinator uses unsupported schemaVersion ${version}`);
+    if (document.size !== 2 || !has(document, 'claim'))
+        throw new JobsError('coordinator contains unsupported fields');
+    if (get(document, 'claim') !== null)
+        validateClaim(get(document, 'claim'));
+    return document;
+}
+export function validateClaim(value) {
+    if (!(value instanceof PythonObject))
+        throw new JobsError('coordinator claim must be a JSON object');
+    const claim = value;
+    const required = ['claimId', 'jobId', 'ownerLabel', 'tokenHash', 'acquiredAt', 'heartbeatAt', 'expiresAt'];
+    if (claim.size !== required.length || keys(claim).some(key => !required.includes(key))
+        || required.some(key => !string(get(claim, key))))
+        throw new JobsError('coordinator claim is invalid');
+    safeAnswerSessionId(get(claim, 'jobId'));
+    for (const key of ['acquiredAt', 'heartbeatAt', 'expiresAt'])
+        claimTime(string(get(claim, key)));
+    return claim;
+}
+export function claimExpired(claim, now) {
+    return claimTime(now) >= claimTime(string(get(claim, 'expiresAt')));
+}
+export function publicClaim(value, now) {
+    if (value === null)
+        return null;
+    const result = copy(object(value, 'coordinator claim'));
+    result.delete(text('tokenHash'));
+    return set(result, 'expired', claimExpired(object(value, 'coordinator claim'), now));
+}
+export function claimTokenHash(token) {
+    if (!(token instanceof PythonText) || !token.length)
+        throw new JobsError('claim token is required');
+    return createHash('sha256').update(token.encodeUtf8()).digest('hex');
+}
+export function makeClaim(jobId, ownerLabel, now) {
+    safeAnswerSessionId(text(jobId));
+    const label = string(ownerLabel);
+    if (label === null || !strip(label))
+        throw new JobsError('owner label must be a non-empty string');
+    const instant = claimTime(now), at = claimTimeString(instant);
+    const token = `claim_${randomBytes(32).toString('base64url')}`;
+    const claim = object(fromJSON({ claimId: randomUUID(), jobId, ownerLabel: strip(label), tokenHash: claimTokenHash(text(token)),
+        acquiredAt: at, heartbeatAt: at, expiresAt: claimTimeString(instant + BigInt(claimLeaseSeconds) * 1000000n) }), 'claim');
+    const points = ownerLabel.codePoints;
+    let start = 0, end = points.length;
+    while (start < end && !strip(String.fromCodePoint(points[start])))
+        start++;
+    while (end > start && !strip(String.fromCodePoint(points[end - 1])))
+        end--;
+    set(claim, 'ownerLabel', PythonText.fromCodePoints(points.slice(start, end)));
+    return { claim, token };
+}
+export function requireClaim(coordinator, jobs, jobId, token, now, allowExpired = false) {
+    const value = get(coordinator, 'claim');
+    if (value === null || string(get(object(value, 'claim'), 'jobId')) !== jobId)
+        throw new JobsError('job is not held by this claim');
+    const claim = object(value, 'claim'), expected = string(get(claim, 'tokenHash'));
+    const supplied = claimTokenHash(token);
+    // Hash comparison remains constant-time for normal, fixed-length hash records.
+    if (!/^[\x00-\x7f]*$/.test(expected))
+        throw new TypeError('comparing strings with non-ASCII characters is not supported');
+    const left = Buffer.from(expected), right = Buffer.from(supplied);
+    if (left.length !== right.length || !timingSafeEqual(left, right))
+        throw new JobsError('claim token is invalid');
+    const rawJob = get(object(get(jobs, 'jobs'), 'jobs'), jobId);
+    if (rawJob === null || get(object(rawJob, 'job'), 'deletedAt') !== null
+        || string(get(object(rawJob, 'job'), 'status')) !== 'in_progress')
+        throw new JobsError('claimed job is not in progress');
+    if (!allowExpired && claimExpired(claim, now))
+        throw new JobsError('claim has expired; use explicit recovery');
+    return claim;
+}
+export function requireJobUnclaimed(coordinator, jobId) {
+    const value = get(coordinator, 'claim');
+    if (value !== null && string(get(object(value, 'claim'), 'jobId')) === jobId)
+        throw new JobsError('claimed job requires a coordinator operation');
+}
+export function heartbeatClaim(claim, now) {
+    const instant = claimTime(now), result = copy(claim);
+    set(result, 'heartbeatAt', text(claimTimeString(instant)));
+    return set(result, 'expiresAt', text(claimTimeString(instant + BigInt(claimLeaseSeconds) * 1000000n)));
+}

--- a/runtime/store/native-claim-history.js
+++ b/runtime/store/native-claim-history.js
@@ -1,0 +1,92 @@
+import { constants } from 'node:fs';
+import { open } from 'node:fs/promises';
+import { join } from 'node:path';
+import { parsePythonPointJsonBytes } from '../contracts/raw-json/point-parser.js';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { validateAnswerHistory } from '../contracts/workspace/answer-session-validation.js';
+import { get, string, JobsError } from '../contracts/workspace/values.js';
+import { strip } from '../contracts/workspace/job-url.js';
+import { encodePointJsonlJson } from './point-persistence.js';
+/** Caller holds the Store lock. Descriptor checks also apply during recovery. */
+export class NativeClaimHistory {
+    root;
+    constructor(root) {
+        this.root = root;
+    }
+    async handle(writable) {
+        const handle = await open(join(this.root, 'applications.jsonl'), (writable ? constants.O_RDWR : constants.O_RDONLY) | constants.O_NOFOLLOW);
+        try {
+            const stat = await handle.stat();
+            if (!stat.isFile() || stat.nlink !== 1 || (stat.mode & 0o077) !== 0 || stat.uid !== process.getuid?.()) {
+                throw new JobsError('native history must be private and owned, without links');
+            }
+            if (stat.size > 32 * 1024 * 1024)
+                throw new JobsError('native history exceeds supported size');
+            return handle;
+        }
+        catch (error) {
+            await handle.close();
+            throw error;
+        }
+    }
+    async read() {
+        const handle = await this.handle(false);
+        try {
+            const content = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(await handle.readFile());
+            return content.split('\n').filter(line => strip(line)).map(line => validateAnswerHistory(parsePythonPointJsonBytes(Buffer.from(line), { diagnosticProfile: '3.12', intMaxStrDigits: 4300 })));
+        }
+        finally {
+            await handle.close();
+        }
+    }
+    async repairPendingTail() {
+        const handle = await this.handle(true);
+        try {
+            const content = await handle.readFile();
+            if (!content.length || content.at(-1) === 10)
+                return;
+            await handle.truncate(content.lastIndexOf(10) + 1);
+            await handle.sync();
+        }
+        finally {
+            await handle.close();
+        }
+    }
+    async isIdempotent(event) {
+        validateAnswerHistory(event);
+        const matching = (await this.read()).filter(item => string(get(item, 'eventId')) === string(get(event, 'eventId')));
+        if (!matching.length)
+            return false;
+        const expected = canonicalJson(event);
+        if (matching.every(item => canonicalJson(item) === expected))
+            return true;
+        throw new JobsError('history event id collision');
+    }
+    async append(event) {
+        if (await this.isIdempotent(event))
+            return;
+        const encoded = encodePointJsonlJson(event, { pathProfile: '3.12', intMaxStrDigits: 4300 });
+        const handle = await this.handle(true);
+        try {
+            const original = (await handle.stat()).size;
+            try {
+                let offset = 0;
+                while (offset < encoded.length) {
+                    const { bytesWritten } = await handle.write(encoded, offset, encoded.length - offset, original + offset);
+                    if (bytesWritten <= 0)
+                        throw new JobsError('history append was incomplete');
+                    offset += bytesWritten;
+                }
+                await handle.sync();
+            }
+            catch (error) {
+                await handle.truncate(original);
+                await handle.sync();
+                throw error;
+            }
+        }
+        finally {
+            await handle.close();
+        }
+    }
+}

--- a/runtime/store/native-claim-journal.js
+++ b/runtime/store/native-claim-journal.js
@@ -1,0 +1,99 @@
+import { validateCoordinator } from '../contracts/workspace/claims.js';
+import { validateAnswerHistory, validateAnswerSession } from '../contracts/workspace/answer-session-validation.js';
+import { validateJobsDocument, safeId } from '../contracts/workspace/jobs.js';
+import { fromJSON, get, has, int, integer, keys, object, parse, serialize, set, string, JobsError } from '../contracts/workspace/values.js';
+import { NativeClaimHistory } from './native-claim-history.js';
+export const claimOperationKinds = new Set(['acquire', 'recover', 'handoff']);
+export function validateClaimJournal(journal) {
+    if (journal.size !== 2 || int(get(journal, 'schemaVersion')) !== 1n || !has(journal, 'operation'))
+        throw new JobsError('invalid coordinator journal');
+    const operation = object(get(journal, 'operation'), 'coordinator journal operation');
+    const kind = string(get(operation, 'kind'));
+    const fields = ['kind', 'operationId', 'jobId', 'at', 'historyEvent', 'resultClaim',
+        ...(kind === 'recover' ? [] : ['sourceStatus', 'targetStatus', 'expectedRevision']), ...(kind === 'handoff' ? ['session'] : [])];
+    if (!claimOperationKinds.has(kind) || operation.size !== fields.length || keys(operation).some(key => !fields.includes(key)))
+        throw new JobsError('coordinator journal operation is invalid');
+    const id = safeId(string(get(operation, 'jobId')));
+    if (!string(get(operation, 'operationId')) || !string(get(operation, 'at')))
+        throw new JobsError('coordinator journal operation is invalid');
+    const event = validateAnswerHistory(get(operation, 'historyEvent'));
+    if (string(get(event, 'applicationId')) !== id)
+        throw new JobsError('coordinator history identity does not match');
+    if (kind !== 'recover' && (int(get(operation, 'expectedRevision')) === null || int(get(operation, 'expectedRevision')) < 1n))
+        throw new JobsError('coordinator journal revision is invalid');
+    if (kind === 'acquire' && (string(get(operation, 'sourceStatus')) !== 'ready' || string(get(operation, 'targetStatus')) !== 'in_progress'))
+        throw new JobsError('coordinator acquisition transition is invalid');
+    if (kind === 'handoff') {
+        if (string(get(operation, 'sourceStatus')) !== 'in_progress' || !['needs_info', 'awaiting_review'].includes(string(get(operation, 'targetStatus'))))
+            throw new JobsError('coordinator handoff transition is invalid');
+        if (string(get(validateAnswerSession(get(operation, 'session')), 'applicationId')) !== id)
+            throw new JobsError('coordinator session identity does not match');
+        if (get(operation, 'resultClaim') !== null)
+            throw new JobsError('coordinator handoff must release its claim');
+    }
+    else {
+        const coordinator = object(fromJSON({ schemaVersion: 1, claim: null }), 'coordinator');
+        set(coordinator, 'claim', get(operation, 'resultClaim'));
+        validateCoordinator(coordinator);
+        if (get(coordinator, 'claim') === null || string(get(object(get(coordinator, 'claim'), 'claim'), 'jobId')) !== id)
+            throw new JobsError('coordinator claim identity does not match');
+    }
+    return operation;
+}
+function project(operation, jobs) {
+    if (!has(operation, 'targetStatus'))
+        return null;
+    const next = validateJobsDocument(object(parse(serialize(jobs)), 'jobs'));
+    const id = string(get(operation, 'jobId')), current = get(object(get(next, 'jobs'), 'jobs'), id);
+    if (current === null || get(object(current, 'job'), 'deletedAt') !== null)
+        throw new JobsError('coordinator journal references a missing job');
+    const job = object(current, 'job'), expected = int(get(operation, 'expectedRevision'));
+    if (int(get(job, 'revision')) === expected) {
+        if (string(get(job, 'status')) !== string(get(operation, 'sourceStatus')))
+            throw new JobsError('coordinator journal source status drifted');
+        set(job, 'status', get(operation, 'targetStatus'));
+        set(job, 'closedOutcome', null);
+        set(job, 'revision', integer(expected + 1n));
+        set(job, 'updatedAt', get(operation, 'at'));
+        set(object(get(next, 'metadata'), 'jobs.metadata'), 'updatedAt', get(operation, 'at'));
+        return validateJobsDocument(next);
+    }
+    if (int(get(job, 'revision')) !== expected + 1n || string(get(job, 'status')) !== string(get(operation, 'targetStatus')))
+        throw new JobsError('coordinator journal cannot be reconciled');
+    return null;
+}
+export class NativeClaimJournal {
+    write;
+    history;
+    checkpoint;
+    constructor(write, history, checkpoint = async () => { }) {
+        this.write = write;
+        this.history = history;
+        this.checkpoint = checkpoint;
+    }
+    async recover(journal, jobs) {
+        const operation = validateClaimJournal(journal), next = project(operation, jobs);
+        const event = object(get(operation, 'historyEvent'), 'history event');
+        // Validate every destination and collision before the first document write.
+        await this.history.isIdempotent(event);
+        if (next)
+            await this.write('jobs', next);
+        if (has(operation, 'session'))
+            await this.write(`sessions/${string(get(operation, 'jobId'))}`, object(get(operation, 'session'), 'session'));
+        await this.history.append(event);
+        await this.checkpoint('history');
+        const coordinator = object(fromJSON({ schemaVersion: 1, claim: null }), 'coordinator');
+        set(coordinator, 'claim', get(operation, 'resultClaim'));
+        await this.write('coordinator', coordinator);
+        await this.write('coordinator-journal', object(fromJSON({ schemaVersion: 1, operation: null }), 'journal'));
+    }
+    async commit(operation, jobs) {
+        const journal = object(fromJSON({ schemaVersion: 1, operation: null }), 'journal');
+        set(journal, 'operation', operation);
+        validateClaimJournal(journal);
+        project(operation, jobs);
+        await this.history.isIdempotent(object(get(operation, 'historyEvent'), 'history event'));
+        await this.write('coordinator-journal', journal);
+        await this.recover(journal, jobs);
+    }
+}

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -1,3 +1,6 @@
+import { NativeClaimJournal, claimOperationKinds, validateClaimJournal } from './native-claim-journal.js';
+import { NativeClaimHistory } from './native-claim-history.js';
+import { validateCoordinator, requireJobUnclaimed } from '../contracts/workspace/claims.js';
 import { constants } from "node:fs";
 import { chmod, lstat, mkdir, open, readdir, realpath } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
@@ -8,19 +11,18 @@ import { fromJSON, get, int, object, set, string, serialize, JobsError } from ".
 import { atomicWritePointJson } from "./point-persistence.js";
 import { withExclusiveFileLock } from "./exclusive-file-lock.js";
 import { NativeAnswerResolutionJournal } from "./native-answer-resolution-journal.js";
-import { NativeAnswerJournal, validateIdleCoordinator, answerJournalName } from "./native-answer-journal.js";
+import { NativeAnswerJournal, answerJournalName } from "./native-answer-journal.js";
 import { answerReferenceCounts } from "../contracts/workspace/answer-sessions.js";
-import { validateAnswerSession, validateAnswerHistory } from "../contracts/workspace/answer-session-validation.js";
+import { validateAnswerSession } from "../contracts/workspace/answer-session-validation.js";
 import { NativeResumeFiles } from "./native-resume-files.js";
 import { NativeExtractionJournal, closeRequestsForResumes, extractionJournalName, validateExtractionResumes } from "./native-extraction-journal.js";
 import { validateExtractionRequests } from "../contracts/workspace/extraction-requests.js";
 import { validateExtractions } from "../contracts/workspace/extraction-proposals.js";
 import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
-import { strip } from "../contracts/workspace/job-url.js";
 import { validateAnswers } from "../contracts/workspace/answers.js";
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 };
-const marker = '{"mode":"native-jobs-fixture","version":7}\n';
+const marker = '{"mode":"native-jobs-fixture","version":8}\n';
 const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 };
@@ -74,10 +76,12 @@ export class NativeJobsRepository {
     root;
     provider;
     write;
-    constructor(root, provider, write = atomicWritePointJson) {
+    checkpoint;
+    constructor(root, provider, write = atomicWritePointJson, checkpoint = async () => { }) {
         this.root = root;
         this.provider = provider;
         this.write = write;
+        this.checkpoint = checkpoint;
     }
     async read(name) {
         const handle = await open(join(this.root, name), constants.O_RDONLY | constants.O_NOFOLLOW);
@@ -173,7 +177,12 @@ export class NativeJobsRepository {
             object(get(await this.document("profile"), "profile"), "profile.profile");
             const resumes = object(get(resumesDocument, "resumes"), "resumes.resumes");
             validateResumeReferences(resumes);
+            const coordinator = validateCoordinator(await this.journal('coordinator'));
+            const claim = get(coordinator, 'claim');
+            const claimedId = claim === null ? null : string(get(object(claim, 'claim'), 'jobId'));
+            const originalClaimed = claimedId === null ? null : serialize(get(object(get(document, 'jobs'), 'jobs'), claimedId));
             return operation({ document,
+                requireUnclaimed: id => requireJobUnclaimed(coordinator, id),
                 requireResume: async (id) => {
                     if (id === null)
                         return;
@@ -190,6 +199,8 @@ export class NativeJobsRepository {
                 },
                 save: async (value) => {
                     validateJobsDocument(value);
+                    if (claimedId !== null && serialize(get(object(get(value, 'jobs'), 'jobs'), claimedId)) !== originalClaimed)
+                        throw new JobsError('claimed job requires a coordinator operation');
                     await this.write(join(this.root, "jobs.json"), value, options);
                 }, });
         }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
@@ -259,27 +270,53 @@ export class NativeJobsRepository {
         }
         return sessions;
     }
-    async answerHistory() {
-        const content = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(await this.read('applications.jsonl'));
-        return content.split('\n').filter(line => strip(line)).map(line => validateAnswerHistory(parsePythonPointJsonBytes(Buffer.from(line), { diagnosticProfile: "3.12", intMaxStrDigits: 4300 })));
+    history() { return new NativeClaimHistory(this.root); }
+    async answerHistory() { return this.history().read(); }
+    claimJournal() {
+        return new NativeClaimJournal((name, document) => this.write(join(this.root, `${name}.json`), document, options), this.history(), this.checkpoint);
     }
     async recoverAnswers() {
-        validateIdleCoordinator(await this.journal('coordinator'));
+        const coordinator = validateCoordinator(await this.journal('coordinator'));
         const sessions = await this.answerSessions();
+        const journal = await this.journal(answerJournalName), operation = get(journal, 'operation');
+        if (operation !== null && claimOperationKinds.has(string(get(object(operation, 'coordinator operation'), 'kind')))) {
+            validateClaimJournal(journal);
+            await this.history().repairPendingTail();
+            await this.claimJournal().recover(journal, validateJobsDocument(await this.document('jobs')));
+            return;
+        }
         await this.answerHistory();
-        const journal = await this.journal(answerJournalName);
-        const operation = get(journal, 'operation');
+        if (operation !== null && get(coordinator, 'claim') !== null)
+            throw new JobsError('answer recovery requires an idle coordinator');
         if (operation !== null && string(get(object(operation, 'coordinator operation'), 'kind')) === 'answer_resolution') {
             await this.resolutionJournal().recover(journal, validateJobsDocument(await this.document('jobs')), sessions);
         }
         else
             await this.answerJournal().recover(journal, validateAnswers(await this.document('answers')), sessions);
     }
+    async claimTransaction(operation) {
+        return this.transaction(async () => {
+            const jobs = validateJobsDocument(await this.document('jobs'));
+            return operation({ jobs, coordinator: validateCoordinator(await this.journal('coordinator')),
+                sessions: await this.answerSessions(), answers: validateAnswers(await this.document('answers')),
+                profile: validateProfile(await this.document('profile')), resumes: validateExtractionResumes(await this.document('resumes')),
+                files: new NativeResumeFiles(this.root),
+                saveJobs: async (document) => { validateJobsDocument(document); await this.write(join(this.root, 'jobs.json'), document, options); },
+                saveCoordinator: async (document) => { validateCoordinator(document); await this.write(join(this.root, 'coordinator.json'), document, options); },
+                saveSession: async (document) => { validateAnswerSession(document); await this.write(join(this.root, `sessions/${safeId(string(get(document, 'applicationId')))}.json`), document, options); },
+                commit: operation => this.claimJournal().commit(operation, jobs) });
+        });
+    }
     async answerMergeTransaction(operation) {
         return this.transaction(async () => {
             const document = validateAnswers(await this.document('answers'));
             const sessions = await this.answerSessions(), history = await this.answerHistory();
-            return operation({ document, sessions, history, commit: value => this.answerJournal().commit(value, document, sessions) });
+            const coordinator = validateCoordinator(await this.journal('coordinator'));
+            return operation({ document, sessions, history, commit: value => {
+                    if (get(coordinator, 'claim') !== null)
+                        throw new JobsError('answer merge requires an idle coordinator');
+                    return this.answerJournal().commit(value, document, sessions);
+                } });
         });
     }
     resolutionJournal() {
@@ -288,9 +325,14 @@ export class NativeJobsRepository {
     async pendingAnswerTransaction(operation) {
         return this.transaction(async () => {
             const jobs = validateJobsDocument(await this.document('jobs')), sessions = await this.answerSessions();
+            const coordinator = validateCoordinator(await this.journal('coordinator'));
             return operation({ jobs, sessions, answers: validateAnswers(await this.document('answers')),
                 profile: validateProfile(await this.document('profile')), resumes: validateExtractionResumes(await this.document('resumes')),
-                files: new NativeResumeFiles(this.root), commit: value => this.resolutionJournal().commit(value, jobs, sessions) });
+                files: new NativeResumeFiles(this.root), requireUnclaimed: id => requireJobUnclaimed(coordinator, id), commit: value => {
+                    if (get(coordinator, 'claim') !== null)
+                        throw new JobsError('answer resolution requires an idle coordinator');
+                    return this.resolutionJournal().commit(value, jobs, sessions);
+                } });
         });
     }
     async resumeSummaries() {

--- a/runtime/workspace-core/claims-http.js
+++ b/runtime/workspace-core/claims-http.js
@@ -1,0 +1,47 @@
+import { ClaimsService } from './claims.js';
+import { get, int, keys, object, parse, serialize, string, JobsError } from '../contracts/workspace/values.js';
+/** Authenticated transport supplies body bounds; bearer credentials are never logged. */
+export async function claimsHttp(repository, method, path, body) {
+    const service = new ClaimsService(repository);
+    if (method === 'GET' && path === '/api/claims')
+        return { status: 200, body: serialize(await service.status()) };
+    const shapes = {
+        select: ['jobId', 'expectedRevision', 'ownerConfirmed'], acquire: ['jobId', 'ownerLabel', 'expectedRevision'],
+        heartbeat: ['jobId', 'token'], recover: ['jobId', 'ownerLabel'], progress: ['jobId', 'token', 'session'],
+        handoff: ['jobId', 'token', 'status', 'session', 'expectedRevision'],
+    };
+    const action = path.startsWith('/api/claims/') ? path.slice('/api/claims/'.length) : '';
+    const fields = shapes[action];
+    if (method !== 'POST' || !fields)
+        return null;
+    const payload = object(parse(body), 'claim body');
+    if (payload.size !== fields.length || keys(payload).some(key => !fields.includes(key)))
+        throw new JobsError('claim body contains unsupported or missing fields');
+    const id = string(get(payload, 'jobId'));
+    if (id === null)
+        throw new JobsError('claim job id must be a string');
+    const revision = () => {
+        const value = int(get(payload, 'expectedRevision'));
+        if (value === null)
+            throw new JobsError('expected revision must be an integer');
+        return value;
+    };
+    let result;
+    if (action === 'select')
+        result = await service.select(id, revision(), get(payload, 'ownerConfirmed') === true);
+    else if (action === 'acquire')
+        result = await service.acquire(id, get(payload, 'ownerLabel'), revision());
+    else if (action === 'heartbeat')
+        result = await service.heartbeat(id, get(payload, 'token'));
+    else if (action === 'recover')
+        result = await service.recover(id, get(payload, 'ownerLabel'));
+    else if (action === 'progress')
+        result = await service.progress(id, get(payload, 'token'), object(get(payload, 'session'), 'session'));
+    else {
+        const status = string(get(payload, 'status'));
+        if (status === null)
+            throw new JobsError('claimed handoff status is unsupported');
+        result = await service.handoff(id, get(payload, 'token'), status, object(get(payload, 'session'), 'session'), revision());
+    }
+    return { status: 200, body: serialize(result) };
+}

--- a/runtime/workspace-core/claims.js
+++ b/runtime/workspace-core/claims.js
@@ -1,0 +1,170 @@
+import { randomUUID } from 'node:crypto';
+import { claimExpired, claimHeartbeatSeconds, claimLeaseSeconds, heartbeatClaim, makeClaim, publicClaim, requireClaim, requireJobUnclaimed } from '../contracts/workspace/claims.js';
+import { buildClaimSession, validateClaimHandoff } from '../contracts/workspace/claim-session.js';
+import { safeId, validateJob } from '../contracts/workspace/jobs.js';
+import { strip } from '../contracts/workspace/job-url.js';
+import { copy, fromJSON, get, has, int, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { preflightJobRecord } from './job-preflight.js';
+const doc = (value) => object(fromJSON(value), 'claim result');
+function activeJob(jobs, id, error = 'job does not exist') {
+    const value = get(object(get(jobs, 'jobs'), 'jobs'), id);
+    if (value === null || get(object(value, 'job'), 'deletedAt') !== null)
+        throw new JobsError(error);
+    return object(value, 'job');
+}
+function owner(value) {
+    const label = string(value);
+    if (label === null || !strip(label))
+        throw new JobsError('owner label must be a non-empty string');
+}
+function transitioned(job, target, at) {
+    const result = copy(job);
+    set(result, 'status', text(target));
+    set(result, 'closedOutcome', null);
+    set(result, 'revision', integer(int(get(job, 'revision')) + 1n));
+    set(result, 'updatedAt', text(at));
+    return validateJob(string(get(job, 'id')), result);
+}
+function projectJob(job) {
+    const result = doc({});
+    for (const field of ['id', 'role', 'company', 'location', 'workplaceType', 'employmentType', 'status', 'priority', 'revision', 'createdAt', 'updatedAt'])
+        if (has(job, field))
+            set(result, field, get(job, field));
+    return result;
+}
+function operation(kind, job, at, eventName, status, claim) {
+    const operationId = randomUUID(), id = string(get(job, 'id'));
+    const event = doc({ schemaVersion: 1, eventId: `coordinator-${operationId}`, applicationId: id, event: eventName, status, answerKeys: [], at });
+    for (const field of ['company', 'role', 'ats'])
+        if (string(get(job, field)) !== null)
+            set(event, field, get(job, field));
+    const result = doc({ kind, operationId, jobId: id, at });
+    set(result, 'historyEvent', event);
+    set(result, 'resultClaim', claim);
+    if (kind !== 'recover') {
+        set(result, 'sourceStatus', get(job, 'status'));
+        set(result, 'targetStatus', text(status));
+        set(result, 'expectedRevision', get(job, 'revision'));
+    }
+    return result;
+}
+export class ClaimsService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    status() {
+        return this.repository.claimTransaction(async (tx) => set(doc({ leaseSeconds: claimLeaseSeconds, heartbeatSeconds: claimHeartbeatSeconds }), 'claim', publicClaim(get(tx.coordinator, 'claim'), this.now())));
+    }
+    select(id, expectedRevision, confirmed) {
+        safeId(id);
+        if (confirmed !== true)
+            throw new JobsError('task selection requires owner confirmation');
+        if (typeof expectedRevision !== 'bigint')
+            throw new JobsError('task selection requires an exact revision');
+        return this.repository.claimTransaction(async (tx) => {
+            const job = activeJob(tx.jobs, id, 'task selection job is unavailable');
+            if (int(get(job, 'revision')) !== expectedRevision)
+                throw new JobsError('task selection revision conflict');
+            requireJobUnclaimed(tx.coordinator, id);
+            if (!['saved', 'needs_info', 'ready'].includes(string(get(job, 'status'))))
+                throw new JobsError('task selection job is unavailable');
+            if (get(await preflightJobRecord(job, tx.profile, tx.resumes, tx.files), 'ready') !== true)
+                throw new JobsError('task selection preflight failed');
+            if (string(get(job, 'status')) === 'ready')
+                return set(doc({ action: 'noop' }), 'job', projectJob(job));
+            const updated = transitioned(job, 'ready', this.now());
+            set(object(get(tx.jobs, 'jobs'), 'jobs'), id, updated);
+            set(object(get(tx.jobs, 'metadata'), 'jobs.metadata'), 'updatedAt', get(updated, 'updatedAt'));
+            await tx.saveJobs(tx.jobs);
+            return set(doc({ action: 'ready' }), 'job', projectJob(updated));
+        });
+    }
+    acquire(id, ownerLabel, expectedRevision) {
+        safeId(id);
+        owner(ownerLabel);
+        return this.repository.claimTransaction(async (tx) => {
+            const current = get(tx.coordinator, 'claim');
+            if (current !== null)
+                throw new JobsError(claimExpired(object(current, 'claim'), this.now()) ? 'expired claim requires explicit same-job recovery' : 'another live job claim already exists');
+            const job = activeJob(tx.jobs, id);
+            if (int(get(job, 'revision')) !== expectedRevision)
+                throw new JobsError('job revision conflict');
+            if (string(get(job, 'status')) !== 'ready')
+                throw new JobsError('only a ready job can be acquired');
+            const preflight = await preflightJobRecord(job, tx.profile, tx.resumes, tx.files);
+            if (get(preflight, 'ready') !== true)
+                throw new JobsError('job is not ready');
+            const now = this.now(), { claim, token } = makeClaim(id, ownerLabel, now);
+            const resume = copy(object(get(object(get(tx.resumes, 'resumes'), 'resumes'), string(get(preflight, 'resumeId'))), 'resume'));
+            set(resume, 'path', string(get(resume, 'storageKind')) === 'managed' ? text(tx.files.path(resume)) : get(resume, 'path'));
+            await tx.commit(operation('acquire', job, now, 'job-started', 'in_progress', claim));
+            const result = doc({ token });
+            set(result, 'job', transitioned(job, 'in_progress', now));
+            set(result, 'resume', resume);
+            return set(result, 'claim', publicClaim(claim, this.now()));
+        });
+    }
+    heartbeat(id, token) {
+        return this.repository.claimTransaction(async (tx) => {
+            const claim = requireClaim(tx.coordinator, tx.jobs, id, token, this.now());
+            const updated = heartbeatClaim(claim, this.now());
+            await tx.saveCoordinator(set(doc({ schemaVersion: 1 }), 'claim', updated));
+            return set(doc({}), 'claim', publicClaim(updated, this.now()));
+        });
+    }
+    recover(id, ownerLabel) {
+        safeId(id);
+        owner(ownerLabel);
+        return this.repository.claimTransaction(async (tx) => {
+            const old = get(tx.coordinator, 'claim');
+            if (old === null || string(get(object(old, 'claim'), 'jobId')) !== id)
+                throw new JobsError('explicit recovery must name the expired claimed job');
+            const raw = get(object(get(tx.jobs, 'jobs'), 'jobs'), id);
+            if (raw === null || string(get(object(raw, 'job'), 'status')) !== 'in_progress')
+                throw new JobsError('expired claim job is not in progress');
+            if (!claimExpired(object(old, 'claim'), this.now()))
+                throw new JobsError('live claim cannot be recovered');
+            const job = object(raw, 'job'), now = this.now(), { claim, token } = makeClaim(id, ownerLabel, now);
+            await tx.commit(operation('recover', job, now, 'claim-recovered', 'in_progress', claim));
+            const result = doc({ token });
+            set(result, 'job', job);
+            return set(result, 'claim', publicClaim(claim, this.now()));
+        });
+    }
+    progress(id, token, incoming) {
+        return this.repository.claimTransaction(async (tx) => {
+            requireClaim(tx.coordinator, tx.jobs, id, token, this.now());
+            const session = this.session(tx, activeJob(tx.jobs, id), incoming);
+            if (string(get(session, 'status')) !== 'active')
+                throw new JobsError('claim progress session must remain active');
+            await tx.saveSession(session);
+            return session;
+        });
+    }
+    handoff(id, token, status, incoming, expectedRevision) {
+        if (!['needs_info', 'awaiting_review'].includes(status))
+            throw new JobsError('claimed handoff status is unsupported');
+        return this.repository.claimTransaction(async (tx) => {
+            requireClaim(tx.coordinator, tx.jobs, id, token, this.now());
+            const job = activeJob(tx.jobs, id);
+            if (int(get(job, 'revision')) !== expectedRevision)
+                throw new JobsError('job revision conflict');
+            const now = this.now(), session = this.session(tx, job, incoming, now);
+            validateClaimHandoff(session, incoming, status, get(job, 'revision'));
+            const op = operation('handoff', job, now, status === 'needs_info' ? 'job-blocked' : 'reviewed', status, null);
+            set(op, 'session', session);
+            await tx.commit(op);
+            const result = doc({ claim: null });
+            set(result, 'job', transitioned(job, status, now));
+            return set(result, 'session', session);
+        });
+    }
+    session(tx, job, incoming, now = this.now()) {
+        const id = string(get(job, 'id'));
+        return buildClaimSession(id, incoming, { now, attemptRevision: get(job, 'revision'), ats: get(job, 'ats'),
+            existing: tx.sessions.find(session => string(get(session, 'applicationId')) === id) ?? null, answers: tx.answers });
+    }
+}

--- a/runtime/workspace-core/jobs-http.js
+++ b/runtime/workspace-core/jobs-http.js
@@ -1,3 +1,4 @@
+import { claimsHttp } from './claims-http.js';
 import { pendingAnswersHttp } from './pending-answers-http.js';
 import { profileHttp } from "./profile-http.js";
 import { fixtureError } from "../store/native-jobs.js";
@@ -14,6 +15,9 @@ const envelope = (key, value) => set(emptyObject(), key, value);
 /** Transport-independent dispatch. Host/token/Origin/body bounds belong to the adapter. */
 export async function jobsHttp(service, repository, method, path, body = "") {
     try {
+        const claim = await claimsHttp(repository, method, path, body);
+        if (claim)
+            return claim;
         const pending = await pendingAnswersHttp(repository, method, path, body);
         if (pending)
             return pending;

--- a/runtime/workspace-core/jobs.js
+++ b/runtime/workspace-core/jobs.js
@@ -87,6 +87,7 @@ export class JobsService {
             if (value === null || get(object(value, "job record"), "deletedAt") !== null)
                 throw new JobsError("job does not exist");
             const current = object(value, "job record");
+            transaction.requireUnclaimed?.(id);
             if (int(get(current, "revision")) !== expectedRevision)
                 throw new JobsError("job revision conflict");
             const currentProvenance = has(current, "provenance") ? object(get(current, "provenance"), "job provenance") : emptyObject();

--- a/runtime/workspace-core/pending-answers.js
+++ b/runtime/workspace-core/pending-answers.js
@@ -55,6 +55,7 @@ export class PendingAnswersService {
                 throw new JobsError('answer resolution revision is invalid');
         }
         return this.repository.pendingAnswerTransaction(async (transaction) => {
+            transaction.requireUnclaimed?.(jobId);
             const rawJob = get(object(get(transaction.jobs, 'jobs'), 'jobs'), jobId);
             if (rawJob === null || get(object(rawJob, 'job'), 'deletedAt') !== null)
                 throw new JobsError('job does not exist');

--- a/src/cli/native-claims.ts
+++ b/src/cli/native-claims.ts
@@ -1,0 +1,34 @@
+import { ClaimsService } from '../workspace-core/claims.js';
+import type { ClaimRepository } from '../workspace-core/claims.js';
+import { object, text, JobsError } from '../contracts/workspace/values.js';
+import type { Value } from '../contracts/workspace/values.js';
+
+export const claimCommands:Record<string,string[]> = {
+  'task-select':['--id','--expected-revision','--owner-confirmed'],
+  'job-acquire':['--id','--owner','--expected-revision'],'claim-status':[],
+  'claim-heartbeat':['--id','--token'],'claim-recover':['--id','--owner'],
+  'claim-progress':['--id','--token','--input'],
+  'claim-handoff':['--id','--token','--status','--input','--expected-revision'],
+};
+export async function runClaimCommand(command:string,repository:ClaimRepository,options:Map<string,string>,payload:()=>Promise<Value>):Promise<Value> {
+  const service = new ClaimsService(repository);
+  const required = (key:string):string => {
+    const value = options.get(key);
+    if (!value) throw new JobsError(`required option: ${key}`);
+    return value;
+  };
+  const revision = ():bigint => {
+    const value = required('--expected-revision');
+    if (!/^[+-]?[0-9]+$/.test(value)) throw new JobsError('expected revision must be an integer');
+    return BigInt(value);
+  };
+  if (command === 'claim-status') return service.status();
+  const id = required('--id');
+  if (command === 'task-select') return service.select(id,revision(),options.has('--owner-confirmed'));
+  if (command === 'job-acquire') return service.acquire(id,text(required('--owner')),revision());
+  if (command === 'claim-recover') return service.recover(id,text(required('--owner')));
+  const token = text(required('--token'));
+  if (command === 'claim-heartbeat') return service.heartbeat(id,token);
+  if (command === 'claim-progress') return service.progress(id,token,object(await payload(),'session'));
+  return service.handoff(id,token,required('--status'),object(await payload(),'session'),revision());
+}

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,3 +1,4 @@
+import { claimCommands, runClaimCommand } from './native-claims.js';
 import { pendingAnswerCommands, runPendingAnswerCommand } from './native-pending-answers.js';
 import { profileCommands, runProfileCommand } from "./native-profile.js";
 import { answerCommands, runAnswerCommand } from "./native-answers.js";
@@ -32,6 +33,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     }
   }
   const fields: Record<string, string[]> = {
+    ...claimCommands,
     ...pendingAnswerCommands,
     ...profileCommands,
     ...answerCommands,
@@ -65,6 +67,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     const limit = ["resume-proposal-create", "resume-extraction-request-complete"].includes(command!) ? 2 * 1024 * 1024 : 65536;
     return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
   };
+  if (Object.hasOwn(claimCommands, command!)) return serialize(await runClaimCommand(command!,repository,options,payload));
   if (Object.hasOwn(pendingAnswerCommands, command!)) return serialize(await runPendingAnswerCommand(command!, repository, options));
   if (Object.hasOwn(profileCommands, command!)) return serialize(await runProfileCommand(command!, repository, options, payload));
   if (Object.hasOwn(answerCommands, command!)) return serialize(await runAnswerCommand(command!, repository, options, payload));

--- a/src/contracts/workspace/claim-session-pending.ts
+++ b/src/contracts/workspace/claim-session-pending.ts
@@ -1,0 +1,105 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { answerRevision, fallback } from './answers.js';
+import { rankCandidates } from './answer-match-scoring.js';
+import { canonicalJson } from './canonical-json.js';
+import { casefold } from './casefold.js';
+import { strip } from './job-url.js';
+import { fields, requireCondition as check } from './answer-session-fields.js';
+import { copy, get, object, parse, same, serialize, set, string, text, truth, integer, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+
+const empty = (): Document => object(parse('{}'), 'object');
+const clone = (value: Value): Value => parse(serialize(value));
+export function claimSessionObject(value: Value, label: string): Document {
+  try { return object(value,label); }
+  catch { throw new JobsError(`${label} must be a JSON object`); }
+}
+export function canonicalClaimAnswer(answers: Document, key: string): string {
+  const redirect = get(object(fallback(answers,'redirects',empty()), 'redirects'),key);
+  return redirect === null ? key : string(get(object(redirect,'redirect'),'targetKey'))!;
+}
+function answerRecord(answers: Document, key: Value): Document | null {
+  const identity = string(key);
+  if (!identity) return null;
+  const value = get(object(get(answers,'answers'),'answers'),canonicalClaimAnswer(answers,identity));
+  if (value === null) return null;
+  const record = object(value,'answer');
+  return get(record,'deletedAt') === null ? record : null;
+}
+function identity(field: Document): string {
+  const result = copy(field);
+  for (const name of ['reference','matchConfidence','matchReasonCodes','matchAnswerRevision']) result.delete(text(name));
+  return canonicalJson(result);
+}
+function candidate(answer: Document): Document {
+  const result = empty();
+  for (const name of ['question','state']) set(result,name,get(answer,name));
+  set(result,'answerKey',get(answer,'key'));
+  set(result,'aliases',(fallback(answer,'aliases',[]) as Value[]).filter(value => string(value) !== null && Boolean(strip(string(value)!))));
+  set(result,'scope',fallback(answer,'scope',empty()));
+  set(result,'fieldClass',fallback(answer,'fieldClass',text('general')));
+  set(result,'sensitivity',fallback(answer,'sensitivity',text('none')));
+  set(result,'recordStatus',text(get(answer,'deletedAt') === null ? 'active':'deleted'));
+  set(result,'reviewStatus',fallback(answer,'reviewStatus',text('accepted')));
+  return set(result,'valueState',text(get(answer,'value') !== null ? 'seen':'missing'));
+}
+export function buildClaimPending(incoming: Document, existing: Document | null, ats: Value, answers: Document): Document[] {
+  const raw = fallback(incoming,'pendingFields',[]);
+  check(Array.isArray(raw), 'session pendingFields must be a list');
+  const reusable = new Map<string,string[]>();
+  for (const value of existing ? fallback(existing,'pendingFields',[]) as Value[] : []) {
+    const field = object(value,'pending field'), key = identity(field);
+    reusable.set(key,[...reusable.get(key) ?? [],string(get(field,'reference'))!]);
+  }
+  return (raw as Value[]).map(value => {
+    const field = claimSessionObject(value,'pending field');
+    check(fields(field,['question','state','answerKey','sensitive','fieldClass','scope','matchConfidence','matchReasonCodes']), 'pending field contains unsupported fields');
+    const result = object(clone(field),'pending field');
+    const question = string(get(result,'question'));
+    result.delete(text('question'));
+    if (question !== null && strip(question)) {
+      const normalized = casefold(question.split(/[\u0009-\u000d\u001c-\u0020\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+/u).filter(Boolean).join(' '));
+      set(result,'questionFingerprint',text(createHash('sha256').update(text(normalized).encodeUtf8()).digest('hex')));
+    }
+    const scope = get(result,'scope') ?? (string(ats) ? set(empty(),'ats',ats):empty());
+    result.delete(text('scope'));
+    let scopeObject: Document;
+    try { scopeObject = object(scope,'pending field scope'); }
+    catch { throw new JobsError('pending field scope must be a JSON object'); }
+    if (truth(scopeObject)) {
+      try { set(result,'scopeFingerprint',text(createHash('sha256').update(canonicalJson(scopeObject)).digest('hex'))); }
+      catch { throw new JobsError('pending field scope is invalid'); }
+    }
+    result.delete(text('matchConfidence'));
+    result.delete(text('matchReasonCodes'));
+    const answer = answerRecord(answers,get(result,'answerKey'));
+    if (answer !== null && string(get(answer,'question')) !== null && strip(string(get(answer,'question'))!) && question !== null && strip(question)) {
+      try {
+        const sensitivity = fallback(answer,'sensitivity',text('none'));
+        const match = rankCandidates({question:text(question),scope:scopeObject,fieldClass:fallback(result,'fieldClass',text('general')),
+          sensitivity:string(sensitivity) !== 'none' ? sensitivity : text(get(result,'sensitive') === true || string(get(result,'state')) === 'sensitive' ? 'high':'none'),
+          candidates:[candidate(answer)],limit:integer(1n)})[0]!;
+        set(result,'matchConfidence',get(match,'confidenceBand'));
+        set(result,'matchReasonCodes',get(match,'reasonCodes'));
+      } catch { throw new JobsError('pending field semantic match is invalid'); }
+    } else if (answer !== null) {
+      set(result,'matchConfidence',text('none'));
+      set(result,'matchReasonCodes',[text('no_semantic_match')]);
+    }
+    if (answer !== null) set(result,'matchAnswerRevision',integer(answerRevision(answer)));
+    const references = reusable.get(identity(result));
+    return set(result,'reference',text(references?.shift() ?? `pending_${randomUUID().replaceAll('-','')}`));
+  });
+}
+export function currentClaimApprovals(existing: Document | null, pending: Document[], answers: Document, attempt: Value): Value[] {
+  if (existing === null || !same(get(existing,'attemptRevision'),attempt)) return [];
+  return (fallback(existing,'approvals',[]) as Value[]).filter(value => {
+    const approval = object(value,'approval');
+    const field = pending.find(item => same(get(item,'reference'),get(approval,'reference')));
+    const fieldKey = field ? string(get(field,'answerKey')):null, approvalKey = string(get(approval,'answerKey'));
+    if (fieldKey === null || approvalKey === null) return false;
+    const resolved = canonicalClaimAnswer(answers,fieldKey), answer = answerRecord(answers,text(resolved));
+    return resolved === canonicalClaimAnswer(answers,approvalKey) && answer !== null && get(answer,'deletedAt') === null
+      && same(integer(answerRevision(answer)),get(approval,'answerRevision'));
+  }).map(clone);
+}

--- a/src/contracts/workspace/claim-session-readiness.ts
+++ b/src/contracts/workspace/claim-session-readiness.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { canonicalJson } from './canonical-json.js';
+import { fields, matches, member, positive, requireCondition as check } from './answer-session-fields.js';
+import { get, object, parse, same, set, string, integer, fromJSON, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+
+const kindByRole: Record<string, string> = { textbox:'text', combobox:'selection', radiogroup:'selection', checkbox:'toggle', file:'upload' };
+const digest = (value: Value): string => createHash('sha256').update(canonicalJson(value)).digest('hex');
+function controlsOf(fixture: Document): Document[] {
+  const steps = get(fixture, 'steps');
+  check(Array.isArray(steps), 'invalid fixture steps');
+  return (steps as Value[]).flatMap(step => {
+    const controls = get(object(step, 'step'), 'controls');
+    check(Array.isArray(controls), 'invalid fixture controls');
+    return (controls as Value[]).map(item => object(item, 'control'));
+  });
+}
+function validateObservation(observation: Document, fixture: Document, controls: Document[]): Document[] {
+  check(fields(observation, ['schemaVersion','platformFamily','observationRevision','adapterState','uploadCapability','controls','validationErrorControlIds','finalControlState'], true), 'invalid observation fields');
+  check(positive(get(observation, 'schemaVersion')) && same(get(observation, 'schemaVersion'), integer(1n)), 'invalid observation version');
+  check(same(get(observation, 'platformFamily'), get(fixture, 'platformFamily')) && positive(get(observation, 'observationRevision')), 'invalid observation identity');
+  check(member(get(observation, 'adapterState'), ['accessible','inaccessible']), 'invalid adapter state');
+  check(member(get(observation, 'uploadCapability'), ['available','external-runtime-unavailable','not-required']), 'invalid upload capability');
+  check(member(get(observation, 'finalControlState'), ['available','unavailable','inaccessible','activated']), 'invalid final state');
+  const raw = get(observation, 'controls');
+  check(Array.isArray(raw), 'invalid controls');
+  const observed = (raw as Value[]).map(item => object(item, 'observed control'));
+  const known = new Map(controls.map(item => [string(get(item,'id'))!, item]));
+  const seen = new Set<string>();
+  for (const item of observed) {
+    check(fields(item, ['controlId','kind','state','observationRevision'], true), 'invalid observed control fields');
+    const id = string(get(item, 'controlId'));
+    check(id !== null && known.has(id) && !seen.has(id), 'invalid observed identity');
+    seen.add(id!);
+    const kind = kindByRole[string(get(known.get(id!)!, 'role'))!];
+    check(kind !== undefined && string(get(item,'kind')) === kind, 'invalid control kind');
+    check(member(get(item,'state'), [kind === 'upload' ? 'accepted':'complete','missing','rejected','unresolved','inaccessible']), 'invalid control state');
+    check(positive(get(item,'observationRevision')), 'invalid control revision');
+  }
+  const errors = get(observation, 'validationErrorControlIds');
+  check(Array.isArray(errors), 'invalid validation errors');
+  const ids = (errors as Value[]).map(string);
+  check(ids.every(id => id !== null && known.has(id)) && new Set(ids).size === ids.length, 'invalid validation identities');
+  check(ids.every((id,index) => index === 0 || ids[index-1]! < id!), 'unsorted validation identities');
+  return observed;
+}
+
+/** Recompute only from an exact bundled fixture and closed, current observation input. */
+export function recomputeClaimReadiness(raw: Value, attempt: Value, ats: Value): Document {
+  let packet: Document;
+  try { packet = object(raw, 'readiness input'); }
+  catch { throw new JobsError('readiness input must be a JSON object'); }
+  check(fields(packet, ['attemptRevision','evidenceKind','fixture','observation','expectedObservationRevision','formManifest'], true), 'readiness input contains unsupported fields');
+  check(same(get(packet,'attemptRevision'), attempt), 'readiness input is not bound to the current attempt');
+  check(member(get(packet,'evidenceKind'), ['agent_attested_current_attempt','repository_replay']), 'readiness evidence kind is unsupported');
+  try {
+    const fixture = object(get(packet,'fixture'), 'readiness fixture');
+    check(matches(get(fixture,'id'), /^[a-z0-9][a-z0-9-]{0,127}$/u), 'invalid fixture id');
+    const trusted = parse(readFileSync(new URL(`../../../qa/fixtures/${string(get(fixture,'id'))}/fixture.json`, import.meta.url), 'utf8'));
+    check(canonicalJson(fixture) === canonicalJson(trusted), 'fixture differs from bundled definition');
+    check(!string(ats) || same(get(fixture,'platformFamily'), ats), 'fixture ATS mismatch');
+    const controls = controlsOf(fixture), required = controls.filter(item => get(item,'required') === true);
+    check(required.length > 0, 'fixture has no required control');
+    const revision = get(packet, 'expectedObservationRevision');
+    check(positive(revision), 'invalid expected revision');
+    const ids = required.map(item => string(get(item,'id'))!).sort();
+    const fingerprint = `sha256:${digest(fromJSON({platformFamily:string(get(fixture,'platformFamily')),requiredControlIds:ids}))}`;
+    const manifest = object(fromJSON({schemaVersion:1,platformFamily:string(get(fixture,'platformFamily')),requiredControlIds:ids,controlSetFingerprint:fingerprint,complete:true}), 'manifest');
+    set(manifest,'observationRevision',revision);
+    check(same(get(packet,'formManifest'),manifest), 'form manifest mismatch');
+    const observation = object(get(packet,'observation'), 'observation');
+    const observed = validateObservation(observation,fixture,controls);
+    const byId = new Map(observed.map(item => [string(get(item,'controlId'))!,item]));
+    const missing = required.filter(item => !byId.has(string(get(item,'id'))!));
+    const present = required.flatMap(item => {
+      const value = byId.get(string(get(item,'id'))!);
+      return value ? [value] : [];
+    });
+    const stale = present.filter(item => !same(get(item,'observationRevision'),revision));
+    const incomplete = present.filter(item => string(get(item,'state')) !== (string(get(item,'kind')) === 'upload' ? 'accepted':'complete'));
+    const requiredUploads = new Set(required.filter(item => string(get(item,'role')) === 'file').map(item => string(get(item,'id'))));
+    const missingUpload = missing.some(item => requiredUploads.has(string(get(item,'id')))) || incomplete.some(item => string(get(item,'kind')) === 'upload' && string(get(item,'state')) === 'missing');
+    const assertions: Record<string, boolean> = {
+      'observation-current':same(get(observation,'observationRevision'),revision) && stale.length === 0,
+      'adapter-accessible':string(get(observation,'adapterState')) === 'accessible',
+      'required-controls-complete':missing.length + stale.length + incomplete.length === 0,
+      'required-uploads-accepted': !missing.some(item => requiredUploads.has(string(get(item,'id')))) && ![...stale,...incomplete].some(item => requiredUploads.has(string(get(item,'controlId')))),
+      'validation-clear':(get(observation,'validationErrorControlIds') as Value[]).length === 0,
+      'final-control-available':string(get(observation,'finalControlState')) === 'available',
+      'final-action-untouched':string(get(observation,'finalControlState')) !== 'activated',
+    };
+    const blockers = new Set<string>();
+    if (!assertions['observation-current']) blockers.add('readiness-evidence-stale');
+    if (!assertions['adapter-accessible']) blockers.add('form-observation-inaccessible');
+    if (missing.length) blockers.add('required-control-evidence-missing');
+    if (missingUpload) blockers.add('required-upload-missing');
+    for (const item of incomplete) {
+      const state = string(get(item,'state')), upload = string(get(item,'kind')) === 'upload';
+      if (state === 'rejected') blockers.add(upload ? 'required-upload-rejected':'required-control-rejected');
+      else if (state === 'unresolved') blockers.add('required-control-unresolved');
+      else if (state === 'inaccessible') blockers.add('required-control-inaccessible');
+      else if (state === 'missing' && !upload) blockers.add('required-control-incomplete');
+    }
+    if (!assertions['validation-clear']) blockers.add('validation-error-present');
+    const final = string(get(observation,'finalControlState'));
+    if (final === 'activated') blockers.add('final-action-activated');
+    else if (final === 'inaccessible') blockers.add('final-control-inaccessible');
+    else if (final === 'unavailable') blockers.add('final-control-unavailable');
+    const fallback = missingUpload && string(get(observation,'uploadCapability')) === 'external-runtime-unavailable' ? 'owner-upload-required':null;
+    if (fallback) blockers.add('external-upload-capability-unavailable');
+    const result = object(fromJSON({status:Object.values(assertions).every(Boolean) ? 'ready':'blocked',
+      assertions:Object.fromEntries(Object.entries(assertions).map(([key,passed]) => [key,passed ? 'passed':'failed'])),
+      blockerCodes:[...blockers].sort(), fallbackCode:fallback, controlSetFingerprint:fingerprint, requiredControlCount:ids.length}), 'readiness');
+    set(result,'attemptRevision',attempt);
+    set(result,'observationRevision',get(observation,'observationRevision'));
+    return set(result,'evidenceKind',get(packet,'evidenceKind'));
+  } catch { throw new JobsError('readiness evidence is invalid'); }
+}

--- a/src/contracts/workspace/claim-session.ts
+++ b/src/contracts/workspace/claim-session.ts
@@ -1,0 +1,107 @@
+import { fallback } from './answers.js';
+import { canonicalJson } from './canonical-json.js';
+import { safeAnswerSessionId, validateAnswerSession } from './answer-session-validation.js';
+import { agentCodes, fields, member, requireCondition as check } from './answer-session-fields.js';
+import { buildClaimPending, currentClaimApprovals, claimSessionObject } from './claim-session-pending.js';
+import { recomputeClaimReadiness } from './claim-session-readiness.js';
+import { get, has, object, parse, same, serialize, set, string, text, truth, fromJSON } from './values.js';
+import type { Document, Value } from './values.js';
+
+export interface ClaimSessionContext { now:string; attemptRevision:Value; ats:Value; existing:Document|null; answers:Document }
+const clone = (value: Value): Value => parse(serialize(value));
+function blockerType(code: string): string {
+  if (code.includes('upload')) return 'upload';
+  if (code.includes('validation')) return 'validation';
+  if (code.includes('final')) return 'final_action';
+  if (code.includes('inaccessible') || code === 'owner-upload-required') return 'browser_handoff';
+  return 'readiness';
+}
+const agentTypes: Record<string,string> = Object.fromEntries(agentCodes.map(code => [code,code === 'consent-required' ? 'owner_review':code === 'owner-input-required' ? 'information':'browser_handoff']));
+export function buildClaimSession(applicationId: string, incoming: Document, context: ClaimSessionContext): Document {
+  check(fields(incoming,['applicationId','status','ats','company','role','url','step','answerKeys','pendingFields','createdAt','updatedAt','attemptRevision','readinessInput','blockers','browserHandoff']), 'session contains unsupported fields');
+  safeAnswerSessionId(text(applicationId));
+  check(same(fallback(incoming,'applicationId',text(applicationId)),text(applicationId)), 'session application id does not match path');
+  const attempt = fallback(incoming,'attemptRevision',context.attemptRevision);
+  check(context.attemptRevision === null || same(attempt,context.attemptRevision), 'session is not bound to the current attempt');
+  const status = fallback(incoming,'status',text('active'));
+  check(member(status,['active','review','completed','abandoned']), 'session status is unsupported');
+  const answerKeys = fallback(incoming,'answerKeys',[]);
+  check(Array.isArray(answerKeys) && answerKeys.every(item => string(item) !== null), 'session answerKeys must be strings');
+  const existing = context.existing;
+  if (existing) {
+    validateAnswerSession(existing);
+    check(string(get(existing,'applicationId')) === applicationId,'session application id does not match path');
+  }
+  const pending = buildClaimPending(incoming,existing,context.ats,context.answers);
+  let readiness: Value = null;
+  if (has(incoming,'readinessInput')) {
+    check(attempt !== null,'readiness requires a current attempt revision');
+    readiness = recomputeClaimReadiness(get(incoming,'readinessInput'),attempt,context.ats);
+  } else if (existing !== null && same(get(existing,'attemptRevision'),attempt)) readiness = clone(get(existing,'readiness'));
+  const blockers: Document[] = pending.map(field => {
+    const sensitive = get(field,'sensitive') === true || string(get(field,'state')) === 'sensitive';
+    const result = object(fromJSON({type:'information',code:sensitive ? 'sensitive-answer-required':'answer-required',sensitivity:sensitive ? 'high':'none'}),'blocker');
+    set(result,'reference',get(field,'reference'));
+    if (has(field,'fieldClass')) set(result,'fieldClass',get(field,'fieldClass'));
+    return result;
+  });
+  if (readiness !== null) {
+    const report = object(readiness,'readiness');
+    for (const code of get(report,'blockerCodes') as Value[]) blockers.push(object(fromJSON({type:blockerType(string(code)!),code:string(code)}),'blocker'));
+    if (get(report,'fallbackCode') !== null) blockers.push(object(fromJSON({type:'browser_handoff',code:string(get(report,'fallbackCode'))}),'blocker'));
+  }
+  const supplied = fallback(incoming,'blockers',[]);
+  check(Array.isArray(supplied),'session blockers must be a list');
+  for (const item of supplied as Value[]) {
+    const blocker = claimSessionObject(item,'session blocker');
+    check(fields(blocker,['type','code'],true),'agent blockers must contain only closed type and code');
+    const code = string(get(blocker,'code'));
+    check(code !== null && Object.hasOwn(agentTypes,code) && string(get(blocker,'type')) === agentTypes[code],'session blocker is invalid');
+    blockers.push(object(clone(blocker),'blocker'));
+  }
+  const unique = [...new Map(blockers.map(item => [canonicalJson(item),item])).values()];
+  const browserReasons = [...agentCodes,'none','owner-upload-required','final-review-required','form-observation-inaccessible','required-control-inaccessible'];
+  const browserBlockers = unique.filter(item => string(get(item,'type')) === 'browser_handoff' && browserReasons.includes(string(get(item,'code'))!));
+  let handoff = get(incoming,'browserHandoff');
+  if (handoff === null) {
+    const fallbackCode = readiness === null ? null : get(object(readiness,'readiness'),'fallbackCode');
+    const reason = fallbackCode !== null ? string(fallbackCode) : browserBlockers.length ? string(get(browserBlockers[0]!,'code')) : null;
+    handoff = fromJSON({state:reason !== null ? 'required':string(status) === 'review' ? 'ready_for_owner':'not_required',
+      reasonCode:reason ?? (string(status) === 'review' ? 'final-review-required':'none'),revision:1});
+  } else {
+    handoff = clone(handoff);
+    check(fields(claimSessionObject(handoff,'browser handoff'),['state','reasonCode','revision'],true),'browser handoff contains unsupported fields');
+  }
+  check(browserBlockers.length === 0 || string(get(object(handoff,'browser handoff'),'state')) === 'required','browser handoff contradicts browser blockers');
+  let created = get(incoming,'createdAt');
+  if (!truth(created) && existing) created = get(existing,'createdAt');
+  const session = object(fromJSON({schemaVersion:1,applicationId,createdAt:context.now,updatedAt:context.now}),'session');
+  for (const name of ['status','step']) if (has(incoming,name)) set(session,name,clone(get(incoming,name)));
+  set(session,'ats',clone(context.ats));
+  set(session,'status',status);
+  set(session,'answerKeys',clone(answerKeys));
+  set(session,'pendingFields',pending);
+  set(session,'attemptRevision',attempt);
+  set(session,'readiness',readiness);
+  set(session,'blockers',unique);
+  set(session,'browserHandoff',handoff);
+  set(session,'approvals',currentClaimApprovals(existing,pending,context.answers,attempt));
+  if (truth(created)) set(session,'createdAt',created);
+  return validateAnswerSession(session);
+}
+export function validateClaimHandoff(session: Document, incoming: Document, target: string, attemptRevision: Value): void {
+  check(['needs_info','awaiting_review'].includes(target),'claimed handoff status is unsupported');
+  check(string(get(session,'status')) === (target === 'needs_info' ? 'active':'review'),'handoff session status does not match job status');
+  if (target !== 'awaiting_review') return;
+  check(has(incoming,'readinessInput'),'awaiting_review requires fresh current live readiness input');
+  const readiness = get(session,'readiness');
+  const complete = readiness !== null && (() => {
+    const report = object(readiness,'readiness');
+    return same(get(report,'attemptRevision'),attemptRevision) && string(get(report,'evidenceKind')) === 'agent_attested_current_attempt'
+      && string(get(report,'status')) === 'ready' && !truth(get(report,'blockerCodes'))
+      && object(get(report,'assertions'),'assertions').entries().every(([,value]) => string(value) === 'passed');
+  })();
+  check(complete && !truth(get(session,'pendingFields')) && !truth(get(session,'blockers'))
+    && same(get(session,'browserHandoff'),fromJSON({state:'ready_for_owner',reasonCode:'final-review-required',revision:1})),
+  'awaiting_review requires complete current agent-attested readiness');
+}

--- a/src/contracts/workspace/claim-time.ts
+++ b/src/contracts/workspace/claim-time.ts
@@ -1,0 +1,60 @@
+import { JobsError } from './values.js';
+
+function invalid(): never { throw new JobsError('coordinator timestamp is invalid'); }
+function overflow(): never {
+  const error = new RangeError('date value out of range');
+  error.name = 'OverflowError';
+  throw error;
+}
+const dayMicros = 86400000000n;
+function midnight(year: number, month: number, day: number): bigint {
+  const date = new Date(0);
+  date.setUTCFullYear(year, month - 1, day);
+  date.setUTCHours(0, 0, 0, 0);
+  if (year < 1 || year > 9999 || date.getUTCFullYear() !== year
+    || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) invalid();
+  return BigInt(date.getTime()) * 1000n;
+}
+function clock(value: string, offset: boolean): bigint {
+  const match = /^(\d{2})(?:(:?)(\d{2})(?:\2(\d{2}))?)?(?:[.,](\d+))?$/.exec(value);
+  if (!match) invalid();
+  const hour = Number(match[1]), minute = Number(match[3] ?? 0), second = Number(match[4] ?? 0);
+  if (!offset && (hour > 23 || minute > 59 || second > 59)) invalid();
+  const integral = BigInt(hour * 3600 + minute * 60 + second) * 1000000n;
+  // CPython treats any all-zero integral UTC offset as UTC, ignoring fractions.
+  if (offset && integral === 0n) return 0n;
+  return integral + BigInt((match[5] ?? '').slice(0, 6).padEnd(6, '0'));
+}
+/** Python's aware ISO calendar/week dates, offsets and truncated microseconds. */
+export function claimTime(value: string): bigint {
+  const input = value.replaceAll('Z', '+00:00');
+  const date = /^(\d{4})(?:(-?)(\d{2})\2(\d{2})|(-?)W(\d{2})(?:\5([1-7]))?)/.exec(input);
+  if (!date) invalid();
+  const year = Number(date[1]);
+  let epoch: bigint;
+  if (date[3]) epoch = midnight(year, Number(date[3]), Number(date[4]));
+  else {
+    const week = Number(date[6]), day = Number(date[7] ?? 1);
+    const jan4 = midnight(year, 1, 4);
+    const weekday = (new Date(Number(jan4 / 1000n)).getUTCDay() + 6) % 7;
+    epoch = jan4 + BigInt((week - 1) * 7 + day - 1 - weekday) * dayMicros;
+    const thursday = new Date(Number((epoch + BigInt(4 - day) * dayMicros) / 1000n));
+    if (week < 1 || week > 53 || thursday.getUTCFullYear() !== year) invalid();
+  }
+  const suffix = input.slice(date[0].length);
+  if (!suffix) invalid();
+  const rest = Array.from(suffix).slice(1).join('');
+  const zone = /([+-])([^+-]+)$/.exec(rest);
+  if (!zone) invalid();
+  const local = clock(rest.slice(0, zone.index), false);
+  const offset = clock(zone[2]!, true);
+  if (offset >= dayMicros) invalid();
+  const result = epoch + local - (zone[1] === '-' ? -offset : offset);
+  if (result < midnight(1, 1, 1) || result >= midnight(9999, 12, 31) + dayMicros) overflow();
+  return result;
+}
+export function claimTimeString(micros: bigint): string {
+  if (micros < midnight(1, 1, 1) || micros >= midnight(9999, 12, 31) + dayMicros) overflow();
+  const milliseconds = micros >= 0n ? micros / 1000n : (micros - 999n) / 1000n;
+  return new Date(Number(milliseconds)).toISOString().replace(/\.\d{3}Z$/, 'Z');
+}

--- a/src/contracts/workspace/claims.ts
+++ b/src/contracts/workspace/claims.ts
@@ -1,0 +1,84 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
+import { PythonObject } from '../python-object.js';
+import { PythonText } from '../python-text.js';
+import { safeAnswerSessionId } from './answer-session-validation.js';
+import { strip } from './job-url.js';
+import { claimTime, claimTimeString } from './claim-time.js';
+import { copy, fromJSON, get, has, int, keys, object, set, string, text, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+
+export const claimLeaseSeconds = 300;
+export const claimHeartbeatSeconds = 60;
+export function validateCoordinator(value: Value): Document {
+  if (!(value instanceof PythonObject)) throw new JobsError('coordinator must be a JSON object');
+  const document = value;
+  const version = int(get(document, 'schemaVersion'));
+  if (version === null) throw new JobsError('coordinator has no valid schemaVersion');
+  if (version > 1n) throw new JobsError(`coordinator uses unsupported future schemaVersion ${version}`);
+  if (version !== 1n) throw new JobsError(`coordinator uses unsupported schemaVersion ${version}`);
+  if (document.size !== 2 || !has(document, 'claim')) throw new JobsError('coordinator contains unsupported fields');
+  if (get(document, 'claim') !== null) validateClaim(get(document, 'claim'));
+  return document;
+}
+export function validateClaim(value: Value): Document {
+  if (!(value instanceof PythonObject)) throw new JobsError('coordinator claim must be a JSON object');
+  const claim = value;
+  const required = ['claimId', 'jobId', 'ownerLabel', 'tokenHash', 'acquiredAt', 'heartbeatAt', 'expiresAt'];
+  if (claim.size !== required.length || keys(claim).some(key => !required.includes(key))
+    || required.some(key => !string(get(claim, key)))) throw new JobsError('coordinator claim is invalid');
+  safeAnswerSessionId(get(claim, 'jobId'));
+  for (const key of ['acquiredAt', 'heartbeatAt', 'expiresAt']) claimTime(string(get(claim, key))!);
+  return claim;
+}
+export function claimExpired(claim: Document, now: string): boolean {
+  return claimTime(now) >= claimTime(string(get(claim, 'expiresAt'))!);
+}
+export function publicClaim(value: Value, now: string): Value {
+  if (value === null) return null;
+  const result = copy(object(value, 'coordinator claim'));
+  result.delete(text('tokenHash'));
+  return set(result, 'expired', claimExpired(object(value, 'coordinator claim'), now));
+}
+export function claimTokenHash(token: Value): string {
+  if (!(token instanceof PythonText) || !token.length) throw new JobsError('claim token is required');
+  return createHash('sha256').update(token.encodeUtf8()).digest('hex');
+}
+export function makeClaim(jobId: string, ownerLabel: Value, now: string): {claim: Document; token: string} {
+  safeAnswerSessionId(text(jobId));
+  const label = string(ownerLabel);
+  if (label === null || !strip(label)) throw new JobsError('owner label must be a non-empty string');
+  const instant = claimTime(now), at = claimTimeString(instant);
+  const token = `claim_${randomBytes(32).toString('base64url')}`;
+  const claim = object(fromJSON({claimId:randomUUID(),jobId,ownerLabel:strip(label),tokenHash:claimTokenHash(text(token)),
+    acquiredAt:at,heartbeatAt:at,expiresAt:claimTimeString(instant + BigInt(claimLeaseSeconds) * 1000000n)}), 'claim');
+  const points = (ownerLabel as PythonText).codePoints;
+  let start = 0, end = points.length;
+  while (start < end && !strip(String.fromCodePoint(points[start]!))) start++;
+  while (end > start && !strip(String.fromCodePoint(points[end - 1]!))) end--;
+  set(claim, 'ownerLabel', PythonText.fromCodePoints(points.slice(start, end)));
+  return {claim,token};
+}
+export function requireClaim(coordinator: Document, jobs: Document, jobId: string, token: Value, now: string, allowExpired = false): Document {
+  const value = get(coordinator, 'claim');
+  if (value === null || string(get(object(value, 'claim'), 'jobId')) !== jobId) throw new JobsError('job is not held by this claim');
+  const claim = object(value, 'claim'), expected = string(get(claim, 'tokenHash'))!;
+  const supplied = claimTokenHash(token);
+  // Hash comparison remains constant-time for normal, fixed-length hash records.
+  if (!/^[\x00-\x7f]*$/.test(expected)) throw new TypeError('comparing strings with non-ASCII characters is not supported');
+  const left = Buffer.from(expected), right = Buffer.from(supplied);
+  if (left.length !== right.length || !timingSafeEqual(left, right)) throw new JobsError('claim token is invalid');
+  const rawJob = get(object(get(jobs, 'jobs'), 'jobs'), jobId);
+  if (rawJob === null || get(object(rawJob, 'job'), 'deletedAt') !== null
+    || string(get(object(rawJob, 'job'), 'status')) !== 'in_progress') throw new JobsError('claimed job is not in progress');
+  if (!allowExpired && claimExpired(claim, now)) throw new JobsError('claim has expired; use explicit recovery');
+  return claim;
+}
+export function requireJobUnclaimed(coordinator: Document, jobId: string): void {
+  const value = get(coordinator, 'claim');
+  if (value !== null && string(get(object(value, 'claim'), 'jobId')) === jobId) throw new JobsError('claimed job requires a coordinator operation');
+}
+export function heartbeatClaim(claim: Document, now: string): Document {
+  const instant = claimTime(now), result = copy(claim);
+  set(result, 'heartbeatAt', text(claimTimeString(instant)));
+  return set(result, 'expiresAt', text(claimTimeString(instant + BigInt(claimLeaseSeconds) * 1000000n)));
+}

--- a/src/store/native-claim-history.ts
+++ b/src/store/native-claim-history.ts
@@ -1,0 +1,69 @@
+import { constants } from 'node:fs';
+import { open } from 'node:fs/promises';
+import { join } from 'node:path';
+import { parsePythonPointJsonBytes } from '../contracts/raw-json/point-parser.js';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { validateAnswerHistory } from '../contracts/workspace/answer-session-validation.js';
+import { get, string, JobsError } from '../contracts/workspace/values.js';
+import type { Document } from '../contracts/workspace/values.js';
+import { strip } from '../contracts/workspace/job-url.js';
+import { encodePointJsonlJson } from './point-persistence.js';
+
+/** Caller holds the Store lock. Descriptor checks also apply during recovery. */
+export class NativeClaimHistory {
+  constructor(private readonly root: string) {}
+  private async handle(writable: boolean) {
+    const handle = await open(join(this.root, 'applications.jsonl'),
+      (writable ? constants.O_RDWR : constants.O_RDONLY) | constants.O_NOFOLLOW);
+    try {
+      const stat = await handle.stat();
+      if (!stat.isFile() || stat.nlink !== 1 || (stat.mode & 0o077) !== 0 || stat.uid !== process.getuid?.()) {
+        throw new JobsError('native history must be private and owned, without links');
+      }
+      if (stat.size > 32 * 1024 * 1024) throw new JobsError('native history exceeds supported size');
+      return handle;
+    } catch (error) { await handle.close(); throw error; }
+  }
+  async read(): Promise<Document[]> {
+    const handle = await this.handle(false);
+    try {
+      const content = new TextDecoder('utf-8', {fatal:true,ignoreBOM:true}).decode(await handle.readFile());
+      return content.split('\n').filter(line => strip(line)).map(line => validateAnswerHistory(
+        parsePythonPointJsonBytes(Buffer.from(line), {diagnosticProfile:'3.12',intMaxStrDigits:4300})));
+    } finally { await handle.close(); }
+  }
+  async repairPendingTail(): Promise<void> {
+    const handle = await this.handle(true);
+    try {
+      const content = await handle.readFile();
+      if (!content.length || content.at(-1) === 10) return;
+      await handle.truncate(content.lastIndexOf(10) + 1);
+      await handle.sync();
+    } finally { await handle.close(); }
+  }
+  async isIdempotent(event: Document): Promise<boolean> {
+    validateAnswerHistory(event);
+    const matching = (await this.read()).filter(item => string(get(item,'eventId')) === string(get(event,'eventId')));
+    if (!matching.length) return false;
+    const expected = canonicalJson(event);
+    if (matching.every(item => canonicalJson(item) === expected)) return true;
+    throw new JobsError('history event id collision');
+  }
+  async append(event: Document): Promise<void> {
+    if (await this.isIdempotent(event)) return;
+    const encoded = encodePointJsonlJson(event, {pathProfile:'3.12',intMaxStrDigits:4300});
+    const handle = await this.handle(true);
+    try {
+      const original = (await handle.stat()).size;
+      try {
+        let offset = 0;
+        while (offset < encoded.length) {
+          const {bytesWritten} = await handle.write(encoded, offset, encoded.length-offset, original+offset);
+          if (bytesWritten <= 0) throw new JobsError('history append was incomplete');
+          offset += bytesWritten;
+        }
+        await handle.sync();
+      } catch (error) { await handle.truncate(original); await handle.sync(); throw error; }
+    } finally { await handle.close(); }
+  }
+}

--- a/src/store/native-claim-journal.ts
+++ b/src/store/native-claim-journal.ts
@@ -1,0 +1,75 @@
+import { validateCoordinator } from '../contracts/workspace/claims.js';
+import { validateAnswerHistory, validateAnswerSession } from '../contracts/workspace/answer-session-validation.js';
+import { validateJobsDocument, safeId } from '../contracts/workspace/jobs.js';
+import { fromJSON, get, has, int, integer, keys, object, parse, serialize, set, string, JobsError } from '../contracts/workspace/values.js';
+import type { Document } from '../contracts/workspace/values.js';
+import { NativeClaimHistory } from './native-claim-history.js';
+
+export const claimOperationKinds = new Set(['acquire','recover','handoff']);
+export function validateClaimJournal(journal: Document): Document {
+  if (journal.size !== 2 || int(get(journal,'schemaVersion')) !== 1n || !has(journal,'operation')) throw new JobsError('invalid coordinator journal');
+  const operation = object(get(journal,'operation'),'coordinator journal operation');
+  const kind = string(get(operation,'kind'))!;
+  const fields = ['kind','operationId','jobId','at','historyEvent','resultClaim',
+    ...(kind === 'recover' ? [] : ['sourceStatus','targetStatus','expectedRevision']), ...(kind === 'handoff' ? ['session'] : [])];
+  if (!claimOperationKinds.has(kind) || operation.size !== fields.length || keys(operation).some(key => !fields.includes(key))) throw new JobsError('coordinator journal operation is invalid');
+  const id = safeId(string(get(operation,'jobId')));
+  if (!string(get(operation,'operationId')) || !string(get(operation,'at'))) throw new JobsError('coordinator journal operation is invalid');
+  const event = validateAnswerHistory(get(operation,'historyEvent'));
+  if (string(get(event,'applicationId')) !== id) throw new JobsError('coordinator history identity does not match');
+  if (kind !== 'recover' && (int(get(operation,'expectedRevision')) === null || int(get(operation,'expectedRevision'))! < 1n)) throw new JobsError('coordinator journal revision is invalid');
+  if (kind === 'acquire' && (string(get(operation,'sourceStatus')) !== 'ready' || string(get(operation,'targetStatus')) !== 'in_progress')) throw new JobsError('coordinator acquisition transition is invalid');
+  if (kind === 'handoff') {
+    if (string(get(operation,'sourceStatus')) !== 'in_progress' || !['needs_info','awaiting_review'].includes(string(get(operation,'targetStatus'))!)) throw new JobsError('coordinator handoff transition is invalid');
+    if (string(get(validateAnswerSession(get(operation,'session')),'applicationId')) !== id) throw new JobsError('coordinator session identity does not match');
+    if (get(operation,'resultClaim') !== null) throw new JobsError('coordinator handoff must release its claim');
+  } else {
+    const coordinator = object(fromJSON({schemaVersion:1,claim:null}),'coordinator');
+    set(coordinator,'claim',get(operation,'resultClaim'));
+    validateCoordinator(coordinator);
+    if (get(coordinator,'claim') === null || string(get(object(get(coordinator,'claim'),'claim'),'jobId')) !== id) throw new JobsError('coordinator claim identity does not match');
+  }
+  return operation;
+}
+function project(operation: Document, jobs: Document): Document | null {
+  if (!has(operation,'targetStatus')) return null;
+  const next = validateJobsDocument(object(parse(serialize(jobs)),'jobs'));
+  const id = string(get(operation,'jobId'))!, current = get(object(get(next,'jobs'),'jobs'),id);
+  if (current === null || get(object(current,'job'),'deletedAt') !== null) throw new JobsError('coordinator journal references a missing job');
+  const job = object(current,'job'), expected = int(get(operation,'expectedRevision'))!;
+  if (int(get(job,'revision')) === expected) {
+    if (string(get(job,'status')) !== string(get(operation,'sourceStatus'))) throw new JobsError('coordinator journal source status drifted');
+    set(job,'status',get(operation,'targetStatus'));set(job,'closedOutcome',null);
+    set(job,'revision',integer(expected+1n));set(job,'updatedAt',get(operation,'at'));
+    set(object(get(next,'metadata'),'jobs.metadata'),'updatedAt',get(operation,'at'));
+    return validateJobsDocument(next);
+  }
+  if (int(get(job,'revision')) !== expected+1n || string(get(job,'status')) !== string(get(operation,'targetStatus'))) throw new JobsError('coordinator journal cannot be reconciled');
+  return null;
+}
+export class NativeClaimJournal {
+  constructor(private readonly write: (name:string,document:Document)=>Promise<void>,
+    private readonly history: NativeClaimHistory, private readonly checkpoint: (stage:string)=>Promise<void> = async () => {}) {}
+  async recover(journal: Document, jobs: Document): Promise<void> {
+    const operation = validateClaimJournal(journal), next = project(operation,jobs);
+    const event = object(get(operation,'historyEvent'),'history event');
+    // Validate every destination and collision before the first document write.
+    await this.history.isIdempotent(event);
+    if (next) await this.write('jobs',next);
+    if (has(operation,'session')) await this.write(`sessions/${string(get(operation,'jobId'))}`,object(get(operation,'session'),'session'));
+    await this.history.append(event);
+    await this.checkpoint('history');
+    const coordinator = object(fromJSON({schemaVersion:1,claim:null}),'coordinator');
+    set(coordinator,'claim',get(operation,'resultClaim'));
+    await this.write('coordinator',coordinator);
+    await this.write('coordinator-journal',object(fromJSON({schemaVersion:1,operation:null}),'journal'));
+  }
+  async commit(operation: Document, jobs: Document): Promise<void> {
+    const journal = object(fromJSON({schemaVersion:1,operation:null}),'journal');
+    set(journal,'operation',operation);
+    validateClaimJournal(journal);project(operation,jobs);
+    await this.history.isIdempotent(object(get(operation,'historyEvent'),'history event'));
+    await this.write('coordinator-journal',journal);
+    await this.recover(journal,jobs);
+  }
+}

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -1,3 +1,7 @@
+import { NativeClaimJournal, claimOperationKinds, validateClaimJournal } from './native-claim-journal.js';
+import { NativeClaimHistory } from './native-claim-history.js';
+import { validateCoordinator, requireJobUnclaimed } from '../contracts/workspace/claims.js';
+import type { ClaimTransaction } from '../workspace-core/claims.js';
 import { constants } from "node:fs";
 import { chmod, lstat, mkdir, open, readdir, realpath } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
@@ -12,9 +16,9 @@ import { withExclusiveFileLock } from "./exclusive-file-lock.js";
 import type { PosixFlockProvider } from "./posix-flock.js";
 import { NativeAnswerResolutionJournal } from "./native-answer-resolution-journal.js";
 import type { PendingAnswerTransaction } from "../workspace-core/pending-answers.js";
-import { NativeAnswerJournal, validateIdleCoordinator, answerJournalName } from "./native-answer-journal.js";
+import { NativeAnswerJournal, answerJournalName } from "./native-answer-journal.js";
 import { answerReferenceCounts } from "../contracts/workspace/answer-sessions.js";
-import { validateAnswerSession, validateAnswerHistory } from "../contracts/workspace/answer-session-validation.js";
+import { validateAnswerSession } from "../contracts/workspace/answer-session-validation.js";
 import type { AnswerMergeTransaction } from "../workspace-core/answer-merges.js";
 import { NativeResumeFiles } from "./native-resume-files.js";
 import { NativeExtractionJournal, closeRequestsForResumes, extractionJournalName, validateExtractionResumes } from "./native-extraction-journal.js";
@@ -24,12 +28,11 @@ import type { ExtractionTransaction } from "../workspace-core/extraction-context
 
 import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
-import { strip } from "../contracts/workspace/job-url.js";
 import { validateAnswers } from "../contracts/workspace/answers.js";
 import type { AnswerReferenceCounts } from "../workspace-core/answers.js";
 
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
-const marker = '{"mode":"native-jobs-fixture","version":7}\n';
+const marker = '{"mode":"native-jobs-fixture","version":8}\n';
 const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
@@ -78,7 +81,8 @@ export async function initializeJobsFixture(root: string): Promise<void> {
 
 export class NativeJobsRepository implements JobsRepository {
   constructor(readonly root: string, private readonly provider: PosixFlockProvider,
-    private readonly write = atomicWritePointJson) {}
+    private readonly write = atomicWritePointJson,
+    private readonly checkpoint: (stage:string)=>Promise<void> = async () => {}) {}
 
   private async read(name: string): Promise<Buffer> {
     const handle = await open(join(this.root, name), constants.O_RDONLY | constants.O_NOFOLLOW);
@@ -175,7 +179,12 @@ export class NativeJobsRepository implements JobsRepository {
       object(get(await this.document("profile"), "profile"), "profile.profile");
       const resumes = object(get(resumesDocument, "resumes"), "resumes.resumes");
       validateResumeReferences(resumes);
+      const coordinator = validateCoordinator(await this.journal('coordinator'));
+      const claim = get(coordinator,'claim');
+      const claimedId = claim === null ? null : string(get(object(claim,'claim'),'jobId'));
+      const originalClaimed = claimedId === null ? null : serialize(get(object(get(document,'jobs'),'jobs'),claimedId));
       return operation({ document,
+        requireUnclaimed: id => requireJobUnclaimed(coordinator,id),
         requireResume: async (id: Value) => {
           if (id === null) return;
           const value = string(id);
@@ -189,6 +198,7 @@ export class NativeJobsRepository implements JobsRepository {
         },
         save: async value => {
           validateJobsDocument(value);
+          if (claimedId !== null && serialize(get(object(get(value,'jobs'),'jobs'),claimedId)) !== originalClaimed) throw new JobsError('claimed job requires a coordinator operation');
           await this.write(join(this.root, "jobs.json"), value, options);
         },
       });
@@ -264,27 +274,51 @@ export class NativeJobsRepository implements JobsRepository {
     return sessions;
   }
 
-  private async answerHistory(): Promise<Document[]> {
-    const content = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(await this.read('applications.jsonl'));
-    return content.split('\n').filter(line => strip(line)).map(line => validateAnswerHistory(parsePythonPointJsonBytes(Buffer.from(line), { diagnosticProfile: "3.12", intMaxStrDigits: 4300 })));
+  private history(): NativeClaimHistory { return new NativeClaimHistory(this.root); }
+  private async answerHistory(): Promise<Document[]> { return this.history().read(); }
+  private claimJournal(): NativeClaimJournal {
+    return new NativeClaimJournal((name,document) => this.write(join(this.root,`${name}.json`),document,options),this.history(),this.checkpoint);
+  }
+  private async recoverAnswers(): Promise<void> {
+    const coordinator = validateCoordinator(await this.journal('coordinator'));
+    const sessions = await this.answerSessions();
+    const journal = await this.journal(answerJournalName), operation = get(journal,'operation');
+    if (operation !== null && claimOperationKinds.has(string(get(object(operation,'coordinator operation'),'kind'))!)) {
+      validateClaimJournal(journal);
+      await this.history().repairPendingTail();
+      await this.claimJournal().recover(journal,validateJobsDocument(await this.document('jobs')));
+      return;
+    }
+    await this.answerHistory();
+    if (operation !== null && get(coordinator,'claim') !== null) throw new JobsError('answer recovery requires an idle coordinator');
+    if (operation !== null && string(get(object(operation,'coordinator operation'),'kind')) === 'answer_resolution') {
+      await this.resolutionJournal().recover(journal,validateJobsDocument(await this.document('jobs')),sessions);
+    } else await this.answerJournal().recover(journal,validateAnswers(await this.document('answers')),sessions);
   }
 
-  private async recoverAnswers(): Promise<void> {
-    validateIdleCoordinator(await this.journal('coordinator'));
-    const sessions = await this.answerSessions();
-    await this.answerHistory();
-    const journal = await this.journal(answerJournalName);
-    const operation = get(journal, 'operation');
-    if (operation !== null && string(get(object(operation, 'coordinator operation'), 'kind')) === 'answer_resolution') {
-      await this.resolutionJournal().recover(journal, validateJobsDocument(await this.document('jobs')), sessions);
-    } else await this.answerJournal().recover(journal, validateAnswers(await this.document('answers')), sessions);
+  async claimTransaction<T>(operation:(transaction:ClaimTransaction)=>Promise<T>):Promise<T> {
+    return this.transaction(async () => {
+      const jobs = validateJobsDocument(await this.document('jobs'));
+      return operation({jobs,coordinator:validateCoordinator(await this.journal('coordinator')),
+        sessions:await this.answerSessions(), answers:validateAnswers(await this.document('answers')),
+        profile:validateProfile(await this.document('profile')),resumes:validateExtractionResumes(await this.document('resumes')),
+        files:new NativeResumeFiles(this.root),
+        saveJobs:async document => { validateJobsDocument(document);await this.write(join(this.root,'jobs.json'),document,options); },
+        saveCoordinator:async document => { validateCoordinator(document);await this.write(join(this.root,'coordinator.json'),document,options); },
+        saveSession:async document => { validateAnswerSession(document);await this.write(join(this.root,`sessions/${safeId(string(get(document,'applicationId')))}.json`),document,options); },
+        commit:operation => this.claimJournal().commit(operation,jobs)});
+    });
   }
 
   async answerMergeTransaction<T>(operation: (transaction: AnswerMergeTransaction) => Promise<T>): Promise<T> {
     return this.transaction(async () => {
       const document = validateAnswers(await this.document('answers'));
       const sessions = await this.answerSessions(), history = await this.answerHistory();
-      return operation({ document, sessions, history, commit: value => this.answerJournal().commit(value, document, sessions) });
+      const coordinator = validateCoordinator(await this.journal('coordinator'));
+      return operation({document,sessions,history,commit:value => {
+        if (get(coordinator,'claim') !== null) throw new JobsError('answer merge requires an idle coordinator');
+        return this.answerJournal().commit(value,document,sessions);
+      }});
     });
   }
 
@@ -295,9 +329,13 @@ export class NativeJobsRepository implements JobsRepository {
   async pendingAnswerTransaction<T>(operation: (transaction: PendingAnswerTransaction) => Promise<T>): Promise<T> {
     return this.transaction(async () => {
       const jobs = validateJobsDocument(await this.document('jobs')), sessions = await this.answerSessions();
+      const coordinator = validateCoordinator(await this.journal('coordinator'));
       return operation({ jobs, sessions, answers: validateAnswers(await this.document('answers')),
         profile: validateProfile(await this.document('profile')), resumes: validateExtractionResumes(await this.document('resumes')),
-        files: new NativeResumeFiles(this.root), commit: value => this.resolutionJournal().commit(value, jobs, sessions) });
+        files: new NativeResumeFiles(this.root), requireUnclaimed: id => requireJobUnclaimed(coordinator,id), commit: value => {
+          if (get(coordinator,'claim') !== null) throw new JobsError('answer resolution requires an idle coordinator');
+          return this.resolutionJournal().commit(value,jobs,sessions);
+        } });
     });
   }
 

--- a/src/workspace-core/claims-http.ts
+++ b/src/workspace-core/claims-http.ts
@@ -1,0 +1,39 @@
+import { ClaimsService } from './claims.js';
+import type { ClaimRepository } from './claims.js';
+import { get, int, keys, object, parse, serialize, string, JobsError } from '../contracts/workspace/values.js';
+import type { Value } from '../contracts/workspace/values.js';
+
+/** Authenticated transport supplies body bounds; bearer credentials are never logged. */
+export async function claimsHttp(repository:ClaimRepository,method:string,path:string,body:string):Promise<{status:number;body:string}|null> {
+  const service = new ClaimsService(repository);
+  if (method === 'GET' && path === '/api/claims') return {status:200,body:serialize(await service.status())};
+  const shapes:Record<string,string[]> = {
+    select:['jobId','expectedRevision','ownerConfirmed'], acquire:['jobId','ownerLabel','expectedRevision'],
+    heartbeat:['jobId','token'],recover:['jobId','ownerLabel'],progress:['jobId','token','session'],
+    handoff:['jobId','token','status','session','expectedRevision'],
+  };
+  const action = path.startsWith('/api/claims/') ? path.slice('/api/claims/'.length) : '';
+  const fields = shapes[action];
+  if (method !== 'POST' || !fields) return null;
+  const payload = object(parse(body),'claim body');
+  if (payload.size !== fields.length || keys(payload).some(key => !fields.includes(key))) throw new JobsError('claim body contains unsupported or missing fields');
+  const id = string(get(payload,'jobId'));
+  if (id === null) throw new JobsError('claim job id must be a string');
+  const revision = ():bigint => {
+    const value = int(get(payload,'expectedRevision'));
+    if (value === null) throw new JobsError('expected revision must be an integer');
+    return value;
+  };
+  let result:Value;
+  if (action === 'select') result = await service.select(id,revision(),get(payload,'ownerConfirmed') === true);
+  else if (action === 'acquire') result = await service.acquire(id,get(payload,'ownerLabel'),revision());
+  else if (action === 'heartbeat') result = await service.heartbeat(id,get(payload,'token'));
+  else if (action === 'recover') result = await service.recover(id,get(payload,'ownerLabel'));
+  else if (action === 'progress') result = await service.progress(id,get(payload,'token'),object(get(payload,'session'),'session'));
+  else {
+    const status = string(get(payload,'status'));
+    if (status === null) throw new JobsError('claimed handoff status is unsupported');
+    result = await service.handoff(id,get(payload,'token'),status,object(get(payload,'session'),'session'),revision());
+  }
+  return {status:200,body:serialize(result)};
+}

--- a/src/workspace-core/claims.ts
+++ b/src/workspace-core/claims.ts
@@ -1,0 +1,145 @@
+import { randomUUID } from 'node:crypto';
+import { claimExpired, claimHeartbeatSeconds, claimLeaseSeconds, heartbeatClaim, makeClaim, publicClaim, requireClaim, requireJobUnclaimed } from '../contracts/workspace/claims.js';
+import { buildClaimSession, validateClaimHandoff } from '../contracts/workspace/claim-session.js';
+import { safeId, validateJob } from '../contracts/workspace/jobs.js';
+import { strip } from '../contracts/workspace/job-url.js';
+import { copy, fromJSON, get, has, int, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import type { NativeResumeFiles } from '../store/native-resume-files.js';
+import { preflightJobRecord } from './job-preflight.js';
+
+export interface ClaimTransaction {
+  jobs: Document; coordinator: Document; profile: Document; resumes: Document; answers: Document;
+  sessions: Document[]; files: NativeResumeFiles;
+  saveJobs(document:Document):Promise<void>;
+  saveCoordinator(document:Document):Promise<void>;
+  saveSession(document:Document):Promise<void>;
+  commit(operation:Document):Promise<void>;
+}
+export interface ClaimRepository {
+  claimTransaction<T>(operation:(transaction:ClaimTransaction)=>Promise<T>):Promise<T>;
+}
+const doc = (value: unknown): Document => object(fromJSON(value),'claim result');
+function activeJob(jobs:Document,id:string,error='job does not exist'):Document {
+  const value = get(object(get(jobs,'jobs'),'jobs'),id);
+  if (value === null || get(object(value,'job'),'deletedAt') !== null) throw new JobsError(error);
+  return object(value,'job');
+}
+function owner(value:Value):void {
+  const label = string(value);
+  if (label === null || !strip(label)) throw new JobsError('owner label must be a non-empty string');
+}
+function transitioned(job:Document,target:string,at:string):Document {
+  const result = copy(job);
+  set(result,'status',text(target));set(result,'closedOutcome',null);
+  set(result,'revision',integer(int(get(job,'revision'))!+1n));set(result,'updatedAt',text(at));
+  return validateJob(string(get(job,'id'))!,result);
+}
+function projectJob(job:Document):Document {
+  const result = doc({});
+  for (const field of ['id','role','company','location','workplaceType','employmentType','status','priority','revision','createdAt','updatedAt']) if (has(job,field)) set(result,field,get(job,field));
+  return result;
+}
+function operation(kind:string,job:Document,at:string,eventName:string,status:string,claim:Value):Document {
+  const operationId = randomUUID(), id = string(get(job,'id'))!;
+  const event = doc({schemaVersion:1,eventId:`coordinator-${operationId}`,applicationId:id,event:eventName,status,answerKeys:[],at});
+  for (const field of ['company','role','ats']) if (string(get(job,field)) !== null) set(event,field,get(job,field));
+  const result = doc({kind,operationId,jobId:id,at});
+  set(result,'historyEvent',event);set(result,'resultClaim',claim);
+  if (kind !== 'recover') {
+    set(result,'sourceStatus',get(job,'status'));set(result,'targetStatus',text(status));set(result,'expectedRevision',get(job,'revision'));
+  }
+  return result;
+}
+export class ClaimsService {
+  constructor(private readonly repository:ClaimRepository,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/,'Z')) {}
+  status():Promise<Value> {
+    return this.repository.claimTransaction(async tx => set(doc({leaseSeconds:claimLeaseSeconds,heartbeatSeconds:claimHeartbeatSeconds}),'claim',publicClaim(get(tx.coordinator,'claim'),this.now())));
+  }
+  select(id:string,expectedRevision:bigint,confirmed:boolean):Promise<Value> {
+    safeId(id);
+    if (confirmed !== true) throw new JobsError('task selection requires owner confirmation');
+    if (typeof expectedRevision !== 'bigint') throw new JobsError('task selection requires an exact revision');
+    return this.repository.claimTransaction(async tx => {
+      const job = activeJob(tx.jobs,id,'task selection job is unavailable');
+      if (int(get(job,'revision')) !== expectedRevision) throw new JobsError('task selection revision conflict');
+      requireJobUnclaimed(tx.coordinator,id);
+      if (!['saved','needs_info','ready'].includes(string(get(job,'status'))!)) throw new JobsError('task selection job is unavailable');
+      if (get(await preflightJobRecord(job,tx.profile,tx.resumes,tx.files),'ready') !== true) throw new JobsError('task selection preflight failed');
+      if (string(get(job,'status')) === 'ready') return set(doc({action:'noop'}),'job',projectJob(job));
+      const updated = transitioned(job,'ready',this.now());
+      set(object(get(tx.jobs,'jobs'),'jobs'),id,updated);
+      set(object(get(tx.jobs,'metadata'),'jobs.metadata'),'updatedAt',get(updated,'updatedAt'));
+      await tx.saveJobs(tx.jobs);
+      return set(doc({action:'ready'}),'job',projectJob(updated));
+    });
+  }
+  acquire(id:string,ownerLabel:Value,expectedRevision:bigint):Promise<Value> {
+    safeId(id);owner(ownerLabel);
+    return this.repository.claimTransaction(async tx => {
+      const current = get(tx.coordinator,'claim');
+      if (current !== null) throw new JobsError(claimExpired(object(current,'claim'),this.now()) ? 'expired claim requires explicit same-job recovery' : 'another live job claim already exists');
+      const job = activeJob(tx.jobs,id);
+      if (int(get(job,'revision')) !== expectedRevision) throw new JobsError('job revision conflict');
+      if (string(get(job,'status')) !== 'ready') throw new JobsError('only a ready job can be acquired');
+      const preflight = await preflightJobRecord(job,tx.profile,tx.resumes,tx.files);
+      if (get(preflight,'ready') !== true) throw new JobsError('job is not ready');
+      const now = this.now(), {claim,token} = makeClaim(id,ownerLabel,now);
+      const resume = copy(object(get(object(get(tx.resumes,'resumes'),'resumes'),string(get(preflight,'resumeId'))!),'resume'));
+      set(resume,'path',string(get(resume,'storageKind')) === 'managed' ? text(tx.files.path(resume)) : get(resume,'path'));
+      await tx.commit(operation('acquire',job,now,'job-started','in_progress',claim));
+      const result = doc({token});set(result,'job',transitioned(job,'in_progress',now));set(result,'resume',resume);
+      return set(result,'claim',publicClaim(claim,this.now()));
+    });
+  }
+  heartbeat(id:string,token:Value):Promise<Value> {
+    return this.repository.claimTransaction(async tx => {
+      const claim = requireClaim(tx.coordinator,tx.jobs,id,token,this.now());
+      const updated = heartbeatClaim(claim,this.now());
+      await tx.saveCoordinator(set(doc({schemaVersion:1}),'claim',updated));
+      return set(doc({}),'claim',publicClaim(updated,this.now()));
+    });
+  }
+  recover(id:string,ownerLabel:Value):Promise<Value> {
+    safeId(id);owner(ownerLabel);
+    return this.repository.claimTransaction(async tx => {
+      const old = get(tx.coordinator,'claim');
+      if (old === null || string(get(object(old,'claim'),'jobId')) !== id) throw new JobsError('explicit recovery must name the expired claimed job');
+      const raw = get(object(get(tx.jobs,'jobs'),'jobs'),id);
+      if (raw === null || string(get(object(raw,'job'),'status')) !== 'in_progress') throw new JobsError('expired claim job is not in progress');
+      if (!claimExpired(object(old,'claim'),this.now())) throw new JobsError('live claim cannot be recovered');
+      const job = object(raw,'job'), now = this.now(), {claim,token} = makeClaim(id,ownerLabel,now);
+      await tx.commit(operation('recover',job,now,'claim-recovered','in_progress',claim));
+      const result = doc({token});set(result,'job',job);
+      return set(result,'claim',publicClaim(claim,this.now()));
+    });
+  }
+  progress(id:string,token:Value,incoming:Document):Promise<Value> {
+    return this.repository.claimTransaction(async tx => {
+      requireClaim(tx.coordinator,tx.jobs,id,token,this.now());
+      const session = this.session(tx,activeJob(tx.jobs,id),incoming);
+      if (string(get(session,'status')) !== 'active') throw new JobsError('claim progress session must remain active');
+      await tx.saveSession(session);
+      return session;
+    });
+  }
+  handoff(id:string,token:Value,status:string,incoming:Document,expectedRevision:bigint):Promise<Value> {
+    if (!['needs_info','awaiting_review'].includes(status)) throw new JobsError('claimed handoff status is unsupported');
+    return this.repository.claimTransaction(async tx => {
+      requireClaim(tx.coordinator,tx.jobs,id,token,this.now());
+      const job = activeJob(tx.jobs,id);
+      if (int(get(job,'revision')) !== expectedRevision) throw new JobsError('job revision conflict');
+      const now = this.now(), session = this.session(tx,job,incoming,now);
+      validateClaimHandoff(session,incoming,status,get(job,'revision'));
+      const op = operation('handoff',job,now,status === 'needs_info' ? 'job-blocked' : 'reviewed',status,null);
+      set(op,'session',session);await tx.commit(op);
+      const result = doc({claim:null});set(result,'job',transitioned(job,status,now));return set(result,'session',session);
+    });
+  }
+  private session(tx:ClaimTransaction,job:Document,incoming:Document,now=this.now()):Document {
+    const id = string(get(job,'id'))!;
+    return buildClaimSession(id,incoming,{now,attemptRevision:get(job,'revision'),ats:get(job,'ats'),
+      existing:tx.sessions.find(session => string(get(session,'applicationId')) === id) ?? null, answers:tx.answers});
+  }
+}

--- a/src/workspace-core/jobs-http.ts
+++ b/src/workspace-core/jobs-http.ts
@@ -1,3 +1,4 @@
+import { claimsHttp } from './claims-http.js';
 import { pendingAnswersHttp } from './pending-answers-http.js';
 import { profileHttp } from "./profile-http.js";
 import type { JobsService } from "./jobs.js";
@@ -22,6 +23,8 @@ const envelope = (key: string, value: Value): Value => set(emptyObject(), key, v
 export async function jobsHttp(service: JobsService, repository: NativeJobsRepository,
   method: string, path: string, body = ""): Promise<ApiResult> {
   try {
+    const claim = await claimsHttp(repository,method,path,body);
+    if (claim) return claim;
     const pending = await pendingAnswersHttp(repository, method, path, body);
     if (pending) return pending;
     const extraction = await extractionHttp(repository, method, path, body);

--- a/src/workspace-core/jobs.ts
+++ b/src/workspace-core/jobs.ts
@@ -7,6 +7,7 @@ import { mayUpdate, nonempty, origin, protectMigration, stamp } from "./job-prov
 
 export interface JobsTransaction {
   document: Document;
+  requireUnclaimed?(id:string):void;
   requireResume(id: Value): Promise<void>;
   save(document: Document): Promise<void>;
 }
@@ -88,6 +89,7 @@ export class JobsService {
       const jobs = object(get(transaction.document, "jobs"), "jobs.jobs"), value = get(jobs, id);
       if (value === null || get(object(value, "job record"), "deletedAt") !== null) throw new JobsError("job does not exist");
       const current = object(value, "job record");
+      transaction.requireUnclaimed?.(id);
       if (int(get(current, "revision")) !== expectedRevision) throw new JobsError("job revision conflict");
       const currentProvenance = has(current, "provenance") ? object(get(current, "provenance"), "job provenance") : emptyObject();
       let provenance = currentProvenance;

--- a/src/workspace-core/pending-answers.ts
+++ b/src/workspace-core/pending-answers.ts
@@ -9,6 +9,7 @@ import type { NativeResumeFiles } from '../store/native-resume-files.js';
 import { preflightJobRecord } from './job-preflight.js';
 
 export interface PendingAnswerTransaction {
+  requireUnclaimed?(id:string):void;
   jobs: Document; answers: Document; sessions: Document[];
   profile: Document; resumes: Document; files: NativeResumeFiles;
   commit(operation: Document): Promise<void>;
@@ -51,6 +52,7 @@ export class PendingAnswersService {
       if (typeof revision !== 'bigint' || revision < 1n) throw new JobsError('answer resolution revision is invalid');
     }
     return this.repository.pendingAnswerTransaction(async transaction => {
+      transaction.requireUnclaimed?.(jobId);
       const rawJob = get(object(get(transaction.jobs, 'jobs'), 'jobs'), jobId);
       if (rawJob === null || get(object(rawJob, 'job'), 'deletedAt') !== null) throw new JobsError('job does not exist');
       const job = object(rawJob, 'job');

--- a/tests_js/jsonl_lock_integration.test.mjs
+++ b/tests_js/jsonl_lock_integration.test.mjs
@@ -78,7 +78,8 @@ const io={...native,async open(...args){const handle=await native.open(...args);
  return {...handle,async write(bytes){
   const count=await handle.write(process.argv[4]==='partial'?bytes.subarray(0,7):bytes);
   report('bytes-written');
-  await new Promise(()=>{});
+  // Keep the suspended write reachable so FileHandle GC cannot release the lock.
+  await new Promise(resolve=>{globalThis.retainInterruptedWrite=resolve;});
   return count;
  }};}};
 const keeper=setInterval(()=>{},1000);

--- a/tests_js/workspace_claim_sessions.test.mjs
+++ b/tests_js/workspace_claim_sessions.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import test from 'node:test';
+import { buildClaimSession, validateClaimHandoff } from '../runtime/contracts/workspace/claim-session.js';
+import { fromJSON, serialize } from '../runtime/contracts/workspace/values.js';
+
+const plain = value => JSON.parse(serialize(value));
+const fixture = JSON.parse(readFileSync(new URL('../qa/fixtures/greenhouse-form-readiness-v1/fixture.json',import.meta.url),'utf8'));
+const clone = value => structuredClone(value);
+function readyPacket() {
+  const controls = fixture.steps.flatMap(step => step.controls);
+  const requiredControlIds = controls.filter(control => control.required).map(control => control.id).sort();
+  const platformFamily = fixture.platformFamily;
+  const fingerprint = createHash('sha256').update(JSON.stringify({platformFamily,requiredControlIds})).digest('hex');
+  const kinds = {textbox:'text',combobox:'selection',radiogroup:'selection',checkbox:'toggle',file:'upload'};
+  return {attemptRevision:3,evidenceKind:'agent_attested_current_attempt',fixture:clone(fixture),expectedObservationRevision:7,
+    formManifest:{schemaVersion:1,platformFamily,observationRevision:7,requiredControlIds,controlSetFingerprint:`sha256:${fingerprint}`,complete:true},
+    observation:{schemaVersion:1,platformFamily,observationRevision:7,adapterState:'accessible',uploadCapability:'available',
+      controls:controls.map(control => ({controlId:control.id,kind:kinds[control.role],state:control.role === 'file' ? 'accepted':'complete',observationRevision:7})),
+      validationErrorControlIds:[],finalControlState:'available'}};
+}
+function base() {
+  return {incoming:{status:'active',company:'EPHEMERAL_COMPANY',role:'EPHEMERAL_ROLE',url:'https://private.invalid',
+    pendingFields:[{question:' Preferred  CITY? ',state:'missing',answerKey:'answer',scope:{ats:'greenhouse'},matchConfidence:'high',matchReasonCodes:['fabricated']}],answerKeys:['answer']},
+    context:{now:'2026-09-10T10:00:00Z',attemptRevision:3,ats:'greenhouse',existing:null,
+      answers:{schemaVersion:1,metadata:{},redirects:{},answers:{answer:{key:'answer',question:'Preferred city?',state:'confirmed',value:'PRIVATE_ANSWER',revision:4,scope:{ats:'greenhouse'}}}}}};
+}
+function native(item) {
+  const incoming = fromJSON(item.incoming), context = {...item.context,attemptRevision:fromJSON(item.context.attemptRevision),ats:fromJSON(item.context.ats),
+    answers:fromJSON(item.context.answers),existing:item.context.existing === null ? null:fromJSON(item.context.existing)};
+  const before = [incoming,context.answers,context.existing].map(serialize);
+  try {
+    const session = buildClaimSession('job',incoming,context);
+    if ('target' in item) validateClaimHandoff(session,incoming,item.target,context.attemptRevision);
+    return {session:plain(session)};
+  } catch (error) { return {error:error.message}; }
+  finally { assert.deepEqual([incoming,context.answers,context.existing].map(serialize),before,'inputs must be unchanged'); }
+}
+function normalize(result, item) {
+  const references = new Map();
+  const existing = new Set((item.context.existing?.pendingFields ?? []).map(field => field.reference));
+  for (const field of result.session?.pendingFields ?? []) {
+    assert.match(field.reference,/^pending_[a-f0-9]{32}$/);
+    if (!existing.has(field.reference)) references.set(field.reference,`new-reference-${references.size}`);
+  }
+  return JSON.parse(JSON.stringify(result,(_key,value) => references.get(value) ?? value));
+}
+function oracle(items) {
+  const run = spawnSync('python3',['tools/contracts/claim-sessions/reference.py'],{input:JSON.stringify(items),encoding:'utf8',timeout:30000});
+  assert.equal(run.status,0,run.stderr);
+  return JSON.parse(run.stdout);
+}
+
+test('claim sessions preserve Python privacy, reference identity, approvals and readiness contracts', () => {
+  const cases = [];
+  function add(name, change = () => {}) { const item=base(); change(item); cases.push({name,item}); }
+  add('ephemeral metadata stripped, semantic claims recomputed');
+  add('unbound question',item => delete item.incoming.pendingFields[0].answerKey);
+  add('question missing',item => delete item.incoming.pendingFields[0].question);
+  add('question whitespace',item => item.incoming.pendingFields[0].question='\u001c \u0085');
+  add('question casefold',item => item.incoming.pendingFields[0].question='Straße\u001fCITY');
+  add('sensitive field',item => item.incoming.pendingFields[0].sensitive=true);
+  add('sensitive answer',item => item.context.answers.answers.answer.sensitivity='personal');
+  add('unknown answer',item => item.incoming.pendingFields[0].answerKey='unknown');
+  add('redirect answer',item => {item.incoming.pendingFields[0].answerKey='old';item.context.answers.redirects.old={targetKey:'answer',mergedAt:'old'};});
+  add('empty scope',item => item.incoming.pendingFields[0].scope={});
+  add('scope from ATS',item => delete item.incoming.pendingFields[0].scope);
+  add('missing ATS',item => {item.context.ats=null;delete item.incoming.pendingFields[0].scope;});
+  for (const [key,value] of [['applicationId','other'],['attemptRevision',2],['status','bad'],['answerKeys',null],['pendingFields',null],['blockers',null],['approvals',[]]]) add(`invalid ${key}`,item => item.incoming[key]=value);
+  for (const [key,value] of [['reference','forged'],['scope',5],['state','bad'],['fieldClass','BAD'],['sensitive',1]]) add(`invalid field ${key}`,item => item.incoming.pendingFields[0][key]=value);
+  for (const code of ['login-required','consent-required','owner-input-required']) add(`agent blocker ${code}`,item => {
+    item.incoming.pendingFields=[];item.incoming.blockers=[{type:code==='consent-required'?'owner_review':code==='owner-input-required'?'information':'browser_handoff',code}];
+  });
+  add('contradictory handoff',item => {item.incoming.blockers=[{type:'browser_handoff',code:'login-required'}];item.incoming.browserHandoff={state:'not_required',reasonCode:'none',revision:1};});
+  add('nonobject pending field',item => item.incoming.pendingFields=[null]);
+  add('nonobject blocker',item => item.incoming.blockers=[null]);
+  add('nonobject handoff',item => item.incoming.browserHandoff=4);
+  add('created timestamp retained',item => item.incoming.createdAt='old');
+  const existing = native(base()).session;
+  const approval = {reference:existing.pendingFields[0].reference,answerKey:'answer',currentUse:true,remember:false,policyMode:'strict',useAuthority:'per_use',eligible:true,confidenceBand:'exact',reasonCodes:['match_exact_question'],answerRevision:4};
+  existing.approvals=[approval];
+  for (const mode of ['same','new-attempt','changed-answer','changed-question','duplicate-fields','changed-match','deleted-answer']) add(`carry ${mode}`,item => {
+    item.context.existing=clone(existing);
+    if(mode==='new-attempt') item.context.attemptRevision=5;
+    if(mode==='changed-answer') item.context.answers.answers.answer.revision++;
+    if(mode==='deleted-answer') item.context.answers.answers.answer.deletedAt='old';
+    if(mode==='changed-question') item.incoming.pendingFields[0].question='New question';
+    if(mode==='changed-match') item.context.answers.answers.answer.question='New match wording';
+    if(mode==='duplicate-fields') item.incoming.pendingFields.push(clone(item.incoming.pendingFields[0]));
+  });
+  function readiness(name, change=()=>{}) { add(`readiness ${name}`,item => {
+    item.incoming={status:'review',readinessInput:readyPacket()};item.target='awaiting_review';change(item,item.incoming.readinessInput);
+  }); }
+  readiness('live ready');
+  readiness('nonobject packet',item=>item.incoming.readinessInput=null);
+  readiness('boolean observation revision',(item,packet)=>packet.observation.observationRevision=true);
+  readiness('duplicate validation IDs',(item,packet)=>packet.observation.validationErrorControlIds=[packet.observation.controls[0].controlId,packet.observation.controls[0].controlId]);
+  readiness('manifest omitted control',(item,packet)=>packet.formManifest.requiredControlIds.pop());
+  readiness('repository replay',(item,packet)=>packet.evidenceKind='repository_replay');
+  readiness('attempt mismatch',(item,packet)=>packet.attemptRevision=2);
+  readiness('missing attempt',item=>{item.context.attemptRevision=null;delete item.incoming.readinessInput.attemptRevision;});
+  readiness('tampered fixture',(item,packet)=>packet.fixture.description='tampered');
+  readiness('wrong ATS',item=>item.context.ats='lever');
+  readiness('manifest incomplete',(item,packet)=>packet.formManifest.complete=false);
+  readiness('manifest fingerprint',(item,packet)=>packet.formManifest.controlSetFingerprint='sha256:'+'0'.repeat(64));
+  readiness('old observation',(item,packet)=>packet.observation.observationRevision=6);
+  readiness('old control',(item,packet)=>packet.observation.controls[0].observationRevision=6);
+  readiness('duplicate control',(item,packet)=>packet.observation.controls.push(clone(packet.observation.controls[0])));
+  readiness('unknown control',(item,packet)=>packet.observation.controls[0].controlId='unknown');
+  readiness('wrong kind',(item,packet)=>packet.observation.controls[0].kind='upload');
+  readiness('private control value',(item,packet)=>packet.observation.controls[0].value='PRIVATE');
+  for(const state of ['missing','rejected','unresolved','inaccessible']) readiness(`upload ${state}`,(item,packet)=>packet.observation.controls.find(control=>control.kind==='upload').state=state);
+  for(const state of ['activated','unavailable','inaccessible']) readiness(`final ${state}`,(item,packet)=>packet.observation.finalControlState=state);
+  readiness('adapter inaccessible',(item,packet)=>packet.observation.adapterState='inaccessible');
+  readiness('validation error',(item,packet)=>packet.observation.validationErrorControlIds=[packet.observation.controls[0].controlId]);
+  readiness('owner upload fallback',(item,packet)=>{packet.observation.controls.find(control=>control.kind==='upload').state='missing';packet.observation.uploadCapability='external-runtime-unavailable';item.target='needs_info';item.incoming.status='active';});
+  readiness('missing evidence controls',(item,packet)=>packet.observation.controls=[]);
+  readiness('pending information',(item)=>item.incoming.pendingFields=base().incoming.pendingFields);
+  readiness('status mismatch',item=>item.incoming.status='active');
+  const readyExisting=native({...base(),incoming:{status:'review',readinessInput:readyPacket()}}).session;
+  add('retained readiness does not authorize handoff',item=>{item.context.existing=readyExisting;item.incoming={status:'review'};item.target='awaiting_review';});
+  add('new attempt drops readiness',item=>{item.context.existing=readyExisting;item.context.attemptRevision=5;item.incoming={status:'active'};});
+  add('same attempt retains readiness',item=>{item.context.existing=readyExisting;item.incoming={status:'active'};});
+  const expected=oracle(cases.map(({item})=>item));
+  const failures=[];
+  for(const [index,{name,item}] of cases.entries()) {
+    const actual=native(item);
+    try { assert.deepEqual(normalize(actual,item),normalize(expected[index],item),name); }
+    catch (error) { failures.push(error.message); }
+    if(actual.session) {
+      const encoded=JSON.stringify(actual.session);
+      for(const secret of ['EPHEMERAL_COMPANY','EPHEMERAL_ROLE','https://private.invalid','PRIVATE_ANSWER','Preferred  CITY']) assert.ok(!encoded.includes(secret),`${name}: private input persisted`);
+    }
+  }
+  assert.deepEqual(failures,[]);
+  console.log(`Validated ${cases.length} Python differential claim-session cases`);
+});

--- a/tests_js/workspace_claims_contracts.test.mjs
+++ b/tests_js/workspace_claims_contracts.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { validateCoordinator, publicClaim, makeClaim, requireClaim, requireJobUnclaimed, heartbeatClaim, claimExpired, claimTokenHash } from '../runtime/contracts/workspace/claims.js';
+import { claimTime } from '../runtime/contracts/workspace/claim-time.js';
+import { fromJSON, serialize, text, parse } from '../runtime/contracts/workspace/values.js';
+import { claim, now, cases } from './workspace_claims_contracts_support.mjs';
+const plain = value => JSON.parse(serialize(value));
+function invoke(item) {
+  switch (item.op) {
+    case 'time': return claimTime(item.value).toString();
+    case 'validate': return plain(validateCoordinator(fromJSON(item.coordinator)));
+    case 'hash': return claimTokenHash(parse(JSON.stringify(item.token)));
+    case 'public': return plain(publicClaim(fromJSON(item.coordinator.claim), item.now));
+    case 'require': return plain(requireClaim(fromJSON(item.coordinator),fromJSON(item.jobs),item.jobId,parse(JSON.stringify(item.token)),item.now,item.allowExpired));
+    case 'unclaimed': requireJobUnclaimed(fromJSON(item.coordinator),item.jobId); return null;
+  }
+}
+test('claim contracts match original Python validation, tokens, expiry and error ordering', () => {
+  const inputs = cases();
+  const oracle = JSON.parse(execFileSync('python3',['tools/contracts/claims/reference.py'],{
+    input:JSON.stringify(inputs),encoding:'utf8',maxBuffer:1024*1024,
+  }));
+  const result = inputs.map(item => {
+    try { return {value:invoke(item)}; }
+    catch (error) { return {error:error.name === 'UnicodeEncodeError' ? 'UnicodeEncodeError' : error.message}; }
+  });
+  for (let i=0;i<inputs.length;i++) assert.deepEqual(result[i],oracle[i],JSON.stringify(inputs[i]));
+});
+test('new claims return unique bearer tokens but only persist hashes and publish metadata', () => {
+  const first = makeClaim('job-1',text('\u0085 Owner \u001c'),now);
+  const second = makeClaim('job-1',text('Owner'),now);
+  assert.match(first.token,/^claim_[A-Za-z0-9_-]{43}$/);
+  assert.notEqual(first.token,second.token);
+  const persisted = plain(first.claim);
+  assert.equal(persisted.ownerLabel,'Owner');
+  assert.equal(persisted.tokenHash,createHash('sha256').update(first.token).digest('hex'));
+  assert.equal(persisted.expiresAt,'2026-09-10T12:05:00Z');
+  assert.ok(!serialize(first.claim).includes(first.token));
+  const published = plain(publicClaim(first.claim,now));
+  assert.equal(published.tokenHash,undefined);
+  assert.equal(published.expired,false);
+  validateCoordinator(fromJSON({schemaVersion:1,claim:persisted}));
+});
+test('heartbeat preserves identity and input and renews at exact expiry boundary', () => {
+  const original = fromJSON(claim), before = serialize(original);
+  const heartbeat = plain(heartbeatClaim(original,'2026-09-10T12:04:59.999999Z'));
+  assert.equal(heartbeat.heartbeatAt,'2026-09-10T12:04:59Z');
+  assert.equal(heartbeat.expiresAt,'2026-09-10T12:09:59Z');
+  assert.equal(heartbeat.tokenHash,claim.tokenHash);
+  assert.equal(serialize(original),before);
+  assert.equal(claimExpired(original,'2026-09-10T12:04:59.999999Z'),false);
+  assert.equal(claimExpired(original,'2026-09-10T12:05:00Z'),true);
+});

--- a/tests_js/workspace_claims_contracts_support.mjs
+++ b/tests_js/workspace_claims_contracts_support.mjs
@@ -1,0 +1,37 @@
+import { createHash } from 'node:crypto';
+export const now = '2026-09-10T12:00:00Z';
+export const claim = {
+  claimId:'fixture-claim',jobId:'job-1',ownerLabel:'Owner',tokenHash:createHash('sha256').update('secret').digest('hex'),
+  acquiredAt:now,heartbeatAt:now,expiresAt:'2026-09-10T12:05:00Z',
+};
+export function fixture(overrides = {}) {
+  return {coordinator:{schemaVersion:1,claim:{...claim}},jobs:{jobs:{'job-1':{status:'in_progress',deletedAt:null}}},
+    now,jobId:'job-1',token:'secret',...overrides};
+}
+export function cases() {
+  const rows = [];
+  for (const value of [now,'20260910T120000Z','2026-W37-4T12Z','2026W374T12Z',
+    '2026-09-10 12:00:00.1234569+02:30','2026-09-10x12:00:00,1-00:00:00.5',
+    '2026-09-10T12.5+01:99','0001-01-01T00Z','9999-12-31T23:59:59.999999Z',
+    '2026-02-30T12Z','2026-W53-1T00Z','2021-W53-1T00Z','2026-09-10','2026-09-10T12',
+    '0001-01-01T00+01','9999-12-31T23:59:59-01','2026-09-10T24Z','2026-09-10T12+24','2026-09-10T12:99Z','invalid']) rows.push({op:'time',value});
+  for (const token of ['secret','é😀','\ufeffsecret','',null,123,'\ud800','\ud800\udc00']) rows.push({op:'hash',token});
+  for (const coordinator of [{schemaVersion:1,claim:null},{schemaVersion:true,claim:null},
+    {schemaVersion:2,claim:null},{schemaVersion:0,claim:null},{schemaVersion:1},
+    {schemaVersion:1,claim:[]},{schemaVersion:1,claim:42},{schemaVersion:1,claim:{...claim,extra:true}},{schemaVersion:1,claim:{...claim,ownerLabel:' '}},
+    {schemaVersion:1,claim:{...claim,jobId:'../bad'}},{schemaVersion:1,claim:{...claim,expiresAt:'yesterday'}},
+    {schemaVersion:1,claim:{...claim,tokenHash:'not-a-hash'}}, {schemaVersion:1,claim:{...claim}}]) rows.push({op:'validate',coordinator});
+  for (const op of ['require','public','unclaimed']) {
+    rows.push(fixture({op}));
+    rows.push(fixture({op,now:'2026-09-10T12:05:00Z'}));
+    rows.push(fixture({op,now:'2026-09-10T12:04:59.999999Z'}));
+    rows.push(fixture({op,coordinator:{schemaVersion:1,claim:null}}));
+    rows.push(fixture({op,jobId:'other'}));
+  }
+  for (const token of ['',null,'wrong','é','\ud800']) rows.push(fixture({op:'require',token}));
+  rows.push(fixture({op:'require',now:'2026-09-10T12:05:00Z',allowExpired:true}));
+  for (const job of [null,{status:'ready'},{status:'in_progress',deletedAt:'yesterday'}]) {
+    rows.push(fixture({op:'require',jobs:{jobs:job === null ? {} : {'job-1':job}}}));
+  }
+  return rows;
+}

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,3 +1,4 @@
+import { claimsBrowser } from './workspace_native_claims_browser_support.mjs';
 import { nativeFactsBrowser } from './workspace_native_facts_browser_support.mjs';
 import { resumeDraftBrowser } from './workspace_native_resumes_browser_support.mjs';
 import { nativeAnswersBrowser } from './workspace_native_answers_browser_support.mjs';
@@ -98,11 +99,21 @@ export async function nativeJobsBrowser(buildRoot) {
     await resumeDraftBrowser(page, root, fixture, buildRoot, browserResume.id);
     const answers = await nativeAnswersBrowser(page, root, fixture, buildRoot);
     const extractions = await nativeExtractionsBrowser(page, root, fixture, buildRoot);
+    await page.getByRole('button',{name:'Jobs',exact:true}).click();
+    await page.setViewportSize({width:390,height:844});
+    await claimsBrowser(page,{jobId:job.id,expireClaim:async id => {
+      const coordinatorPath = join(root,'coordinator.json');
+      const coordinator = JSON.parse(await readFile(coordinatorPath,'utf8'));
+      assert.equal(coordinator.claim.jobId,id);
+      coordinator.claim.expiresAt = '2000-01-01T00:00:00Z';
+      await writeFile(coordinatorPath,JSON.stringify(coordinator),{mode:0o600});
+    }});
+    assert.equal(await page.evaluate(()=>document.documentElement.scrollWidth<=innerWidth),true);
     const token = new URLSearchParams(new URL(startup.url).hash.slice(1)).get('token');
     const unsupported = await fetch(startup.origin + '/api/overview', { headers: { Authorization: `Bearer ${token}` } });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     if (browser) await browser.close();
     if (child && child.exitCode === null && child.signalCode === null) {

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -15,7 +15,7 @@ const execute = promisify(execFile);
 
 export async function nativeJobsBrowser(buildRoot) {
   const fixture = await nativeFixture();
-  let child, browser;
+  let child, browser, releaseInitialClaim;
   try {
     const root = join(await realpath(fixture.root), 'jobs');
     await initializeJobsFixture(root);
@@ -47,9 +47,22 @@ export async function nativeJobsBrowser(buildRoot) {
       }
     });
     page.on('pageerror', error => pageErrors.push(error.message));
+    let initialClaimSeen;
+    const claimStarted = new Promise(resolve => { initialClaimSeen = resolve; });
+    const claimGate = new Promise(resolve => { releaseInitialClaim = resolve; });
+    let firstClaim = true;
+    await page.route('**/api/claims', async route => {
+      if (firstClaim && route.request().method() === 'GET') {
+        firstClaim = false; initialClaimSeen(); await claimGate;
+      }
+      await route.continue();
+    });
     await page.goto(startup.url);
     await page.getByText(/Synthetic native workspace/).waitFor();
     assert.equal(await page.getByRole('link', { name: 'Open full workspace' }).count(), 0);
+    await claimStarted;
+    await page.locator('[data-job-create]:disabled').waitFor();
+    releaseInitialClaim();
     await page.getByRole('button', { name: 'New job', exact: true }).click();
     await page.locator('dialog [name="url"]').fill('https://example.invalid/native');
     await page.locator('dialog [name="role"]').fill('Native fixture role');
@@ -115,6 +128,7 @@ export async function nativeJobsBrowser(buildRoot) {
     assert.deepEqual(pageErrors, []);
     return { claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
+    releaseInitialClaim?.();
     if (browser) await browser.close();
     if (child && child.exitCode === null && child.signalCode === null) {
       await new Promise((resolve, reject) => {

--- a/tests_js/workspace_native_claims.test.mjs
+++ b/tests_js/workspace_native_claims.test.mjs
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, plain, read, write, snapshot, readyPacket, cli } from './workspace_native_claims_support.mjs';
+import { NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { ClaimsService } from '../runtime/workspace-core/claims.js';
+import { AnswersService } from '../runtime/workspace-core/answers.js';
+import { AnswerMergeService } from '../runtime/workspace-core/answer-merges.js';
+import { PendingAnswersService } from '../runtime/workspace-core/pending-answers.js';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { fromJSON, text } from '../runtime/contracts/workspace/values.js';
+
+async function acquire(state,id='job') {
+  const selected=plain(await state.claims.select(id,1n,true));
+  assert.equal(selected.job.revision,2);
+  return plain(await state.claims.acquire(id,text('Synthetic owner'),2n));
+}
+async function unchangedFailure(root,operation,pattern) {
+  const before=await snapshot(root);
+  await assert.rejects(async()=>operation(),pattern);
+  assert.deepEqual(await snapshot(root),before);
+}
+
+test('native active claims persist complete lifecycle, exact expiry and safe recovery', {timeout:60000}, async t=>{
+  const fixture=await nativeFixture();
+  try {
+    await t.test('select, acquire, heartbeat, progress, both handoffs, and reopen',async()=>{
+      const state=await setup(fixture,'lifecycle'), {root,claims,jobs,clock,provider}=state;
+      await unchangedFailure(root,()=>claims.select('job',1n,false),/owner confirmation/);
+      const first=await acquire(state), token=text(first.token);
+      assert.equal(first.job.status,'in_progress');assert.equal(first.job.revision,3);
+      assert.equal(await readFile(first.resume.path,'utf8'),'PRIVATE-RESUME');
+      const reopened=new ClaimsService(new NativeJobsRepository(root,provider),()=>clock.now);
+      const before=await snapshot(root), publicStatus=plain(await reopened.status());
+      assert.equal(publicStatus.claim.jobId,'job');assert.equal(publicStatus.claim.expired,false);
+      assert.equal(publicStatus.leaseSeconds,300);assert.equal(publicStatus.heartbeatSeconds,60);
+      assert.doesNotMatch(JSON.stringify(publicStatus),/token|PRIVATE-/i);
+      assert.deepEqual(await snapshot(root),before);
+      await unchangedFailure(root,()=>claims.heartbeat('job',text('wrong')),/token is invalid/);
+      await unchangedFailure(root,()=>claims.heartbeat('other',token),/not held/);
+      await unchangedFailure(root,()=>jobs.update('job',fromJSON({notes:'blocked'}),3n),/coordinator operation/);
+      const other=plain(await jobs.update('other',fromJSON({notes:'allowed'}),1n));assert.equal(other.revision,2);
+      clock.now='2026-09-10T12:01:00Z';
+      assert.equal(plain(await claims.heartbeat('job',token)).claim.expiresAt,'2026-09-10T12:06:00Z');
+      const pending={status:'active',company:'EPHEMERAL',pendingFields:[{question:'PRIVATE QUESTION',state:'missing'}]};
+      const session=plain(await claims.progress('job',token,fromJSON(pending)));
+      assert.equal(session.attemptRevision,3);assert.equal(session.pendingFields.length,1);
+      assert.doesNotMatch(JSON.stringify(session),/EPHEMERAL|PRIVATE QUESTION/);
+      const blocked=plain(await claims.handoff('job',token,'needs_info',fromJSON(pending),3n));
+      assert.equal(blocked.job.revision,4);assert.equal(blocked.claim,null);
+      assert.equal(plain(await claims.status()).claim,null);
+      await unchangedFailure(root,()=>claims.heartbeat('job',token),/not held/);
+      const selected=plain(await claims.select('job',4n,true));assert.equal(selected.job.revision,5);
+      const second=plain(await claims.acquire('job',text('Second owner'),5n));
+      assert.notEqual(second.token,first.token);assert.equal(second.job.revision,6);
+      await unchangedFailure(root,()=>claims.handoff('job',text(second.token),'awaiting_review',fromJSON({status:'review'}),6n),/fresh current live/);
+      const review={status:'review',readinessInput:readyPacket(6)};
+      const replay=structuredClone(review);replay.readinessInput.evidenceKind='repository_replay';
+      await unchangedFailure(root,()=>claims.handoff('job',text(second.token),'awaiting_review',fromJSON(replay),6n),/agent-attested readiness/);
+      const completed=plain(await claims.handoff('job',text(second.token),'awaiting_review',fromJSON(review),6n));
+      assert.equal(completed.job.revision,7);assert.equal(completed.job.status,'awaiting_review');
+      assert.equal((await read(root,'coordinator-journal.json')).operation,null);
+      const history=await readFile(join(root,'applications.jsonl'),'utf8');
+      assert.deepEqual(history.trim().split('\n').map(line=>JSON.parse(line).event),['job-started','job-blocked','job-started','reviewed']);
+      for(const secret of [first.token,second.token,'tokenHash','PRIVATE QUESTION']) assert.ok(!history.includes(secret));
+      assert.equal(plain(await reopened.status()).claim,null);
+    });
+    await t.test('exact expiry prevents reuse until explicit same-job recovery rotates bearer',async()=>{
+      const state=await setup(fixture,'expiry'), {root,claims,clock}=state;
+      const first=await acquire(state), token=text(first.token);
+      clock.now='2026-09-10T12:04:59.999999Z';assert.equal(plain(await claims.status()).claim.expired,false);
+      await unchangedFailure(root,()=>claims.recover('job',text('Recovery owner')),/live claim/);
+      clock.now='2026-09-10T12:05:00Z';assert.equal(plain(await claims.status()).claim.expired,true);
+      await unchangedFailure(root,()=>claims.heartbeat('job',token),/expired/);
+      await unchangedFailure(root,()=>claims.acquire('other',text('Owner'),1n),/expired claim requires/);
+      await unchangedFailure(root,()=>claims.recover('other',text('Owner')),/expired claimed job/);
+      const jobsBefore=await readFile(join(root,'jobs.json'),'utf8');
+      const recovered=plain(await claims.recover('job',text('Recovery owner')));
+      assert.notEqual(recovered.token,first.token);assert.equal(recovered.job.revision,3);
+      assert.equal(await readFile(join(root,'jobs.json'),'utf8'),jobsBefore);
+      await unchangedFailure(root,()=>claims.heartbeat('job',token),/token is invalid/);
+      assert.equal(plain(await claims.heartbeat('job',text(recovered.token))).claim.expired,false);
+      const history=await readFile(join(root,'applications.jsonl'),'utf8');
+      assert.ok(history.includes('claim-recovered'));assert.ok(!history.includes(recovered.token));
+      const raw=await read(root,'coordinator.json');assert.ok(raw.claim.tokenHash);assert.ok(!JSON.stringify(raw).includes(recovered.token));
+    });
+    await t.test('concurrent acquisition has one winner and answer workflows cannot clear its claim',async()=>{
+      const state=await setup(fixture,'race'),{root,claims,repository}=state;
+      await claims.select('job',1n,true);await claims.select('other',1n,true);
+      const results=await Promise.allSettled([claims.acquire('job',text('One'),2n),claims.acquire('other',text('Two'),2n)]);
+      assert.equal(results.filter(result=>result.status==='fulfilled').length,1);
+      assert.match(results.find(result=>result.status==='rejected').reason.message,/live job claim/);
+      const winner=plain(results.find(result=>result.status==='fulfilled').value);
+      const answers=new AnswersService(repository);
+      for(const [key,question] of [['a','Preferred city?'],['b','Preferred location?']]) await answers.put(fromJSON({key,question,state:'confirmed',value:'PRIVATE'}));
+      await unchangedFailure(root,()=>new AnswerMergeService(repository).merge('a','b',1n,1n),/idle coordinator/);
+      const otherId=winner.job.id==='job'?'other':'job';
+      const jobs=await read(root,'jobs.json');jobs.jobs[otherId].status='needs_info';await write(root,'jobs.json',jobs);
+      await write(root,`sessions/${otherId}.json`,{schemaVersion:1,applicationId:otherId,status:'active',pendingFields:[{reference:`pending_${'a'.repeat(32)}`,answerKey:'a',state:'missing'}],blockers:[],answerKeys:[]});
+      const pending=new PendingAnswersService(repository), group=plain(await pending.list()).jobs[0];
+      await unchangedFailure(root,()=>pending.resolve(otherId,group.pendingInformation[0].reference,BigInt(group.jobRevision),BigInt(group.sessionRevision),1n,true),/idle coordinator/);
+      assert.equal(plain(await claims.status()).claim.jobId,winner.job.id);
+    });
+    await t.test('HTTP and CLI share persisted claims with Python absent from PATH',async()=>{
+      const state=await setup(fixture,'transports'),{root,repository,jobs}=state;
+      const http=async(action,body)=>jobsHttp(jobs,repository,body===undefined?'GET':'POST',`/api/claims${action?'/'+action:''}`,body===undefined?'':JSON.stringify(body));
+      const selected=await cli(fixture,root,'task-select',['--id','job','--expected-revision','1','--owner-confirmed']);assert.equal(selected.job.status,'ready');
+      const acquired=await http('acquire',{jobId:'job',ownerLabel:'Transport owner',expectedRevision:2});assert.equal(acquired.status,200);
+      const result=JSON.parse(acquired.body);
+      const status=await cli(fixture,root,'claim-status');assert.equal(status.claim.jobId,'job');assert.doesNotMatch(JSON.stringify(status),/token/i);
+      const beat=await cli(fixture,root,'claim-heartbeat',['--id','job','--token',result.token]);assert.equal(beat.claim.expired,false);
+      const denied=await http('heartbeat',{jobId:'job',token:'wrong'});assert.equal(denied.status,400);assert.doesNotMatch(denied.body,new RegExp(result.token));
+      const bad=await http('select',{jobId:'other',expectedRevision:1,ownerConfirmed:true,extra:1});assert.equal(bad.status,400);
+      const progress=await http('progress',{jobId:'job',token:result.token,session:{status:'active',step:'questions'}});assert.equal(progress.status,200);
+      const completed=await cli(fixture,root,'claim-handoff',['--id','job','--token',result.token,'--status','needs_info','--expected-revision','3'],{status:'active'});
+      assert.equal(completed.job.status,'needs_info');assert.equal(completed.claim,null);
+      assert.equal(JSON.parse((await http('')).body).claim,null);
+    });
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_claims_browser_support.mjs
+++ b/tests_js/workspace_native_claims_browser_support.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+
+// The caller owns the disposable fixture and prepares one preflight-ready job.
+// expireClaim must adjust only that fixture's lease; never use an owner Store.
+export async function claimsBrowser(page, { jobId, expireClaim }) {
+    const panel = page.getByRole('region', { name: 'Active application', exact: true });
+    await panel.getByText('No active application claim.', { exact: true }).waitFor();
+    await panel.getByRole('combobox', { name: 'Job for application work', exact: true }).selectOption(jobId);
+    page.once('dialog', dialog => dialog.accept());
+    await panel.getByRole('button', { name: 'Select this job', exact: true }).click();
+    await panel.getByText('Job selected. Acquisition checks readiness again.', { exact: true }).waitFor();
+    const acquired = page.waitForResponse(response => response.url().endsWith('/api/claims/acquire') && response.request().method() === 'POST');
+    await panel.getByRole('button', { name: 'Acquire application work', exact: true }).click();
+    const response = await acquired;
+    assert.equal(response.status(), 200);
+    const { token } = await response.json();
+    assert.equal(typeof token, 'string');
+    await panel.getByText('Application work acquired. You can return it for owner input below.', { exact: true }).waitFor();
+    assert.equal((await page.locator('body').innerText()).includes(token), false);
+    assert.equal(await page.evaluate(secret => [...Object.values(localStorage), ...Object.values(sessionStorage)].some(value => value.includes(secret)), token), false);
+
+    // Leaving loses the ephemeral credential and stops the old component's renewal timer.
+    page.once('dialog', dialog => dialog.accept());
+    await page.reload();
+    await page.getByText('This view does not hold the claim credential. After reload or navigation, wait for expiry, refresh status, and explicitly recover the same job.', { exact: true }).waitFor();
+    assert.equal(await panel.getByRole('button', { name: 'Recover expired application', exact: true }).count(), 0);
+    await expireClaim(jobId);
+    await panel.getByRole('button', { name: 'Refresh application status', exact: true }).click();
+    const recovery = page.waitForResponse(result => result.url().endsWith('/api/claims/recover') && result.request().method() === 'POST');
+    await panel.getByRole('button', { name: 'Recover expired application', exact: true }).click();
+    const recovered = await recovery;
+    assert.equal(recovered.status(), 200);
+    const recoveredPayload = await recovered.json();
+    assert.notEqual(recoveredPayload.token, token);
+    assert.equal(recoveredPayload.claim.jobId, jobId);
+    const handoff = page.waitForResponse(result => result.url().endsWith('/api/claims/handoff') && result.request().method() === 'POST');
+    await panel.getByRole('button', { name: 'Return for owner input', exact: true }).click();
+    const handedOff = await handoff;
+    assert.equal(handedOff.status(), 200);
+    const request = handedOff.request().postDataJSON();
+    assert.equal(request.status, 'needs_info');
+    assert.deepEqual(request.session.blockers, [{ type: 'information', code: 'owner-input-required' }]);
+    await panel.getByText('Application returned for owner input.', { exact: true }).waitFor();
+    await panel.getByText('No active application claim.', { exact: true }).waitFor();
+    assert.equal((await page.locator('body').innerText()).includes(recoveredPayload.token), false);
+}

--- a/tests_js/workspace_native_claims_recovery.test.mjs
+++ b/tests_js/workspace_native_claims_recovery.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { appendFile, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { atomicWritePointJson } from '../runtime/store/point-persistence.js';
+import { bytes, fixed, killAt, recover, seed } from './workspace_native_claims_recovery_support.mjs';
+const events = source => source.trim().split('\n').filter(line=>line.trim()).map(line=>JSON.parse(line));
+
+test('SIGKILL at all six claim handoff boundaries recovers exactly once on ordinary access', {timeout:60000}, async t=>{
+  const fixture=await nativeFixture();
+  try {
+    for(const boundary of ['journal','jobs.json','sessions/job.json','history','coordinator.json','clear']) {
+      await t.test(boundary,async()=>{
+        const {root,provider,token}=await seed(fixture,boundary.replaceAll('/','-'));
+        const intended=await killAt(root,fixture.receipt.artifact,boundary,token);
+        assert.equal(intended.kind,'handoff');
+        assert.equal(intended.at,fixed);
+        const recovered=await recover(root,fixture.receipt.artifact);
+        const job=JSON.parse(recovered['jobs.json']).jobs.job;
+        assert.equal(job.status,'needs_info');
+        assert.equal(job.revision,3);
+        assert.deepEqual(JSON.parse(recovered['sessions/job.json']),intended.session);
+        const history=events(recovered['applications.jsonl']);
+        assert.equal(history.length,2);
+        assert.deepEqual(history.filter(event=>event.eventId===intended.historyEvent.eventId),[intended.historyEvent]);
+        assert.deepEqual(JSON.parse(recovered['coordinator.json']),{schemaVersion:1,claim:null});
+        assert.deepEqual(JSON.parse(recovered['coordinator-journal.json']),{schemaVersion:1,operation:null});
+        for(const content of Object.values(recovered)) assert.ok(!content.includes(token),'Bearer token must never be persisted');
+        await new NativeJobsRepository(root,provider).transaction(async()=>{});
+        assert.deepEqual(await bytes(root),recovered,'Replay must be byte-idempotent');
+      });
+    }
+  } finally {await fixture.cleanup();}
+});
+
+test('pending claim recovery rejects colliding event IDs before canonical writes', {timeout:60000},async()=>{
+  const fixture=await nativeFixture();
+  try {
+    const {root,provider,token}=await seed(fixture,'collision');
+    const intended=await killAt(root,fixture.receipt.artifact,'journal',token);
+    await appendFile(join(root,'applications.jsonl'),JSON.stringify({...intended.historyEvent,event:'different-event'})+'\n');
+    const before=await bytes(root),writes=[];
+    const repository=new NativeJobsRepository(root,provider,async(path,value,options)=>{
+      writes.push(path);await atomicWritePointJson(path,value,options);
+    });
+    await assert.rejects(repository.transaction(async()=>{}),/history event id collision/);
+    assert.deepEqual(writes,[]);
+    assert.deepEqual(await bytes(root),before);
+  } finally {await fixture.cleanup();}
+});
+
+test('pending claim recovery repairs a truncated append tail and appends one complete event', {timeout:60000},async()=>{
+  const fixture=await nativeFixture();
+  try {
+    const {root,token}=await seed(fixture,'tail');
+    const intended=await killAt(root,fixture.receipt.artifact,'journal',token);
+    const original=await readFile(join(root,'applications.jsonl'),'utf8');
+    await appendFile(join(root,'applications.jsonl'),'\n{"eventId":"partial');
+    const recovered=await recover(root,fixture.receipt.artifact);
+    assert.ok(recovered['applications.jsonl'].startsWith(original));
+    assert.deepEqual(events(recovered['applications.jsonl']).filter(event=>event.eventId===intended.historyEvent.eventId),[intended.historyEvent]);
+    const twice=await recover(root,fixture.receipt.artifact);
+    assert.deepEqual(twice,recovered);
+  } finally {await fixture.cleanup();}
+});

--- a/tests_js/workspace_native_claims_recovery_support.mjs
+++ b/tests_js/workspace_native_claims_recovery_support.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { readFile, realpath } from 'node:fs/promises';
+import { join } from 'node:path';
+import { child } from './exclusive_file_lock_support.mjs';
+import { loadPosixFlockProvider } from '../runtime/store/posix-flock.js';
+import { initializeJobsFixture, NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { atomicWritePointJson } from '../runtime/store/point-persistence.js';
+import { JobsService } from '../runtime/workspace-core/jobs.js';
+import { ResumeService } from '../runtime/workspace-core/resumes.js';
+import { ClaimsService } from '../runtime/workspace-core/claims.js';
+import { fromJSON, serialize, text } from '../runtime/contracts/workspace/values.js';
+export const fixed = '2026-09-10T12:00:00Z';
+export const options = {pathProfile:'3.12',intMaxStrDigits:4300};
+export const names = ['jobs.json','sessions/job.json','applications.jsonl','coordinator.json','coordinator-journal.json'];
+const plain = value => JSON.parse(serialize(value));
+const moduleUrl = path => new URL(`../runtime/${path}.js`,import.meta.url).href;
+const imports = `
+import {relative,join} from 'node:path';
+import {readFile} from 'node:fs/promises';
+import {NativeJobsRepository} from ${JSON.stringify(moduleUrl('store/native-jobs'))};
+import {loadPosixFlockProvider} from ${JSON.stringify(moduleUrl('store/posix-flock'))};
+import {atomicWritePointJson} from ${JSON.stringify(moduleUrl('store/point-persistence'))};
+import {ClaimsService} from ${JSON.stringify(moduleUrl('workspace-core/claims'))};
+import {get,serialize,fromJSON,text} from ${JSON.stringify(moduleUrl('contracts/workspace/values'))};
+const [root,addon,boundary,token] = process.argv.slice(1);
+`;
+export const incoming = {status:'active',blockers:[{type:'information',code:'owner-input-required'}]};
+const writerScript = imports + `
+let intended;
+async function checkpoint(stage) {
+  if(stage !== boundary) return;
+  console.log(JSON.stringify({intended}));
+  console.log('durable-boundary');
+  await new Promise(() => {setInterval(()=>{},1000);});
+}
+const repository = new NativeJobsRepository(root,loadPosixFlockProvider(addon),async(path,document,options)=>{
+  const name=relative(root,path);
+  if(name==='coordinator-journal.json' && get(document,'operation')!==null) intended=JSON.parse(serialize(get(document,'operation')));
+  await atomicWritePointJson(path,document,options);
+  await checkpoint(name==='coordinator-journal.json' ? get(document,'operation')===null ? 'clear':'journal':name);
+},checkpoint);
+await new ClaimsService(repository,()=>${JSON.stringify(fixed)}).handoff('job',text(token),'needs_info',fromJSON(${JSON.stringify(incoming)}),2n);
+throw Error('Writer unexpectedly passed its kill boundary');
+`;
+const recoveryScript = imports + `
+await new NativeJobsRepository(root,loadPosixFlockProvider(addon)).transaction(async()=>{});
+const bytes={};
+for(const name of ${JSON.stringify(names)}) bytes[name]=await readFile(join(root,name),'utf8');
+console.log(JSON.stringify(bytes));
+`;
+export async function seed(fixture,name) {
+  const root=join(await realpath(fixture.root),name),provider=loadPosixFlockProvider(fixture.receipt.artifact);
+  await initializeJobsFixture(root);
+  const repository=new NativeJobsRepository(root,provider);
+  await new JobsService(repository,()=>fixed).create(fromJSON({id:'job',url:'https://example.invalid/job',role:'Engineer',company:'Fixture'}));
+  const jobs=JSON.parse(await readFile(join(root,'jobs.json'),'utf8'));
+  jobs.jobs.job.status='ready';
+  await atomicWritePointJson(join(root,'jobs.json'),fromJSON(jobs),options);
+  const profile=JSON.parse(await readFile(join(root,'profile.json'),'utf8'));
+  profile.profile.name='Synthetic Owner';
+  await atomicWritePointJson(join(root,'profile.json'),fromJSON(profile),options);
+  await new ResumeService(repository,()=>fixed).import(fromJSON({id:'resume',label:'Fixture',default:true}),'fixture.txt',Buffer.from('Synthetic resume'));
+  const service=new ClaimsService(repository,()=>fixed);
+  const {token}=plain(await service.acquire('job',text('Fixture worker'),1n));
+  await service.progress('job',text(token),fromJSON(incoming));
+  return {root,provider,token,repository};
+}
+export async function killAt(root,addon,boundary,token) {
+  const writer=child(writerScript,[root,addon,boundary,token]);
+  try {
+    await writer.line('durable-boundary');
+    const intended=JSON.parse(writer.lines.find(line=>line.startsWith('{'))).intended;
+    assert.equal(writer.process.kill('SIGKILL'),true);
+    assert.deepEqual(await writer.exited,{code:null,signal:'SIGKILL'});
+    return intended;
+  } finally {await writer.stop();}
+}
+export async function recover(root,addon) {
+  const process=child(recoveryScript,[root,addon]);
+  try {
+    await process.success();
+    return JSON.parse(process.lines.find(line=>line.startsWith('{')));
+  } finally {await process.stop();}
+}
+export async function bytes(root) {
+  return Object.fromEntries(await Promise.all(names.map(async name=>[name,await readFile(join(root,name),'utf8')])));
+}

--- a/tests_js/workspace_native_claims_support.mjs
+++ b/tests_js/workspace_native_claims_support.mjs
@@ -1,0 +1,53 @@
+import { readFile, writeFile, readdir, realpath } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { initializeJobsFixture, NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { loadPosixFlockProvider } from '../runtime/store/posix-flock.js';
+import { ClaimsService } from '../runtime/workspace-core/claims.js';
+import { JobsService } from '../runtime/workspace-core/jobs.js';
+import { ResumeService } from '../runtime/workspace-core/resumes.js';
+import { fromJSON, serialize } from '../runtime/contracts/workspace/values.js';
+export const plain = value => JSON.parse(serialize(value));
+export const read = async (root,name) => JSON.parse(await readFile(join(root,name),'utf8'));
+export const write = (root,name,value) => writeFile(join(root,name),JSON.stringify(value),{mode:0o600});
+export async function snapshot(root) {
+  const paths=(await readdir(root)).filter(path=>path.endsWith('.json')||path.endsWith('.jsonl'));
+  paths.push(...(await readdir(join(root,'sessions'))).map(path=>`sessions/${path}`));
+  return Object.fromEntries(await Promise.all(paths.map(async path=>[path,await readFile(join(root,path),'utf8')])));
+}
+export async function setup(fixture,name) {
+  const root=join(await realpath(fixture.root),name);
+  await initializeJobsFixture(root);
+  const provider=loadPosixFlockProvider(fixture.receipt.artifact), repository=new NativeJobsRepository(root,provider);
+  const clock={now:'2026-09-10T12:00:00Z'}, now=()=>clock.now;
+  const jobs=new JobsService(repository,now), claims=new ClaimsService(repository,now);
+  for(const id of ['job','other']) await jobs.create(fromJSON({id,url:`https://example.invalid/${id}`,role:'Engineer',company:'Synthetic',ats:'greenhouse'}));
+  const profile=await read(root,'profile.json'); profile.profile.name='PRIVATE-PROFILE'; await write(root,'profile.json',profile);
+  await new ResumeService(repository,now).import(fromJSON({id:'resume',label:'Synthetic',default:true}),'resume.txt',Buffer.from('PRIVATE-RESUME'));
+  return {root,provider,repository,jobs,claims,clock};
+}
+export function readyPacket(attemptRevision) {
+  const fixture=JSON.parse(readFileSync(new URL('../qa/fixtures/greenhouse-form-readiness-v1/fixture.json',import.meta.url),'utf8'));
+  const controls=fixture.steps.flatMap(step=>step.controls), platformFamily=fixture.platformFamily;
+  const requiredControlIds=controls.filter(control=>control.required).map(control=>control.id).sort();
+  const fingerprint=createHash('sha256').update(JSON.stringify({platformFamily,requiredControlIds})).digest('hex');
+  const kinds={textbox:'text',combobox:'selection',radiogroup:'selection',checkbox:'toggle',file:'upload'};
+  return {attemptRevision,evidenceKind:'agent_attested_current_attempt',fixture,expectedObservationRevision:7,
+    formManifest:{schemaVersion:1,platformFamily,observationRevision:7,requiredControlIds,controlSetFingerprint:`sha256:${fingerprint}`,complete:true},
+    observation:{schemaVersion:1,platformFamily,observationRevision:7,adapterState:'accessible',uploadCapability:'available',
+      controls:controls.map(control=>({controlId:control.id,kind:kinds[control.role],state:control.role==='file'?'accepted':'complete',observationRevision:7})),
+      validationErrorControlIds:[],finalControlState:'available'}};
+}
+export async function cli(fixture,root,command,args=[],payload) {
+  if(payload!==undefined) {
+    const path=join(fixture.root,`input-${command}.json`);
+    await writeFile(path,JSON.stringify(payload));args=[...args,'--input',path];
+  }
+  const result=await promisify(execFile)(process.execPath,['runtime/cli/native-jobs.js','--root',root,'--native-lock',fixture.receipt.artifact,command,...args],
+    {cwd:new URL('../',import.meta.url),env:{PATH:''},timeout:15000});
+  if(result.stderr) throw Error(result.stderr);
+  return JSON.parse(result.stdout);
+}

--- a/tests_js/workspace_native_facts_browser_support.mjs
+++ b/tests_js/workspace_native_facts_browser_support.mjs
@@ -66,9 +66,22 @@ export async function nativeFactsBrowser(page,root,fixture,buildRoot) {
   await page.getByRole('button',{name:'Edit Contact renamed',exact:true}).waitFor();
   const groups=JSON.parse(await readFile(join(root,'fact-groups.json'),'utf8')).groups;
   assert.deepEqual(Object.values(groups)[0].paths,['/firstName','/phone ']);
-  await page.reload();
-  await page.getByRole('button',{name:'Facts',exact:true}).click();
-  await page.getByLabel('firstName',{exact:true}).waitFor();
+  let releaseClaim, claimRequested;
+  const heldClaim = new Promise(resolve => { releaseClaim = resolve; });
+  const startedClaim = new Promise(resolve => { claimRequested = resolve; });
+  const holdStatus = async route => { claimRequested(); await heldClaim; await route.continue(); };
+  await page.route('**/api/claims', holdStatus);
+  try {
+    await page.reload();
+    await startedClaim;
+    await page.locator('[data-job-create]:disabled').waitFor();
+    // Read-only claim loading must not trigger a discard prompt or prevent navigation.
+    await page.getByRole('button',{name:'Facts',exact:true}).click();
+    await page.getByLabel('firstName',{exact:true}).waitFor();
+  } finally {
+    releaseClaim();
+    await page.unroute('**/api/claims', holdStatus);
+  }
   assert.equal(await page.getByLabel('firstName',{exact:true}).inputValue(),'Browser draft');
   assert.equal(await page.getByLabel('phone',{exact:true}).inputValue(),'CLI phone');
   assert.equal(await page.getByLabel('company',{exact:true}).inputValue(),'Synthetic employer');

--- a/tools/contracts/claim-sessions/reference.py
+++ b/tools/contracts/claim-sessions/reference.py
@@ -1,0 +1,75 @@
+"""Synthetic build-session differential oracle; stdin contains test-owned documents."""
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "scripts"))
+spec = importlib.util.spec_from_file_location("claim_session_store", ROOT / "scripts/job-apply-store.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class Oracle(module.Store):
+    def __init__(self, item):
+        self.item = copy.deepcopy(item)
+
+    def _session_path(self, identity):
+        return SimpleNamespace(exists=lambda: self.item["context"]["existing"] is not None)
+
+    def _read_session_projection(self, *args):
+        return self.item["context"]["existing"]
+
+    def _load_answers_document(self):
+        return self.item["context"]["answers"]
+
+
+def handoff(session, incoming, target, attempt):
+    # Exercise the production handoff method through fake locked persistence.
+    class HandoffOracle(Oracle):
+        def initialize(self): pass
+        def _ensure_coordinator_files(self): pass
+        def _require_claim_locked(self, *args): pass
+        def _load_jobs_document(self):
+            return {"jobs": {"job": {"id": "job", "revision": attempt, "status": "in_progress", "ats": "greenhouse"}}}
+        def _now(self): return "now"
+        def _build_session(self, *args, **kwargs): return session
+        def _history_event_for_operation(self, *args): return {}
+        def _commit_coordinator_operation_locked(self, operation): pass
+        def _session_summary(self, *args): return {}
+    import contextlib
+    original = module.exclusive_file_lock
+    module.exclusive_file_lock = lambda *args: contextlib.nullcontext()
+    try:
+        instance = HandoffOracle({"context": {"existing": None, "answers": {}}})
+        instance.store_lock_path = None
+        # The return projection is irrelevant; isolate validation by terminating
+        # at the first commit, after all production handoff checks.
+        class Committed(Exception): pass
+        def committed(*args): raise Committed()
+        instance._commit_coordinator_operation_locked = committed
+        try:
+            instance.handoff_claimed_job("job", "synthetic-token", target, incoming, attempt)
+        except Committed:
+            return
+    finally:
+        module.exclusive_file_lock = original
+
+
+result = []
+for item in json.load(sys.stdin):
+    try:
+        context = item["context"]
+        session = Oracle(item)._build_session(
+            "job", item["incoming"], context["now"],
+            expected_attempt_revision=context["attemptRevision"], expected_ats=context["ats"],
+        )
+        if "target" in item:
+            handoff(session, item["incoming"], item["target"], context["attemptRevision"])
+        result.append({"session": session})
+    except Exception as error:
+        result.append({"error": str(error)})
+print(json.dumps(result))

--- a/tools/contracts/claims/reference.py
+++ b/tools/contracts/claims/reference.py
@@ -1,0 +1,60 @@
+"""Pure claim reference against original Python validators and mixin."""
+import hashlib
+import json
+from pathlib import Path
+import sys
+from datetime import timezone
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / 'scripts'))
+from job_apply_store.validation.sessions import _parse_coordinator_time, _validate_claim_record
+from job_apply_store.io import validate_version
+from job_apply_store.errors import StoreError
+from job_apply_store.domains.coordinator.claims import CoordinatorClaimsMixin
+
+class Fixture(CoordinatorClaimsMixin):
+    def __init__(self, item):
+        self.item = item
+        self.coordinator_path = self
+    def exists(self):
+        return True
+    def _load_coordinator_document(self):
+        return self.item['coordinator']
+    def _load_jobs_document(self):
+        return self.item['jobs']
+    def _now_datetime(self):
+        return _parse_coordinator_time(self.item['now'])
+
+def invoke(item):
+    operation = item['op']
+    if operation == 'time':
+        parsed = _parse_coordinator_time(item['value'])
+        from datetime import datetime
+        delta = parsed - datetime(1970, 1, 1, tzinfo=timezone.utc)
+        return str((delta.days * 86400 + delta.seconds) * 1000000 + delta.microseconds)
+    if operation == 'validate':
+        document = item['coordinator']
+        validate_version(document, 'coordinator')
+        if set(document) != {'schemaVersion', 'claim'}:
+            raise StoreError('coordinator contains unsupported fields')
+        if document['claim'] is not None:
+            _validate_claim_record(document['claim'])
+        return document
+    if operation == 'hash':
+        return CoordinatorClaimsMixin._token_hash(item['token'])
+    fixture = Fixture(item)
+    if operation == 'require':
+        return fixture._require_claim_locked(item['jobId'], item['token'], item.get('allowExpired', False))
+    if operation == 'unclaimed':
+        return fixture._require_job_unclaimed_locked(item['jobId'])
+    if operation == 'public':
+        return fixture._public_claim(item['coordinator']['claim'])
+    raise ValueError('unknown operation')
+
+rows = []
+for item in json.load(sys.stdin):
+    try:
+        rows.append({'value': invoke(item)})
+    except Exception as error:
+        # Unicode encoder wording is implementation-specific; preserve category.
+        rows.append({'error': 'UnicodeEncodeError' if isinstance(error, UnicodeEncodeError) else str(error)})
+print(json.dumps(rows, ensure_ascii=True))


### PR DESCRIPTION
Synthetic native workspaces can now select a ready job, acquire and renew its claim, explicitly recover an expired claim, save progress, and hand off for owner input or validated review. CLI and authenticated HTTP share a locked service; Companion provides selection, acquisition, memory-only credentials, renewal, recovery and owner-input handoff.

Acquisition, recovery and handoff use durable coordinator journals and application history. Replay handles interrupted appends without duplicate events or revision increments. Claimed jobs reject ordinary edits; answer merges and pending-answer resolution require an idle coordinator. This applies to new v8 synthetic fixtures; live Store adoption and final submission remain outside this change.

Validation includes 65 claim and 73 session Python differential cases, disk lifecycle/concurrency and HTTP/CLI tests, six real SIGKILL boundaries, and production standalone browser workflows with Python absent from PATH. Pre-push testing identified and fixed two UI races: enabled-looking editor controls during status loading, and read-only status loading incorrectly marking navigation dirty. Deterministic gated-request regressions cover both. A pre-existing lock-test GC race was reproduced and corrected by retaining the suspended write.

Independent correctness, tests, silent-failure, contracts/types and documentation reviews found no remaining high-confidence issues. The native review command could not run because the installed CLI does not support its configured model. Local validation preserves all original failures, including intermittent legacy archive and answer-walkthrough failures that passed unchanged in focused reruns. Final exact-head validation and CI results will be recorded before merge.

Local pre-push status: no all-green deep receipt. Repeated full runs encountered varying failures in unchanged legacy launcher shutdown, archive creation/copy, answer CRUD lookup and a short Python reference subprocess timeout; focused package, launcher and hybrid-browser reruns passed unchanged. The new claim/browser regressions and final native checks passed. This draft is published with a disclosed local push-hook bypass to obtain fresh platform and release CI; it must not merge until those workflows are green. Local commit hooks passed normally.

Final CI at `613951c0a296dbcba9f0061c42055d22a8760011`: [Validate Plugin](https://github.com/neonwatty/job-apply-plugin/actions/runs/34506439726) and [Release Validation](https://github.com/neonwatty/job-apply-plugin/actions/runs/34506443400) both passed on their first attempts. Validation includes the aggregate PR gate, Linux browser/contract shards, Windows Store/workspace checks, Mac helper checks, and installed-package release smoke. Staging remained at the reviewed base `d6916afc4bd54681f8401cac58b16b971e7be7c3` before merge. The disclosed local validation limitations remain part of the record.
