### PR TITLE
Add native Overview, Needs Attention, and Activity

### DIFF
--- a/apps/companion/components/Companion.tsx
+++ b/apps/companion/components/Companion.tsx
@@ -8,13 +8,16 @@ import { Jobs } from './Jobs';
 import { Resumes } from './Resumes';
 import { Answers } from './Answers';
 import { Extractions } from './Extractions';
+import { NeedsAttention } from './NeedsAttention';
 import './companion.css';
+type WorkspaceTab = 'overview'|'jobs'|'facts'|'resumes'|'answers'|'extractions'|'attention';
 export default function Companion() {
     const [client,setClient]=useState<Client|null>(null);
     const [boot,setBoot]=useState<Boot|null>(null);
     const [error,setError]=useState('');
     const [token,setToken]=useState('');
-    const [tab,setTab]=useState<'overview'|'jobs'|'facts'|'resumes'|'answers'|'extractions'>('overview');
+    const [tab,setTab]=useState<WorkspaceTab>('overview');
+    const [requestedJob,setRequestedJob]=useState<string|null>(null);
     const [dirty,setDirty]=useState(false);
     const [attempt,setAttempt]=useState(0);
     useEffect(() => {
@@ -55,7 +58,8 @@ export default function Companion() {
         return () => window.removeEventListener('beforeunload',before);
     },[dirty]);
     const dirtyChanged=useCallback((value: boolean) => setDirty(value),[]);
-    function navigate(next: 'overview'|'jobs'|'facts'|'resumes'|'answers'|'extractions') {
+    const jobOpened=useCallback(() => setRequestedJob(null),[]);
+    function navigate(next: WorkspaceTab) {
         if(next===tab)
             return;
         if(dirty&&!confirm('Discard unsaved changes?'))
@@ -80,8 +84,9 @@ export default function Companion() {
             </span>
         </div>
         <nav aria-label="Workspace sections">
-            {!nativeFixture&&<button aria-current={tab==='overview'? 'page':undefined} onClick={() => navigate('overview')}>Overview
-            </button>}
+            <button aria-current={tab==='overview'? 'page':undefined} onClick={() => navigate('overview')}>Overview
+            </button>
+            {nativeFixture&&<button aria-current={tab==='attention'?'page':undefined} onClick={() => navigate('attention')}>Needs Attention</button>}
             <button aria-current={tab==='jobs'? 'page':undefined} onClick={() => navigate('jobs')}>Jobs
             </button>
             <button aria-current={tab==='facts'?'page':undefined} onClick={()=>navigate('facts')}>Facts</button>
@@ -96,7 +101,7 @@ export default function Companion() {
         </nav>
         <p className="trust">Your canonical data stays local. You direct changes and submissions; agents assist from the same record.
         </p>
-        {nativeFixture&&<p role="status">Synthetic native workspace. Manage jobs, facts, resumes, extraction reviews and remembered answers here; other workflows are not available yet.</p>}
+        {nativeFixture&&<p role="status">Synthetic native workspace. Manage jobs, facts, resumes, extraction reviews and remembered answers; review your next step, attention items and application activity.</p>}
         {error&&<p role="alert" className="error">
             {error}{' '}
             {token&&<button onClick={() => setAttempt(value => value+1)}>Retry connection</button>}
@@ -111,7 +116,8 @@ export default function Companion() {
         </section>:boot?.status==='ready'&&client? (tab==='overview'? <Overview
             client={client}
             openJobs={() => navigate('jobs')}
-            legacyHref={legacyHref} />:tab==='facts'?<Facts client={client} dirtyChanged={dirtyChanged}/>:tab==='resumes'?<Resumes client={client} dirtyChanged={dirtyChanged}/>:tab==='extractions'?<Extractions client={client} dirtyChanged={dirtyChanged}/>:tab==='answers'?<Answers client={client} dirtyChanged={dirtyChanged}/>:<Jobs client={client} dirtyChanged={dirtyChanged} claimsEnabled={nativeFixture} />):!error&&<p>Loading workspace…
+            openWorkspace={nativeFixture ? navigate : undefined}
+            legacyHref={legacyHref} />:tab==='attention'?<NeedsAttention client={client} openJob={id => { setRequestedJob(id); navigate('jobs'); }}/>:tab==='facts'?<Facts client={client} dirtyChanged={dirtyChanged}/>:tab==='resumes'?<Resumes client={client} dirtyChanged={dirtyChanged}/>:tab==='extractions'?<Extractions client={client} dirtyChanged={dirtyChanged}/>:tab==='answers'?<Answers client={client} dirtyChanged={dirtyChanged}/>:<Jobs client={client} dirtyChanged={dirtyChanged} claimsEnabled={nativeFixture} requestedJobId={requestedJob} jobOpened={jobOpened} openAnswers={() => navigate('answers')} />):!error&&<p>Loading workspace…
             </p>}
     </main>;
 }

--- a/apps/companion/components/JobActivity.tsx
+++ b/apps/companion/components/JobActivity.tsx
@@ -1,0 +1,30 @@
+'use client';
+import type { Client } from './client';
+import { activityProjection, recoveryGuidance } from './projection-model';
+import { humanize, useProjection } from './projection-view';
+export function JobActivity({client,jobId,refreshKey=0,openAnswers}:{client:Client;jobId:string;refreshKey?:number;openAnswers?:()=>void}) {
+  const {data,loading,error,refresh}=useProjection(client,`/api/jobs/${encodeURIComponent(jobId)}/activity`,activityProjection,refreshKey);
+  return <section aria-label="Job activity" style={{minWidth:0,overflowWrap:'anywhere'}}>
+    <h3>Job activity</h3><button type="button" onClick={refresh} disabled={loading}>Refresh activity</button>
+    {loading && <p role="status">Loading job activity…</p>}
+    {error && <p role="alert">{error} {data && 'Showing the last successful snapshot for this job; it may be stale.'}</p>}
+    {data && <>
+      <p>Status: {humanize(data.job.status)} · Revision {String(data.job.revision)}</p>
+      <h4>Agent attempt</h4><p>{humanize(data.claim.state)}</p>
+      {data.claim.state==='active' || data.claim.state==='expired' ? <p>Acquired: {data.claim.acquiredAt}<br/>Last heartbeat: {data.claim.heartbeatAt}<br/>Expires: {data.claim.expiresAt}</p> : null}
+      {(data.claim.state==='expired'||data.claim.state==='interrupted') && <p>{recoveryGuidance[data.claim.state]} Current job revision: {String(data.job.revision)}.</p>}
+      {!data.session ? <p>No application session recorded.</p> : <>
+        <h4>Application session</h4>
+        <p>{humanize(data.session.status)} · Session revision {String(data.session.revision)}{data.session.attemptRevision!==undefined && ` · Attempt revision ${data.session.attemptRevision}`}</p>
+        <p>Step: {data.session.step}<br/>Updated: {data.session.updatedAt}<br/>Readiness: {humanize(data.session.readiness)}</p>
+        <p>Browser handoff: {humanize(data.session.handoff)}{data.session.handoffReason && ` · ${humanize(data.session.handoffReason)}`}</p>
+        {data.session.handoff==='required' && <p>Continue in the visible browser. Personally review and perform final submission.</p>}
+        <h4>Blockers</h4>{data.session.blockers.length===0 ? <p>No typed blockers recorded.</p> : <ul>{data.session.blockers.map((blocker,index)=><li key={index}>{humanize(blocker.type)}: {humanize(blocker.code)}</li>)}</ul>}
+        <h4>Pending information</h4><p>{data.session.pending.length} pending items · {data.session.approvalCount} current session approvals</p>
+        <ul>{data.session.pending.map((field,index)=><li key={index}>Item {index+1} · {humanize(field.fieldClass)} · {humanize(field.state)}. {field.sensitive ? 'Sensitive: separate confirmation required.' : field.eligible ? 'Saved answer eligible for recheck with your confirmation.' : 'Further review required before resolution.'} {field.approved ? 'Current session approval recorded.' : 'No current session approval.'}</li>)}</ul>
+        {data.session.pending.length>0 && openAnswers && <button type="button" onClick={openAnswers}>Open Answers</button>}
+      </>}
+      <h4>History</h4>{data.history.length===0 ? <p>No history recorded for this job.</p> : <ol>{data.history.map((event,index)=><li key={index}>{event.at} · {humanize(event.event)} · {humanize(event.status)}</li>)}</ol>}
+    </>}
+  </section>;
+}

--- a/apps/companion/components/JobEditor.tsx
+++ b/apps/companion/components/JobEditor.tsx
@@ -1,7 +1,9 @@
 import { useEffect,useId,useRef } from 'react';
+import type { ReactNode } from 'react';
 import { textFields,type JobFields,type Resume } from './contracts';
 import type { Editor } from './job-editor-state';
-export function JobEditor({ editor,resumes,busy,error,change,close,save,reapply,load,refresh }: {
+export function JobEditor({ editor,resumes,busy,error,change,close,save,reapply,load,refresh,children }: {
+    children?: ReactNode;
     editor: Editor;
     resumes: Resume[];
     busy: boolean;
@@ -163,5 +165,6 @@ export function JobEditor({ editor,resumes,busy,error,change,close,save,reapply,
 
 
         </form>
+        {children}
     </dialog>;
 }

--- a/apps/companion/components/Jobs.tsx
+++ b/apps/companion/components/Jobs.tsx
@@ -5,10 +5,14 @@ import type { Job, JobFields, WorkspaceState } from './contracts';
 import { edit, observe, openEditor, reapply, type Editor } from './job-editor-state';
 import { JobEditor } from './JobEditor';
 import { Claims } from './Claims';
+import { JobActivity } from './JobActivity';
 
-export function Jobs({ client, dirtyChanged, claimsEnabled = false }: {
+export function Jobs({ client, dirtyChanged, claimsEnabled = false, requestedJobId, jobOpened, openAnswers }: {
     client: Client;
     claimsEnabled?: boolean;
+    requestedJobId?: string | null;
+    jobOpened?: () => void;
+    openAnswers?: () => void;
     dirtyChanged: (dirty: boolean) => void;
 }) {
     const [data, setData] = useState<WorkspaceState | null>(null);
@@ -65,6 +69,13 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false }: {
         dirtyChanged(Boolean(editor?.dirty.size) || busy || claimsDirty);
         return () => dirtyChanged(false);
     }, [editor, busy, claimsDirty, dirtyChanged]);
+    useEffect(() => {
+        if (!requestedJobId || !data || loading || loadError || claimsActive) return;
+        const selected = data.jobs.find(job => job.id === requestedJobId);
+        if (selected) open(selected);
+        else setError('The selected job is no longer available. Refresh Jobs to check its current state.');
+        jobOpened?.();
+    }, [requestedJobId, data, loading, loadError, claimsActive, jobOpened]);
 
     function open(job: Job | null) {
         if (mutation.current || claimsActive) return;
@@ -149,6 +160,7 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false }: {
             {data ? 'Showing previously loaded jobs. ' : 'Jobs could not be loaded. '}{loadError}{' '}
             <button disabled={busy} onClick={() => void refresh()}>Retry loading jobs</button>
         </p>}
+        {!editor && error && <p role="alert" className="error">{error}</p>}
         <div className="filters">
             <label>Search jobs<input value={query} onChange={e => setQuery(e.target.value)} /></label>
             <label>Status<select value={status} onChange={e => setStatus(e.target.value)}>
@@ -186,6 +198,9 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false }: {
                     setEditor(openEditor(editor.latest));
                     setError('');
                 }
-            }} />}
+            }} >
+            {claimsEnabled && editor.selected && <JobActivity client={client} jobId={editor.selected.id}
+                refreshKey={editor.selected.revision} openAnswers={openAnswers} />}
+        </JobEditor>}
     </section>;
 }

--- a/apps/companion/components/NeedsAttention.tsx
+++ b/apps/companion/components/NeedsAttention.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useState } from 'react';
+import type { Client } from './client';
+import { attentionGuidance, attentionProjection, attentionReasons, filterAttention, type AttentionReason } from './projection-model';
+import { humanize, useProjection } from './projection-view';
+export function NeedsAttention({client,openJob}:{client:Client;openJob:(id:string)=>void}) {
+  const {data,loading,error,refresh}=useProjection(client,'/api/attention',attentionProjection);
+  const [reason,setReason]=useState('');
+  const visible=filterAttention(data?.items ?? [],reason);
+  return <section aria-label="Needs Attention" style={{minWidth:0,overflowWrap:'anywhere'}}>
+    <h2>Needs Attention</h2>
+    <p>Review jobs that need your information, browser action, or recovery. Final submission stays manual.</p>
+    <label>Filter by reason <select value={reason} onChange={event=>setReason(event.target.value)}>
+      <option value="">All reasons</option>{Object.entries(attentionReasons).map(([code,label])=><option key={code} value={code}>{label}</option>)}
+    </select></label>{' '}<button type="button" onClick={refresh} disabled={loading}>Refresh attention</button>
+    {loading && <p role="status">Loading attention…</p>}
+    {error && <p role="alert">{error} {data && 'Showing the last successful snapshot; it may be stale.'}</p>}
+    {data && <><p role="status">{data.items.length} jobs need attention. {visible.length} shown.</p>
+      {data.items.length===0 ? <p>No jobs need attention.</p> : visible.length===0 ? <p>No jobs match this reason filter.</p> :
+        <ul>{visible.map(item=><li key={item.jobId}>
+          <h3>{attentionReasons[item.reasonCode as AttentionReason]}</h3>
+          <p>Job: {item.jobId} · {humanize(item.status)} · Revision {String(item.revision)}</p>
+          <p>Since {item.attentionAt}{item.reasonCode==='needs_information' && ` · ${item.missingInformationCount} missing information items`}</p>
+          <p>{attentionGuidance[item.reasonCode]}</p>
+          {item.session.blockers.length>0 && <p>{item.session.blockers.length} blockers: {item.session.blockers.map(blocker=>humanize(blocker.code)).join(', ')}</p>}
+          <button type="button" onClick={()=>openJob(item.jobId)} aria-label={`Open job ${item.jobId}`}>Open Job details</button>
+        </li>)}</ul>}
+    </>}
+  </section>;
+}

--- a/apps/companion/components/Overview.tsx
+++ b/apps/companion/components/Overview.tsx
@@ -3,10 +3,11 @@ import { useEffect, useRef, useState } from 'react';
 import type { Client } from './client';
 import type { OverviewData } from './contracts';
 
-export function Overview({ client, openJobs, legacyHref }: {
+export function Overview({ client, openJobs, legacyHref, openWorkspace }: {
     client: Client;
     openJobs: () => void;
     legacyHref: string;
+    openWorkspace?: (workspace: 'facts' | 'resumes' | 'attention') => void;
 }) {
     const [data, setData] = useState<OverviewData | null>(null);
     const [error, setError] = useState('');
@@ -64,15 +65,17 @@ export function Overview({ client, openJobs, legacyHref }: {
                 <h2>{heading}</h2>
                 <p>Your canonical data stays local. You direct changes and submissions.</p>
                 {target === 'jobs' ? <button className="primary" onClick={openJobs}>Open Jobs</button>
+                    : openWorkspace && (target === 'facts' || target === 'resumes' || target === 'attention')
+                        ? <button className="primary" onClick={() => openWorkspace(target)}>Open {destinations[target]}</button>
                     : <a className="button primary" href={link(destination)}>Open {destinations[destination]}</a>}
             </div>
             <section aria-labelledby="setup-heading">
                 <h2 id="setup-heading">Application setup</h2>
                 <ul className="setup-list">
                     <li><span>{data.setup.hasProfileFacts ? 'Profile facts added' : 'Add your profile facts'}</span>
-                        <a href={link('facts')}>Edit Facts</a></li>
+                        {openWorkspace ? <button onClick={() => openWorkspace('facts')}>Edit Facts</button> : <a href={link('facts')}>Edit Facts</a>}</li>
                     <li><span>{data.setup.hasResume ? 'Resume available' : 'Add a resume'}</span>
-                        <a href={link('resumes')}>Manage Resumes</a></li>
+                        {openWorkspace ? <button onClick={() => openWorkspace('resumes')}>Manage Resumes</button> : <a href={link('resumes')}>Manage Resumes</a>}</li>
                 </ul>
             </section>
             <div className="counts">

--- a/apps/companion/components/projection-model.ts
+++ b/apps/companion/components/projection-model.ts
@@ -1,0 +1,91 @@
+import { get, has, int, object, parse, string } from '../../../src/contracts/workspace/values';
+import type { Document, Value } from '../../../src/contracts/workspace/values';
+export const attentionReasons = {
+  expired_agent_attempt: 'Expired agent attempt', claimless_interrupted_attempt: 'Interrupted agent attempt',
+  awaiting_human_review: 'Awaiting your review', browser_action_required: 'Browser action required', needs_information: 'Needs information',
+} as const;
+export type AttentionReason = keyof typeof attentionReasons;
+export const recoveryGuidance = {
+  expired: 'Resume this attempt using the supported CLI claim-recover command for this job.',
+  interrupted: 'This attempt was interrupted without an active claim. Recovery for this state is not available in the native workspace yet.',
+};
+export const attentionGuidance: Record<AttentionReason, string> = {
+  expired_agent_attempt: recoveryGuidance.expired, claimless_interrupted_attempt: recoveryGuidance.interrupted,
+  awaiting_human_review: 'Open Job details and personally review and submit on the third-party site. Recording Applied or Closed in the native workspace is deferred.',
+  browser_action_required: 'Continue in the visible browser. Saved information is already known; do not create or re-enter an answer in Companion.',
+  needs_information: 'Open Job details and resolve missing facts, resume, or answers. Run preflight, then mark the job Ready.',
+};
+function str(d: Document, key: string, fallback?: string): string {
+  const value = get(d,key);
+  if ((value === undefined || value === null) && fallback !== undefined) return fallback;
+  const result = string(value);
+  if (result === null) throw Error('Invalid projection text');
+  return result;
+}
+function revision(d: Document, key: string, minimum = 1n): bigint {
+  const result = int(get(d,key));
+  if (result === null || result < minimum) throw Error('Invalid projection revision');
+  return result;
+}
+function array(d: Document, key: string, optional = false): Value[] {
+  const value = get(d,key);
+  if (!has(d,key) && optional) return [];
+  if (!Array.isArray(value)) throw Error('Invalid projection list');
+  return value;
+}
+function bool(d: Document, key: string, fallback?: boolean): boolean {
+  const value = get(d,key);
+  if (!has(d,key) && fallback !== undefined) return fallback;
+  if (typeof value !== 'boolean') throw Error('Invalid projection eligibility');
+  return value;
+}
+function nullableRecord(value: Value | undefined): Document | null {
+  return value === null || value === undefined ? null : object(value,'projection');
+}
+export interface SessionSummary {
+  readiness: string; blockers: {type:string;code:string}[]; handoff: string; handoffReason: string; attemptRevision?: bigint;
+}
+function summary(d: Document | null): SessionSummary {
+  const readiness = d && nullableRecord(get(d,'readiness'));
+  const handoff = d && nullableRecord(get(d,'browserHandoff'));
+  return {
+    readiness: readiness ? str(readiness,'status','Not recorded') : 'Not recorded',
+    blockers: d ? array(d,'blockers',true).map(value=>{const item=object(value,'blocker');return {type:str(item,'type'),code:str(item,'code')};}) : [],
+    handoff: handoff ? str(handoff,'state','Not recorded') : 'Not recorded',
+    handoffReason: handoff ? str(handoff,'reasonCode','') : '',
+    ...(d && has(d,'attemptRevision') && get(d,'attemptRevision') !== null ? {attemptRevision:revision(d,'attemptRevision')} : {}),
+  };
+}
+export interface AttentionItem {
+  jobId:string; status:string; revision:bigint; reasonCode:AttentionReason; attentionAt:string; missingInformationCount:bigint; session:SessionSummary;
+}
+export function attentionProjection(raw:string): {items:AttentionItem[]} {
+  const doc=object(parse(raw),'attention');
+  const items=array(doc,'items').map(value=>{
+    const item=object(value,'attention item'), reasonCode=str(item,'reasonCode');
+    if (!Object.hasOwn(attentionReasons,reasonCode)) throw Error('Invalid attention reason');
+    return {jobId:str(item,'jobId'),status:str(item,'status'),revision:revision(item,'revision'),reasonCode:reasonCode as AttentionReason,
+      attentionAt:str(item,'attentionAt'),missingInformationCount:revision(item,'missingInformationCount',0n),session:summary(nullableRecord(get(item,'session')))};
+  });
+  if (new Set(items.map(item=>item.jobId)).size !== items.length) throw Error('Duplicate attention job');
+  // The server sorts by reason, descending priority, timestamp, then canonical id.
+  return {items};
+}
+export function filterAttention(items:AttentionItem[],reason:string):AttentionItem[] { return reason ? items.filter(item=>item.reasonCode===reason) : items; }
+export interface ActivityProjection {
+  job:{status:string;revision:bigint};
+  session:(SessionSummary & {revision:bigint;status:string;step:string;updatedAt:string;approvalCount:number;pending:{sensitive:boolean;eligible:boolean;approved:boolean;state:string;fieldClass:string}[]}) | null;
+  claim:{state:string;acquiredAt:string;heartbeatAt:string;expiresAt:string}; history:{event:string;status:string;at:string}[];
+}
+export function activityProjection(raw:string):ActivityProjection {
+  const doc=object(parse(raw),'activity'), job=object(get(doc,'job'),'job'), session=nullableRecord(get(doc,'session')), claim=object(get(doc,'claim'),'claim');
+  const state=str(claim,'state');
+  const approvals=session ? array(session,'approvals',true).map(value=>object(value,'approval')) : [];
+  if (!['none','active','expired','interrupted'].includes(state)) throw Error('Invalid claim state');
+  return {job:{status:str(job,'status'),revision:revision(job,'revision')},
+    session:session ? {...summary(session),revision:revision(session,'revision'),status:str(session,'status','Not recorded'),step:str(session,'step','Not recorded'),updatedAt:str(session,'updatedAt','Not recorded'),approvalCount:approvals.length,
+      pending:array(session,'pendingInformation',true).map(value=>{const field=object(value,'pending information');return {sensitive:bool(field,'sensitive',false)||str(field,'state','')==='sensitive',eligible:bool(field,'resolutionEligible'),approved:approvals.some(approval=>str(approval,'reference','')===str(field,'reference','') && str(field,'reference','')!==''),state:str(field,'state','Not recorded'),fieldClass:str(field,'fieldClass','general')};})} : null,
+    claim:{state,acquiredAt:str(claim,'acquiredAt','Not recorded'),heartbeatAt:str(claim,'heartbeatAt','Not recorded'),expiresAt:str(claim,'expiresAt','Not recorded')},
+    history:array(doc,'history').map(value=>{const event=object(value,'history event');return {event:str(event,'event','Event'),status:str(event,'status','Not recorded'),at:str(event,'at','Not recorded')};}),
+  };
+}

--- a/apps/companion/components/projection-view.ts
+++ b/apps/companion/components/projection-view.ts
@@ -1,0 +1,31 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+import type { Client } from './client';
+/** Scope-tagged snapshots hide the previous job synchronously on a job switch. */
+export function useProjection<T>(client:Client,path:string,parse:(raw:string)=>T,refreshKey=0) {
+  const [snapshot,setSnapshot]=useState<{client:Client;path:string;value:T}|null>(null);
+  const [state,setState]=useState<{client:Client;path:string;loading:boolean;error:string}|null>(null);
+  const [retry,setRetry]=useState(0);
+  const sequence=useRef(0);
+  useEffect(()=>{
+    const version=++sequence.current, controller=new AbortController();
+    setState({client,path,loading:true,error:''});
+    const timer=setTimeout(()=>{
+      if(sequence.current!==version)return;
+      controller.abort();
+      setState({client,path,loading:false,error:'The request timed out. Retry to load the latest information.'});
+    },30_000);
+    void client.extractionRequest(path,'GET',undefined,controller.signal).then(raw=>{
+      if(sequence.current!==version || controller.signal.aborted)return;
+      const value=parse(raw);
+      setSnapshot({client,path,value});
+      setState({client,path,loading:false,error:''});
+    }).catch(()=>{
+      if(sequence.current===version && !controller.signal.aborted) setState({client,path,loading:false,error:'Unable to load the latest information. Retry to refresh.'});
+    }).finally(()=>clearTimeout(timer));
+    return ()=>{++sequence.current;clearTimeout(timer);controller.abort();};
+  },[client,path,parse,refreshKey,retry]);
+  const current=state?.client===client && state.path===path ? state : null;
+  return {data:snapshot?.client===client && snapshot.path===path ? snapshot.value:null,loading:current?.loading ?? true,error:current?.error ?? '',refresh:()=>setRetry(value=>value+1)};
+}
+export const humanize=(value:string)=>value.replaceAll('_',' ').replaceAll('-',' ');

--- a/config/migration/browser-native-projections-surfaces.json
+++ b/config/migration/browser-native-projections-surfaces.json
@@ -1,0 +1,225 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "browser:apps/companion/components/JobActivity.tsx:JobActivity",
+      "kind": "browser",
+      "export": "JobActivity",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/JobActivity.tsx"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/NeedsAttention.tsx:NeedsAttention",
+      "kind": "browser",
+      "export": "NeedsAttention",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/NeedsAttention.tsx"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/projection-model.ts:attentionReasons",
+      "kind": "browser",
+      "export": "attentionReasons",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/projection-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/projection-model.ts:recoveryGuidance",
+      "kind": "browser",
+      "export": "recoveryGuidance",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/projection-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/projection-model.ts:attentionGuidance",
+      "kind": "browser",
+      "export": "attentionGuidance",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/projection-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/projection-model.ts:attentionProjection",
+      "kind": "browser",
+      "export": "attentionProjection",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/projection-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/projection-model.ts:filterAttention",
+      "kind": "browser",
+      "export": "filterAttention",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/projection-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/projection-model.ts:activityProjection",
+      "kind": "browser",
+      "export": "activityProjection",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/projection-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/projection-view.ts:useProjection",
+      "kind": "browser",
+      "export": "useProjection",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/projection-view.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/projection-view.ts:humanize",
+      "kind": "browser",
+      "export": "humanize",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/projection-view.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/cli-native-projections-surfaces.json
+++ b/config/migration/cli-native-projections-surfaces.json
@@ -1,0 +1,130 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:owner-beta-overview",
+      "kind": "cli",
+      "command": "owner-beta-overview",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-projections.ts",
+        "src/workspace-core/workspace-projections.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:needs-attention",
+      "kind": "cli",
+      "command": "needs-attention",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-projections.ts",
+        "src/workspace-core/workspace-projections.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:job-activity",
+      "kind": "cli",
+      "command": "job-activity",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-projections.ts",
+        "src/workspace-core/workspace-projections.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:job-preflight",
+      "kind": "cli",
+      "command": "job-preflight",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-projections.ts",
+        "src/workspace-core/workspace-projections.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:task-snapshot",
+      "kind": "cli",
+      "command": "task-snapshot",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-projections.ts",
+        "src/workspace-core/workspace-projections.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/http-read-detail-surfaces.json
+++ b/config/migration/http-read-detail-surfaces.json
@@ -314,7 +314,10 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/workspace-projections-http.ts",
+        "src/workspace-core/workspace-projections.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -341,7 +344,10 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/workspace-projections-http.ts",
+        "src/workspace-core/workspace-projections.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-read-surfaces.json
+++ b/config/migration/http-read-surfaces.json
@@ -41,7 +41,10 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/workspace-projections-http.ts",
+        "src/workspace-core/workspace-projections.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -127,7 +130,10 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/workspace-projections-http.ts",
+        "src/workspace-core/workspace-projections.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -46,6 +46,10 @@
       "sha256": "ac960232d6b5234f38fab48d567eabf436f72e291def557f9f52ab53cedee658"
     },
     {
+      "path": "browser-native-projections-surfaces.json",
+      "sha256": "8d0522433ddaa7e6efaad2d80a50b994b20e767ee5ae75b94f3d59353c4eb820"
+    },
+    {
       "path": "cli-01-surfaces.json",
       "sha256": "b05ac334f9949992f3497f79885033b970692cb798e831d4866d62050ce56841"
     },
@@ -98,6 +102,10 @@
       "sha256": "8757138a819fd1166abfeb7e86aed548a42f3d2d6f832da404370f9c483e8963"
     },
     {
+      "path": "cli-native-projections-surfaces.json",
+      "sha256": "db44fabe54a6f0bfb360f02880cdc06fc2780f4f78c3c0a487492cb485344a06"
+    },
+    {
       "path": "cli-native-resumes-surfaces.json",
       "sha256": "23b9fd1e5a29720b5b4143d59a9767dfb9ee98a00e09ef3962f9112c9cda4e5c"
     },
@@ -139,11 +147,11 @@
     },
     {
       "path": "http-read-detail-surfaces.json",
-      "sha256": "dd8d077cbb24c86469471b48c86f2e1fc4e266b63d32a1ddc5fe071c4dad789e"
+      "sha256": "7f039ce87a6342f7bdb3945a86b8b83274ff5be7acdde7ab0fc766a22f794d04"
     },
     {
       "path": "http-read-surfaces.json",
-      "sha256": "83d6316a567e0b04e344c92ff4ce6e9cde1cb6826199165a9c852065cafec0bf"
+      "sha256": "aa97ebab7f77fed0ad74a9a9b7c56fd315f2d6068e350b39fbc4df661f8b8c9c"
     },
     {
       "path": "http-write-accounts-surfaces.json",
@@ -251,7 +259,7 @@
     },
     {
       "path": "source-catalog-g02-next.json",
-      "sha256": "d7488366d6a60227b244b6e6e35d6f0de59856b36f93ccb07a144751a382ac02"
+      "sha256": "2877d59f50b3b70a2001d75ff5b79bf30a3baa94837a12a71451e1b7500ef093"
     },
     {
       "path": "source-catalog-m01.json",
@@ -291,11 +299,15 @@
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "ccc7789775a78e1eb71ede45a2381c0471c9efb87cd4fb13903cfbe9365c0706"
+      "sha256": "6783f12f7d886afd6d2779b26b0233209dcb7d8dc770a99b8bab248fd0dedf90"
     },
     {
       "path": "source-catalog-native-pending-answers.json",
       "sha256": "ee5ef37a557f1275b2a954c5d88ca6bceac66891ecd01d4b3128542f43453719"
+    },
+    {
+      "path": "source-catalog-native-projections.json",
+      "sha256": "6c6261242acc2c2d5197faf70c08c0cd8bda903701f0a80f19bdc783d05a712e"
     },
     {
       "path": "source-catalog-native-resumes.json",

--- a/config/migration/source-catalog-g02-next.json
+++ b/config/migration/source-catalog-g02-next.json
@@ -13,22 +13,22 @@
     },
     {
       "path": "apps/companion/components/Companion.tsx",
-      "sha256": "4b724f74163ce3b799c8aecf371b29795d2d6cc9b0a424699f161112cb143f26",
+      "sha256": "c7094e4f71fa89adbd11baade44b8175dc052d4f7e9dc21cef98a874e8e5d6ba",
       "classification": "unreviewed"
     },
     {
       "path": "apps/companion/components/JobEditor.tsx",
-      "sha256": "fd4d0522672785b2607c844a2acf2adef4bc5b22a325f2ec508aaf00c366446f",
+      "sha256": "2556555521566b54fd04ef8f6adb78eb1dc05755f888b7a66afc6abfbf7218e7",
       "classification": "unreviewed"
     },
     {
       "path": "apps/companion/components/Jobs.tsx",
-      "sha256": "878a91279d498b798d165060d8af33e65237e6b9df441624b8b447f2e0aa35fb",
+      "sha256": "620ac39dfe6d3e3df1aa59d87d9560d4d065d2fd762f371a95c49ad10cc27ae7",
       "classification": "unreviewed"
     },
     {
       "path": "apps/companion/components/Overview.tsx",
-      "sha256": "581cba99f50d8efaaf4643627f70c2bc4ffd5e5ece219066167df4091dae221f",
+      "sha256": "4c8d4b6598c33a657a3ce708afd5e3c8dacec31ffbab44b0f7221ead579ee809",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "312c7b4562d965cdc1b4de1dab5f14d6c7690f8ff470b5e83bb2e5590d281dee",
+      "sha256": "814980f90ae506302ab2b2a2521c183dfd8ba06c43e9d41c61c0ce6d987bfdd9",
       "classification": "unreviewed"
     },
     {
@@ -43,7 +43,7 @@
     },
     {
       "path": "runtime/workspace-core/jobs-http.js",
-      "sha256": "b4fa069710a1ca246fd588a8d1e09026369dac37aa28a8ce4ceecafc42bf7dcf",
+      "sha256": "e662801c1d86f7c40827ddf8cd8b36a32e3aa39e2707fe55c7ba83761af2bd1b",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "d97009b8cef103b34c8d8ed7b29d47de0a594ec0d01061bd2270c7817d928759",
+      "sha256": "d8554000f26b76fe03656286a81652c66250a274adf7eaa4334c3bf6ac927e1e",
       "classification": "unreviewed"
     },
     {
@@ -93,7 +93,7 @@
     },
     {
       "path": "src/workspace-core/jobs-http.ts",
-      "sha256": "c1c629da3b4ffecd5eb418d3a2f3886addb97671673a1065347faca4302cfa85",
+      "sha256": "bc891981865ad77970ad5682ea20cd078946d5668dce7ee427f10ed2c82abac4",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-projections.json
+++ b/config/migration/source-catalog-native-projections.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "apps/companion/components/JobActivity.tsx",
+      "sha256": "31d86a46e3ece931c79dc4e16456eeb5db1cf962fc62a72854f762b163b166ba",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/NeedsAttention.tsx",
+      "sha256": "68fc90f773371b59893b23979315c0bbb3a821eb1c6d7ba76ac763a15997513d",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/projection-model.ts",
+      "sha256": "172fc6f45027f193144b4086fd241867ce52d51380060ef18ca78eab7fc0e102",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/projection-view.ts",
+      "sha256": "c90f9241a81eb657a39eaa54c06b98acf6addb5743540c4ffc592a3f96c6a376",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/cli/native-projections.js",
+      "sha256": "10b33a7734490d534e153f5cbd423e799f6934c72b859c613080c613e1f85e2f",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/workspace-projections-http.js",
+      "sha256": "59ef614900dee29f9a32754519d72d91a400034cdad21218003d5e3992c2cbdc",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/workspace-projections.js",
+      "sha256": "b86a78120ffd7b45c9bca0ce47b10b42af59b7a55acfc3f1e33c323f8e5809b1",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-projections.ts",
+      "sha256": "477471d05760ec95735d2ef14571498cc13d8bd4cc9e27ebd9d90c027f80041b",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/workspace-projections-http.ts",
+      "sha256": "b49b29207e62df81a6283211b0326bf81cab19985591542662b023294bd39c77",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/workspace-projections.ts",
+      "sha256": "718afe784743c9a107ce781469ed90723af22ecae1f032014ce85a5a540876f5",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/docs/native-projections-fixture.md
+++ b/docs/native-projections-fixture.md
@@ -1,0 +1,29 @@
+# Native workspace projections
+
+The synthetic native fixture supports Overview, Needs Attention, and selected-job Activity in Companion. Overview opens native Facts, Resumes, Jobs, or Needs Attention. Attention opens the current canonical job; its detail dialog includes Activity and a route to Answers for pending information. Refresh updates resolved attention items. Failed reads retain an explicitly stale snapshot and offer retry.
+
+These projections use the same native Store lock and recovery path as application work. Pending native journals are recovered before reading. An ordinary read with no recovery pending leaves canonical document and session bytes unchanged. Corrupt or unsupported state fails closed; it is never displayed as an empty workspace.
+
+## Synthetic CLI and HTTP
+
+Use a newly initialized v9 fixture and the native lock artifact described in [the claims fixture guide](native-claims-fixture.md). No existing/live Store is adopted or upgraded.
+
+```sh
+node runtime/cli/native-jobs.js --root /absolute/synthetic/root --native-lock /absolute/posix-lock.node owner-beta-overview
+node runtime/cli/native-jobs.js --root /absolute/synthetic/root --native-lock /absolute/posix-lock.node needs-attention
+node runtime/cli/native-jobs.js --root /absolute/synthetic/root --native-lock /absolute/posix-lock.node job-activity --id example-job
+node runtime/cli/native-jobs.js --root /absolute/synthetic/root --native-lock /absolute/posix-lock.node job-preflight --id example-job
+node runtime/cli/native-jobs.js --root /absolute/synthetic/root --native-lock /absolute/posix-lock.node task-snapshot
+```
+
+Authenticated GET routes are `/api/overview`, `/api/attention`, `/api/jobs/{id}/activity`, and `/api/jobs/{id}/preflight`. The task snapshot is CLI-only and combines overview, privacy-minimized jobs, and attention under one lock. CLI and HTTP call shared TypeScript services; neither invokes Python on the fixture.
+
+Overview counts active jobs/resumes and accepted answers, derives missing setup, and checks actual resume readiness before recommending a ready job. Attention distinguishes expired claims, claimless interruptions, owner review, browser actions, and missing information, with stable ordering and a canonical snapshot signature. Activity includes only the selected job's history, claim timing, session readiness/blockers, and value-free pending-answer eligibility/current approvals. It omits URLs, notes, profile/resume content, pending question text, answer values, claim owner labels, and bearer credentials. Revisions remain lossless in the projections.
+
+The response contracts preserve Python behavior for native-supported records. Existing native v9 validation is intentionally stricter: legacy sessions without durable pending references and unrelated corrupt sessions/history are rejected before projection. This does not establish compatibility with arbitrary legacy Stores.
+
+## Remaining work
+
+Expired claims can be recovered explicitly through native application controls. Claimless interruption recovery, recording Applied/Closed outcomes, lifecycle/Trash, and the remaining application transitions are not available in this native fixture yet. The UI states these limits. API guidance retains the existing Python contract; compatibility command names are not authorization to run Python against a native fixture.
+
+Final submission on third-party sites remains human-only. Live Store adoption, native writer activation, and final Python-free package cutover remain separate milestones.

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,4 +1,5 @@
 import { claimCommands, runClaimCommand } from './native-claims.js';
+import { projectionCommands, runProjectionCommand } from './native-projections.js';
 import { pendingAnswerCommands, runPendingAnswerCommand } from './native-pending-answers.js';
 import { profileCommands, runProfileCommand } from "./native-profile.js";
 import { answerCommands, runAnswerCommand } from "./native-answers.js";
@@ -37,6 +38,7 @@ export async function runJobsCli(args, input) {
         }
     }
     const fields = {
+        ...projectionCommands,
         ...claimCommands,
         ...pendingAnswerCommands,
         ...profileCommands,
@@ -75,6 +77,8 @@ export async function runJobsCli(args, input) {
         const limit = ["resume-proposal-create", "resume-extraction-request-complete"].includes(command) ? 2 * 1024 * 1024 : 65536;
         return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
     };
+    if (Object.hasOwn(projectionCommands, command))
+        return serialize(await runProjectionCommand(command, repository, options));
     if (Object.hasOwn(claimCommands, command))
         return serialize(await runClaimCommand(command, repository, options, payload));
     if (Object.hasOwn(pendingAnswerCommands, command))

--- a/runtime/cli/native-projections.js
+++ b/runtime/cli/native-projections.js
@@ -1,0 +1,20 @@
+import { WorkspaceProjectionsService } from '../workspace-core/workspace-projections.js';
+import { JobsError } from '../contracts/workspace/values.js';
+export const projectionCommands = {
+    'owner-beta-overview': [], 'needs-attention': [], 'task-snapshot': [], 'job-activity': ['--id'], 'job-preflight': ['--id'],
+};
+export async function runProjectionCommand(command, repository, options) {
+    const service = new WorkspaceProjectionsService(repository);
+    if (command === 'owner-beta-overview')
+        return service.overview();
+    if (command === 'needs-attention')
+        return service.attention();
+    if (command === 'task-snapshot')
+        return service.taskSnapshot();
+    const id = options.get('--id');
+    if (!id)
+        throw new JobsError('required option: --id');
+    if (command === 'job-preflight')
+        return service.preflight(id);
+    return service.activity(id);
+}

--- a/runtime/workspace-core/jobs-http.js
+++ b/runtime/workspace-core/jobs-http.js
@@ -1,4 +1,5 @@
 import { claimsHttp } from './claims-http.js';
+import { workspaceProjectionsHttp } from './workspace-projections-http.js';
 import { pendingAnswersHttp } from './pending-answers-http.js';
 import { profileHttp } from "./profile-http.js";
 import { fixtureError } from "../store/native-jobs.js";
@@ -15,6 +16,9 @@ const envelope = (key, value) => set(emptyObject(), key, value);
 /** Transport-independent dispatch. Host/token/Origin/body bounds belong to the adapter. */
 export async function jobsHttp(service, repository, method, path, body = "") {
     try {
+        const projection = await workspaceProjectionsHttp(repository, method, path);
+        if (projection)
+            return projection;
         const claim = await claimsHttp(repository, method, path, body);
         if (claim)
             return claim;

--- a/runtime/workspace-core/workspace-projections-http.js
+++ b/runtime/workspace-core/workspace-projections-http.js
@@ -1,0 +1,17 @@
+import { WorkspaceProjectionsService } from './workspace-projections.js';
+import { serialize } from '../contracts/workspace/values.js';
+/** The authenticated adapter owns route, request and response bounds. */
+export async function workspaceProjectionsHttp(repository, method, path) {
+    if (method !== 'GET')
+        return null;
+    const service = new WorkspaceProjectionsService(repository);
+    if (path === '/api/overview')
+        return { status: 200, body: serialize(await service.overview()) };
+    if (path === '/api/attention')
+        return { status: 200, body: serialize(await service.attention()) };
+    const match = /^\/api\/jobs\/([^/]+)\/(activity|preflight)$/.exec(path);
+    if (!match)
+        return null;
+    const id = decodeURIComponent(match[1]);
+    return { status: 200, body: serialize(await (match[2] === 'activity' ? service.activity(id) : service.preflight(id))) };
+}

--- a/runtime/workspace-core/workspace-projections.js
+++ b/runtime/workspace-core/workspace-projections.js
@@ -1,0 +1,210 @@
+import { createHash } from 'node:crypto';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { claimExpired } from '../contracts/workspace/claims.js';
+import { currentClaimApprovals } from '../contracts/workspace/claim-session-pending.js';
+import { pendingResolutionProjection, sessionRevision } from '../contracts/workspace/answer-resolution.js';
+import { validateAnswerSession } from '../contracts/workspace/answer-session-validation.js';
+import { safeId } from '../contracts/workspace/jobs.js';
+import { fromJSON, get, has, int, integer, keys, object, same, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { preflightJobRecord } from './job-preflight.js';
+const doc = (value) => object(fromJSON(value), 'projection');
+const digest = (value) => createHash('sha256').update(canonicalJson(value)).digest('hex');
+const label = (value, key) => string(get(value, key)) ?? '';
+const rank = (value) => int(get(value, 'priority')) ?? 0n;
+function select(value, fields) {
+    const result = doc({});
+    for (const field of fields)
+        if (has(value, field))
+            set(result, field, get(value, field));
+    return result;
+}
+function records(document, field) {
+    return object(get(document, field), field).entries().map(([, value]) => object(value, field));
+}
+const active = (items) => items.filter(item => get(item, 'deletedAt') === null);
+function jobRecord(tx, id) {
+    const result = get(object(get(tx.jobs, 'jobs'), 'jobs'), id);
+    if (result === null || get(object(result, 'job'), 'deletedAt') !== null)
+        throw new JobsError('job does not exist');
+    return object(result, 'job');
+}
+function sessionRecord(tx, id) {
+    const session = tx.sessions.find(item => label(item, 'applicationId') === id);
+    // Native repository accepts only closed modern sessions. Validate again for structural repositories.
+    return session === undefined ? null : validateAnswerSession(session);
+}
+function selectedClaim(tx, id) {
+    const raw = get(tx.coordinator, 'claim');
+    if (raw === null)
+        return null;
+    const claim = object(raw, 'claim');
+    return label(claim, 'jobId') === id ? claim : null;
+}
+const jobFields = ['id', 'role', 'company', 'location', 'workplaceType', 'employmentType', 'status', 'priority', 'revision', 'createdAt', 'updatedAt'];
+const sessionFields = ['attemptRevision', 'readiness', 'blockers', 'browserHandoff'];
+const reasons = [
+    ['expired_agent_attempt', 'Expired agent attempt', 'Resume this attempt with the CLI claim-recover command for this job.'],
+    ['claimless_interrupted_attempt', 'Interrupted agent attempt', 'Reset this claimless attempt to needs_info with the revision-bound CLI job-transition command, then resolve it before starting a new attempt.'],
+    ['awaiting_human_review', 'Awaiting your review', 'Open Job details. After you personally submit on the third-party site, confirm Applied, or close the job with an outcome.'],
+    ['browser_action_required', 'Browser action required', 'Open Job details and continue in the visible browser. The saved information is already known; do not create or re-enter an answer in Companion.'],
+    ['needs_information', 'Needs information', 'Open Job details and resolve the missing facts, resume, or answers, then run preflight and mark the job ready.'],
+];
+function compareText(a, b) {
+    return text(a).compare(text(b));
+}
+function comparePriority(a, b) {
+    return rank(a) === rank(b) ? 0 : rank(a) > rank(b) ? -1 : 1;
+}
+function browserOnly(session) {
+    const handoff = get(session, 'browserHandoff');
+    if (handoff === null)
+        return false;
+    const expected = doc({ state: 'required', reasonCode: 'unsupported-control' });
+    set(expected, 'revision', get(object(handoff, 'browser handoff'), 'revision'));
+    const blockers = (get(session, 'blockers') ?? []);
+    const pairs = new Set(blockers.map(item => `${label(item, 'type')}/${label(item, 'code')}`));
+    return same(handoff, expected) && pairs.size === 2
+        && pairs.has('browser_handoff/unsupported-control') && pairs.has('information/owner-input-required');
+}
+function attentionLocked(tx, now) {
+    const rows = [];
+    for (const job of active(records(tx.jobs, 'jobs'))) {
+        const id = label(job, 'id'), status = label(job, 'status');
+        let reason = null, at = get(job, 'updatedAt');
+        if (status === 'in_progress') {
+            const claim = selectedClaim(tx, id);
+            if (claim === null)
+                reason = 1;
+            else if (claimExpired(claim, now)) {
+                reason = 0;
+                at = get(claim, 'expiresAt');
+            }
+        }
+        else if (status === 'awaiting_review')
+            reason = 2;
+        else if (status === 'needs_info')
+            reason = 4;
+        if (reason === null)
+            continue;
+        let missing = 0, revision = null, projected = null;
+        if (reason === 2 || reason === 4) {
+            const session = sessionRecord(tx, id);
+            if (session !== null) {
+                missing = (get(session, 'pendingFields') ?? []).length;
+                revision = integer(sessionRevision(session));
+                projected = select(session, sessionFields);
+                if (reason === 4 && missing === 0 && browserOnly(session))
+                    reason = 3;
+            }
+        }
+        const [code, reasonLabel, guidance] = reasons[reason];
+        const row = doc({ jobId: id, status, reasonCode: code, reasonLabel, guidance, missingInformationCount: missing });
+        set(row, 'revision', get(job, 'revision'));
+        set(row, 'priority', get(job, 'priority') ?? integer(0n));
+        set(row, 'attentionAt', at);
+        set(row, 'sessionRevision', revision);
+        set(row, 'session', projected);
+        rows.push(row);
+    }
+    rows.sort((a, b) => reasons.findIndex(item => item[0] === label(a, 'reasonCode'))
+        - reasons.findIndex(item => item[0] === label(b, 'reasonCode'))
+        || comparePriority(a, b) || compareText(label(a, 'attentionAt'), label(b, 'attentionAt'))
+        || compareText(label(a, 'jobId'), label(b, 'jobId')));
+    return set(doc({ snapshotSignature: digest(rows) }), 'items', rows);
+}
+async function overviewLocked(tx, now) {
+    const jobs = active(records(tx.jobs, 'jobs')), resumes = active(records(tx.resumes, 'resumes'));
+    const answers = active(records(tx.answers, 'answers')).filter(item => !has(item, 'reviewStatus') || label(item, 'reviewStatus') === 'accepted');
+    const profile = object(get(tx.profile, 'profile'), 'profile');
+    const hasProfileFacts = keys(profile).some(key => key !== 'preferences');
+    const attentionJobs = jobs.filter(job => {
+        const status = label(job, 'status');
+        if (['needs_info', 'awaiting_review'].includes(status))
+            return true;
+        const claim = selectedClaim(tx, label(job, 'id'));
+        return status === 'in_progress' && (claim === null || claimExpired(claim, now));
+    }).length;
+    const rawClaim = get(tx.coordinator, 'claim');
+    let acquirable = false;
+    if (rawClaim === null || claimExpired(object(rawClaim, 'claim'), now)) {
+        for (const job of jobs.filter(item => label(item, 'status') === 'ready')) {
+            // Do not stop early: Python preflights every ready job, including file errors.
+            if (get(await preflightJobRecord(job, tx.profile, tx.resumes, tx.files), 'ready') === true)
+                acquirable = true;
+        }
+    }
+    const [nextAction, targetWorkspace] = !resumes.length ? ['import_resume', 'resumes']
+        : !hasProfileFacts ? ['review_facts', 'facts']
+            : attentionJobs ? ['resolve_attention', 'attention']
+                : acquirable ? ['handoff_ready_job', 'jobs']
+                    : !jobs.length ? ['capture_job', 'jobs'] : ['prepare_job', 'jobs'];
+    return doc({ setup: { hasProfileFacts, hasResume: resumes.length > 0 },
+        counts: { jobs: jobs.length, readyJobs: jobs.filter(item => label(item, 'status') === 'ready').length,
+            attentionJobs, resumes: resumes.length, answers: answers.length }, nextAction, targetWorkspace });
+}
+/** Read-only privacy projections from a single coherent native Store transaction. */
+export class WorkspaceProjectionsService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    overview() {
+        return this.repository.claimTransaction(tx => overviewLocked(tx, this.now()));
+    }
+    attention() {
+        return this.repository.claimTransaction(async (tx) => attentionLocked(tx, this.now()));
+    }
+    preflight(id) {
+        safeId(id);
+        return this.repository.claimTransaction(tx => preflightJobRecord(jobRecord(tx, id), tx.profile, tx.resumes, tx.files));
+    }
+    taskSnapshot() {
+        return this.repository.claimTransaction(async (tx) => {
+            const now = this.now(), overview = await overviewLocked(tx, now), attention = attentionLocked(tx, now);
+            const jobs = active(records(tx.jobs, 'jobs')).sort((a, b) => comparePriority(a, b)
+                || compareText(label(a, 'createdAt'), label(b, 'createdAt')) || compareText(label(a, 'id'), label(b, 'id')))
+                .map(job => select(job, jobFields));
+            const signatureInput = set(set(doc({}), 'overview', overview), 'jobs', jobs);
+            set(signatureInput, 'attentionSignature', get(attention, 'snapshotSignature'));
+            const result = doc({ snapshotSignature: digest(signatureInput) });
+            set(result, 'overview', overview);
+            set(result, 'jobs', jobs);
+            return set(result, 'attention', attention);
+        });
+    }
+    activity(id) {
+        safeId(id);
+        return this.repository.claimTransaction(async (tx) => {
+            const job = jobRecord(tx, id), stored = sessionRecord(tx, id);
+            let session = null;
+            if (stored !== null) {
+                session = select(stored, ['status', 'step', ...sessionFields, 'approvals', 'createdAt', 'updatedAt']);
+                const pending = (get(stored, 'pendingFields') ?? []);
+                const current = ['needs_info', 'awaiting_review'].includes(label(job, 'status'))
+                    || label(job, 'status') === 'in_progress' && same(get(stored, 'attemptRevision'), get(job, 'revision'));
+                set(session, 'approvals', current ? currentClaimApprovals(stored, pending, tx.answers, get(stored, 'attemptRevision')) : []);
+                set(session, 'revision', integer(sessionRevision(stored)));
+                set(session, 'pendingInformation', pending.map(field => {
+                    const result = select(field, ['state', 'sensitive', 'fieldClass', 'matchConfidence', 'matchReasonCodes']);
+                    for (const [key, value] of pendingResolutionProjection(field, tx.answers).entries())
+                        result.set(key, value);
+                    return result;
+                }));
+            }
+            const persisted = selectedClaim(tx, id);
+            const claim = persisted === null ? doc({ state: label(job, 'status') === 'in_progress' ? 'interrupted' : 'none' })
+                : set(select(persisted, ['acquiredAt', 'heartbeatAt', 'expiresAt']), 'state', text(claimExpired(persisted, this.now()) ? 'expired' : 'active'));
+            if (label(claim, 'state') === 'expired')
+                set(claim, 'recoveryGuidance', text(reasons[0][2]));
+            else if (label(claim, 'state') === 'interrupted')
+                set(claim, 'recoveryGuidance', text(`Reset this claimless attempt with the CLI job-transition command to needs_info using revision ${int(get(job, 'revision'))}; resolve any missing information, then mark it ready for a new agent attempt.`));
+            const result = set(doc({}), 'job', select(job, ['status', 'revision']));
+            set(result, 'session', session);
+            set(result, 'claim', claim);
+            return set(result, 'history', tx.history.filter(event => label(event, 'applicationId') === id)
+                .map(event => select(event, ['event', 'status', 'ats', 'at'])));
+        });
+    }
+}

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,4 +1,5 @@
 import { claimCommands, runClaimCommand } from './native-claims.js';
+import { projectionCommands, runProjectionCommand } from './native-projections.js';
 import { pendingAnswerCommands, runPendingAnswerCommand } from './native-pending-answers.js';
 import { profileCommands, runProfileCommand } from "./native-profile.js";
 import { answerCommands, runAnswerCommand } from "./native-answers.js";
@@ -33,6 +34,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     }
   }
   const fields: Record<string, string[]> = {
+    ...projectionCommands,
     ...claimCommands,
     ...pendingAnswerCommands,
     ...profileCommands,
@@ -67,6 +69,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     const limit = ["resume-proposal-create", "resume-extraction-request-complete"].includes(command!) ? 2 * 1024 * 1024 : 65536;
     return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
   };
+  if (Object.hasOwn(projectionCommands, command!)) return serialize(await runProjectionCommand(command!, repository, options));
   if (Object.hasOwn(claimCommands, command!)) return serialize(await runClaimCommand(command!,repository,options,payload));
   if (Object.hasOwn(pendingAnswerCommands, command!)) return serialize(await runPendingAnswerCommand(command!, repository, options));
   if (Object.hasOwn(profileCommands, command!)) return serialize(await runProfileCommand(command!, repository, options, payload));

--- a/src/cli/native-projections.ts
+++ b/src/cli/native-projections.ts
@@ -1,0 +1,17 @@
+import { WorkspaceProjectionsService } from '../workspace-core/workspace-projections.js';
+import type { ClaimRepository } from '../workspace-core/claims.js';
+import { JobsError } from '../contracts/workspace/values.js';
+
+export const projectionCommands: Record<string,string[]> = {
+  'owner-beta-overview': [], 'needs-attention': [], 'task-snapshot': [], 'job-activity': ['--id'], 'job-preflight': ['--id'],
+};
+export async function runProjectionCommand(command: string, repository: ClaimRepository, options: Map<string,string>) {
+  const service = new WorkspaceProjectionsService(repository);
+  if (command === 'owner-beta-overview') return service.overview();
+  if (command === 'needs-attention') return service.attention();
+  if (command === 'task-snapshot') return service.taskSnapshot();
+  const id = options.get('--id');
+  if (!id) throw new JobsError('required option: --id');
+  if (command === 'job-preflight') return service.preflight(id);
+  return service.activity(id);
+}

--- a/src/workspace-core/jobs-http.ts
+++ b/src/workspace-core/jobs-http.ts
@@ -1,4 +1,5 @@
 import { claimsHttp } from './claims-http.js';
+import { workspaceProjectionsHttp } from './workspace-projections-http.js';
 import { pendingAnswersHttp } from './pending-answers-http.js';
 import { profileHttp } from "./profile-http.js";
 import type { JobsService } from "./jobs.js";
@@ -23,6 +24,8 @@ const envelope = (key: string, value: Value): Value => set(emptyObject(), key, v
 export async function jobsHttp(service: JobsService, repository: NativeJobsRepository,
   method: string, path: string, body = ""): Promise<ApiResult> {
   try {
+    const projection = await workspaceProjectionsHttp(repository, method, path);
+    if (projection) return projection;
     const claim = await claimsHttp(repository,method,path,body);
     if (claim) return claim;
     const pending = await pendingAnswersHttp(repository, method, path, body);

--- a/src/workspace-core/workspace-projections-http.ts
+++ b/src/workspace-core/workspace-projections-http.ts
@@ -1,0 +1,15 @@
+import { WorkspaceProjectionsService } from './workspace-projections.js';
+import type { ClaimRepository } from './claims.js';
+import { serialize } from '../contracts/workspace/values.js';
+
+/** The authenticated adapter owns route, request and response bounds. */
+export async function workspaceProjectionsHttp(repository: ClaimRepository, method: string, path: string): Promise<{status:number;body:string}|null> {
+  if (method !== 'GET') return null;
+  const service = new WorkspaceProjectionsService(repository);
+  if (path === '/api/overview') return {status:200,body:serialize(await service.overview())};
+  if (path === '/api/attention') return {status:200,body:serialize(await service.attention())};
+  const match = /^\/api\/jobs\/([^/]+)\/(activity|preflight)$/.exec(path);
+  if (!match) return null;
+  const id = decodeURIComponent(match[1]!);
+  return {status:200,body:serialize(await (match[2] === 'activity' ? service.activity(id) : service.preflight(id)))};
+}

--- a/src/workspace-core/workspace-projections.ts
+++ b/src/workspace-core/workspace-projections.ts
@@ -1,0 +1,199 @@
+import { createHash } from 'node:crypto';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { claimExpired } from '../contracts/workspace/claims.js';
+import { currentClaimApprovals } from '../contracts/workspace/claim-session-pending.js';
+import { pendingResolutionProjection, sessionRevision } from '../contracts/workspace/answer-resolution.js';
+import { validateAnswerSession } from '../contracts/workspace/answer-session-validation.js';
+import { safeId } from '../contracts/workspace/jobs.js';
+import { fromJSON, get, has, int, integer, keys, object, same, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import type { ClaimTransaction } from './claims.js';
+import { preflightJobRecord } from './job-preflight.js';
+
+type ProjectionTransaction = Pick<ClaimTransaction,
+  'jobs' | 'coordinator' | 'profile' | 'resumes' | 'answers' | 'sessions' | 'history' | 'files'>;
+export interface WorkspaceProjectionsRepository {
+  claimTransaction<T>(operation: (transaction: ProjectionTransaction) => Promise<T>): Promise<T>;
+}
+const doc = (value: unknown): Document => object(fromJSON(value), 'projection');
+const digest = (value: Value): string => createHash('sha256').update(canonicalJson(value)).digest('hex');
+const label = (value: Document, key: string): string => string(get(value, key)) ?? '';
+const rank = (value: Document): bigint => int(get(value, 'priority')) ?? 0n;
+function select(value: Document, fields: string[]): Document {
+  const result = doc({});
+  for (const field of fields) if (has(value, field)) set(result, field, get(value, field));
+  return result;
+}
+function records(document: Document, field: string): Document[] {
+  return object(get(document, field), field).entries().map(([, value]) => object(value, field));
+}
+const active = (items: Document[]): Document[] => items.filter(item => get(item, 'deletedAt') === null);
+function jobRecord(tx: ProjectionTransaction, id: string): Document {
+  const result = get(object(get(tx.jobs, 'jobs'), 'jobs'), id);
+  if (result === null || get(object(result, 'job'), 'deletedAt') !== null) throw new JobsError('job does not exist');
+  return object(result, 'job');
+}
+function sessionRecord(tx: ProjectionTransaction, id: string): Document | null {
+  const session = tx.sessions.find(item => label(item, 'applicationId') === id);
+  // Native repository accepts only closed modern sessions. Validate again for structural repositories.
+  return session === undefined ? null : validateAnswerSession(session);
+}
+function selectedClaim(tx: ProjectionTransaction, id: string): Document | null {
+  const raw = get(tx.coordinator, 'claim');
+  if (raw === null) return null;
+  const claim = object(raw, 'claim');
+  return label(claim, 'jobId') === id ? claim : null;
+}
+const jobFields = ['id', 'role', 'company', 'location', 'workplaceType', 'employmentType', 'status', 'priority', 'revision', 'createdAt', 'updatedAt'];
+const sessionFields = ['attemptRevision', 'readiness', 'blockers', 'browserHandoff'];
+const reasons = [
+  ['expired_agent_attempt', 'Expired agent attempt', 'Resume this attempt with the CLI claim-recover command for this job.'],
+  ['claimless_interrupted_attempt', 'Interrupted agent attempt', 'Reset this claimless attempt to needs_info with the revision-bound CLI job-transition command, then resolve it before starting a new attempt.'],
+  ['awaiting_human_review', 'Awaiting your review', 'Open Job details. After you personally submit on the third-party site, confirm Applied, or close the job with an outcome.'],
+  ['browser_action_required', 'Browser action required', 'Open Job details and continue in the visible browser. The saved information is already known; do not create or re-enter an answer in Companion.'],
+  ['needs_information', 'Needs information', 'Open Job details and resolve the missing facts, resume, or answers, then run preflight and mark the job ready.'],
+] as const;
+function compareText(a: string, b: string): number {
+  return text(a).compare(text(b));
+}
+function comparePriority(a: Document, b: Document): number {
+  return rank(a) === rank(b) ? 0 : rank(a) > rank(b) ? -1 : 1;
+}
+function browserOnly(session: Document): boolean {
+  const handoff = get(session, 'browserHandoff');
+  if (handoff === null) return false;
+  const expected = doc({state:'required', reasonCode:'unsupported-control'});
+  set(expected, 'revision', get(object(handoff, 'browser handoff'), 'revision'));
+  const blockers = (get(session, 'blockers') ?? []) as Document[];
+  const pairs = new Set(blockers.map(item => `${label(item, 'type')}/${label(item, 'code')}`));
+  return same(handoff, expected) && pairs.size === 2
+    && pairs.has('browser_handoff/unsupported-control') && pairs.has('information/owner-input-required');
+}
+function attentionLocked(tx: ProjectionTransaction, now: string): Document {
+  const rows: Document[] = [];
+  for (const job of active(records(tx.jobs, 'jobs'))) {
+    const id = label(job, 'id'), status = label(job, 'status');
+    let reason: number | null = null, at = get(job, 'updatedAt');
+    if (status === 'in_progress') {
+      const claim = selectedClaim(tx, id);
+      if (claim === null) reason = 1;
+      else if (claimExpired(claim, now)) {
+        reason = 0;
+        at = get(claim, 'expiresAt');
+      }
+    } else if (status === 'awaiting_review') reason = 2;
+    else if (status === 'needs_info') reason = 4;
+    if (reason === null) continue;
+    let missing = 0, revision: Value = null, projected: Value = null;
+    if (reason === 2 || reason === 4) {
+      const session = sessionRecord(tx, id);
+      if (session !== null) {
+        missing = ((get(session, 'pendingFields') ?? []) as Value[]).length;
+        revision = integer(sessionRevision(session));
+        projected = select(session, sessionFields);
+        if (reason === 4 && missing === 0 && browserOnly(session)) reason = 3;
+      }
+    }
+    const [code, reasonLabel, guidance] = reasons[reason]!;
+    const row = doc({jobId:id, status, reasonCode:code, reasonLabel, guidance, missingInformationCount:missing});
+    set(row, 'revision', get(job, 'revision'));
+    set(row, 'priority', get(job, 'priority') ?? integer(0n));
+    set(row, 'attentionAt', at);
+    set(row, 'sessionRevision', revision);
+    set(row, 'session', projected);
+    rows.push(row);
+  }
+  rows.sort((a, b) => reasons.findIndex(item => item[0] === label(a, 'reasonCode'))
+    - reasons.findIndex(item => item[0] === label(b, 'reasonCode'))
+    || comparePriority(a, b) || compareText(label(a, 'attentionAt'), label(b, 'attentionAt'))
+    || compareText(label(a, 'jobId'), label(b, 'jobId')));
+  return set(doc({snapshotSignature:digest(rows)}), 'items', rows);
+}
+async function overviewLocked(tx: ProjectionTransaction, now: string): Promise<Document> {
+  const jobs = active(records(tx.jobs, 'jobs')), resumes = active(records(tx.resumes, 'resumes'));
+  const answers = active(records(tx.answers, 'answers')).filter(item => !has(item, 'reviewStatus') || label(item, 'reviewStatus') === 'accepted');
+  const profile = object(get(tx.profile, 'profile'), 'profile');
+  const hasProfileFacts = keys(profile).some(key => key !== 'preferences');
+  const attentionJobs = jobs.filter(job => {
+    const status = label(job, 'status');
+    if (['needs_info', 'awaiting_review'].includes(status)) return true;
+    const claim = selectedClaim(tx, label(job, 'id'));
+    return status === 'in_progress' && (claim === null || claimExpired(claim, now));
+  }).length;
+  const rawClaim = get(tx.coordinator, 'claim');
+  let acquirable = false;
+  if (rawClaim === null || claimExpired(object(rawClaim, 'claim'), now)) {
+    for (const job of jobs.filter(item => label(item, 'status') === 'ready')) {
+      // Do not stop early: Python preflights every ready job, including file errors.
+      if (get(await preflightJobRecord(job, tx.profile, tx.resumes, tx.files), 'ready') === true) acquirable = true;
+    }
+  }
+  const [nextAction, targetWorkspace] = !resumes.length ? ['import_resume', 'resumes']
+    : !hasProfileFacts ? ['review_facts', 'facts']
+    : attentionJobs ? ['resolve_attention', 'attention']
+    : acquirable ? ['handoff_ready_job', 'jobs']
+    : !jobs.length ? ['capture_job', 'jobs'] : ['prepare_job', 'jobs'];
+  return doc({setup:{hasProfileFacts, hasResume:resumes.length > 0},
+    counts:{jobs:jobs.length, readyJobs:jobs.filter(item => label(item, 'status') === 'ready').length,
+      attentionJobs, resumes:resumes.length, answers:answers.length}, nextAction, targetWorkspace});
+}
+/** Read-only privacy projections from a single coherent native Store transaction. */
+export class WorkspaceProjectionsService {
+  constructor(private readonly repository: WorkspaceProjectionsRepository,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+  overview(): Promise<Document> {
+    return this.repository.claimTransaction(tx => overviewLocked(tx, this.now()));
+  }
+  attention(): Promise<Document> {
+    return this.repository.claimTransaction(async tx => attentionLocked(tx, this.now()));
+  }
+  preflight(id: string): Promise<Document> {
+    safeId(id);
+    return this.repository.claimTransaction(tx => preflightJobRecord(jobRecord(tx, id), tx.profile, tx.resumes, tx.files));
+  }
+  taskSnapshot(): Promise<Document> {
+    return this.repository.claimTransaction(async tx => {
+      const now = this.now(), overview = await overviewLocked(tx, now), attention = attentionLocked(tx, now);
+      const jobs = active(records(tx.jobs, 'jobs')).sort((a, b) => comparePriority(a, b)
+        || compareText(label(a, 'createdAt'), label(b, 'createdAt')) || compareText(label(a, 'id'), label(b, 'id')))
+        .map(job => select(job, jobFields));
+      const signatureInput = set(set(doc({}), 'overview', overview), 'jobs', jobs);
+      set(signatureInput, 'attentionSignature', get(attention, 'snapshotSignature'));
+      const result = doc({snapshotSignature:digest(signatureInput)});
+      set(result, 'overview', overview);
+      set(result, 'jobs', jobs);
+      return set(result, 'attention', attention);
+    });
+  }
+  activity(id: string): Promise<Document> {
+    safeId(id);
+    return this.repository.claimTransaction(async tx => {
+      const job = jobRecord(tx, id), stored = sessionRecord(tx, id);
+      let session: Value = null;
+      if (stored !== null) {
+        session = select(stored, ['status', 'step', ...sessionFields, 'approvals', 'createdAt', 'updatedAt']);
+        const pending = (get(stored, 'pendingFields') ?? []) as Document[];
+        const current = ['needs_info', 'awaiting_review'].includes(label(job, 'status'))
+          || label(job, 'status') === 'in_progress' && same(get(stored, 'attemptRevision'), get(job, 'revision'));
+        set(session, 'approvals', current ? currentClaimApprovals(stored, pending, tx.answers, get(stored, 'attemptRevision')) : []);
+        set(session, 'revision', integer(sessionRevision(stored)));
+        set(session, 'pendingInformation', pending.map(field => {
+          const result = select(field, ['state', 'sensitive', 'fieldClass', 'matchConfidence', 'matchReasonCodes']);
+          for (const [key, value] of pendingResolutionProjection(field, tx.answers).entries()) result.set(key, value);
+          return result;
+        }));
+      }
+      const persisted = selectedClaim(tx, id);
+      const claim = persisted === null ? doc({state:label(job, 'status') === 'in_progress' ? 'interrupted' : 'none'})
+        : set(select(persisted, ['acquiredAt', 'heartbeatAt', 'expiresAt']), 'state', text(claimExpired(persisted, this.now()) ? 'expired' : 'active'));
+      if (label(claim, 'state') === 'expired') set(claim, 'recoveryGuidance', text(reasons[0][2]));
+      else if (label(claim, 'state') === 'interrupted') set(claim, 'recoveryGuidance', text(
+        `Reset this claimless attempt with the CLI job-transition command to needs_info using revision ${int(get(job, 'revision'))}; resolve any missing information, then mark it ready for a new agent attempt.`));
+      const result = set(doc({}), 'job', select(job, ['status', 'revision']));
+      set(result, 'session', session);
+      set(result, 'claim', claim);
+      return set(result, 'history', tx.history.filter(event => label(event, 'applicationId') === id)
+        .map(event => select(event, ['event', 'status', 'ats', 'at'])));
+    });
+  }
+}

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,4 +1,5 @@
 import { claimsBrowser } from './workspace_native_claims_browser_support.mjs';
+import { projectionsBrowser } from './workspace_native_projections_browser_support.mjs';
 import { nativeFactsBrowser } from './workspace_native_facts_browser_support.mjs';
 import { resumeDraftBrowser } from './workspace_native_resumes_browser_support.mjs';
 import { nativeAnswersBrowser } from './workspace_native_answers_browser_support.mjs';
@@ -63,6 +64,10 @@ export async function nativeJobsBrowser(buildRoot) {
     await claimStarted;
     await page.locator('[data-job-create]:disabled').waitFor();
     releaseInitialClaim();
+    await page.locator('[data-job-create]:enabled').waitFor();
+    await page.getByRole('button',{name:'Needs Attention',exact:true}).click();
+    await page.getByText('No jobs need attention.',{exact:true}).waitFor();
+    await page.getByRole('button',{name:'Jobs',exact:true}).click();
     await page.getByRole('button', { name: 'New job', exact: true }).click();
     await page.locator('dialog [name="url"]').fill('https://example.invalid/native');
     await page.locator('dialog [name="role"]').fill('Native fixture role');
@@ -123,10 +128,15 @@ export async function nativeJobsBrowser(buildRoot) {
     }});
     assert.equal(await page.evaluate(()=>document.documentElement.scrollWidth<=innerWidth),true);
     const token = new URLSearchParams(new URL(startup.url).hash.slice(1)).get('token');
-    const unsupported = await fetch(startup.origin + '/api/overview', { headers: { Authorization: `Bearer ${token}` } });
+    const projections = await projectionsBrowser(page,{jobId:job.id,markReady:async()=>{
+      const current = JSON.parse(await readFile(join(root,'jobs.json'),'utf8')).jobs[job.id];
+      await execute(process.execPath,[cli,'--root',root,'--native-lock',fixture.receipt.artifact,
+        'task-select','--id',job.id,'--expected-revision',String(current.revision),'--owner-confirmed'],{env:{PATH:''}});
+    }});
+    const unsupported = await fetch(startup.origin + '/api/trash', { headers: { Authorization: `Bearer ${token}` } });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     releaseInitialClaim?.();
     if (browser) await browser.close();

--- a/tests_js/workspace_native_projection_adapters.test.mjs
+++ b/tests_js/workspace_native_projection_adapters.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, snapshot, cli } from './workspace_native_claims_support.mjs';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { fromJSON, text } from '../runtime/contracts/workspace/values.js';
+
+test('native projection HTTP and Python-free CLI agree without rewriting canonical documents', {timeout:60000}, async () => {
+  const fixture = await nativeFixture();
+  try {
+    const {root, repository, jobs, claims} = await setup(fixture, 'projection-adapters');
+    await claims.select('job', 1n, true);
+    const acquired = JSON.parse((await import('../runtime/contracts/workspace/values.js')).serialize(await claims.acquire('job', text('PRIVATE-OWNER'), 2n)));
+    await claims.handoff('job', text(acquired.token), 'needs_info', fromJSON({status:'active', attemptRevision:3,
+      blockers:[{type:'information',code:'owner-input-required'}]}), 3n);
+    const before = await snapshot(root);
+    for (const [path, command, args] of [
+      ['/api/overview','owner-beta-overview',[]],
+      ['/api/attention','needs-attention',[]],
+      ['/api/jobs/job/activity','job-activity',['--id','job']],
+      ['/api/jobs/job/preflight','job-preflight',['--id','job']],
+    ]) {
+      const http = await jobsHttp(jobs, repository, 'GET', path);
+      assert.equal(http.status, 200, path);
+      const value = JSON.parse(http.body);
+      assert.deepEqual(await cli(fixture, root, command, args), value);
+      assert.doesNotMatch(http.body, /PRIVATE-PROFILE|PRIVATE-RESUME|PRIVATE-OWNER|tokenHash|example\.invalid/);
+      assert.ok(!http.body.includes(acquired.token));
+    }
+    const attention = JSON.parse((await jobsHttp(jobs,repository,'GET','/api/attention')).body);
+    assert.deepEqual(attention.items.map(item=>[item.jobId,item.reasonCode]), [['job','needs_information']]);
+    assert.equal((await jobsHttp(jobs,repository,'GET','/api/jobs/missing/activity')).status,404);
+    assert.equal((await jobsHttp(jobs,repository,'POST','/api/overview','{}')).status,501);
+    await assert.rejects(()=>cli(fixture,root,'job-activity',['--id','missing']),/does not exist/);
+    await assert.rejects(()=>cli(fixture,root,'needs-attention',['--id','job']),/unsupported/);
+    assert.deepEqual(await snapshot(root),before);
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_projection_model.test.mjs
+++ b/tests_js/workspace_native_projection_model.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import ts from 'typescript';
+const source = await readFile(new URL('../apps/companion/components/projection-model.ts', import.meta.url), 'utf8');
+const emitted = ts.transpileModule(source, { compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022 } }).outputText
+  .replaceAll('../../../src/contracts/workspace/values', new URL('../runtime/contracts/workspace/values.js', import.meta.url).href);
+const model = await import(`data:text/javascript;base64,${Buffer.from(emitted).toString('base64')}`);
+const row = {jobId:'job/a',status:'needs_info',revision:1,priority:0,reasonCode:'needs_information',attentionAt:'2026-09-01T00:00:00Z',missingInformationCount:2,sessionRevision:null,session:null};
+test('attention preserves canonical server order and lossless revisions', () => {
+ const parsed=model.attentionProjection(JSON.stringify({items:[row,{...row,jobId:'b'}],snapshotSignature:'x'}).replace('"revision":1','"revision":9007199254740993'));
+ assert.deepEqual(parsed.items.map(r=>r.jobId), ['job/a','b']);
+ assert.equal(parsed.items[0].revision,9007199254740993n);
+ assert.equal(model.filterAttention(parsed.items,'browser_action_required').length,0);
+});
+test('malformed attention fails without silently producing an empty queue',()=>{
+ for(const items of [null,[{...row,revision:0}],[{...row,missingInformationCount:-1}],[{...row,reasonCode:'secret'}],[row,row]]) assert.throws(()=>model.attentionProjection(JSON.stringify({items,snapshotSignature:'x'})));
+});
+test('activity strips arbitrary values, tokens, answer identities and approval contents',()=>{
+ const activity=model.activityProjection(JSON.stringify({job:{status:'needs_info',revision:1},session:{revision:2,step:'Review',pendingInformation:[{reference:'private-ref',answerKey:'private-key',resolutionEligible:false,sensitive:true,value:'private-value'}],approvals:[{reference:'private-ref',token:'private-token'}]},claim:{state:'expired',token:'private-token'},history:[{event:'opened',status:'saved',at:'2026-09-01'}],value:'private-value'}));
+ assert.doesNotMatch(JSON.stringify(activity,(_,v)=>typeof v==='bigint'?String(v):v),/private-/);
+ assert.equal(activity.session.pending[0].sensitive,true);
+ assert.equal(activity.session.approvalCount,1);
+ assert.equal(activity.session.pending[0].approved,true);
+});
+test('activity rejects malformed revision and eligibility',()=>{
+ for(const revision of [0,true,1.5]) assert.throws(()=>model.activityProjection(JSON.stringify({job:{status:'saved',revision},session:null,claim:{state:'none'},history:[]})));
+ assert.throws(()=>model.activityProjection(JSON.stringify({job:{status:'saved',revision:1},session:{revision:1,pendingInformation:[{resolutionEligible:'yes'}]},claim:{state:'none'},history:[]})));
+});
+
+test('native recovery and review guidance describes only supported authority',()=>{
+ assert.equal(model.recoveryGuidance.interrupted, 'This attempt was interrupted without an active claim. Recovery for this state is not available in the native workspace yet.');
+ assert.equal(model.attentionGuidance.claimless_interrupted_attempt, model.recoveryGuidance.interrupted);
+ assert.doesNotMatch(model.attentionGuidance.claimless_interrupted_attempt, /job-transition/);
+ assert.match(model.recoveryGuidance.expired, /claim-recover/);
+ assert.match(model.attentionGuidance.awaiting_human_review, /personally review and submit on the third-party site/);
+ assert.match(model.attentionGuidance.awaiting_human_review, /Recording Applied or Closed in the native workspace is deferred/);
+});
+
+test('attention and activity allow a null unbound attempt revision but reject malformed bindings',()=>{
+ const attention = attemptRevision => model.attentionProjection(JSON.stringify({items:[{...row,session:{attemptRevision}}],snapshotSignature:'x'})).items[0].session;
+ const activity = attemptRevision => model.activityProjection(JSON.stringify({job:{status:'needs_info',revision:1},session:{revision:2,attemptRevision},claim:{state:'none'},history:[]})).session;
+ for (const project of [attention,activity]) {
+   assert.equal(Object.hasOwn(project(null),'attemptRevision'),false);
+   assert.equal(Object.hasOwn(project(undefined),'attemptRevision'),false);
+   assert.equal(project(3).attemptRevision,3n);
+   for (const invalid of [0,-1,true,1.5,'3',{},[]]) assert.throws(()=>project(invalid));
+ }
+});

--- a/tests_js/workspace_native_projections.test.mjs
+++ b/tests_js/workspace_native_projections.test.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup as nativeSetup, snapshot, write } from './workspace_native_claims_support.mjs';
+import { WorkspaceProjectionsService } from '../runtime/workspace-core/workspace-projections.js';
+import { fromJSON, serialize } from '../runtime/contracts/workspace/values.js';
+const plain = value => JSON.parse(serialize(value));
+const now = '2026-09-10T12:00:00Z';
+function setup(jobs = [], sessions = [], claim = null) {
+  const tx = {
+    jobs: fromJSON({jobs:Object.fromEntries(jobs.map(job=>[job.id,job]))}),
+    sessions:sessions.map(fromJSON), coordinator:fromJSON({claim}), history:[],
+    profile:fromJSON({profile:{}}),resumes:fromJSON({resumes:{}}),answers:fromJSON({answers:{},redirects:{}}),
+    files:{externalObservation:async()=>({exists:true,size:1,modifiedAt:now})},
+  };
+  return {tx,service:new WorkspaceProjectionsService({claimTransaction:async operation=>operation(tx)},()=>now)};
+}
+const job = (id,status,extra={}) => ({id,status,revision:2,priority:0,createdAt:now,updatedAt:now,...extra});
+const session = (id,extra={}) => ({schemaVersion:1,applicationId:id,status:'active',pendingFields:[],...extra});
+test('attention sorts all reasons and expiry is inclusive, task snapshot hides job metadata',async()=>{
+  const jobs=[job('needs','needs_info'),job('review','awaiting_review'),job('interrupted','in_progress'),job('expired','in_progress'),job('browser','needs_info'),job('deleted','needs_info',{deletedAt:now})];
+  const claim={jobId:'expired',expiresAt:now,acquiredAt:now,heartbeatAt:now,ownerLabel:'PRIVATE OWNER',tokenHash:'PRIVATE TOKEN'};
+  const browser=session('browser',{browserHandoff:{state:'required',reasonCode:'unsupported-control',revision:1},blockers:[{type:'browser_handoff',code:'unsupported-control'},{type:'information',code:'owner-input-required'}]});
+  const {service}=setup(jobs,[browser],claim);
+  const attention=plain(await service.attention());
+  assert.deepEqual(attention.items.map(row=>row.jobId),['expired','interrupted','review','browser','needs']);
+  assert.equal(attention.items[0].reasonCode,'expired_agent_attempt');
+  assert.equal(attention.snapshotSignature.length,64);
+  assert.deepEqual(plain(await service.attention()),attention);
+  const snapshot=plain(await service.taskSnapshot());
+  assert.equal(snapshot.overview.counts.attentionJobs,5);
+  assert.equal(snapshot.jobs.length,5);
+  assert.doesNotMatch(JSON.stringify(snapshot),/PRIVATE/);
+  assert.equal(plain(await service.activity('expired')).claim.state,'expired');
+  assert.equal(plain(await service.activity('interrupted')).claim.state,'interrupted');
+});
+test('activity is selected-job-only, missing sessions work and unknown/deleted jobs fail',async()=>{
+  const {service,tx}=setup([job('one','saved'),job('deleted','saved',{deletedAt:now})]);
+  tx.history=[fromJSON({applicationId:'other',event:'PRIVATE'}),fromJSON({applicationId:'one',event:'reviewed',status:'review',at:now,company:'PRIVATE'})];
+  assert.deepEqual(plain(await service.activity('one')),{job:{status:'saved',revision:2},session:null,claim:{state:'none'},history:[{event:'reviewed',status:'review',at:now}]});
+  await assert.rejects(service.activity('missing'),/job does not exist/);
+  await assert.rejects(service.activity('deleted'),/job does not exist/);
+  assert.throws(()=>service.activity('../escape'));
+});
+test('activity pending information is value-free and stale approvals are suppressed',async()=>{
+  const reference=`pending_${'a'.repeat(32)}`;
+  const approval={reference,answerKey:'answer',answerRevision:1,currentUse:true,remember:false,policyMode:'strict',useAuthority:'per_use',eligible:true,confidenceBand:'none',reasonCodes:[]};
+  const pending={reference,answerKey:'answer',state:'missing',questionFingerprint:'b'.repeat(64)};
+  const {service,tx}=setup([job('one','needs_info')],[session('one',{attemptRevision:1,pendingFields:[pending],approvals:[approval]})]);
+  tx.answers=fromJSON({answers:{answer:{key:'answer',revision:1,state:'confirmed',value:'PRIVATE ANSWER',question:'PRIVATE QUESTION'}},redirects:{}});
+  let output=plain(await service.activity('one'));
+  assert.equal(output.session.pendingInformation[0].resolutionEligible,true);
+  assert.doesNotMatch(JSON.stringify(output),/PRIVATE|Fingerprint/);
+  assert.equal(output.session.approvals.length,1);
+  tx.answers=fromJSON({answers:{answer:{key:'answer',revision:2,state:'confirmed',value:'PRIVATE ANSWER'}},redirects:{}});
+  assert.deepEqual(plain(await service.activity('one')).session.approvals,[]);
+  tx.jobs=fromJSON({jobs:{one:job('one','in_progress')}});
+  assert.deepEqual(plain(await service.activity('one')).session.approvals,[]);
+  tx.sessions=[fromJSON(session('one',{pendingFields:[{...pending,question:'PRIVATE QUESTION'}]}))];
+  assert.doesNotMatch(JSON.stringify(plain(await service.activity('one'))),/PRIVATE QUESTION/);
+  // Invalid persisted session metadata must fail closed before it reaches projection.
+  tx.sessions=[fromJSON(session('one',{pendingFields:[{...pending,value:'PRIVATE ANSWER'}]}))];
+  await assert.rejects(service.activity('one'),/pending field/);
+});
+test('overview setup precedence and accepted active counts',async()=>{
+  const {service,tx}=setup([job('ready','ready')]);
+  assert.equal(plain(await service.overview()).nextAction,'import_resume');
+  tx.resumes=fromJSON({resumes:{r:{id:'r',default:true,path:'/synthetic',observedSize:1,observedModifiedAt:now}}});
+  assert.equal(plain(await service.overview()).nextAction,'review_facts');
+  tx.profile=fromJSON({profile:{name:'PRIVATE'}});
+  assert.equal(plain(await service.overview()).nextAction,'handoff_ready_job');
+  tx.coordinator=fromJSON({claim:{jobId:'other',expiresAt:'2026-09-10T12:00:01Z'}});
+  assert.equal(plain(await service.overview()).nextAction,'prepare_job');
+  tx.answers=fromJSON({answers:{a:{},b:{reviewStatus:'proposed'},c:{deletedAt:now}}});
+  assert.equal(plain(await service.overview()).counts.answers,1);
+});
+
+test('all modern projection payloads and signatures match authoritative Python',async()=>{
+  const {service,tx}=setup([job('α','needs_info'),job('one','awaiting_review'),job('two','in_progress'),job('deleted','saved',{deletedAt:now})]);
+  // Canonical job ids are ASCII; unicode in projected labels still tests canonical hashing.
+  tx.jobs=fromJSON({jobs:{one:job('one','awaiting_review',{company:'会社',notes:'PRIVATE'}),two:job('two','in_progress'),three:job('three','needs_info'),deleted:job('deleted','saved',{deletedAt:now})}});
+  tx.sessions=[fromJSON(session('three',{pendingFields:[{reference:`pending_${'a'.repeat(32)}`,state:'missing',question:'PRIVATE QUESTION'}]}))];
+  tx.history=[fromJSON({applicationId:'one',event:'reviewed',at:now,company:'PRIVATE'})];
+  const input=Object.fromEntries(['jobs','coordinator','profile','resumes','answers'].map(key=>[key,plain(tx[key])]));
+  Object.assign(input,{sessions:tx.sessions.map(plain),history:tx.history.map(plain),now});
+  const result=spawnSync(process.env.JOB_APPLY_CONTRACT_PYTHON || 'python3',['tools/contracts/workspace-projections/reference.py'],{input:JSON.stringify(input),encoding:'utf8'});
+  assert.equal(result.status,0,result.stderr);
+  const expected=JSON.parse(result.stdout);
+  assert.deepEqual(plain(await service.overview()),expected.overview);
+  assert.deepEqual(plain(await service.attention()),expected.attention);
+  assert.deepEqual(plain(await service.taskSnapshot()),expected.snapshot);
+  for (const [id,activity] of Object.entries(expected.activity)) assert.deepEqual(plain(await service.activity(id)),activity);
+});
+
+test('native fixture projections are read-only and reject corrupt persisted sessions', {timeout:60000},async()=>{
+  const fixture=await nativeFixture();
+  try {
+    const state=await nativeSetup(fixture,'projections');
+    const service=new WorkspaceProjectionsService(state.repository,()=>state.clock.now);
+    const before=await snapshot(state.root);
+    assert.equal(plain(await service.overview()).counts.jobs,2);
+    assert.deepEqual(plain(await service.attention()).items,[]);
+    assert.equal(plain(await service.preflight('job')).ready,true);
+    assert.equal(plain(await service.activity('job')).session,null);
+    assert.equal(plain(await service.taskSnapshot()).jobs.length,2);
+    assert.deepEqual(await snapshot(state.root),before);
+    await write(state.root,'sessions/job.json',{schemaVersion:1,applicationId:'job',status:'active',pendingFields:[{reference:'invalid',value:'PRIVATE'}]});
+    const corrupted=await snapshot(state.root);
+    await assert.rejects(service.activity('job'),/pending field/);
+    assert.deepEqual(await snapshot(state.root),corrupted);
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_projections_browser_support.mjs
+++ b/tests_js/workspace_native_projections_browser_support.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+
+export async function projectionsBrowser(page, {jobId, markReady}) {
+  const navigation = page.getByRole('navigation', {name:'Workspace sections'});
+  await navigation.getByRole('button', {name:'Overview',exact:true}).click();
+  await page.getByRole('heading', {name:'Your next step',exact:true}).waitFor();
+  await page.getByRole('button', {name:'Open Needs Attention',exact:true}).waitFor();
+  assert.equal(await page.getByRole('link', {name:'Edit Facts',exact:true}).count(),0);
+  await page.getByRole('button', {name:'Manage Resumes',exact:true}).click();
+  await page.getByRole('button', {name:'Import resume',exact:true}).waitFor();
+  await navigation.getByRole('button', {name:'Overview',exact:true}).click();
+  await page.getByRole('button', {name:'Open Needs Attention',exact:true}).waitFor();
+  await page.route('**/api/overview',route=>route.fulfill({status:503,contentType:'application/json',body:'{"error":{"message":"Synthetic outage"}}'}));
+  await page.getByRole('button', {name:'Refresh overview',exact:true}).click();
+  await page.getByText(/Showing the last loaded overview/).waitFor();
+  await page.unroute('**/api/overview');
+  await page.getByRole('button', {name:'Retry overview',exact:true}).click();
+  await page.getByText(/Showing the last loaded overview/).waitFor({state:'hidden'});
+  await page.getByRole('button', {name:'Open Needs Attention',exact:true}).click();
+  const attention = page.getByRole('region', {name:'Needs Attention',exact:true});
+  await attention.getByRole('button', {name:`Open job ${jobId}`,exact:true}).waitFor();
+  await attention.getByLabel('Filter by reason').selectOption('expired_agent_attempt');
+  await attention.getByText('No jobs match this reason filter.',{exact:true}).waitFor();
+  await attention.getByLabel('Filter by reason').selectOption('');
+  await attention.getByRole('button', {name:`Open job ${jobId}`,exact:true}).click();
+  const modal = page.getByRole('dialog', {name:'Edit job',exact:true});
+  await modal.waitFor();
+  const activity = modal.getByRole('region',{name:'Job activity',exact:true});
+  await activity.getByText(/Status: needs info/i).waitFor();
+  await activity.getByText(/Job restarted/i).first().waitFor();
+  assert.equal(await page.evaluate(()=>document.documentElement.scrollWidth<=innerWidth),true);
+  await page.route('**/api/jobs/*/activity',route=>route.fulfill({status:503,contentType:'application/json',body:'{}'}));
+  await activity.getByRole('button',{name:'Refresh activity',exact:true}).click();
+  await activity.getByText(/last successful snapshot for this job/).waitFor();
+  await page.unroute('**/api/jobs/*/activity');
+  await activity.getByRole('button',{name:'Refresh activity',exact:true}).click();
+  await activity.getByText(/last successful snapshot for this job/).waitFor({state:'hidden'});
+  await modal.locator('[name="notes"]').fill('Projection navigation draft');
+  page.once('dialog',dialog=>dialog.dismiss());
+  await modal.getByRole('button',{name:'Close job details',exact:true}).click();
+  assert.equal(await modal.locator('[name="notes"]').inputValue(),'Projection navigation draft');
+  page.once('dialog',dialog=>dialog.accept());
+  await modal.getByRole('button',{name:'Close job details',exact:true}).click();
+  await navigation.getByRole('button',{name:'Needs Attention',exact:true}).click();
+  await attention.getByRole('button',{name:`Open job ${jobId}`,exact:true}).waitFor();
+  await markReady();
+  await attention.getByRole('button',{name:'Refresh attention',exact:true}).click();
+  await attention.getByRole('button',{name:`Open job ${jobId}`,exact:true}).waitFor({state:'hidden'});
+  // The preceding Answers walkthrough deliberately retains another unresolved job.
+  await attention.getByRole('button',{name:'Open job pending-browser-job',exact:true}).waitFor();
+  await navigation.getByRole('button',{name:'Overview',exact:true}).click();
+  await page.getByRole('button',{name:'Open Needs Attention',exact:true}).waitFor();
+  return {overview:true,attention:true,activity:true,staleRetry:true,resolvedAttention:true};
+}

--- a/tests_js/workspace_next_security_support.mjs
+++ b/tests_js/workspace_next_security_support.mjs
@@ -19,7 +19,7 @@ export async function nextSecurity() {
                 await readFile(join(componentDirectory, name), 'utf8'));
         }
         const catalogs = ['browser-g02-next-surfaces.json', 'browser-native-answers-surfaces.json',
-            'browser-native-extractions-surfaces.json'];
+            'browser-native-extractions-surfaces.json', 'browser-native-projections-surfaces.json'];
         const surfaces = (await Promise.all(catalogs.map(async name =>
             JSON.parse(await readFile(join(root, 'config/migration', name), 'utf8')).surfaces))).flat();
         assert.deepEqual(checkBrowserBindings(discoverNextBrowserExports(components), surfaces), []);

--- a/tools/contracts/workspace-projections/reference.py
+++ b/tools/contracts/workspace-projections/reference.py
@@ -1,0 +1,35 @@
+"""Execute authoritative Python projections against synthetic in-memory documents."""
+import contextlib
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from datetime import datetime
+from types import SimpleNamespace
+
+repo = Path(__file__).resolve().parents[3]
+spec = importlib.util.spec_from_file_location("projection_contract_store", repo / "scripts/job-apply-store.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+module.exclusive_file_lock = lambda *_: contextlib.nullcontext()
+state = json.load(sys.stdin)
+store = module.Store.__new__(module.Store)
+store.initialize = lambda: None
+store._ensure_coordinator_files = lambda: None
+store.store_lock_path = Path('/synthetic/unused-lock')
+store._overview_resume_digest_cache = {}
+for name in ('jobs', 'profile', 'resumes', 'answers', 'coordinator'):
+    setattr(store, f'_load_{name}_document', lambda name=name: state[name])
+store._now_datetime = lambda: datetime.fromisoformat(state['now'].replace('Z', '+00:00'))
+sessions = {item['applicationId']: item for item in state['sessions']}
+store._session_path = lambda identity: SimpleNamespace(exists=lambda: identity in sessions)
+store._read_session_projection = lambda path, identity, ats=None: sessions[identity]
+store.read_history = lambda: state['history']
+# File observations have their own native contract; these fixtures carry no ready jobs.
+result = {
+    'overview': store.owner_beta_overview(),
+    'attention': store.list_needs_attention(),
+    'snapshot': store.task_snapshot(),
+    'activity': {identity: store.get_job_activity(identity) for identity, job in state['jobs']['jobs'].items() if job.get('deletedAt') is None},
+}
+print(json.dumps(result, ensure_ascii=False))


### PR DESCRIPTION
Native synthetic fixtures now expose Overview and Needs Attention in Companion, with selected-job Activity inside job details. Shared TypeScript services also provide authenticated reads and Python-free CLI overview, attention, activity, preflight, and coherent task snapshots. Attention opens the canonical job and removes resolved items; failed refreshes preserve explicitly stale data and drafts remain guarded.

Projections match the Python contract for supported fixture records, including ordering/signatures, expiry, current approvals, and value-free pending information. They reuse the existing Store lock/recovery path. UI guidance states unavailable claimless recovery and Applied/Closed transitions. Explicitly null attempt revisions remain valid and render as unbound sessions.

Validation: focused service/Python differential, HTTP/CLI, model, and production standalone browser checks passed. Ten normal commit suites passed. Independent correctness, tests, silent-failures, contracts/types, and docs reviews completed; one null-revision parser defect was independently validated, fixed, and re-reviewed. Native `codex review` remains unavailable because the installed CLI cannot run its configured model. All 27 deep clean-snapshot suites passed on `96416bf`. Push reuses that evidence and runs fresh native checks through the unchanged hook implementation; a per-invocation Node entrypoint preserves OLDPWD, which the shell entrypoint removes from the receipt environment. No checks are bypassed or persistent hook configuration changed. Remote [Validate Plugin](https://github.com/neonwatty/job-apply-plugin/actions/runs/34522973837) and [Release Validation](https://github.com/neonwatty/job-apply-plugin/actions/runs/34522977561) both passed on the exact head, including Windows, macOS, and the PR gate; original failed/superseded test receipts are retained.

Scope remains synthetic native v9 fixtures. Existing/live Store adoption, native writer activation, remaining job transitions, and complete Python-free package cutover are not claimed.
