### PR TITLE
Add owner-confirmed native reviewed restart

### DIFF
--- a/apps/companion/components/Claims.tsx
+++ b/apps/companion/components/Claims.tsx
@@ -67,16 +67,18 @@ export function Claims({ client, jobs, disabled, changed, activityChanged, navig
     }, [client]);
     useEffect(() => { activityChanged(owned || busy); return () => activityChanged(false); }, [owned, busy, activityChanged]);
     useEffect(() => { navigationChanged(owned || writing); return () => navigationChanged(false); }, [owned, writing, navigationChanged]);
-    async function action(kind: 'select' | 'acquire' | 'recover' | 'heartbeat' | 'handoff') {
+    async function action(kind: 'select' | 'acquire' | 'review-restart' | 'recover' | 'heartbeat' | 'handoff') {
         if (pending.current) return;
         const held = credential.current;
         const current = kind === 'heartbeat' || kind === 'handoff' ? held?.job : selected;
         if (!current && kind !== 'recover') return;
         if (kind === 'select' && !confirm(`Select ${String(current!.role || current!.id)} for application work at revision ${current!.revision}?`)) return;
+        if (kind === 'review-restart' && !confirm(`Confirm you have not submitted this application. Restart ${String(current!.role || current!.id)} at revision ${current!.revision} for another review? Final submission remains yours.`)) return;
         const controller = new AbortController(); pending.current = controller; setBusy(true); setWriting(true); setError(''); setNotice('');
         try {
             const body = kind === 'select' ? { jobId: current!.id, expectedRevision: current!.revision, ownerConfirmed: true }
                 : kind === 'acquire' ? { jobId: current!.id, expectedRevision: current!.revision, ownerLabel: owner }
+                : kind === 'review-restart' ? { jobId: current!.id, expectedRevision: current!.revision, ownerLabel: owner, ownerConfirmedNotSubmitted: true }
                 : kind === 'recover' ? { jobId: claim!.jobId, ownerLabel: owner }
                 : kind === 'heartbeat' ? { jobId: current!.id, token: held!.token }
                 : { jobId: current!.id, token: held!.token, expectedRevision: current!.revision, status: 'needs_info',
@@ -84,7 +86,7 @@ export function Claims({ client, jobs, disabled, changed, activityChanged, navig
                         blockers: [{ type: 'information', code: 'owner-input-required' }] } };
             const value = await request('/' + kind, body, controller.signal);
             if (!alive.current || controller.signal.aborted) return;
-            if (kind === 'acquire' || kind === 'recover') {
+            if (kind === 'acquire' || kind === 'recover' || kind === 'review-restart') {
                 const nextClaim = claimValue(value.claim), nextJob = decodeJob(value.job);
                 if (!nextClaim || typeof value.token !== 'string' || !value.token) throw Error('Invalid acquisition');
                 credential.current = { token: value.token, job: nextJob, claimId: nextClaim.claimId };
@@ -141,6 +143,7 @@ export function Claims({ client, jobs, disabled, changed, activityChanged, navig
             {selected && <p>Selected revision {selected.revision}. Refresh the jobs list and choose again after a conflict.</p>}
             <button disabled={blocked || !selected} onClick={() => void action('select')}>Select this job</button>{' '}
             <button disabled={blocked || selected?.status !== 'ready' || !owner.trim()} onClick={() => void action('acquire')}>Acquire application work</button>
+            {selected?.status === 'awaiting_review' && <button disabled={blocked || !owner.trim()} onClick={() => void action('review-restart')}>Restart reviewed application</button>}
         </>}
         {claim?.expired && <button disabled={blocked || !owner.trim()} onClick={() => void action('recover')}>Recover expired application</button>}
         {owned && !claim?.expired && <button disabled={blocked} onClick={() => void action('handoff')}>Return for owner input</button>}

--- a/apps/companion/components/Extractions.tsx
+++ b/apps/companion/components/Extractions.tsx
@@ -32,6 +32,7 @@ export function Extractions({ client, dirtyChanged }: { client: ExtractionClient
   const [choices, setChoices] = useState<Choices>({});
   const [confirmed, setConfirmed] = useState<string[]>([]);
   const [busy, setBusy] = useState(false);
+  const [writing, setWriting] = useState(false);
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState('');
@@ -42,7 +43,7 @@ export function Extractions({ client, dirtyChanged }: { client: ExtractionClient
   const dirty = Object.keys(choices).length > 0;
   const managed = resumes.filter(item => string(get(item, 'storageKind')) === 'managed' && get(item, 'deletedAt') === null);
   const selectedResume = managed.find(item => string(get(item, 'id')) === resumeId);
-  useEffect(() => { dirtyChanged(dirty || busy); return () => dirtyChanged(false); }, [dirty, busy, dirtyChanged]);
+  useEffect(() => { dirtyChanged(dirty || writing); return () => dirtyChanged(false); }, [dirty, writing, dirtyChanged]);
   useEffect(() => () => {
     generation.current++;
     listGeneration.current++;
@@ -102,20 +103,23 @@ export function Extractions({ client, dirtyChanged }: { client: ExtractionClient
     request.current?.abort();
     request.current = controller;
     setBusy(true);
+    setWriting(true);
     setError('');
     setNotice('');
     const path = '/api/resume-extraction-requests' + (record ? `/${encodeURIComponent(string(get(record, 'requestId'))!)}/${action}` : '');
     try {
       await client.extractionRequest(path, 'POST', requestMutation(resume, record, action), controller.signal);
       if (version !== generation.current) return;
+      setWriting(false);
       setNotice(action === 'cancel' ? 'Extraction request cancelled.' : 'Extraction requested. An agent can now extract facts from this resume.');
       await refreshLists();
     } catch (failure) {
       if (version === generation.current && !controller.signal.aborted) {
+        setWriting(false);
         setError(failure instanceof Error ? failure.message : 'Unable to update extraction request');
         await refreshLists();
       }
-    } finally { if (version === generation.current) setBusy(false); }
+    } finally { if (version === generation.current) { setBusy(false); setWriting(false); } }
   }
   async function saveReview() {
     if (!base || latest) return;
@@ -127,12 +131,14 @@ export function Extractions({ client, dirtyChanged }: { client: ExtractionClient
     request.current = controller;
     const id = string(get(base, 'id'))!;
     setBusy(true);
+    setWriting(true);
     setError('');
     setNotice('');
     try {
       await client.extractionRequest(`/api/resume-proposals/${encodeURIComponent(id)}/review`, 'POST', body, controller.signal);
       if (version !== generation.current) return;
       // The mutation succeeded even if its subsequent detail refresh fails.
+      setWriting(false);
       setBase(null);
       setChoices({});
       setConfirmed([]);
@@ -145,12 +151,13 @@ export function Extractions({ client, dirtyChanged }: { client: ExtractionClient
       await refreshLists();
     } catch (failure) {
       if (version !== generation.current || controller.signal.aborted) return;
+      setWriting(false);
       setError(failure instanceof Error ? failure.message : 'Unable to save review');
       try {
         const next = proposalSnapshot(await client.extractionRequest(`/api/resume-proposals/${encodeURIComponent(id)}`, 'GET', undefined, controller.signal));
         if (version === generation.current && string(get(next, 'id')) === id) setLatest(next);
       } catch { /* Keep the original failure and unsaved choices visible. */ }
-    } finally { if (version === generation.current) setBusy(false); }
+    } finally { if (version === generation.current) { setBusy(false); setWriting(false); } }
   }
   const staleReasons = base ? get(base, 'staleReasons') : null;
   const stale = Array.isArray(staleReasons) && staleReasons.length > 0;

--- a/apps/companion/server/routes.ts
+++ b/apps/companion/server/routes.ts
@@ -3,6 +3,7 @@ export const apiRoutes = [
   ["GET","/api/claims"],
   ["POST","/api/claims/select"],
   ["POST","/api/claims/acquire"],
+  ["POST","/api/claims/review-restart"],
   ["POST","/api/claims/heartbeat"],
   ["POST","/api/claims/recover"],
   ["POST","/api/claims/progress"],

--- a/config/migration/cli-native-claims-surfaces.json
+++ b/config/migration/cli-native-claims-surfaces.json
@@ -175,6 +175,32 @@
         "recovery": "unverified",
         "platform": "unverified"
       }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:job-review-restart",
+      "kind": "cli",
+      "command": "job-review-restart",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-claims.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/review-restart.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
     }
   ]
 }

--- a/config/migration/http-native-claims-surfaces.json
+++ b/config/migration/http-native-claims-surfaces.json
@@ -189,6 +189,34 @@
         "recovery": "unverified",
         "platform": "unverified"
       }
+    },
+    {
+      "id": "http:POST:/api/claims/review-restart",
+      "kind": "http",
+      "method": "POST",
+      "path": "/api/claims/review-restart",
+      "node": "SESS",
+      "sources": [
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/claims-http.ts",
+        "src/workspace-core/claims.ts",
+        "src/store/native-jobs.ts",
+        "src/contracts/workspace/review-restart.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
     }
   ]
 }

--- a/config/migration/journal-01-surfaces.json
+++ b/config/migration/journal-01-surfaces.json
@@ -126,7 +126,10 @@
       "value": "review_restart",
       "node": "JOUR",
       "sources": [
-        "scripts/job_apply_store/domains/coordinator/persistence.py"
+        "scripts/job_apply_store/domains/coordinator/persistence.py",
+        "src/store/native-claim-journal.ts",
+        "src/store/native-claim-history.ts",
+        "src/workspace-core/claims.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -83,7 +83,7 @@
     },
     {
       "path": "cli-native-claims-surfaces.json",
-      "sha256": "09810dd8553247c6a265c27a2c12790313c8b5db5b372723d7e84a31f6dd1b99"
+      "sha256": "f63132d680ba790131f9b9e4e2fc81ad0b1abdf8ee161bfdb804943ac398f8c9"
     },
     {
       "path": "cli-native-extractions-surfaces.json",
@@ -135,7 +135,7 @@
     },
     {
       "path": "http-native-claims-surfaces.json",
-      "sha256": "3f1f986998a1824d6c8d99a4bef9f9969ad931cec2768cec84a78579defa6d20"
+      "sha256": "3192149822e06167a25f849689b9fcc68f829bfd40ac8d0923eee8c24c396ad9"
     },
     {
       "path": "http-read-detail-surfaces.json",
@@ -175,7 +175,7 @@
     },
     {
       "path": "journal-01-surfaces.json",
-      "sha256": "4035b629e5d5223e9ec9e449012393ee960c0139e10ec7a0043584530715ffa5"
+      "sha256": "d2131a630b1e45e8b8c416dd97928357ec1e2bb4b02b6734d2a3e210cdbd215a"
     },
     {
       "path": "journal-02-surfaces.json",
@@ -251,7 +251,7 @@
     },
     {
       "path": "source-catalog-g02-next.json",
-      "sha256": "821097bba1c91450dd91a5d5062a8b20b734e51e855b0596bb38121802374a24"
+      "sha256": "d7488366d6a60227b244b6e6e35d6f0de59856b36f93ccb07a144751a382ac02"
     },
     {
       "path": "source-catalog-m01.json",
@@ -279,11 +279,11 @@
     },
     {
       "path": "source-catalog-native-claims.json",
-      "sha256": "73d0eb2f6bd8509745ad5771e00663128979acc63ef25525187ab2c11cfc76be"
+      "sha256": "4e6cf635ff0237706cdfa8b0a8cc01210382ca8df322e77b817c6619cc38e2af"
     },
     {
       "path": "source-catalog-native-extractions.json",
-      "sha256": "0ccd58b8d6e52a0f2818b43e8cd8d16dd39dc1f52898f3a61e42aa2ea77602f7"
+      "sha256": "aa76199456b7285281ce3f0a32a098f337d37e6d66b40dc6927693c9064c4658"
     },
     {
       "path": "source-catalog-native-facts.json",
@@ -291,7 +291,7 @@
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "d0653eae3e3a109e5adf7d5ea49f7b5445cd7791cf721397062b607651e62649"
+      "sha256": "ccc7789775a78e1eb71ede45a2381c0471c9efb87cd4fb13903cfbe9365c0706"
     },
     {
       "path": "source-catalog-native-pending-answers.json",

--- a/config/migration/source-catalog-g02-next.json
+++ b/config/migration/source-catalog-g02-next.json
@@ -103,7 +103,7 @@
     },
     {
       "path": "apps/companion/server/routes.ts",
-      "sha256": "a5b8a3807b9c981db027c5be7a2a37dc8038628c636289553e1e64eb35fb3381",
+      "sha256": "99437370e892cad4eaffa71385981dd5ebc9a01048455a9ce0cc91070060e3d3",
       "classification": "unreviewed"
     }
   ]

--- a/config/migration/source-catalog-native-claims.json
+++ b/config/migration/source-catalog-native-claims.json
@@ -3,12 +3,12 @@
   "sources": [
     {
       "path": "apps/companion/components/Claims.tsx",
-      "sha256": "55250cd607e692c495889b468ba945b984739c30ddaa73f237d3eac19f2a3e1d",
+      "sha256": "a5ef9ee72694054a546f8ac40e19a46cbc945b6194646e600614dd73e867ccae",
       "classification": "unreviewed"
     },
     {
       "path": "runtime/cli/native-claims.js",
-      "sha256": "5d4117f694fa82ec850cb47c99fafc3a56770f5abf492646173571be39ece480",
+      "sha256": "5a1297ef36e1a432e11c51d07dac2c925672b3c84a1d7588115b5cf3fffa163d",
       "classification": "unreviewed"
     },
     {
@@ -43,22 +43,22 @@
     },
     {
       "path": "runtime/store/native-claim-journal.js",
-      "sha256": "6f6158c76d6c03dc2d90b50d72ee8577802d1fcd651a04b1c03bcb003e0021dc",
+      "sha256": "560c4c32afd7c6e206b9de0d3602a929c5fef9bb37b22ffdc3b62daf6e99927e",
       "classification": "unreviewed"
     },
     {
       "path": "runtime/workspace-core/claims-http.js",
-      "sha256": "43795b75d117e586dfe5192472a0b91340ce1829be9276ebc0ba12fa2d6b459d",
+      "sha256": "208d86d30dd8298dc0ab7296da00df919c136a6af91d190bd2861b7198a8f89d",
       "classification": "unreviewed"
     },
     {
       "path": "runtime/workspace-core/claims.js",
-      "sha256": "23f6d734e07f794f727a344065ba17b9d0a07aae828b1a4f5131d7deb9e14800",
+      "sha256": "db8fbbbbbd8d85b4b63ed35c33528b7085300de2f71a58b9359e6f5c0e9134a4",
       "classification": "unreviewed"
     },
     {
       "path": "src/cli/native-claims.ts",
-      "sha256": "ba9441b0bb68942779f8506b8985a54e73999c7d8ddbe4200a00ba61ab02af93",
+      "sha256": "927ab4f8d700b6d39967dd53a5f117e8505e546dd64d5a24b9a45bd2a26482a0",
       "classification": "unreviewed"
     },
     {
@@ -93,17 +93,27 @@
     },
     {
       "path": "src/store/native-claim-journal.ts",
-      "sha256": "f174f3f8a16a84111f0bca4ce3b7b6f73e66c9c12f3de3b66c167211ca4b4392",
+      "sha256": "5d828fee45b709b317ac0d2053a0f32d210beab0213160340717ced30bf8a5ba",
       "classification": "unreviewed"
     },
     {
       "path": "src/workspace-core/claims-http.ts",
-      "sha256": "dad301002abfb44e0acb2a6fe5fc3c2ff0a78ae4ca525c80e2d4ec31eeb34ec1",
+      "sha256": "0a1c79bfed203ef73fbea5c93c141da4ba40b0f6bc5764434837a02be3bb1610",
       "classification": "unreviewed"
     },
     {
       "path": "src/workspace-core/claims.ts",
-      "sha256": "6406a6e80d27e891cccfcd069851c681d6a1dd5868517ecf19c73ee28da693f8",
+      "sha256": "91de8fdae4749ff56393a351266060d19a5e52d8f80341fe0734e5067e235e3e",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/review-restart.ts",
+      "sha256": "5089b2ef2c767a9b8b66ef6d63abe7789f91a317115cedfaabab01c4f44c2d31",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/review-restart.js",
+      "sha256": "b73869d011c2b50073a226783977ebb1af972c6820d1355c477035497847da24",
       "classification": "unreviewed"
     }
   ]

--- a/config/migration/source-catalog-native-extractions.json
+++ b/config/migration/source-catalog-native-extractions.json
@@ -3,7 +3,7 @@
   "sources": [
     {
       "path": "apps/companion/components/Extractions.tsx",
-      "sha256": "343bf8b6fe7cedebb5418591a09ccb1b880a60aae82238b7dec8b4bbc26ff68f",
+      "sha256": "d74c6c609e97829ce7799c1e68f7aefc941f9b9e81fef55f3df5b923a1bd37c3",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "2581263768a3c6ddaa3695741022e60644e55b467641bb4dd5b55ee330b8f373",
+      "sha256": "312c7b4562d965cdc1b4de1dab5f14d6c7690f8ff470b5e83bb2e5590d281dee",
       "classification": "unreviewed"
     },
     {
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "236bfd38aa565990c00768622f91843d644c642498093e3d8618727a329d2a9c",
+      "sha256": "8a87a16971fe888ab7ae32066b194a40497a1a68007aa9c57c1cbf3474905f40",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "e878b9280a23f361fffbc339722e40abdbc780dc4d69f29e2b1ac74e8b68b14c",
+      "sha256": "d97009b8cef103b34c8d8ed7b29d47de0a594ec0d01061bd2270c7817d928759",
       "classification": "unreviewed"
     },
     {
@@ -83,7 +83,7 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "a59815f1f00d44d48ca965646d2489deb26adef78af7d6bc8f089f3a0a9616c7",
+      "sha256": "46cb2cadfe59aab1ca2f921bc96adce98c271cf1317f5ef07eca7545b64ffcaa",
       "classification": "unreviewed"
     },
     {

--- a/docs/native-answers-fixture.md
+++ b/docs/native-answers-fixture.md
@@ -118,9 +118,9 @@ requires a separate confirmation for each proposed merge.
 
 ## Durable merge and approval
 
-Fixture v8 includes private `sessions/*.json`, `applications.jsonl`, `coordinator.json`
+Fixture v9 includes private `sessions/*.json`, `applications.jsonl`, `coordinator.json`
 and `coordinator-journal.json`. New synthetic roots start with an idle coordinator;
-[active claims](native-claims-fixture.md) and their acquisition, recovery and
+[active claims](native-claims-fixture.md) and their acquisition, reviewed restart, recovery and
 handoff journals are supported. Answer merges and pending-answer resolution
 require an idle coordinator. Existing
 fixtures and live Stores are not upgraded or adopted.

--- a/docs/native-claims-fixture.md
+++ b/docs/native-claims-fixture.md
@@ -1,7 +1,7 @@
 # Native active-claim fixture
 
-New v8 synthetic roots support selection, acquisition, public status, heartbeat,
-expired-claim recovery, progress and durable handoff. Follow the setup in
+New v9 synthetic roots support selection, acquisition, public status, heartbeat,
+expired-claim recovery, progress, durable handoff and reviewed restart. Follow the setup in
 [native Jobs](native-jobs-fixture.md); existing fixtures and live Stores are not
 adopted or upgraded. The native implementation uses no Python subprocess.
 
@@ -15,6 +15,12 @@ expiry and explicitly recover the named job. Recovery rotates the credential
 without increasing the job revision. Returning a job for owner input writes a
 session, records history and releases the claim.
 
+For an awaiting-review job, choose **Restart reviewed application** and confirm
+that you have not submitted it. Restart requires intact prior review evidence,
+the exact job revision, an idle coordinator and a current managed resume. It
+preserves the old session, records a new attempt and acquires a fresh credential.
+The new attempt must produce fresh readiness evidence before another review handoff.
+
 ## CLI and HTTP
 
 Use `node runtime/cli/native-jobs.js --root ROOT --native-lock ADDON COMMAND`
@@ -24,13 +30,14 @@ with these command arguments:
 | --- | --- |
 | `task-select` | `--id ID --expected-revision N --owner-confirmed` |
 | `job-acquire` | `--id ID --owner LABEL --expected-revision N` |
+| `job-review-restart` | `--id ID --owner LABEL --expected-revision N --owner-confirmed-not-submitted` |
 | `claim-status` | none |
 | `claim-heartbeat` | `--id ID --token TOKEN` |
 | `claim-recover` | `--id ID --owner LABEL` |
 | `claim-progress` | `--id ID --token TOKEN --input SESSION_JSON` |
 | `claim-handoff` | `--id ID --token TOKEN --status STATUS --input SESSION_JSON --expected-revision N` |
 
-Only acquisition and recovery return a new bearer token. Session input accepts
+Only acquisition, reviewed restart and recovery return a new bearer token. Session input accepts
 stdin with `--input -`. Progress and handoff use the existing Python-compatible
 session packet contract. Handoff accepts `needs_info` or `awaiting_review`;
 review handoff recomputes readiness against current answers, approvals, attempt
@@ -38,18 +45,21 @@ revision and trusted fixture evidence. It does not submit an application.
 
 The authenticated native HTTP adapter exposes `GET /api/claims` and POST routes
 under `/api/claims/`: `select`, `acquire`, `heartbeat`, `recover`, `progress` and
-`handoff`. They share the CLI service and Store lock. Selection takes
+`handoff`, plus `review-restart`. Restart takes `jobId`, `ownerLabel`,
+`expectedRevision` and `ownerConfirmedNotSubmitted: true`. They share the CLI service and Store lock. Selection takes
 `ownerConfirmed: true`; writes use `jobId`, applicable `expectedRevision`,
 `ownerLabel`, `token`, `session` and `status` fields.
 
 ## Persistence and boundaries
 
-Acquisition, recovery and handoff use the coordinator journal and append durable
+Acquisition, reviewed restart, recovery and handoff use the coordinator journal and append durable
 application history. Replay validates identities and event collisions before
 writing documents, repairs an interrupted final history append and avoids duplicate
 events and revision increments. All domain entry points recover pending journals.
 
 Ordinary edits cannot change a claimed job; unrelated jobs remain editable.
 Answer merge and pending-answer resolution require an idle coordinator, including
-when they concern a different job. Complete the handoff first. Reviewed restart,
-broader attention projections and live Store activation remain separate work.
+when they concern a different job. Complete the handoff first. A legacy session
+with no review envelope can be rebuilt once, only with complete final-review
+evidence and reviewed history; a partial or null envelope is rejected. Broader
+attention projections and live Store activation remain separate work.

--- a/runtime/cli/native-claims.js
+++ b/runtime/cli/native-claims.js
@@ -1,6 +1,7 @@
 import { ClaimsService } from '../workspace-core/claims.js';
 import { object, text, JobsError } from '../contracts/workspace/values.js';
 export const claimCommands = {
+    'job-review-restart': ['--id', '--owner', '--expected-revision', '--owner-confirmed-not-submitted'],
     'task-select': ['--id', '--expected-revision', '--owner-confirmed'],
     'job-acquire': ['--id', '--owner', '--expected-revision'], 'claim-status': [],
     'claim-heartbeat': ['--id', '--token'], 'claim-recover': ['--id', '--owner'],
@@ -26,6 +27,8 @@ export async function runClaimCommand(command, repository, options, payload) {
     const id = required('--id');
     if (command === 'task-select')
         return service.select(id, revision(), options.has('--owner-confirmed'));
+    if (command === 'job-review-restart')
+        return service.restart(id, text(required('--owner')), revision(), options.has('--owner-confirmed-not-submitted'));
     if (command === 'job-acquire')
         return service.acquire(id, text(required('--owner')), revision());
     if (command === 'claim-recover')

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -26,7 +26,7 @@ export async function runJobsCli(args, input) {
         else {
             if (options.has(key))
                 throw new JobsError("duplicate CLI option");
-            if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses", "--summary-only", "--owner-confirmed"].includes(key))
+            if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses", "--summary-only", "--owner-confirmed", "--owner-confirmed-not-submitted"].includes(key))
                 options.set(key, "true");
             else {
                 const value = args[++index];

--- a/runtime/contracts/workspace/review-restart.js
+++ b/runtime/contracts/workspace/review-restart.js
@@ -1,0 +1,95 @@
+import { createHash } from 'node:crypto';
+import { PythonObject } from '../python-object.js';
+import { safeAnswerSessionId, validateAnswerSession } from './answer-session-validation.js';
+import { fields, member, optionalStrings, requireCondition as check } from './answer-session-fields.js';
+import { answerStates } from './answers.js';
+import { canonicalJson } from './canonical-json.js';
+import { casefold } from './casefold.js';
+import { strip } from './job-url.js';
+import { copy, fromJSON, get, has, int, integer, object, same, set, string, text, truth, JobsError } from './values.js';
+/** Project only in memory, retaining Python's legacy pending validation order. */
+function projectReviewSession(raw, ats) {
+    const pending = get(raw, 'pendingFields');
+    if (!Array.isArray(pending) || !pending.some(value => value instanceof PythonObject && !has(value, 'reference'))) {
+        return validateAnswerSession(raw);
+    }
+    const id = safeAnswerSessionId(get(raw, 'applicationId'));
+    check(!pending.some(value => value instanceof PythonObject && has(value, 'reference')), 'legacy and modern pending fields cannot be mixed');
+    optionalStrings(raw, ['company', 'role', 'url'], 'session');
+    const projected = copy(raw);
+    set(projected, 'ats', ats);
+    for (const key of ['company', 'role', 'url'])
+        projected.delete(text(key));
+    const references = new Set();
+    const digest = (value) => createHash('sha256').update(canonicalJson(value)).digest('hex');
+    const projectedFields = pending.map(value => {
+        check(value instanceof PythonObject, 'pending field must be a JSON object');
+        const field = object(value, 'pending field');
+        check(fields(field, ['question', 'state', 'answerKey', 'sensitive']), 'pending field reference is invalid');
+        optionalStrings(field, ['question', 'state', 'answerKey'], 'pending field');
+        if (has(field, 'state'))
+            check(member(get(field, 'state'), answerStates), 'pending field state is unsupported');
+        if (has(field, 'sensitive'))
+            check(typeof get(field, 'sensitive') === 'boolean', 'pending field sensitive must be a boolean');
+        const candidate = copy(field), question = string(get(candidate, 'question'));
+        candidate.delete(text('question'));
+        if (question !== null && strip(question)) {
+            const normalized = casefold(strip(question).replace(/[\t-\r\x1c-\x20\x85\xa0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+/gu, ' '));
+            set(candidate, 'questionFingerprint', text(createHash('sha256').update(normalized).digest('hex')));
+        }
+        if (string(ats))
+            set(candidate, 'scopeFingerprint', text(digest(set(new PythonObject(), 'ats', ats))));
+        const identity = set(set(new PythonObject(), 'applicationId', text(id)), 'pendingField', field);
+        const reference = `pending_${digest(identity).slice(0, 32)}`;
+        check(!references.has(reference), 'pending field references must be unique');
+        references.add(reference);
+        return set(candidate, 'reference', text(reference));
+    });
+    return validateAnswerSession(set(projected, 'pendingFields', projectedFields));
+}
+/** Validate evidence after job/claim guards and before managed-resume preflight.
+ * The caller supplies validated job/history records; raw session bytes stay intact.
+ */
+export function validateReviewRestartEvidence(job, rawSession, history) {
+    check(rawSession !== null, 'review restart requires prior review evidence');
+    const raw = rawSession;
+    const version = int(get(raw, 'schemaVersion'));
+    check(version !== null, 'session has no valid schemaVersion');
+    check(version <= 1n, `session uses unsupported future schemaVersion ${version}`);
+    check(version === 1n, `session uses unsupported schemaVersion ${version}`);
+    let session;
+    try {
+        session = projectReviewSession(raw, get(job, 'ats'));
+    }
+    catch (error) {
+        if (error instanceof JobsError && error.message.endsWith(' must be an object')) {
+            throw new JobsError(error.message.replace(' must be an object', ' must be a JSON object'));
+        }
+        throw error;
+    }
+    const legacy = !['attemptRevision', 'readiness', 'browserHandoff'].some(key => has(raw, key));
+    const complete = string(get(session, 'status')) === 'review'
+        && !truth(get(session, 'pendingFields')) && !truth(get(session, 'blockers'));
+    const evidenceError = 'review restart requires complete prior review evidence';
+    if (legacy) {
+        check(complete && string(get(session, 'step')) === 'final_review', evidenceError);
+    }
+    else {
+        const readinessValue = get(session, 'readiness');
+        check(complete && same(get(session, 'attemptRevision'), integer(int(get(job, 'revision')) - 1n))
+            && readinessValue !== null, evidenceError);
+        const readiness = object(readinessValue, 'session readiness');
+        check(string(get(readiness, 'status')) === 'ready'
+            && string(get(readiness, 'evidenceKind')) === 'agent_attested_current_attempt'
+            && same(get(readiness, 'attemptRevision'), get(session, 'attemptRevision'))
+            && !truth(get(readiness, 'blockerCodes'))
+            && object(get(readiness, 'assertions'), 'session readiness assertions').entries().every(([, value]) => string(value) === 'passed')
+            && same(get(session, 'browserHandoff'), fromJSON({ state: 'ready_for_owner', reasonCode: 'final-review-required', revision: 1 })), evidenceError);
+    }
+    const jobHistory = history.filter(event => same(get(event, 'applicationId'), get(job, 'id')));
+    const last = jobHistory.at(-1);
+    check(last !== undefined && string(get(last, 'event')) === 'reviewed'
+        && string(get(last, 'status')) === 'awaiting_review', 'review restart requires prior reviewed history');
+    check(!legacy || !jobHistory.slice(0, -1).some(event => member(get(event, 'event'), ['job-restarted', 'legacy-review-rebuild'])), 'legacy review restart was already used');
+    return legacy ? 'legacy-review-rebuild' : 'job-restarted';
+}

--- a/runtime/store/native-claim-journal.js
+++ b/runtime/store/native-claim-journal.js
@@ -3,7 +3,7 @@ import { validateAnswerHistory, validateAnswerSession } from '../contracts/works
 import { validateJobsDocument, safeId } from '../contracts/workspace/jobs.js';
 import { fromJSON, get, has, int, integer, keys, object, parse, serialize, set, string, JobsError } from '../contracts/workspace/values.js';
 import { NativeClaimHistory } from './native-claim-history.js';
-export const claimOperationKinds = new Set(['acquire', 'recover', 'handoff']);
+export const claimOperationKinds = new Set(['acquire', 'review_restart', 'recover', 'handoff']);
 export function validateClaimJournal(journal) {
     if (journal.size !== 2 || int(get(journal, 'schemaVersion')) !== 1n || !has(journal, 'operation'))
         throw new JobsError('invalid coordinator journal');
@@ -23,6 +23,8 @@ export function validateClaimJournal(journal) {
         throw new JobsError('coordinator journal revision is invalid');
     if (kind === 'acquire' && (string(get(operation, 'sourceStatus')) !== 'ready' || string(get(operation, 'targetStatus')) !== 'in_progress'))
         throw new JobsError('coordinator acquisition transition is invalid');
+    if (kind === 'review_restart' && (string(get(operation, 'sourceStatus')) !== 'awaiting_review' || string(get(operation, 'targetStatus')) !== 'in_progress'))
+        throw new JobsError('coordinator review restart transition is invalid');
     if (kind === 'handoff') {
         if (string(get(operation, 'sourceStatus')) !== 'in_progress' || !['needs_info', 'awaiting_review'].includes(string(get(operation, 'targetStatus'))))
             throw new JobsError('coordinator handoff transition is invalid');

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -22,7 +22,7 @@ import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
 import { validateAnswers } from "../contracts/workspace/answers.js";
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 };
-const marker = '{"mode":"native-jobs-fixture","version":8}\n';
+const marker = '{"mode":"native-jobs-fixture","version":9}\n';
 const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 };
@@ -298,7 +298,7 @@ export class NativeJobsRepository {
         return this.transaction(async () => {
             const jobs = validateJobsDocument(await this.document('jobs'));
             return operation({ jobs, coordinator: validateCoordinator(await this.journal('coordinator')),
-                sessions: await this.answerSessions(), answers: validateAnswers(await this.document('answers')),
+                sessions: await this.answerSessions(), history: await this.answerHistory(), answers: validateAnswers(await this.document('answers')),
                 profile: validateProfile(await this.document('profile')), resumes: validateExtractionResumes(await this.document('resumes')),
                 files: new NativeResumeFiles(this.root),
                 saveJobs: async (document) => { validateJobsDocument(document); await this.write(join(this.root, 'jobs.json'), document, options); },

--- a/runtime/workspace-core/claims-http.js
+++ b/runtime/workspace-core/claims-http.js
@@ -6,6 +6,7 @@ export async function claimsHttp(repository, method, path, body) {
     if (method === 'GET' && path === '/api/claims')
         return { status: 200, body: serialize(await service.status()) };
     const shapes = {
+        'review-restart': ['jobId', 'ownerLabel', 'expectedRevision', 'ownerConfirmedNotSubmitted'],
         select: ['jobId', 'expectedRevision', 'ownerConfirmed'], acquire: ['jobId', 'ownerLabel', 'expectedRevision'],
         heartbeat: ['jobId', 'token'], recover: ['jobId', 'ownerLabel'], progress: ['jobId', 'token', 'session'],
         handoff: ['jobId', 'token', 'status', 'session', 'expectedRevision'],
@@ -29,6 +30,8 @@ export async function claimsHttp(repository, method, path, body) {
     let result;
     if (action === 'select')
         result = await service.select(id, revision(), get(payload, 'ownerConfirmed') === true);
+    else if (action === 'review-restart')
+        result = await service.restart(id, get(payload, 'ownerLabel'), revision(), get(payload, 'ownerConfirmedNotSubmitted') === true);
     else if (action === 'acquire')
         result = await service.acquire(id, get(payload, 'ownerLabel'), revision());
     else if (action === 'heartbeat')

--- a/runtime/workspace-core/claims.js
+++ b/runtime/workspace-core/claims.js
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { claimExpired, claimHeartbeatSeconds, claimLeaseSeconds, heartbeatClaim, makeClaim, publicClaim, requireClaim, requireJobUnclaimed } from '../contracts/workspace/claims.js';
 import { buildClaimSession, validateClaimHandoff } from '../contracts/workspace/claim-session.js';
+import { validateReviewRestartEvidence } from '../contracts/workspace/review-restart.js';
 import { safeId, validateJob } from '../contracts/workspace/jobs.js';
 import { strip } from '../contracts/workspace/job-url.js';
 import { copy, fromJSON, get, has, int, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
@@ -101,6 +102,39 @@ export class ClaimsService {
             const resume = copy(object(get(object(get(tx.resumes, 'resumes'), 'resumes'), string(get(preflight, 'resumeId'))), 'resume'));
             set(resume, 'path', string(get(resume, 'storageKind')) === 'managed' ? text(tx.files.path(resume)) : get(resume, 'path'));
             await tx.commit(operation('acquire', job, now, 'job-started', 'in_progress', claim));
+            const result = doc({ token });
+            set(result, 'job', transitioned(job, 'in_progress', now));
+            set(result, 'resume', resume);
+            return set(result, 'claim', publicClaim(claim, this.now()));
+        });
+    }
+    restart(id, ownerLabel, expectedRevision, ownerConfirmedNotSubmitted) {
+        safeId(id);
+        if (ownerConfirmedNotSubmitted !== true)
+            throw new JobsError('review restart requires explicit owner confirmation that the application was not submitted');
+        owner(ownerLabel);
+        if (typeof expectedRevision !== 'bigint' || expectedRevision < 1n)
+            throw new JobsError('job revision is invalid');
+        return this.repository.claimTransaction(async (tx) => {
+            const current = get(tx.coordinator, 'claim');
+            if (current !== null)
+                throw new JobsError(claimExpired(object(current, 'claim'), this.now()) ? 'expired claim requires explicit same-job recovery' : 'another live job claim already exists');
+            const job = activeJob(tx.jobs, id);
+            if (int(get(job, 'revision')) !== expectedRevision)
+                throw new JobsError('job revision conflict');
+            if (string(get(job, 'status')) !== 'awaiting_review')
+                throw new JobsError('review restart requires an awaiting_review job');
+            const session = tx.sessions.find(item => string(get(item, 'applicationId')) === id) ?? null;
+            const event = validateReviewRestartEvidence(job, session, tx.history);
+            const preflight = await preflightJobRecord(job, tx.profile, tx.resumes, tx.files);
+            const rawResume = get(object(get(tx.resumes, 'resumes'), 'resumes'), string(get(preflight, 'resumeId')) ?? '');
+            if (get(preflight, 'ready') !== true || rawResume === null || string(get(object(rawResume, 'resume'), 'storageKind')) !== 'managed')
+                throw new JobsError('job is not ready with a current managed resume');
+            const resume = copy(object(rawResume, 'resume'));
+            set(resume, 'path', text(tx.files.path(resume)));
+            const now = this.now(), { claim, token } = makeClaim(id, ownerLabel, now);
+            // The prior review remains immutable evidence; new progress belongs to the new revision.
+            await tx.commit(operation('review_restart', job, now, event, 'in_progress', claim));
             const result = doc({ token });
             set(result, 'job', transitioned(job, 'in_progress', now));
             set(result, 'resume', resume);

--- a/src/cli/native-claims.ts
+++ b/src/cli/native-claims.ts
@@ -4,6 +4,7 @@ import { object, text, JobsError } from '../contracts/workspace/values.js';
 import type { Value } from '../contracts/workspace/values.js';
 
 export const claimCommands:Record<string,string[]> = {
+  'job-review-restart':['--id','--owner','--expected-revision','--owner-confirmed-not-submitted'],
   'task-select':['--id','--expected-revision','--owner-confirmed'],
   'job-acquire':['--id','--owner','--expected-revision'],'claim-status':[],
   'claim-heartbeat':['--id','--token'],'claim-recover':['--id','--owner'],
@@ -25,6 +26,7 @@ export async function runClaimCommand(command:string,repository:ClaimRepository,
   if (command === 'claim-status') return service.status();
   const id = required('--id');
   if (command === 'task-select') return service.select(id,revision(),options.has('--owner-confirmed'));
+  if (command === 'job-review-restart') return service.restart(id,text(required('--owner')),revision(),options.has('--owner-confirmed-not-submitted'));
   if (command === 'job-acquire') return service.acquire(id,text(required('--owner')),revision());
   if (command === 'claim-recover') return service.recover(id,text(required('--owner')));
   const token = text(required('--token'));

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -24,7 +24,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
       command = key;
     } else {
       if (options.has(key)) throw new JobsError("duplicate CLI option");
-      if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses", "--summary-only", "--owner-confirmed"].includes(key)) options.set(key, "true");
+      if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses", "--summary-only", "--owner-confirmed", "--owner-confirmed-not-submitted"].includes(key)) options.set(key, "true");
       else {
         const value = args[++index];
         if (!value || value.startsWith("--")) throw new JobsError("missing CLI option value");

--- a/src/contracts/workspace/review-restart.ts
+++ b/src/contracts/workspace/review-restart.ts
@@ -1,0 +1,93 @@
+import { createHash } from 'node:crypto';
+import { PythonObject } from '../python-object.js';
+import { safeAnswerSessionId, validateAnswerSession } from './answer-session-validation.js';
+import { fields, member, optionalStrings, requireCondition as check } from './answer-session-fields.js';
+import { answerStates } from './answers.js';
+import { canonicalJson } from './canonical-json.js';
+import { casefold } from './casefold.js';
+import { strip } from './job-url.js';
+import { copy, fromJSON, get, has, int, integer, object, same, set, string, text, truth, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+
+/** Project only in memory, retaining Python's legacy pending validation order. */
+function projectReviewSession(raw: Document, ats: Value): Document {
+  const pending = get(raw, 'pendingFields');
+  if (!Array.isArray(pending) || !pending.some(value => value instanceof PythonObject && !has(value, 'reference'))) {
+    return validateAnswerSession(raw);
+  }
+  const id = safeAnswerSessionId(get(raw, 'applicationId'));
+  check(!pending.some(value => value instanceof PythonObject && has(value, 'reference')), 'legacy and modern pending fields cannot be mixed');
+  optionalStrings(raw, ['company', 'role', 'url'], 'session');
+  const projected = copy(raw);
+  set(projected, 'ats', ats);
+  for (const key of ['company', 'role', 'url']) projected.delete(text(key));
+  const references = new Set<string>();
+  const digest = (value: Value): string => createHash('sha256').update(canonicalJson(value)).digest('hex');
+  const projectedFields = pending.map(value => {
+    check(value instanceof PythonObject, 'pending field must be a JSON object');
+    const field = object(value, 'pending field');
+    check(fields(field, ['question', 'state', 'answerKey', 'sensitive']), 'pending field reference is invalid');
+    optionalStrings(field, ['question', 'state', 'answerKey'], 'pending field');
+    if (has(field, 'state')) check(member(get(field, 'state'), answerStates), 'pending field state is unsupported');
+    if (has(field, 'sensitive')) check(typeof get(field, 'sensitive') === 'boolean', 'pending field sensitive must be a boolean');
+    const candidate = copy(field), question = string(get(candidate, 'question'));
+    candidate.delete(text('question'));
+    if (question !== null && strip(question)) {
+      const normalized = casefold(strip(question).replace(/[\t-\r\x1c-\x20\x85\xa0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+/gu, ' '));
+      set(candidate, 'questionFingerprint', text(createHash('sha256').update(normalized).digest('hex')));
+    }
+    if (string(ats)) set(candidate, 'scopeFingerprint', text(digest(set(new PythonObject<Value>(), 'ats', ats))));
+    const identity = set(set(new PythonObject<Value>(), 'applicationId', text(id)), 'pendingField', field);
+    const reference = `pending_${digest(identity).slice(0, 32)}`;
+    check(!references.has(reference), 'pending field references must be unique');
+    references.add(reference);
+    return set(candidate, 'reference', text(reference));
+  });
+  return validateAnswerSession(set(projected, 'pendingFields', projectedFields));
+}
+
+/** Validate evidence after job/claim guards and before managed-resume preflight.
+ * The caller supplies validated job/history records; raw session bytes stay intact.
+ */
+export function validateReviewRestartEvidence(
+  job: Document, rawSession: Document | null, history: Document[],
+): 'job-restarted' | 'legacy-review-rebuild' {
+  check(rawSession !== null, 'review restart requires prior review evidence');
+  const raw = rawSession!;
+  const version = int(get(raw, 'schemaVersion'));
+  check(version !== null, 'session has no valid schemaVersion');
+  check(version! <= 1n, `session uses unsupported future schemaVersion ${version}`);
+  check(version === 1n, `session uses unsupported schemaVersion ${version}`);
+  let session: Document;
+  try { session = projectReviewSession(raw, get(job, 'ats')); }
+  catch (error) {
+    if (error instanceof JobsError && error.message.endsWith(' must be an object')) {
+      throw new JobsError(error.message.replace(' must be an object', ' must be a JSON object'));
+    }
+    throw error;
+  }
+  const legacy = !['attemptRevision', 'readiness', 'browserHandoff'].some(key => has(raw, key));
+  const complete = string(get(session, 'status')) === 'review'
+    && !truth(get(session, 'pendingFields')) && !truth(get(session, 'blockers'));
+  const evidenceError = 'review restart requires complete prior review evidence';
+  if (legacy) {
+    check(complete && string(get(session, 'step')) === 'final_review', evidenceError);
+  } else {
+    const readinessValue = get(session, 'readiness');
+    check(complete && same(get(session, 'attemptRevision'), integer(int(get(job, 'revision'))! - 1n))
+      && readinessValue !== null, evidenceError);
+    const readiness = object(readinessValue, 'session readiness');
+    check(string(get(readiness, 'status')) === 'ready'
+      && string(get(readiness, 'evidenceKind')) === 'agent_attested_current_attempt'
+      && same(get(readiness, 'attemptRevision'), get(session, 'attemptRevision'))
+      && !truth(get(readiness, 'blockerCodes'))
+      && object(get(readiness, 'assertions'), 'session readiness assertions').entries().every(([, value]) => string(value) === 'passed')
+      && same(get(session, 'browserHandoff'), fromJSON({state:'ready_for_owner',reasonCode:'final-review-required',revision:1})), evidenceError);
+  }
+  const jobHistory = history.filter(event => same(get(event, 'applicationId'), get(job, 'id')));
+  const last = jobHistory.at(-1);
+  check(last !== undefined && string(get(last, 'event')) === 'reviewed'
+    && string(get(last, 'status')) === 'awaiting_review', 'review restart requires prior reviewed history');
+  check(!legacy || !jobHistory.slice(0, -1).some(event => member(get(event, 'event'), ['job-restarted', 'legacy-review-rebuild'])), 'legacy review restart was already used');
+  return legacy ? 'legacy-review-rebuild' : 'job-restarted';
+}

--- a/src/store/native-claim-journal.ts
+++ b/src/store/native-claim-journal.ts
@@ -5,7 +5,7 @@ import { fromJSON, get, has, int, integer, keys, object, parse, serialize, set, 
 import type { Document } from '../contracts/workspace/values.js';
 import { NativeClaimHistory } from './native-claim-history.js';
 
-export const claimOperationKinds = new Set(['acquire','recover','handoff']);
+export const claimOperationKinds = new Set(['acquire','review_restart','recover','handoff']);
 export function validateClaimJournal(journal: Document): Document {
   if (journal.size !== 2 || int(get(journal,'schemaVersion')) !== 1n || !has(journal,'operation')) throw new JobsError('invalid coordinator journal');
   const operation = object(get(journal,'operation'),'coordinator journal operation');
@@ -19,6 +19,7 @@ export function validateClaimJournal(journal: Document): Document {
   if (string(get(event,'applicationId')) !== id) throw new JobsError('coordinator history identity does not match');
   if (kind !== 'recover' && (int(get(operation,'expectedRevision')) === null || int(get(operation,'expectedRevision'))! < 1n)) throw new JobsError('coordinator journal revision is invalid');
   if (kind === 'acquire' && (string(get(operation,'sourceStatus')) !== 'ready' || string(get(operation,'targetStatus')) !== 'in_progress')) throw new JobsError('coordinator acquisition transition is invalid');
+  if (kind === 'review_restart' && (string(get(operation,'sourceStatus')) !== 'awaiting_review' || string(get(operation,'targetStatus')) !== 'in_progress')) throw new JobsError('coordinator review restart transition is invalid');
   if (kind === 'handoff') {
     if (string(get(operation,'sourceStatus')) !== 'in_progress' || !['needs_info','awaiting_review'].includes(string(get(operation,'targetStatus'))!)) throw new JobsError('coordinator handoff transition is invalid');
     if (string(get(validateAnswerSession(get(operation,'session')),'applicationId')) !== id) throw new JobsError('coordinator session identity does not match');

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -32,7 +32,7 @@ import { validateAnswers } from "../contracts/workspace/answers.js";
 import type { AnswerReferenceCounts } from "../workspace-core/answers.js";
 
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
-const marker = '{"mode":"native-jobs-fixture","version":8}\n';
+const marker = '{"mode":"native-jobs-fixture","version":9}\n';
 const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
@@ -300,7 +300,7 @@ export class NativeJobsRepository implements JobsRepository {
     return this.transaction(async () => {
       const jobs = validateJobsDocument(await this.document('jobs'));
       return operation({jobs,coordinator:validateCoordinator(await this.journal('coordinator')),
-        sessions:await this.answerSessions(), answers:validateAnswers(await this.document('answers')),
+        sessions:await this.answerSessions(), history:await this.answerHistory(), answers:validateAnswers(await this.document('answers')),
         profile:validateProfile(await this.document('profile')),resumes:validateExtractionResumes(await this.document('resumes')),
         files:new NativeResumeFiles(this.root),
         saveJobs:async document => { validateJobsDocument(document);await this.write(join(this.root,'jobs.json'),document,options); },

--- a/src/workspace-core/claims-http.ts
+++ b/src/workspace-core/claims-http.ts
@@ -8,6 +8,7 @@ export async function claimsHttp(repository:ClaimRepository,method:string,path:s
   const service = new ClaimsService(repository);
   if (method === 'GET' && path === '/api/claims') return {status:200,body:serialize(await service.status())};
   const shapes:Record<string,string[]> = {
+    'review-restart':['jobId','ownerLabel','expectedRevision','ownerConfirmedNotSubmitted'],
     select:['jobId','expectedRevision','ownerConfirmed'], acquire:['jobId','ownerLabel','expectedRevision'],
     heartbeat:['jobId','token'],recover:['jobId','ownerLabel'],progress:['jobId','token','session'],
     handoff:['jobId','token','status','session','expectedRevision'],
@@ -26,6 +27,7 @@ export async function claimsHttp(repository:ClaimRepository,method:string,path:s
   };
   let result:Value;
   if (action === 'select') result = await service.select(id,revision(),get(payload,'ownerConfirmed') === true);
+  else if (action === 'review-restart') result = await service.restart(id,get(payload,'ownerLabel'),revision(),get(payload,'ownerConfirmedNotSubmitted') === true);
   else if (action === 'acquire') result = await service.acquire(id,get(payload,'ownerLabel'),revision());
   else if (action === 'heartbeat') result = await service.heartbeat(id,get(payload,'token'));
   else if (action === 'recover') result = await service.recover(id,get(payload,'ownerLabel'));

--- a/src/workspace-core/claims.ts
+++ b/src/workspace-core/claims.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { claimExpired, claimHeartbeatSeconds, claimLeaseSeconds, heartbeatClaim, makeClaim, publicClaim, requireClaim, requireJobUnclaimed } from '../contracts/workspace/claims.js';
 import { buildClaimSession, validateClaimHandoff } from '../contracts/workspace/claim-session.js';
+import { validateReviewRestartEvidence } from '../contracts/workspace/review-restart.js';
 import { safeId, validateJob } from '../contracts/workspace/jobs.js';
 import { strip } from '../contracts/workspace/job-url.js';
 import { copy, fromJSON, get, has, int, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
@@ -10,7 +11,7 @@ import { preflightJobRecord } from './job-preflight.js';
 
 export interface ClaimTransaction {
   jobs: Document; coordinator: Document; profile: Document; resumes: Document; answers: Document;
-  sessions: Document[]; files: NativeResumeFiles;
+  sessions: Document[]; history: Document[]; files: NativeResumeFiles;
   saveJobs(document:Document):Promise<void>;
   saveCoordinator(document:Document):Promise<void>;
   saveSession(document:Document):Promise<void>;
@@ -89,6 +90,31 @@ export class ClaimsService {
       const resume = copy(object(get(object(get(tx.resumes,'resumes'),'resumes'),string(get(preflight,'resumeId'))!),'resume'));
       set(resume,'path',string(get(resume,'storageKind')) === 'managed' ? text(tx.files.path(resume)) : get(resume,'path'));
       await tx.commit(operation('acquire',job,now,'job-started','in_progress',claim));
+      const result = doc({token});set(result,'job',transitioned(job,'in_progress',now));set(result,'resume',resume);
+      return set(result,'claim',publicClaim(claim,this.now()));
+    });
+  }
+  restart(id:string,ownerLabel:Value,expectedRevision:bigint,ownerConfirmedNotSubmitted:boolean):Promise<Value> {
+    safeId(id);
+    if (ownerConfirmedNotSubmitted !== true) throw new JobsError('review restart requires explicit owner confirmation that the application was not submitted');
+    owner(ownerLabel);
+    if (typeof expectedRevision !== 'bigint' || expectedRevision < 1n) throw new JobsError('job revision is invalid');
+    return this.repository.claimTransaction(async tx => {
+      const current = get(tx.coordinator,'claim');
+      if (current !== null) throw new JobsError(claimExpired(object(current,'claim'),this.now()) ? 'expired claim requires explicit same-job recovery' : 'another live job claim already exists');
+      const job = activeJob(tx.jobs,id);
+      if (int(get(job,'revision')) !== expectedRevision) throw new JobsError('job revision conflict');
+      if (string(get(job,'status')) !== 'awaiting_review') throw new JobsError('review restart requires an awaiting_review job');
+      const session = tx.sessions.find(item => string(get(item,'applicationId')) === id) ?? null;
+      const event = validateReviewRestartEvidence(job,session,tx.history);
+      const preflight = await preflightJobRecord(job,tx.profile,tx.resumes,tx.files);
+      const rawResume = get(object(get(tx.resumes,'resumes'),'resumes'),string(get(preflight,'resumeId')) ?? '');
+      if (get(preflight,'ready') !== true || rawResume === null || string(get(object(rawResume,'resume'),'storageKind')) !== 'managed') throw new JobsError('job is not ready with a current managed resume');
+      const resume = copy(object(rawResume,'resume'));
+      set(resume,'path',text(tx.files.path(resume)));
+      const now = this.now(), {claim,token} = makeClaim(id,ownerLabel,now);
+      // The prior review remains immutable evidence; new progress belongs to the new revision.
+      await tx.commit(operation('review_restart',job,now,event,'in_progress',claim));
       const result = doc({token});set(result,'job',transitioned(job,'in_progress',now));set(result,'resume',resume);
       return set(result,'claim',publicClaim(claim,this.now()));
     });

--- a/tests/test_job_apply_workspace_launcher.py
+++ b/tests/test_job_apply_workspace_launcher.py
@@ -16,7 +16,11 @@ class WorkspaceProcessTests(unittest.TestCase):
                 self.assertIn("/#token=", details["url"])
                 connection = http.client.HTTPConnection("127.0.0.1", details["port"], timeout=3)
                 connection.request("GET", "/", headers={"Host": f"127.0.0.1:{details['port']}"})
-                self.assertEqual(connection.getresponse().status, 200)
+                response = connection.getresponse()
+                self.assertEqual(response.status, 200)
+                # Finish the request before testing shutdown; an unread body
+                # can reset the socket while the server writes its response.
+                response.read()
                 connection.close()
                 if os.name == "nt":
                     process.send_signal(signal.CTRL_BREAK_EVENT)

--- a/tests_js/workspace_native_claims_browser_support.mjs
+++ b/tests_js/workspace_native_claims_browser_support.mjs
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
+import { reviewRestartBrowser } from './workspace_native_review_restart_browser_support.mjs';
 
 // The caller owns the disposable fixture and prepares one preflight-ready job.
 // expireClaim must adjust only that fixture's lease; never use an owner Store.
 export async function claimsBrowser(page, { jobId, expireClaim }) {
     const panel = page.getByRole('region', { name: 'Active application', exact: true });
-    await panel.getByText('No active application claim.', { exact: true }).waitFor();
+    try { await panel.getByText('No active application claim.', { exact: true }).waitFor(); }
+    catch (error) { throw Error(`${error.message}\n${await page.locator('body').innerText()}`); }
     await panel.getByRole('combobox', { name: 'Job for application work', exact: true }).selectOption(jobId);
     page.once('dialog', dialog => dialog.accept());
     await panel.getByRole('button', { name: 'Select this job', exact: true }).click();
@@ -43,4 +45,5 @@ export async function claimsBrowser(page, { jobId, expireClaim }) {
     await panel.getByText('Application returned for owner input.', { exact: true }).waitFor();
     await panel.getByText('No active application claim.', { exact: true }).waitFor();
     assert.equal((await page.locator('body').innerText()).includes(recoveredPayload.token), false);
+    await reviewRestartBrowser(page, jobId);
 }

--- a/tests_js/workspace_native_extractions_browser_support.mjs
+++ b/tests_js/workspace_native_extractions_browser_support.mjs
@@ -18,7 +18,28 @@ export async function nativeExtractionsBrowser(page, root, fixture, buildRoot) {
   await cli('profile-patch', ['--source', 'user', '--expected-revision', String(profile.metadata.revision)], { employer: ['Existing employer'] });
   await page.getByRole('button', { name: 'Resume extraction', exact: true }).click();
   await page.getByLabel('Resume to extract').selectOption(resume.id);
-  await page.getByRole('button', { name: 'Request extraction', exact: true }).click();
+  // With no review choices, an unacknowledged request write still needs navigation protection.
+  let releaseWrite, writeStarted;
+  const writeGate = new Promise(resolve => { releaseWrite = resolve; });
+  const writeEntered = new Promise(resolve => { writeStarted = resolve; });
+  await page.route('**/api/resume-extraction-requests', async route => {
+    if (route.request().method() === 'POST') { writeStarted(); await writeGate; }
+    await route.continue();
+  });
+  let writePrompt;
+  const dismissWrite = async dialog => { writePrompt = dialog.message(); await dialog.dismiss(); };
+  try {
+    await page.getByRole('button', { name: 'Request extraction', exact: true }).click();
+    await writeEntered;
+    page.on('dialog', dismissWrite);
+    await page.getByRole('button', { name: 'Jobs', exact: true }).click();
+    assert.equal(typeof writePrompt, 'string', 'An unacknowledged extraction request must guard navigation');
+    await page.getByRole('heading', { name: 'Resume extraction', exact: true }).waitFor();
+  } finally {
+    page.off('dialog', dismissWrite);
+    releaseWrite();
+    await page.unroute('**/api/resume-extraction-requests');
+  }
   await page.getByRole('button', { name: 'Cancel extraction', exact: true }).waitFor();
   await page.getByRole('button', { name: 'Cancel extraction', exact: true }).click();
   await page.getByText('Extraction request cancelled.', { exact: true }).waitFor();
@@ -45,8 +66,33 @@ export async function nativeExtractionsBrowser(page, root, fixture, buildRoot) {
   await page.getByRole('button', { name: 'Reapply my decisions', exact: true }).click();
   assert.equal(await page.getByLabel('I confirm replacing /employer for /employer/title.').isChecked(), false);
   await page.getByLabel('I confirm replacing /employer for /employer/title.').check();
-  await page.getByRole('button', { name: 'Save review decisions', exact: true }).click();
-  await page.getByText('Review decisions saved.', { exact: true }).waitFor();
+  // Once the write is acknowledged, a slow detail read must not claim the saved decisions are dirty.
+  let releaseDetail, detailStarted;
+  const detailGate = new Promise(resolve => { releaseDetail = resolve; });
+  const detailEntered = new Promise(resolve => { detailStarted = resolve; });
+  const detailPath = `**/api/resume-proposals/${result.proposalSummary.id}`;
+  const dialogs = [];
+  const dismissDialog = async dialog => { dialogs.push(dialog.message()); await dialog.dismiss(); };
+  await page.route(detailPath, async route => {
+    detailStarted();
+    await detailGate;
+    await route.continue();
+  });
+  try {
+    await page.getByRole('button', { name: 'Save review decisions', exact: true }).click();
+    await page.getByText('Review decisions saved.', { exact: true }).waitFor();
+    await detailEntered;
+    page.on('dialog', dismissDialog);
+    await page.getByRole('button', { name: 'Jobs', exact: true }).click();
+    assert.deepEqual(dialogs, [], 'Saved review decisions must allow navigation during the detail refresh');
+    await page.getByRole('heading', { name: 'Jobs', exact: true }).waitFor();
+  } finally {
+    page.off('dialog', dismissDialog);
+    releaseDetail();
+    await page.unroute(detailPath);
+  }
+  await page.getByRole('button', { name: 'Resume extraction', exact: true }).click();
+  await page.getByRole('button', { name: 'Review extraction result', exact: true }).click();
   await page.getByText('This proposal is complete. No further review is needed.', { exact: true }).waitFor();
   profile = await document('profile');
   assert.equal(profile.profile.employer.title, 'Engineer');
@@ -56,5 +102,6 @@ export async function nativeExtractionsBrowser(page, root, fixture, buildRoot) {
   assert.equal((await document('resume-extractions')).proposals[result.proposalSummary.id].status, 'completed');
   await page.setViewportSize({ width: 390, height: 844 });
   assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1));
-  return { requestCancel: true, cliCompletion: true, replacementConsent: true, conflictReapply: true, provenance: true, narrow: true };
+  return { requestCancel: true, cliCompletion: true, replacementConsent: true, conflictReapply: true,
+    pendingWriteNavigationGuard: true, savedNavigationDuringRefresh: true, provenance: true, narrow: true };
 }

--- a/tests_js/workspace_native_review_restart.test.mjs
+++ b/tests_js/workspace_native_review_restart.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, plain, read, snapshot, readyPacket, cli } from './workspace_native_claims_support.mjs';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { fromJSON, text } from '../runtime/contracts/workspace/values.js';
+
+async function reviewed(fixture,name) {
+  const state=await setup(fixture,name);
+  await state.claims.select('job',1n,true);
+  const acquired=plain(await state.claims.acquire('job',text('First owner'),2n));
+  await state.claims.handoff('job',text(acquired.token),'awaiting_review',fromJSON({status:'review',readinessInput:readyPacket(3)}),3n);
+  return {...state,oldToken:acquired.token};
+}
+async function denied(state,operation,pattern) {
+  const before=await snapshot(state.root);
+  await assert.rejects(async()=>operation(),pattern);
+  assert.deepEqual(await snapshot(state.root),before);
+}
+
+test('reviewed restart requires owner confirmation and preserves evidence for a fresh attempt',{timeout:60000},async()=>{
+  const fixture=await nativeFixture();
+  try {
+    const state=await reviewed(fixture,'restart'),{root,claims,oldToken}=state;
+    await denied(state,()=>claims.restart('job',text('Owner'),4n,false),/explicit owner confirmation/);
+    await denied(state,()=>claims.restart('job',text('Owner'),3n,true),/revision conflict/);
+    await denied(state,()=>claims.restart('job',text(' '),4n,true),/owner label/);
+    await denied(state,()=>claims.restart('job',text('Owner'),0n,true),/revision is invalid/);
+    const evidence=await readFile(join(root,'sessions/job.json'),'utf8');
+    const result=plain(await claims.restart('job',text(' New owner '),4n,true));
+    assert.equal(result.job.status,'in_progress');assert.equal(result.job.revision,5);
+    assert.equal(result.claim.ownerLabel,'New owner');assert.notEqual(result.token,oldToken);
+    assert.equal(await readFile(result.resume.path,'utf8'),'PRIVATE-RESUME');
+    assert.equal(await readFile(join(root,'sessions/job.json'),'utf8'),evidence);
+    assert.doesNotMatch(JSON.stringify(plain(await claims.status())),/token/i);
+    await denied(state,()=>claims.heartbeat('job',text(oldToken)),/token is invalid/);
+    await denied(state,()=>claims.handoff('job',text(result.token),'awaiting_review',fromJSON({status:'review'}),5n),/fresh current live/);
+    await claims.handoff('job',text(result.token),'awaiting_review',fromJSON({status:'review',readinessInput:readyPacket(5)}),5n);
+    assert.equal(plain(await claims.restart('job',text('Again'),6n,true)).job.revision,7);
+    const history=await readFile(join(root,'applications.jsonl'),'utf8');
+    assert.deepEqual(history.trim().split('\n').map(line=>JSON.parse(line).event),['job-started','reviewed','job-restarted','reviewed','job-restarted']);
+    assert.ok(!history.includes(result.token));
+  } finally {await fixture.cleanup();}
+});
+
+test('restart preflight and claim arbitration reject without modifying canonical bytes',{timeout:60000},async t=>{
+  const fixture=await nativeFixture();
+  try {
+    await t.test('current managed resume required',async()=>{
+      const state=await reviewed(fixture,'resume');
+      const resumes=await read(state.root,'resumes.json');
+      await unlink(join(state.root,'resume-files',resumes.resumes.resume.managedFile));
+      await denied(state,()=>state.claims.restart('job',text('Owner'),4n,true),/current managed resume/);
+    });
+    await t.test('one concurrent restart wins and expiry requires explicit recovery',async()=>{
+      const state=await reviewed(fixture,'race');
+      const results=await Promise.allSettled([state.claims.restart('job',text('One'),4n,true),state.claims.restart('job',text('Two'),4n,true)]);
+      assert.equal(results.filter(result=>result.status==='fulfilled').length,1);
+      assert.match(results.find(result=>result.status==='rejected').reason.message,/live job claim/);
+      state.clock.now='2026-09-10T12:05:00Z';
+      await denied(state,()=>state.claims.restart('job',text('Three'),5n,true),/expired claim requires explicit same-job recovery/);
+    });
+    await t.test('missing prior evidence',async()=>{
+      const state=await reviewed(fixture,'missing');await unlink(join(state.root,'sessions/job.json'));
+      await denied(state,()=>state.claims.restart('job',text('Owner'),4n,true),/prior review evidence/);
+    });
+  } finally {await fixture.cleanup();}
+});
+
+test('restart HTTP and Python-free CLI enforce confirmation and share canonical state',{timeout:60000},async()=>{
+  const fixture=await nativeFixture();
+  try {
+    const state=await reviewed(fixture,'http'),{root,repository,jobs}=state;
+    const http=body=>jobsHttp(jobs,repository,'POST','/api/claims/review-restart',JSON.stringify(body));
+    const body={jobId:'job',ownerLabel:'HTTP owner',expectedRevision:4,ownerConfirmedNotSubmitted:false};
+    const before=await snapshot(root);
+    assert.equal((await http(body)).status,400);
+    assert.deepEqual(await snapshot(root),before);
+    assert.equal((await http({...body,ownerConfirmedNotSubmitted:true,expectedRevision:3})).status,409);
+    const result=await http({...body,ownerConfirmedNotSubmitted:true});assert.equal(result.status,200);
+    const acquired=JSON.parse(result.body);assert.equal(acquired.job.revision,5);
+    await cli(fixture,root,'claim-handoff',['--id','job','--token',acquired.token,'--status','awaiting_review','--expected-revision','5'],{status:'review',readinessInput:readyPacket(5)});
+    const cliBefore=await snapshot(root);
+    await assert.rejects(()=>cli(fixture,root,'job-review-restart',['--id','job','--owner','CLI owner','--expected-revision','6']),/explicit owner confirmation/);
+    assert.deepEqual(await snapshot(root),cliBefore);
+    const restarted=await cli(fixture,root,'job-review-restart',['--id','job','--owner','CLI owner','--expected-revision','6','--owner-confirmed-not-submitted']);
+    assert.equal(restarted.job.revision,7);assert.equal(restarted.claim.ownerLabel,'CLI owner');
+  } finally {await fixture.cleanup();}
+});

--- a/tests_js/workspace_native_review_restart_browser_support.mjs
+++ b/tests_js/workspace_native_review_restart_browser_support.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { readyPacket } from './workspace_native_claims_support.mjs';
+
+// Disposable native fixture only. Prepare review with the real authenticated API.
+export async function reviewRestartBrowser(page, jobId) {
+    const authorization = await page.evaluate(() => `Bearer ${sessionStorage.getItem('jobApplyWorkspaceToken')}`);
+    async function api(path, body, method = body === undefined ? 'GET' : 'POST') {
+        const response = await page.request.fetch(new URL(path, page.url()).href, {
+            method, headers: { Authorization: authorization, Origin: new URL(page.url()).origin }, data: body,
+        });
+        assert.equal(response.status(), 200, await response.text());
+        return response.json();
+    }
+    let job = await api(`/api/jobs/${jobId}`);
+    job = (await api('/api/claims/select', { jobId, expectedRevision: job.revision, ownerConfirmed: true })).job;
+    const first = await api('/api/claims/acquire', { jobId, expectedRevision: job.revision, ownerLabel: 'Review fixture' });
+    const reviewed = await api('/api/claims/handoff', { jobId, token: first.token, status: 'awaiting_review',
+        expectedRevision: first.job.revision, session: { status: 'review', readinessInput: readyPacket(first.job.revision) } });
+    assert.equal(reviewed.job.status, 'awaiting_review');
+    await page.reload();
+    const panel = page.getByRole('region', { name: 'Active application', exact: true });
+    const choice = panel.getByRole('combobox', { name: 'Job for application work', exact: true });
+    await panel.getByText('No active application claim.', { exact: true }).waitFor();
+    await choice.selectOption(jobId);
+    const restart = panel.getByRole('button', { name: 'Restart reviewed application', exact: true });
+
+    // Missing confirmation, or sending a request on cancellation, can restart an owner-submitted application.
+    let requests = 0;
+    const countRequest = request => { if (request.url().endsWith('/api/claims/review-restart')) requests++; };
+    page.on('request', countRequest);
+    let confirmation;
+    page.once('dialog', async dialog => { confirmation = dialog.message(); await dialog.dismiss(); });
+    await restart.click({ timeout: 5000 });
+    assert.match(confirmation, /not submitted/i);
+    assert.equal(requests, 0);
+    assert.deepEqual(await api(`/api/jobs/${jobId}`), reviewed.job);
+    assert.equal((await api('/api/claims')).claim, null);
+
+    // Another attempt can reach review while this view still has the old revision.
+    const concurrent = await api('/api/claims/review-restart', {
+        jobId, expectedRevision: reviewed.job.revision, ownerLabel: 'Concurrent owner', ownerConfirmedNotSubmitted: true,
+    });
+    const updated = (await api('/api/claims/handoff', {
+        jobId, token: concurrent.token, expectedRevision: concurrent.job.revision, status: 'awaiting_review',
+        session: { status: 'review', readinessInput: readyPacket(concurrent.job.revision) },
+    })).job;
+    const conflict = page.waitForResponse(response => response.url().endsWith('/api/claims/review-restart'));
+    page.once('dialog', dialog => dialog.accept());
+    await restart.click();
+    assert.equal((await conflict).status(), 409);
+    await panel.getByRole('alert').waitFor();
+    assert.deepEqual(await api(`/api/jobs/${jobId}`), updated);
+    assert.equal((await api('/api/claims')).claim, null);
+    await page.reload();
+    await panel.getByText('No active application claim.', { exact: true }).waitFor();
+    await choice.selectOption(jobId);
+
+    const acquired = page.waitForResponse(response => response.url().endsWith('/api/claims/review-restart'));
+    page.once('dialog', dialog => dialog.accept());
+    await restart.click();
+    const response = await acquired;
+    assert.equal(response.status(), 200);
+    assert.deepEqual(response.request().postDataJSON(), {
+        jobId, ownerLabel: 'Companion owner', expectedRevision: updated.revision, ownerConfirmedNotSubmitted: true,
+    });
+    const result = await response.json();
+    assert.equal(result.job.status, 'in_progress');
+    assert.notEqual(result.token, first.token);
+    assert.equal(typeof result.token, 'string');
+    await panel.getByRole('button', { name: 'Return for owner input', exact: true }).waitFor();
+    assert.equal((await page.locator('body').innerText()).includes(result.token), false);
+    assert.equal(await page.evaluate(secret => [...Object.values(localStorage), ...Object.values(sessionStorage)]
+        .some(value => value.includes(secret)), result.token), false);
+    page.once('dialog', dialog => dialog.dismiss());
+    await page.getByRole('button', { name: 'Resumes', exact: true }).click();
+    await panel.getByRole('button', { name: 'Return for owner input', exact: true }).waitFor();
+    const handoff = page.waitForResponse(response => response.url().endsWith('/api/claims/handoff'));
+    await panel.getByRole('button', { name: 'Return for owner input', exact: true }).click();
+    const handedOff = await handoff;
+    assert.equal(handedOff.status(), 200);
+    assert.equal(handedOff.request().postDataJSON().token, result.token);
+    assert.equal(handedOff.request().postDataJSON().expectedRevision, result.job.revision);
+    assert.equal((await handedOff.json()).job.status, 'needs_info');
+    await panel.getByText('No active application claim.', { exact: true }).waitFor();
+    page.off('request', countRequest);
+    return { cancellation: true, revisionConflict: true, memoryOnlyCredential: true, navigationGuard: true, handoff: true };
+}

--- a/tests_js/workspace_native_review_restart_recovery.test.mjs
+++ b/tests_js/workspace_native_review_restart_recovery.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { appendFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { atomicWritePointJson } from '../runtime/store/point-persistence.js';
+import { bytes, fixed, killAt, recover, seed } from './workspace_native_review_restart_recovery_support.mjs';
+
+const events = source => source.trim().split('\n').filter(line=>line.trim()).map(line=>JSON.parse(line));
+
+// Catches missing replay steps, double revision/event replay, and rewriting old review evidence.
+for(const legacy of [false,true]) {
+  const kind=legacy?'legacy':'modern';
+  test(`${kind} reviewed restart survives SIGKILL at all five durable boundaries`,{timeout:60000},async t=>{
+    const fixture=await nativeFixture();
+    try {
+      for(const boundary of ['journal','jobs.json','history','coordinator.json','clear']) {
+        await t.test(boundary,async()=>{
+          const {root,provider,token,sessionBytes}=await seed(fixture,`${kind}-${boundary}`,legacy);
+          const intended=await killAt(root,fixture.receipt.artifact,boundary);
+          assert.equal(intended.kind,'review_restart');
+          assert.equal(intended.at,fixed);
+          assert.equal(intended.sourceStatus,'awaiting_review');
+          assert.equal(intended.targetStatus,'in_progress');
+          assert.equal(intended.expectedRevision,4);
+          assert.equal(Object.hasOwn(intended,'session'),false);
+          const recovered=await recover(root,fixture.receipt.artifact);
+          const job=JSON.parse(recovered['jobs.json']).jobs.job;
+          assert.equal(job.status,'in_progress');
+          assert.equal(job.revision,5);
+          assert.equal(recovered['sessions/job.json'],sessionBytes);
+          const history=events(recovered['applications.jsonl']);
+          assert.deepEqual(history.map(event=>event.event),['job-started','reviewed',legacy?'legacy-review-rebuild':'job-restarted']);
+          assert.deepEqual(history.filter(event=>event.eventId===intended.historyEvent.eventId),[intended.historyEvent]);
+          assert.deepEqual(JSON.parse(recovered['coordinator.json']),{schemaVersion:1,claim:intended.resultClaim});
+          assert.equal(intended.resultClaim.jobId,'job');
+          assert.equal(intended.resultClaim.ownerLabel,'Restart owner');
+          assert.equal(intended.resultClaim.expiresAt,'2026-09-10T12:05:00Z');
+          assert.ok(intended.resultClaim.tokenHash);
+          assert.deepEqual(JSON.parse(recovered['coordinator-journal.json']),{schemaVersion:1,operation:null});
+          for(const content of [...Object.values(recovered),JSON.stringify(intended)]) {
+            assert.ok(!content.includes(token),'Prior bearer token must never be persisted');
+            assert.doesNotMatch(content,/"token"\s*:/,'Restart bearer must never be a persisted field');
+          }
+          assert.doesNotMatch(recovered['applications.jsonl'],/tokenHash/);
+          await new NativeJobsRepository(root,provider).transaction(async()=>{});
+          assert.deepEqual(await bytes(root),recovered,'Second access must not revise or append again');
+          assert.deepEqual(await recover(root,fixture.receipt.artifact),recovered,'Fresh-process replay must be byte-idempotent');
+        });
+      }
+    } finally {await fixture.cleanup();}
+  });
+
+  // Catches recovery overwriting canonical state before detecting a conflicting audit event.
+  test(`${kind} pending reviewed restart rejects event ID collision before writes`,{timeout:60000},async()=>{
+    const fixture=await nativeFixture();
+    try {
+      const {root,provider}=await seed(fixture,`${kind}-collision`,legacy);
+      const intended=await killAt(root,fixture.receipt.artifact,'journal');
+      await appendFile(join(root,'applications.jsonl'),JSON.stringify({...intended.historyEvent,event:'different-event'})+'\n');
+      const before=await bytes(root),writes=[];
+      const repository=new NativeJobsRepository(root,provider,async(path,value,options)=>{
+        writes.push(path);
+        await atomicWritePointJson(path,value,options);
+      });
+      await assert.rejects(repository.transaction(async()=>{}),/history event id collision/);
+      assert.deepEqual(writes,[]);
+      assert.deepEqual(await bytes(root),before);
+    } finally {await fixture.cleanup();}
+  });
+}

--- a/tests_js/workspace_native_review_restart_recovery_support.mjs
+++ b/tests_js/workspace_native_review_restart_recovery_support.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { child } from './exclusive_file_lock_support.mjs';
+import { setup, plain, readyPacket } from './workspace_native_claims_support.mjs';
+import { fromJSON, text } from '../runtime/contracts/workspace/values.js';
+
+export const fixed = '2026-09-10T12:00:00Z';
+export const names = ['jobs.json','sessions/job.json','applications.jsonl','coordinator.json','coordinator-journal.json'];
+const moduleUrl = path => new URL(`../runtime/${path}.js`,import.meta.url).href;
+const imports = `
+import {relative,join} from 'node:path';
+import {readFile} from 'node:fs/promises';
+import {NativeJobsRepository} from ${JSON.stringify(moduleUrl('store/native-jobs'))};
+import {loadPosixFlockProvider} from ${JSON.stringify(moduleUrl('store/posix-flock'))};
+import {atomicWritePointJson} from ${JSON.stringify(moduleUrl('store/point-persistence'))};
+import {ClaimsService} from ${JSON.stringify(moduleUrl('workspace-core/claims'))};
+import {get,serialize,text} from ${JSON.stringify(moduleUrl('contracts/workspace/values'))};
+const [root,addon,boundary] = process.argv.slice(1);
+`;
+const writerScript = imports + `
+let intended;
+async function checkpoint(stage) {
+  if(stage !== boundary) return;
+  console.log(JSON.stringify({intended}));
+  console.log('durable-boundary');
+  await new Promise(resolve => {
+    globalThis.pausedRestartResolve=resolve;
+    process.stdin.resume();
+  });
+}
+const repository = new NativeJobsRepository(root,loadPosixFlockProvider(addon),async(path,document,options)=>{
+  const name=relative(root,path);
+  if(name.startsWith('sessions/')) throw Error('Restart must not rewrite prior session');
+  if(name==='coordinator-journal.json' && get(document,'operation')!==null) intended=JSON.parse(serialize(get(document,'operation')));
+  await atomicWritePointJson(path,document,options);
+  await checkpoint(name==='coordinator-journal.json' ? get(document,'operation')===null ? 'clear':'journal':name);
+},checkpoint);
+await new ClaimsService(repository,()=>${JSON.stringify(fixed)}).restart('job',text('Restart owner'),4n,true);
+throw Error('Writer unexpectedly passed its kill boundary');
+`;
+const recoveryScript = imports + `
+await new NativeJobsRepository(root,loadPosixFlockProvider(addon)).transaction(async()=>{});
+const bytes={};
+for(const name of ${JSON.stringify(names)}) bytes[name]=await readFile(join(root,name),'utf8');
+console.log(JSON.stringify(bytes));
+`;
+export async function seed(fixture,name,legacy=false) {
+  const state=await setup(fixture,name), {root,claims}=state;
+  await claims.select('job',1n,true);
+  const acquired=plain(await claims.acquire('job',text('Prior owner'),2n));
+  await claims.handoff('job',text(acquired.token),'awaiting_review',fromJSON({status:'review',readinessInput:readyPacket(3)}),3n);
+  const path=join(root,'sessions/job.json');
+  const session=JSON.parse(await readFile(path,'utf8'));
+  if(legacy) {
+    for(const field of ['attemptRevision','readiness','browserHandoff']) delete session[field];
+    session.step='final_review';
+  }
+  // Deliberate noncanonical formatting detects read/normalize/rewrite of prior evidence.
+  const sessionBytes=`\n${JSON.stringify(session,null,3)}\n\n`;
+  await writeFile(path,sessionBytes,{mode:0o600});
+  return {...state,token:acquired.token,sessionBytes};
+}
+export async function killAt(root,addon,boundary) {
+  const writer=child(writerScript,[root,addon,boundary]);
+  try {
+    await writer.line('durable-boundary');
+    const intended=JSON.parse(writer.lines.find(line=>line.startsWith('{'))).intended;
+    assert.equal(writer.process.kill('SIGKILL'),true);
+    assert.deepEqual(await writer.exited,{code:null,signal:'SIGKILL'});
+    return intended;
+  } finally {await writer.stop();}
+}
+export async function recover(root,addon) {
+  const process=child(recoveryScript,[root,addon]);
+  try {
+    await process.success();
+    return JSON.parse(process.lines.find(line=>line.startsWith('{')));
+  } finally {await process.stop();}
+}
+export async function bytes(root) {
+  return Object.fromEntries(await Promise.all(names.map(async name=>[name,await readFile(join(root,name),'utf8')])));
+}

--- a/tests_js/workspace_review_restart_contracts.test.mjs
+++ b/tests_js/workspace_review_restart_contracts.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+import {validateReviewRestartEvidence} from '../runtime/contracts/workspace/review-restart.js';
+import {fromJSON,serialize} from '../runtime/contracts/workspace/values.js';
+import {cases,job,legacy,modern,reviewed} from './workspace_review_restart_contracts_support.mjs';
+
+test('review restart distinguishes a full current attempt from the one-time legacy review', () => {
+  assert.equal(validateReviewRestartEvidence(fromJSON(job),fromJSON(modern),[fromJSON(reviewed)]),'job-restarted');
+  assert.equal(validateReviewRestartEvidence(fromJSON(job),fromJSON(legacy),[fromJSON(reviewed)]),'legacy-review-rebuild');
+});
+test('review evidence gates match original Python restart including validation and history ordering', () => {
+  const inputs = cases();
+  const oracle = JSON.parse(execFileSync('python3',['tools/contracts/review-restart/reference.py'], {
+    input:JSON.stringify(inputs),encoding:'utf8',maxBuffer:1024*1024,
+  }));
+  for (const [index,item] of inputs.entries()) {
+    const record = fromJSON(item.job), session = fromJSON(item.session), history = item.history.map(fromJSON);
+    const before = [record,session,...history].map(serialize);
+    let actual;
+    try { actual = {value:validateReviewRestartEvidence(record,session,history)}; }
+    catch (error) { actual = {error:error.message}; }
+    assert.deepEqual(actual,oracle[index],item.name);
+    assert.deepEqual([record,session,...history].map(serialize),before,`${item.name}: inputs remain unchanged`);
+  }
+});

--- a/tests_js/workspace_review_restart_contracts_support.mjs
+++ b/tests_js/workspace_review_restart_contracts_support.mjs
@@ -1,0 +1,59 @@
+export const job = {id:'job-1',revision:4,status:'awaiting_review',ats:'greenhouse'};
+export const reviewed = {applicationId:'job-1',event:'reviewed',status:'awaiting_review'};
+export const legacy = {schemaVersion:1,applicationId:'job-1',status:'review',step:'final_review',pendingFields:[],blockers:[]};
+export const modern = {...legacy, attemptRevision:3, readiness:{
+  status:'ready',evidenceKind:'agent_attested_current_attempt',attemptRevision:3,
+  observationRevision:1,controlSetFingerprint:`sha256:${'a'.repeat(64)}`,requiredControlCount:1,
+  assertions:Object.fromEntries(['observation-current','adapter-accessible','required-controls-complete',
+    'required-uploads-accepted','validation-clear','final-control-available','final-action-untouched'].map(key=>[key,'passed'])),
+  blockerCodes:[],fallbackCode:null,
+},browserHandoff:{state:'ready_for_owner',reasonCode:'final-review-required',revision:1}};
+export function cases() {
+  const rows = [];
+  const add = (name, session, history=[reviewed], record=job) => rows.push({name,job:record,session,history});
+  add('current review', modern);
+  add('legacy review', legacy);
+  add('missing file', null);
+  add('legacy omitted optional lists', {schemaVersion:1,applicationId:'job-1',status:'review',step:'final_review'});
+  for (const key of ['attemptRevision','readiness','browserHandoff']) {
+    add(`legacy explicit null ${key}`, {...legacy,[key]:null});
+    const partial = structuredClone(modern); delete partial[key]; add(`partial ${key}`,partial);
+  }
+  for (const [key,value] of [['status','active'],['step','fill'],['pendingFields',null],['blockers',null],
+    ['schemaVersion',2],['schemaVersion',true],['unexpected',true],['applicationId','../job']]) {
+    add(`legacy invalid ${key}`, {...legacy,[key]:value});
+  }
+  add('modern step need not be final_review', {...modern,step:'fill'});
+  add('stale attempt', {...modern,attemptRevision:2,readiness:{...modern.readiness,attemptRevision:2}});
+  add('future attempt', {...modern,attemptRevision:4,readiness:{...modern.readiness,attemptRevision:4}});
+  add('boolean attempt', {...modern,attemptRevision:true});
+  add('repository replay', {...modern,readiness:{...modern.readiness,evidenceKind:'repository_replay'}});
+  add('unbound readiness', {...modern,readiness:{...modern.readiness,attemptRevision:2}});
+  add('missing assertions', {...modern,readiness:{...modern.readiness,assertions:{}}});
+  add('contradictory readiness', {...modern,readiness:{...modern.readiness,blockerCodes:['validation-error-present']}});
+  add('failed readiness', {...modern,readiness:{...modern.readiness,status:'blocked',
+    blockerCodes:['validation-error-present'],assertions:{...modern.readiness.assertions,'validation-clear':'failed'}}});
+  add('changed handoff revision', {...modern,browserHandoff:{...modern.browserHandoff,revision:2}});
+  add('completed handoff', {...modern,browserHandoff:{state:'complete',reasonCode:'none',revision:1}});
+  add('handoff extra field', {...modern,browserHandoff:{...modern.browserHandoff,extra:1}});
+  add('blocker', {...modern,blockers:[{type:'information',code:'answer-required'}]});
+  add('modern pending', {...modern,pendingFields:[{reference:`pending_${'1'.repeat(32)}`} ]});
+  add('legacy pending', {...legacy,pendingFields:[{question:'Name?',state:'missing'}]});
+  add('legacy duplicate pending', {...legacy,pendingFields:[{question:'Name?'},{question:'Name?'}]});
+  add('legacy invalid pending property', {...legacy,pendingFields:[{question:'Name?',fieldClass:'name'}]});
+  add('legacy mixed pending', {...legacy,pendingFields:[{question:'Name?'},{reference:`pending_${'1'.repeat(32)}`} ]});
+  add('legacy wrong pending type', {...legacy,pendingFields:[{question:'Name?'},null]});
+  add('legacy job metadata invalid', {...legacy,company:4,pendingFields:[{question:'Name?'}]});
+  add('legacy canonical ATS replaces old ATS', {...legacy,ats:4,pendingFields:[{}]});
+  add('missing history', modern, []);
+  add('other job does not supply evidence', modern, [{...reviewed,applicationId:'job-2'}]);
+  add('later own event invalidates review', modern, [reviewed,{...reviewed,event:'progressed'}]);
+  add('later other job does not invalidate review', modern, [reviewed,{...reviewed,applicationId:'job-2',event:'progressed'}]);
+  add('last reviewed status mismatch', modern, [{...reviewed,status:'in_progress'}]);
+  for (const event of ['job-restarted','legacy-review-rebuild']) {
+    add(`legacy one time ${event}`, legacy, [{...reviewed,event},reviewed]);
+    add(`modern may restart again ${event}`, modern, [{...reviewed,event},reviewed]);
+    add(`other job previous ${event}`, legacy, [{...reviewed,applicationId:'job-2',event},reviewed]);
+  }
+  return rows;
+}

--- a/tools/contracts/review-restart/reference.py
+++ b/tools/contracts/review-restart/reference.py
@@ -1,0 +1,53 @@
+"""Run the original reviewed-restart gates with real disk IO and projection.
+
+Only coordinator setup and post-evidence acquisition are replaced: reaching
+preflight proves all original evidence gates completed, before any claim write.
+"""
+import json
+from pathlib import Path
+import sys
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / 'scripts'))
+from job_apply_store.domains.coordinator import claims
+from job_apply_store.sessions_runtime import _project_legacy_session
+
+claims._bind_runtime(lambda: {**vars(claims), '_project_legacy_session': _project_legacy_session})
+
+class EvidenceAccepted(Exception):
+    pass
+
+class Fixture(claims.CoordinatorClaimsMixin):
+    def __init__(self, root, item):
+        self.item = item
+        self.store_lock_path = root / 'store.lock'
+        self.path = root / 'session.json'
+        if item['session'] is not None:
+            self.path.write_text(json.dumps(item['session']), encoding='utf-8')
+    def initialize(self):
+        pass
+    def _ensure_coordinator_files(self):
+        pass
+    def _load_coordinator_document(self):
+        return {'schemaVersion': 1, 'claim': None}
+    def _load_jobs_document(self):
+        return {'jobs': {self.item['job']['id']: self.item['job']}}
+    def _session_path(self, job_id):
+        return self.path
+    def read_history(self):
+        return self.item['history']
+    def _preflight_job_record(self, job):
+        raise EvidenceAccepted()
+
+rows = []
+for item in json.load(sys.stdin):
+    with TemporaryDirectory() as directory:
+        fixture = Fixture(Path(directory), item)
+        try:
+            fixture.restart_reviewed_job(item['job']['id'], 'Fixture', item['job']['revision'], True)
+        except EvidenceAccepted:
+            modern = {'attemptRevision', 'readiness', 'browserHandoff'} & set(item['session'])
+            rows.append({'value': 'job-restarted' if modern else 'legacy-review-rebuild'})
+        except Exception as error:
+            rows.append({'error': str(error)})
+print(json.dumps(rows, ensure_ascii=True))


### PR DESCRIPTION
Reviewed applications in the native fixture can now be restarted after explicit owner confirmation that they were not submitted. CLI, HTTP, and Companion share strict prior-review, exact-revision, idle-claim, and current-managed-resume checks. Restart preserves prior session bytes and atomically creates a fresh claim and attempt revision through the coordinator journal. Modern review and one-time legacy rebuild match the Python contract; the next handoff requires fresh readiness evidence.

Also fixes extraction navigation prompting to discard saved decisions during read-only refreshes, while preserving pending-write protection. Stabilizes the legacy launcher shutdown test by consuming its HTTP response before closing; controlled reproduction traced the old hang to a connection-reset traceback blocking on an undrained stderr pipe.

Validation on `f2e7afb`: all 27 local deep-gate suites passed, including installed-package smoke, native/browser checks, 50 Python differential evidence cases, and SIGKILL recovery at every restart boundary. Normal commit hooks passed. Five independent focused PR reviews found no high-confidence issues; the launcher test fix received a separate review. Native `codex review` was unavailable because the installed CLI cannot run its configured model. Earlier failed/superseded validation receipts are retained; no hook bypass was used. Remote [Validate Plugin](https://github.com/neonwatty/job-apply-plugin/actions/runs/34515850124) and [Release Validation](https://github.com/neonwatty/job-apply-plugin/actions/runs/34515853047) both passed on the exact head commit, including the PR gate.

Scope remains new synthetic fixture v9 roots. Existing/live Stores are not adopted, and native writer activation or complete migration is not claimed.
