### PR TITLE
Add native job transitions and owner-confirmed outcomes

### DIFF
--- a/apps/companion/components/JobTransitions.tsx
+++ b/apps/companion/components/JobTransitions.tsx
@@ -1,0 +1,108 @@
+'use client';
+import { useEffect, useId, useRef, useState } from 'react';
+import type { Client } from './client';
+import type { Job } from './contracts';
+import { closedOutcomes, transitionAcknowledgement, transitionBody, transitionConfirmation,
+  transitionFailure, transitionTargets, type TransitionTarget } from './job-transition-model';
+
+const labels: Record<TransitionTarget, string> = {
+  saved: 'Mark saved', needs_info: 'Mark needs info', ready: 'Mark ready',
+  awaiting_review: 'Mark awaiting review', applied: 'Mark applied', closed: 'Close job',
+};
+export function JobTransitions({ client, job, disabled, onBusyChanged, onChanged }: {
+  client: Client;
+  job: Job;
+  disabled: boolean;
+  onBusyChanged: (busy: boolean) => void;
+  onChanged: (job: Job) => void;
+}) {
+  const headingId = useId();
+  const [outcome, setOutcome] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [notice, setNotice] = useState('');
+  const request = useRef<AbortController | null>(null);
+  const generation = useRef(0);
+  const currentJobId = useRef(job.id);
+  const busyChanged = useRef(onBusyChanged);
+  currentJobId.current = job.id;
+  busyChanged.current = onBusyChanged;
+  useEffect(() => {
+    setOutcome('');
+    setError('');
+    setNotice('');
+    setBusy(false);
+    return () => {
+      generation.current++;
+      if (request.current) {
+        request.current.abort();
+        request.current = null;
+        busyChanged.current(false);
+      }
+    };
+  }, [job.id]);
+
+  async function transition(status: TransitionTarget) {
+    if (disabled || request.current) return;
+    let body: string;
+    try { body = transitionBody(job, status, outcome, status === 'applied'); }
+    catch (failure) { setError(transitionFailure(failure)); return; }
+    if (!window.confirm(transitionConfirmation(job, status, outcome))) return;
+    const controller = new AbortController();
+    const version = ++generation.current;
+    const base = job;
+    request.current = controller;
+    setBusy(true);
+    busyChanged.current(true);
+    setError('');
+    setNotice('');
+    const alive = () => version === generation.current && currentJobId.current === base.id && !controller.signal.aborted;
+    function release() {
+      request.current = null;
+      setBusy(false);
+      busyChanged.current(false);
+    }
+    try {
+      const raw = await client.extractionRequest(`/api/jobs/${encodeURIComponent(base.id)}/transition`, 'POST', body, controller.signal);
+      if (!alive()) return;
+      const next = transitionAcknowledgement(raw, base, status);
+      release();
+      setNotice(`Local status changed to ${status.replaceAll('_', ' ')}.`);
+      onChanged(next);
+    } catch (failure) {
+      if (!alive()) return;
+      release();
+      setError(transitionFailure(failure));
+    }
+  }
+  const targets = transitionTargets(job);
+  return <section aria-labelledby={headingId} aria-busy={busy}>
+    <h3 id={headingId}>Job status</h3>
+    <p>Current status: {job.status.replaceAll('_', ' ')}. These actions update the local record only. Final application submission stays manual.</p>
+    {targets.includes('ready') && <p>Mark ready runs preflight checks for the job, profile, and resume.</p>}
+    {job.status === 'in_progress' && <p>After an active claim is released, mark needs info to recover a job that needs more work.</p>}
+    {disabled && <p>Finish or save current work and refresh any changed values before changing status. Active claims must be released first.</p>}
+    {error && <p role="alert" className="error">{error}</p>}
+    {notice && <p role="status">{notice}</p>}
+    {busy && <p role="status">Updating local status…</p>}
+    <fieldset disabled={disabled || busy} style={{ minWidth: 0 }}>
+      <legend>Change local status</legend>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+        {targets.filter(target => target !== 'closed').map(target => <button
+          key={target} type="button" onClick={() => void transition(target)}>
+          {target === 'saved' && job.status === 'closed' ? 'Reopen as saved' : labels[target]}
+        </button>)}
+      </div>
+      {targets.includes('closed') && <div>
+        <label>Closing outcome
+          <select value={outcome} onChange={event => setOutcome(event.target.value)}>
+            <option value="">Choose an outcome</option>
+            {closedOutcomes.map(value => <option key={value} value={value}>{value.replaceAll('_', ' ')}</option>)}
+          </select>
+        </label>
+        <button type="button" disabled={!outcome} onClick={() => void transition('closed')}>Close job</button>
+      </div>}
+      {!targets.length && <p>No status changes are available.</p>}
+    </fieldset>
+  </section>;
+}

--- a/apps/companion/components/Jobs.tsx
+++ b/apps/companion/components/Jobs.tsx
@@ -6,6 +6,7 @@ import { edit, observe, openEditor, reapply, type Editor } from './job-editor-st
 import { JobEditor } from './JobEditor';
 import { Claims } from './Claims';
 import { JobActivity } from './JobActivity';
+import { JobTransitions } from './JobTransitions';
 
 export function Jobs({ client, dirtyChanged, claimsEnabled = false, requestedJobId, jobOpened, openAnswers }: {
     client: Client;
@@ -18,6 +19,7 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false, requestedJob
     const [data, setData] = useState<WorkspaceState | null>(null);
     const [editor, setEditor] = useState<Editor | null>(null);
     const [busy, setBusy] = useState(false);
+    const [transitionBusy, setTransitionBusy] = useState(false);
     const [claimsActive, setClaimsActive] = useState(false);
     const [claimsDirty, setClaimsDirty] = useState(false);
     const [loading, setLoading] = useState(true);
@@ -66,9 +68,9 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false, requestedJob
         };
     }, [client]);
     useEffect(() => {
-        dirtyChanged(Boolean(editor?.dirty.size) || busy || claimsDirty);
+        dirtyChanged(Boolean(editor?.dirty.size) || busy || transitionBusy || claimsDirty);
         return () => dirtyChanged(false);
-    }, [editor, busy, claimsDirty, dirtyChanged]);
+    }, [editor, busy, transitionBusy, claimsDirty, dirtyChanged]);
     useEffect(() => {
         if (!requestedJobId || !data || loading || loadError || claimsActive) return;
         const selected = data.jobs.find(job => job.id === requestedJobId);
@@ -78,7 +80,7 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false, requestedJob
     }, [requestedJobId, data, loading, loadError, claimsActive, jobOpened]);
 
     function open(job: Job | null) {
-        if (mutation.current || claimsActive) return;
+        if (mutation.current || transitionBusy || claimsActive) return;
         if (editor?.dirty.size && !confirm('Discard unsaved job changes?')) return;
         generation.current++;
         setError('');
@@ -86,14 +88,14 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false, requestedJob
         setEditor(openEditor(job));
     }
     function close() {
-        if (mutation.current) return;
+        if (mutation.current || transitionBusy) return;
         if (editor?.dirty.size && !confirm('Discard unsaved job changes?')) return;
         generation.current++;
         setEditor(null);
         setError('');
     }
     async function save() {
-        if (!editor || mutation.current || editor.missing || editor.latest) return;
+        if (!editor || mutation.current || transitionBusy || editor.missing || editor.latest) return;
         const current = editor;
         const version = generation.current;
         const controller = new AbortController();
@@ -151,14 +153,14 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false, requestedJob
         <header>
             <div><p className="eyebrow">Your pipeline</p><h1>Jobs</h1></div>
             <div>
-                <button disabled={busy} onClick={() => void refresh()}>Refresh</button>{' '}
-                <button className="primary" data-job-create disabled={busy || claimsActive} onClick={() => open(null)}>New job</button>
+                <button disabled={busy || transitionBusy} onClick={() => void refresh()}>Refresh</button>{' '}
+                <button className="primary" data-job-create disabled={busy || transitionBusy || claimsActive} onClick={() => open(null)}>New job</button>
             </div>
         </header>
         <p role="status">{loading ? (data ? 'Refreshing jobs…' : 'Loading jobs…') : notice}</p>
         {loadError && <p role="alert" className="error">
             {data ? 'Showing previously loaded jobs. ' : 'Jobs could not be loaded. '}{loadError}{' '}
-            <button disabled={busy} onClick={() => void refresh()}>Retry loading jobs</button>
+            <button disabled={busy || transitionBusy} onClick={() => void refresh()}>Retry loading jobs</button>
         </p>}
         {!editor && error && <p role="alert" className="error">{error}</p>}
         <div className="filters">
@@ -170,7 +172,7 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false, requestedJob
             </select></label>
         </div>
         <div className="job-list">
-            {jobs.map(job => <button className="job-card" disabled={busy || claimsActive} key={job.id} onClick={() => open(job)}>
+            {jobs.map(job => <button className="job-card" disabled={busy || transitionBusy || claimsActive} key={job.id} onClick={() => open(job)}>
                 <strong>{String(job.role || job.url)}</strong>
                 <span>{String(job.company || '')} · {String(job.location || '')}</span>
                 <small>{job.status.replaceAll('_', ' ')} · revision {job.revision}</small>
@@ -179,9 +181,9 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false, requestedJob
         {data && !loading && !loadError && !jobs.length && (allJobs.length
             ? <p>No jobs match these filters. <button onClick={() => { setQuery(''); setStatus(''); }}>Clear filters</button></p>
             : <p>No jobs yet. Capture a job to get started.</p>)}
-        {claimsEnabled && <Claims client={client} jobs={allJobs} disabled={busy || loading || Boolean(editor?.dirty.size)}
+        {claimsEnabled && <Claims client={client} jobs={allJobs} disabled={busy || transitionBusy || loading || Boolean(editor?.dirty.size)}
             activityChanged={setClaimsActive} navigationChanged={setClaimsDirty} changed={() => { void refresh(); }} />}
-        {editor && <JobEditor editor={editor} resumes={data?.resumes ?? []} busy={busy || claimsActive} error={error}
+        {editor && <JobEditor editor={editor} resumes={data?.resumes ?? []} busy={busy || transitionBusy || claimsActive} error={error}
             change={(fields: Partial<JobFields>) => setEditor(current => current ? edit(current, fields) : current)}
             close={close} save={() => void save()}
             refresh={() => {
@@ -199,6 +201,15 @@ export function Jobs({ client, dirtyChanged, claimsEnabled = false, requestedJob
                     setError('');
                 }
             }} >
+            {claimsEnabled && editor.selected && <JobTransitions client={client} job={editor.selected}
+                disabled={busy || loading || claimsActive || Boolean(editor.dirty.size) || Boolean(editor.latest) || editor.missing}
+                onBusyChanged={setTransitionBusy} onChanged={job => {
+                    // The write is acknowledged: replace the clean editor before a background read.
+                    refreshRequest.current?.abort(); listGeneration.current++;
+                    setData(current => current ? {...current,jobs:current.jobs.map(item=>item.id===job.id?job:item)} : current);
+                    setEditor(openEditor(job)); setError('');
+                    void refresh();
+                }} />}
             {claimsEnabled && editor.selected && <JobActivity client={client} jobId={editor.selected.id}
                 refreshKey={editor.selected.revision} openAnswers={openAnswers} />}
         </JobEditor>}

--- a/apps/companion/components/job-transition-model.ts
+++ b/apps/companion/components/job-transition-model.ts
@@ -1,0 +1,47 @@
+import { job as decodeJob, type Job } from './contracts';
+
+export type TransitionTarget = 'saved' | 'needs_info' | 'ready' | 'awaiting_review' | 'applied' | 'closed';
+export const closedOutcomes = ['rejected', 'withdrawn', 'expired', 'duplicate', 'not_interested'] as const;
+const transitions: Record<string, TransitionTarget[]> = {
+  saved: ['needs_info', 'ready', 'closed'],
+  needs_info: ['saved', 'ready', 'closed'],
+  ready: ['saved', 'needs_info', 'closed'],
+  in_progress: ['needs_info', 'awaiting_review', 'closed'],
+  awaiting_review: ['applied', 'closed'],
+  applied: ['closed'],
+  closed: ['saved'],
+};
+export function transitionTargets(job: Job): TransitionTarget[] {
+  return job.deletedAt != null || !Object.hasOwn(transitions, job.status) ? [] : [...transitions[job.status]!];
+}
+export function transitionBody(job: Job, status: string, closedOutcome = '', userConfirmed = false): string {
+  if (!job.id) throw Error('The job identity is missing.');
+  if (!Number.isSafeInteger(job.revision) || job.revision < 1) throw Error('The job revision is invalid.');
+  if (!transitionTargets(job).includes(status as TransitionTarget)) throw Error('This status transition is unavailable.');
+  if (status === 'applied' && userConfirmed !== true) throw Error('Confirm that you personally submitted this application.');
+  if (status === 'closed' && !closedOutcomes.some(value => value === closedOutcome)) throw Error('Choose a closing outcome.');
+  return JSON.stringify({ status, expectedRevision: job.revision,
+    ...(status === 'closed' ? { closedOutcome } : {}),
+    ...(status === 'applied' ? { userConfirmed: true } : {}),
+  });
+}
+export function transitionConfirmation(job: Job, status: TransitionTarget, closedOutcome = ''): string {
+  const local = 'This changes local status only and never submits an application to an employer.';
+  if (status === 'applied') return `I confirm that I personally submitted this application. Mark it as applied? ${local}`;
+  if (status === 'closed') return `Close this job as ${closedOutcome.replaceAll('_', ' ')}? ${local}`;
+  if (status === 'ready') return `Mark this job ready? The workspace will run preflight checks first. ${local}`;
+  if (status === 'saved' && job.status === 'closed') return `Reopen this job as saved? ${local}`;
+  return `Change this job to ${status.replaceAll('_', ' ')}? ${local}`;
+}
+export function transitionAcknowledgement(raw: string, previous: Job, status: TransitionTarget): Job {
+  const next = decodeJob(JSON.parse(raw));
+  if (next.id !== previous.id || next.status !== status || next.revision <= previous.revision)
+    throw Error('The transition response did not acknowledge the requested job change.');
+  return next;
+}
+export function transitionFailure(failure: unknown): string {
+  const conflict = typeof failure === 'object' && failure !== null && 'status' in failure && failure.status === 409;
+  const detail = conflict ? 'This job changed or has an active claim.'
+    : failure instanceof Error ? failure.message : 'The status change was not acknowledged.';
+  return `${detail} Refresh latest values and review the current status before trying again. Your closing outcome choice is retained.`;
+}

--- a/apps/companion/components/projection-model.ts
+++ b/apps/companion/components/projection-model.ts
@@ -7,11 +7,11 @@ export const attentionReasons = {
 export type AttentionReason = keyof typeof attentionReasons;
 export const recoveryGuidance = {
   expired: 'Resume this attempt using the supported CLI claim-recover command for this job.',
-  interrupted: 'This attempt was interrupted without an active claim. Recovery for this state is not available in the native workspace yet.',
+  interrupted: 'Open Job details and change this interrupted attempt to Needs information, then resolve it before starting a new attempt.',
 };
 export const attentionGuidance: Record<AttentionReason, string> = {
   expired_agent_attempt: recoveryGuidance.expired, claimless_interrupted_attempt: recoveryGuidance.interrupted,
-  awaiting_human_review: 'Open Job details and personally review and submit on the third-party site. Recording Applied or Closed in the native workspace is deferred.',
+  awaiting_human_review: 'Personally review and submit on the third-party site, then confirm Applied in Job details. You can also close the job with an outcome.',
   browser_action_required: 'Continue in the visible browser. Saved information is already known; do not create or re-enter an answer in Companion.',
   needs_information: 'Open Job details and resolve missing facts, resume, or answers. Run preflight, then mark the job Ready.',
 };

--- a/config/migration/browser-native-job-transitions-surfaces.json
+++ b/config/migration/browser-native-job-transitions-surfaces.json
@@ -1,0 +1,159 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "browser:apps/companion/components/JobTransitions.tsx:JobTransitions",
+      "kind": "browser",
+      "export": "JobTransitions",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/JobTransitions.tsx"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/job-transition-model.ts:closedOutcomes",
+      "kind": "browser",
+      "export": "closedOutcomes",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/job-transition-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/job-transition-model.ts:transitionTargets",
+      "kind": "browser",
+      "export": "transitionTargets",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/job-transition-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/job-transition-model.ts:transitionBody",
+      "kind": "browser",
+      "export": "transitionBody",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/job-transition-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/job-transition-model.ts:transitionConfirmation",
+      "kind": "browser",
+      "export": "transitionConfirmation",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/job-transition-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/job-transition-model.ts:transitionAcknowledgement",
+      "kind": "browser",
+      "export": "transitionAcknowledgement",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/job-transition-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/job-transition-model.ts:transitionFailure",
+      "kind": "browser",
+      "export": "transitionFailure",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/job-transition-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/cli-native-job-transitions-surfaces.json
+++ b/config/migration/cli-native-job-transitions-surfaces.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:job-transition",
+      "kind": "cli",
+      "command": "job-transition",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-job-transitions.ts",
+        "src/workspace-core/job-transitions.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/http-write-jobs-surfaces.json
+++ b/config/migration/http-write-jobs-surfaces.json
@@ -160,7 +160,11 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/job-transitions-http.ts",
+        "src/workspace-core/job-transitions.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -46,6 +46,10 @@
       "sha256": "ac960232d6b5234f38fab48d567eabf436f72e291def557f9f52ab53cedee658"
     },
     {
+      "path": "browser-native-job-transitions-surfaces.json",
+      "sha256": "2afb9c0150aad10440a77dea64415886b478a1c83060fad8ac694c23f73a2f4b"
+    },
+    {
       "path": "browser-native-projections-surfaces.json",
       "sha256": "8d0522433ddaa7e6efaad2d80a50b994b20e767ee5ae75b94f3d59353c4eb820"
     },
@@ -96,6 +100,10 @@
     {
       "path": "cli-native-facts-surfaces.json",
       "sha256": "b9710c5943613cea49bf1742e5aea7570220f3ef2db45e956ea4576adcbae223"
+    },
+    {
+      "path": "cli-native-job-transitions-surfaces.json",
+      "sha256": "3310d133626397a57545af50e70591523b906036cdf4a0d04884e4a1630f1c3b"
     },
     {
       "path": "cli-native-jobs-surfaces.json",
@@ -167,7 +175,7 @@
     },
     {
       "path": "http-write-jobs-surfaces.json",
-      "sha256": "ffa938ec3fc4ccf77d344b88b497c4766c1ac1165d78befe3f2fc2cb2fbbceb9"
+      "sha256": "86b63f3fbe0dc1ae2a75a3897b6debb14392d04a063dd6201916c01281c5ed77"
     },
     {
       "path": "http-write-profile-surfaces.json",
@@ -259,7 +267,7 @@
     },
     {
       "path": "source-catalog-g02-next.json",
-      "sha256": "2877d59f50b3b70a2001d75ff5b79bf30a3baa94837a12a71451e1b7500ef093"
+      "sha256": "3fa963521183a55ab54bbd404e5b7ae794fe7c386a5ca63aeb585a2ad109b208"
     },
     {
       "path": "source-catalog-m01.json",
@@ -298,8 +306,12 @@
       "sha256": "8a41ab419b7b46311658f0ec43e970c7cda36f6322aa8dba415c41ae9e6e6424"
     },
     {
+      "path": "source-catalog-native-job-transitions.json",
+      "sha256": "d3586b035af22d3f4b4fa3ba3aa7d9e1bc781632317005aff9d158ac78625772"
+    },
+    {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "6783f12f7d886afd6d2779b26b0233209dcb7d8dc770a99b8bab248fd0dedf90"
+      "sha256": "38ef913d3e0ed7235a3ff4e81091f7e750e09fb68be7a39be4f51b85d0dec223"
     },
     {
       "path": "source-catalog-native-pending-answers.json",
@@ -307,7 +319,7 @@
     },
     {
       "path": "source-catalog-native-projections.json",
-      "sha256": "6c6261242acc2c2d5197faf70c08c0cd8bda903701f0a80f19bdc783d05a712e"
+      "sha256": "9547436e8a2bdb0556915f4e87687aa65f3bee908312b3f461301476e9bcc421"
     },
     {
       "path": "source-catalog-native-resumes.json",

--- a/config/migration/source-catalog-g02-next.json
+++ b/config/migration/source-catalog-g02-next.json
@@ -23,7 +23,7 @@
     },
     {
       "path": "apps/companion/components/Jobs.tsx",
-      "sha256": "620ac39dfe6d3e3df1aa59d87d9560d4d065d2fd762f371a95c49ad10cc27ae7",
+      "sha256": "3cccc86444ca50ee2c2a1fe698e0c8512fc3132047f7f53ae34f7818855729ce",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-job-transitions.json
+++ b/config/migration/source-catalog-native-job-transitions.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "apps/companion/components/JobTransitions.tsx",
+      "sha256": "a92cd352404b526caaba390f4ea5168d1dccec65fc518b17ae4ac2da292fe4b5",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/job-transition-model.ts",
+      "sha256": "3e85e19c6785a72756fc7d9571cae58419b662b3a0e0daedff2d97d412bd89c6",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/cli/native-job-transitions.js",
+      "sha256": "831fa09b8cc4feb57afbe5796bb2a48384327e950a961e50182163d65097e50f",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/job-transitions-http.js",
+      "sha256": "193aa062eea6b58926438a432b332c1a952604607322a0cb75fdf433e40ee845",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/job-transitions.js",
+      "sha256": "8bcea6077ecdb78385aac0d2b7aa1eec04e844e08f9a70bc64ee90014bb64b90",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-job-transitions.ts",
+      "sha256": "ee364a4ba72e77d93ce6de2daf4777003b245df42a0e9b667699d03ff94921d7",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/job-transitions-http.ts",
+      "sha256": "7f160ce64292b04b0a3fb5f281282657c8467ca6cb8dd21c041bfddcbca0c447",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/job-transitions.ts",
+      "sha256": "9ce8713117a83ba45225c1eaad2f8601b9c0dca4a434a2d3ce05884f441a92dc",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "814980f90ae506302ab2b2a2521c183dfd8ba06c43e9d41c61c0ce6d987bfdd9",
+      "sha256": "18f4d9122cbb3cc62c4cc8db2fab67bd54ec921a660eda16620c7119a5a7d262",
       "classification": "unreviewed"
     },
     {
@@ -43,7 +43,7 @@
     },
     {
       "path": "runtime/workspace-core/jobs-http.js",
-      "sha256": "e662801c1d86f7c40827ddf8cd8b36a32e3aa39e2707fe55c7ba83761af2bd1b",
+      "sha256": "92cc141f2e6f02dfd465c175a42e7c1a455f98c71c46fdf78506f5a05d5488ad",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "d8554000f26b76fe03656286a81652c66250a274adf7eaa4334c3bf6ac927e1e",
+      "sha256": "f93c2b682e9829eaa65783bf05710cf54b29460c6b3ad53245f9a60e9ea5b9f9",
       "classification": "unreviewed"
     },
     {
@@ -93,7 +93,7 @@
     },
     {
       "path": "src/workspace-core/jobs-http.ts",
-      "sha256": "bc891981865ad77970ad5682ea20cd078946d5668dce7ee427f10ed2c82abac4",
+      "sha256": "eb9b07e63b780c53ddd3aec8321dcfff670e11707bc1b132f46c7ea3429ffcd2",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-projections.json
+++ b/config/migration/source-catalog-native-projections.json
@@ -13,7 +13,7 @@
     },
     {
       "path": "apps/companion/components/projection-model.ts",
-      "sha256": "172fc6f45027f193144b4086fd241867ce52d51380060ef18ca78eab7fc0e102",
+      "sha256": "01553c51666fdae1e8bb1bf8d7db6ad35cf6bc676d9b2c0673d663bff845ffaf",
       "classification": "unreviewed"
     },
     {

--- a/docs/native-claims-fixture.md
+++ b/docs/native-claims-fixture.md
@@ -58,8 +58,13 @@ writing documents, repairs an interrupted final history append and avoids duplic
 events and revision increments. All domain entry points recover pending journals.
 
 Ordinary edits cannot change a claimed job; unrelated jobs remain editable.
+[Ordinary job transitions](native-job-transitions-fixture.md) also reject a claim
+on that job, including an expired claim and same-status requests. They support
+claimless interruption recovery, owner-confirmed Applied status, closing outcomes
+and reopening without modifying sessions or application history.
 Answer merge and pending-answer resolution require an idle coordinator, including
 when they concern a different job. Complete the handoff first. A legacy session
 with no review envelope can be rebuilt once, only with complete final-review
-evidence and reviewed history; a partial or null envelope is rejected. Broader
-attention projections and live Store activation remain separate work.
+evidence and reviewed history; a partial or null envelope is rejected.
+[Native projections](native-projections-fixture.md) provide Overview, Needs Attention
+and Activity in the synthetic fixture. Live Store activation remains separate work.

--- a/docs/native-job-transitions-fixture.md
+++ b/docs/native-job-transitions-fixture.md
@@ -1,0 +1,57 @@
+# Native job transitions
+
+New v9 synthetic fixtures support ordinary job status transitions through the shared TypeScript service, authenticated HTTP adapter, native CLI and Companion Jobs dialog. Use the setup in [the native claims guide](native-claims-fixture.md). Existing fixtures and live Stores are not adopted or upgraded, and the native path never falls back to Python.
+
+## Status changes and safeguards
+
+`JobTransitionsService.transition(id, status, expectedRevision, closedOutcome = null, userConfirmed = false)` requires a positive `bigint` revision and a boolean confirmation. Under the Store lock it checks that the job exists and is not deleted, compares its exact revision, and rejects a claim on that job before considering a same-status no-op. An expired claim still blocks ordinary transitions. A claim on an unrelated job does not block them.
+
+These are the supported changes for an unclaimed job:
+
+| Current status | Ordinary transition targets |
+| --- | --- |
+| `saved` | `needs_info`, `ready`, `closed` |
+| `needs_info` | `saved`, `ready`, `closed` |
+| `ready` | `saved`, `needs_info`, `closed` |
+| `in_progress` | `needs_info`, `awaiting_review`, `closed` |
+| `awaiting_review` | `applied`, `closed` |
+| `applied` | `closed` |
+| `closed` | `saved` |
+
+A same-status request with the current revision returns the current record without writing, including an unclaimed `in_progress` record. Entering `in_progress` requires atomic acquisition or the reviewed-restart workflow; it cannot be done with an ordinary transition.
+
+Entering `ready` runs profile and resume preflight under the same lock. Missing profile facts, missing resumes/files, or changed managed resume content prevent readiness. A same-status `ready` no-op does not rerun preflight. Entering `applied` requires explicit user confirmation. Entering `closed` requires one of `rejected`, `withdrawn`, `expired`, `duplicate` or `not_interested`. Every transition to an open status clears the closing outcome.
+
+## CLI and HTTP
+
+Use the native fixture root and lock artifact:
+
+```sh
+node runtime/cli/native-jobs.js --root /absolute/synthetic/root --native-lock /absolute/posix-lock.node job-transition --id example-job --status needs_info --expected-revision 3
+node runtime/cli/native-jobs.js --root /absolute/synthetic/root --native-lock /absolute/posix-lock.node job-transition --id example-job --status applied --expected-revision 4 --user-confirmed
+node runtime/cli/native-jobs.js --root /absolute/synthetic/root --native-lock /absolute/posix-lock.node job-transition --id example-job --status closed --expected-revision 5 --closed-outcome withdrawn
+```
+
+The examples illustrate independent operations; the source status must allow the requested target. `--user-confirmed` is a flag, not a string value. Always use the latest job revision.
+
+Authenticated `POST /api/jobs/{id}/transition` accepts a JSON object with required `status` and positive integer `expectedRevision`, plus optional string-or-null `closedOutcome` and boolean `userConfirmed`. Unknown fields are rejected. For example, an owner who has personally submitted an awaiting-review application can send:
+
+```json
+{"status":"applied","expectedRevision":4,"userConfirmed":true}
+```
+
+Success returns HTTP 200 and the full updated job record, or the unchanged record for a valid no-op. CLI and HTTP share the same service. Service/CLI revisions remain exact beyond JavaScript's safe integer range; Companion rejects revisions it cannot represent safely.
+
+## Companion and recovery
+
+The selected Jobs dialog offers targets for the current status, requests confirmation for every action, and requires an explicit choice before closing. The Applied confirmation states that the owner personally submitted the application. Errors retain the closing outcome choice and ask the owner to refresh and review current state. Controls remain busy through the write; a response must acknowledge the requested job and status before the dialog accepts it.
+
+For a claimless interrupted `in_progress` job, transition to `needs_info` to return it for owner input; it can subsequently become ready and be acquired again. An expired claim instead requires explicit same-job recovery through [application controls](native-claims-fixture.md). Reopening a closed job sets it to `saved` and clears its outcome. Restarting an awaiting-review application uses reviewed restart and requires confirmation that it was not submitted, intact review evidence and current managed resume readiness.
+
+## Persistence, verification and remaining work
+
+A successful change atomically replaces only `jobs.json`, increments the job revision once, and updates the job and document metadata timestamps. It does not write a session, append application history, rotate credentials or create a coordinator journal. Reopening and ordinary transitions preserve existing session/history evidence; they do not certify fresh form readiness. Pending native journals are recovered before the transaction, so recovery can independently repair prior interrupted work.
+
+The synthetic test suite compares all status pairs and scalar outcomes with actual Python behavior, plus preflight, stale revisions, no-ops and claim guards. Native tests cover strict direct-call inputs, large exact revisions, unchanged bytes on denial, concurrent writers and injected write/fsync/replace failures. Array/object outcomes are rejected through native validation rather than reproducing Python's raw unhashable-value error.
+
+Trash, restore, permanent deletion, intake/upsert and legacy job import remain outside this transition fixture. Final submission on employer sites remains human-only. Live Store adoption, native writer activation and final Python-free package cutover remain separate milestones.

--- a/docs/native-jobs-fixture.md
+++ b/docs/native-jobs-fixture.md
@@ -9,8 +9,9 @@ including URL deduplication, revisions and human/agent provenance. Resume
 selection validates the shared registry. Managed resume import, list, get,
 metadata update, file replacement, legacy adoption, default selection, integrity
 check, content read and resolution are available through the same Store lock.
-Facts/profile operations and [active claims](native-claims-fixture.md) are also
-available. Other
+Facts/profile operations, [active claims](native-claims-fixture.md),
+[workspace projections](native-projections-fixture.md), and
+[job status transitions](native-job-transitions-fixture.md) are also available. Other
 workflows return `unsupported_native_workflow`; they never fall back to Python.
 
 ## Run against a new synthetic root

--- a/docs/native-projections-fixture.md
+++ b/docs/native-projections-fixture.md
@@ -24,6 +24,6 @@ The response contracts preserve Python behavior for native-supported records. Ex
 
 ## Remaining work
 
-Expired claims can be recovered explicitly through native application controls. Claimless interruption recovery, recording Applied/Closed outcomes, lifecycle/Trash, and the remaining application transitions are not available in this native fixture yet. The UI states these limits. API guidance retains the existing Python contract; compatibility command names are not authorization to run Python against a native fixture.
+Expired claims can be recovered explicitly through native application controls. [Native job transitions](native-job-transitions-fixture.md) now support claimless interruption recovery, owner-confirmed Applied status, Closed outcomes and reopening. Trash, restore, permanent deletion, intake/upsert and legacy job import remain unavailable. API guidance retains the existing Python contract; compatibility command names are not authorization to run Python against a native fixture.
 
 Final submission on third-party sites remains human-only. Live Store adoption, native writer activation, and final Python-free package cutover remain separate milestones.

--- a/runtime/cli/native-job-transitions.js
+++ b/runtime/cli/native-job-transitions.js
@@ -1,0 +1,17 @@
+import { JobTransitionsService } from '../workspace-core/job-transitions.js';
+import { text, JobsError } from '../contracts/workspace/values.js';
+export const jobTransitionCommands = {
+    'job-transition': ['--id', '--status', '--expected-revision', '--closed-outcome', '--user-confirmed'],
+};
+export function runJobTransitionCommand(repository, options) {
+    const required = (key) => {
+        const value = options.get(key);
+        if (!value)
+            throw new JobsError(`required option: ${key}`);
+        return value;
+    };
+    const revision = required('--expected-revision');
+    if (!/^[+-]?[0-9]+$/.test(revision) || BigInt(revision) < 1n)
+        throw new JobsError('expected revision must be a positive integer');
+    return new JobTransitionsService(repository).transition(required('--id'), required('--status'), BigInt(revision), options.has('--closed-outcome') ? text(options.get('--closed-outcome')) : null, options.has('--user-confirmed'));
+}

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,4 +1,5 @@
 import { claimCommands, runClaimCommand } from './native-claims.js';
+import { jobTransitionCommands, runJobTransitionCommand } from './native-job-transitions.js';
 import { projectionCommands, runProjectionCommand } from './native-projections.js';
 import { pendingAnswerCommands, runPendingAnswerCommand } from './native-pending-answers.js';
 import { profileCommands, runProfileCommand } from "./native-profile.js";
@@ -27,7 +28,7 @@ export async function runJobsCli(args, input) {
         else {
             if (options.has(key))
                 throw new JobsError("duplicate CLI option");
-            if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses", "--summary-only", "--owner-confirmed", "--owner-confirmed-not-submitted"].includes(key))
+            if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses", "--summary-only", "--owner-confirmed", "--owner-confirmed-not-submitted", "--user-confirmed"].includes(key))
                 options.set(key, "true");
             else {
                 const value = args[++index];
@@ -38,6 +39,7 @@ export async function runJobsCli(args, input) {
         }
     }
     const fields = {
+        ...jobTransitionCommands,
         ...projectionCommands,
         ...claimCommands,
         ...pendingAnswerCommands,
@@ -77,6 +79,8 @@ export async function runJobsCli(args, input) {
         const limit = ["resume-proposal-create", "resume-extraction-request-complete"].includes(command) ? 2 * 1024 * 1024 : 65536;
         return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
     };
+    if (Object.hasOwn(jobTransitionCommands, command))
+        return serialize(await runJobTransitionCommand(repository, options));
     if (Object.hasOwn(projectionCommands, command))
         return serialize(await runProjectionCommand(command, repository, options));
     if (Object.hasOwn(claimCommands, command))

--- a/runtime/workspace-core/job-transitions-http.js
+++ b/runtime/workspace-core/job-transitions-http.js
@@ -1,0 +1,24 @@
+import { JobTransitionsService } from './job-transitions.js';
+import { get, has, int, keys, object, parse, serialize, string, JobsError } from '../contracts/workspace/values.js';
+export async function jobTransitionsHttp(repository, method, path, body) {
+    const match = /^\/api\/jobs\/([^/]+)\/transition$/.exec(path);
+    if (method !== 'POST' || !match)
+        return null;
+    const payload = object(parse(body), 'transition body');
+    const allowed = ['status', 'expectedRevision', 'closedOutcome', 'userConfirmed'];
+    if (!has(payload, 'status') || !has(payload, 'expectedRevision') || keys(payload).some(key => !allowed.includes(key)))
+        throw new JobsError('transition body is invalid');
+    const status = string(get(payload, 'status'));
+    if (status === null)
+        throw new JobsError('transition status must be a string');
+    const outcome = get(payload, 'closedOutcome');
+    if (outcome !== null && string(outcome) === null)
+        throw new JobsError('closedOutcome must be a string or null');
+    if (has(payload, 'userConfirmed') && typeof get(payload, 'userConfirmed') !== 'boolean')
+        throw new JobsError('userConfirmed must be a boolean');
+    const revision = int(get(payload, 'expectedRevision'));
+    if (revision === null || revision < 1n)
+        throw new JobsError('expectedRevision must be a positive integer');
+    const result = await new JobTransitionsService(repository).transition(decodeURIComponent(match[1]), status, revision, outcome, get(payload, 'userConfirmed') === true);
+    return { status: 200, body: serialize(result) };
+}

--- a/runtime/workspace-core/job-transitions.js
+++ b/runtime/workspace-core/job-transitions.js
@@ -1,0 +1,63 @@
+import { requireJobUnclaimed } from '../contracts/workspace/claims.js';
+import { safeId, statuses, validateJob } from '../contracts/workspace/jobs.js';
+import { copy, get, int, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { preflightJobRecord } from './job-preflight.js';
+const transitions = {
+    saved: ['needs_info', 'ready', 'closed'],
+    needs_info: ['saved', 'ready', 'in_progress', 'closed'],
+    ready: ['saved', 'needs_info', 'in_progress', 'closed'],
+    in_progress: ['needs_info', 'awaiting_review', 'closed'],
+    awaiting_review: ['in_progress', 'applied', 'closed'],
+    applied: ['closed'],
+    closed: ['saved'],
+};
+export class JobTransitionsService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    async transition(id, status, expectedRevision, closedOutcome = null, userConfirmed = false) {
+        safeId(id);
+        if (!statuses.has(status))
+            throw new JobsError('job status is unsupported');
+        if (typeof expectedRevision !== 'bigint' || expectedRevision < 1n)
+            throw new JobsError('job revision is invalid');
+        if (typeof userConfirmed !== 'boolean')
+            throw new JobsError('user confirmation must be a boolean');
+        return this.repository.claimTransaction(async (tx) => {
+            const jobs = object(get(tx.jobs, 'jobs'), 'jobs.jobs');
+            const value = get(jobs, id);
+            if (value === null || get(object(value, 'job record'), 'deletedAt') !== null) {
+                throw new JobsError('job does not exist');
+            }
+            const current = object(value, 'job record');
+            if (int(get(current, 'revision')) !== expectedRevision)
+                throw new JobsError('job revision conflict');
+            requireJobUnclaimed(tx.coordinator, id);
+            const source = string(get(current, 'status'));
+            if (status === source)
+                return current;
+            if (!transitions[source].includes(status))
+                throw new JobsError('job status transition is unsupported');
+            if (status === 'in_progress')
+                throw new JobsError('in_progress requires atomic job-acquire');
+            if (status === 'applied' && !userConfirmed)
+                throw new JobsError('applied status requires explicit user confirmation');
+            if (status === 'ready' && get(await preflightJobRecord(current, tx.profile, tx.resumes, tx.files), 'ready') !== true) {
+                throw new JobsError('job is not ready');
+            }
+            const updated = copy(current);
+            set(updated, 'status', text(status));
+            set(updated, 'closedOutcome', status === 'closed' ? closedOutcome : null);
+            set(updated, 'revision', integer(expectedRevision + 1n));
+            set(updated, 'updatedAt', text(this.now()));
+            validateJob(id, updated);
+            set(jobs, id, updated);
+            set(object(get(tx.jobs, 'metadata'), 'jobs.metadata'), 'updatedAt', get(updated, 'updatedAt'));
+            await tx.saveJobs(tx.jobs);
+            return updated;
+        });
+    }
+}

--- a/runtime/workspace-core/jobs-http.js
+++ b/runtime/workspace-core/jobs-http.js
@@ -1,4 +1,5 @@
 import { claimsHttp } from './claims-http.js';
+import { jobTransitionsHttp } from './job-transitions-http.js';
 import { workspaceProjectionsHttp } from './workspace-projections-http.js';
 import { pendingAnswersHttp } from './pending-answers-http.js';
 import { profileHttp } from "./profile-http.js";
@@ -16,6 +17,9 @@ const envelope = (key, value) => set(emptyObject(), key, value);
 /** Transport-independent dispatch. Host/token/Origin/body bounds belong to the adapter. */
 export async function jobsHttp(service, repository, method, path, body = "") {
     try {
+        const transition = await jobTransitionsHttp(repository, method, path, body);
+        if (transition)
+            return transition;
         const projection = await workspaceProjectionsHttp(repository, method, path);
         if (projection)
             return projection;

--- a/src/cli/native-job-transitions.ts
+++ b/src/cli/native-job-transitions.ts
@@ -1,0 +1,18 @@
+import { JobTransitionsService } from '../workspace-core/job-transitions.js';
+import type { ClaimRepository } from '../workspace-core/claims.js';
+import { text, JobsError } from '../contracts/workspace/values.js';
+
+export const jobTransitionCommands:Record<string,string[]>={
+  'job-transition':['--id','--status','--expected-revision','--closed-outcome','--user-confirmed'],
+};
+export function runJobTransitionCommand(repository:ClaimRepository,options:Map<string,string>) {
+  const required=(key:string):string=>{
+    const value=options.get(key);
+    if(!value)throw new JobsError(`required option: ${key}`);
+    return value;
+  };
+  const revision=required('--expected-revision');
+  if(!/^[+-]?[0-9]+$/.test(revision)||BigInt(revision)<1n)throw new JobsError('expected revision must be a positive integer');
+  return new JobTransitionsService(repository).transition(required('--id'),required('--status'),BigInt(revision),
+    options.has('--closed-outcome')?text(options.get('--closed-outcome')!):null,options.has('--user-confirmed'));
+}

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,4 +1,5 @@
 import { claimCommands, runClaimCommand } from './native-claims.js';
+import { jobTransitionCommands, runJobTransitionCommand } from './native-job-transitions.js';
 import { projectionCommands, runProjectionCommand } from './native-projections.js';
 import { pendingAnswerCommands, runPendingAnswerCommand } from './native-pending-answers.js';
 import { profileCommands, runProfileCommand } from "./native-profile.js";
@@ -25,7 +26,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
       command = key;
     } else {
       if (options.has(key)) throw new JobsError("duplicate CLI option");
-      if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses", "--summary-only", "--owner-confirmed", "--owner-confirmed-not-submitted"].includes(key)) options.set(key, "true");
+      if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses", "--summary-only", "--owner-confirmed", "--owner-confirmed-not-submitted", "--user-confirmed"].includes(key)) options.set(key, "true");
       else {
         const value = args[++index];
         if (!value || value.startsWith("--")) throw new JobsError("missing CLI option value");
@@ -34,6 +35,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     }
   }
   const fields: Record<string, string[]> = {
+    ...jobTransitionCommands,
     ...projectionCommands,
     ...claimCommands,
     ...pendingAnswerCommands,
@@ -69,6 +71,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     const limit = ["resume-proposal-create", "resume-extraction-request-complete"].includes(command!) ? 2 * 1024 * 1024 : 65536;
     return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
   };
+  if (Object.hasOwn(jobTransitionCommands, command!)) return serialize(await runJobTransitionCommand(repository, options));
   if (Object.hasOwn(projectionCommands, command!)) return serialize(await runProjectionCommand(command!, repository, options));
   if (Object.hasOwn(claimCommands, command!)) return serialize(await runClaimCommand(command!,repository,options,payload));
   if (Object.hasOwn(pendingAnswerCommands, command!)) return serialize(await runPendingAnswerCommand(command!, repository, options));

--- a/src/workspace-core/job-transitions-http.ts
+++ b/src/workspace-core/job-transitions-http.ts
@@ -1,0 +1,20 @@
+import { JobTransitionsService } from './job-transitions.js';
+import type { ClaimRepository } from './claims.js';
+import { get, has, int, keys, object, parse, serialize, string, JobsError } from '../contracts/workspace/values.js';
+
+export async function jobTransitionsHttp(repository:ClaimRepository,method:string,path:string,body:string):Promise<{status:number;body:string}|null> {
+  const match=/^\/api\/jobs\/([^/]+)\/transition$/.exec(path);
+  if(method!=='POST'||!match)return null;
+  const payload=object(parse(body),'transition body');
+  const allowed=['status','expectedRevision','closedOutcome','userConfirmed'];
+  if(!has(payload,'status')||!has(payload,'expectedRevision')||keys(payload).some(key=>!allowed.includes(key)))throw new JobsError('transition body is invalid');
+  const status=string(get(payload,'status'));
+  if(status===null)throw new JobsError('transition status must be a string');
+  const outcome=get(payload,'closedOutcome');
+  if(outcome!==null&&string(outcome)===null)throw new JobsError('closedOutcome must be a string or null');
+  if(has(payload,'userConfirmed')&&typeof get(payload,'userConfirmed')!=='boolean')throw new JobsError('userConfirmed must be a boolean');
+  const revision=int(get(payload,'expectedRevision'));
+  if(revision===null||revision<1n)throw new JobsError('expectedRevision must be a positive integer');
+  const result=await new JobTransitionsService(repository).transition(decodeURIComponent(match[1]!),status,revision,outcome,get(payload,'userConfirmed')===true);
+  return {status:200,body:serialize(result)};
+}

--- a/src/workspace-core/job-transitions.ts
+++ b/src/workspace-core/job-transitions.ts
@@ -1,0 +1,57 @@
+import { requireJobUnclaimed } from '../contracts/workspace/claims.js';
+import { safeId, statuses, validateJob } from '../contracts/workspace/jobs.js';
+import { copy, get, int, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Value } from '../contracts/workspace/values.js';
+import type { ClaimRepository } from './claims.js';
+import { preflightJobRecord } from './job-preflight.js';
+
+const transitions: Readonly<Record<string, readonly string[]>> = {
+  saved: ['needs_info', 'ready', 'closed'],
+  needs_info: ['saved', 'ready', 'in_progress', 'closed'],
+  ready: ['saved', 'needs_info', 'in_progress', 'closed'],
+  in_progress: ['needs_info', 'awaiting_review', 'closed'],
+  awaiting_review: ['in_progress', 'applied', 'closed'],
+  applied: ['closed'],
+  closed: ['saved'],
+};
+
+export class JobTransitionsService {
+  constructor(private readonly repository: ClaimRepository,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+
+  async transition(id: string, status: string, expectedRevision: bigint,
+    closedOutcome: Value = null, userConfirmed: boolean = false): Promise<Value> {
+    safeId(id);
+    if (!statuses.has(status)) throw new JobsError('job status is unsupported');
+    if (typeof expectedRevision !== 'bigint' || expectedRevision < 1n) throw new JobsError('job revision is invalid');
+    if (typeof userConfirmed !== 'boolean') throw new JobsError('user confirmation must be a boolean');
+    return this.repository.claimTransaction(async tx => {
+      const jobs = object(get(tx.jobs, 'jobs'), 'jobs.jobs');
+      const value = get(jobs, id);
+      if (value === null || get(object(value, 'job record'), 'deletedAt') !== null) {
+        throw new JobsError('job does not exist');
+      }
+      const current = object(value, 'job record');
+      if (int(get(current, 'revision')) !== expectedRevision) throw new JobsError('job revision conflict');
+      requireJobUnclaimed(tx.coordinator, id);
+      const source = string(get(current, 'status'))!;
+      if (status === source) return current;
+      if (!transitions[source]!.includes(status)) throw new JobsError('job status transition is unsupported');
+      if (status === 'in_progress') throw new JobsError('in_progress requires atomic job-acquire');
+      if (status === 'applied' && !userConfirmed) throw new JobsError('applied status requires explicit user confirmation');
+      if (status === 'ready' && get(await preflightJobRecord(current, tx.profile, tx.resumes, tx.files), 'ready') !== true) {
+        throw new JobsError('job is not ready');
+      }
+      const updated = copy(current);
+      set(updated, 'status', text(status));
+      set(updated, 'closedOutcome', status === 'closed' ? closedOutcome : null);
+      set(updated, 'revision', integer(expectedRevision + 1n));
+      set(updated, 'updatedAt', text(this.now()));
+      validateJob(id, updated);
+      set(jobs, id, updated);
+      set(object(get(tx.jobs, 'metadata'), 'jobs.metadata'), 'updatedAt', get(updated, 'updatedAt'));
+      await tx.saveJobs(tx.jobs);
+      return updated;
+    });
+  }
+}

--- a/src/workspace-core/jobs-http.ts
+++ b/src/workspace-core/jobs-http.ts
@@ -1,4 +1,5 @@
 import { claimsHttp } from './claims-http.js';
+import { jobTransitionsHttp } from './job-transitions-http.js';
 import { workspaceProjectionsHttp } from './workspace-projections-http.js';
 import { pendingAnswersHttp } from './pending-answers-http.js';
 import { profileHttp } from "./profile-http.js";
@@ -24,6 +25,8 @@ const envelope = (key: string, value: Value): Value => set(emptyObject(), key, v
 export async function jobsHttp(service: JobsService, repository: NativeJobsRepository,
   method: string, path: string, body = ""): Promise<ApiResult> {
   try {
+    const transition = await jobTransitionsHttp(repository, method, path, body);
+    if (transition) return transition;
     const projection = await workspaceProjectionsHttp(repository, method, path);
     if (projection) return projection;
     const claim = await claimsHttp(repository,method,path,body);

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,4 +1,5 @@
 import { claimsBrowser } from './workspace_native_claims_browser_support.mjs';
+import { jobTransitionsBrowser } from './workspace_native_job_transitions_browser_support.mjs';
 import { projectionsBrowser } from './workspace_native_projections_browser_support.mjs';
 import { nativeFactsBrowser } from './workspace_native_facts_browser_support.mjs';
 import { resumeDraftBrowser } from './workspace_native_resumes_browser_support.mjs';
@@ -133,10 +134,29 @@ export async function nativeJobsBrowser(buildRoot) {
       await execute(process.execPath,[cli,'--root',root,'--native-lock',fixture.receipt.artifact,
         'task-select','--id',job.id,'--expected-revision',String(current.revision),'--owner-confirmed'],{env:{PATH:''}});
     }});
+    const transitions = await jobTransitionsBrowser(page, {
+      jobId: job.id,
+      readJob: async () => JSON.parse(await readFile(join(root, 'jobs.json'), 'utf8')).jobs[job.id],
+      prepareInterrupted: async () => {
+        // root was initialized above from nativeFixture(), never an owner Store.
+        const coordinator = JSON.parse(await readFile(join(root, 'coordinator.json'), 'utf8'));
+        assert.equal(coordinator.claim, null);
+        const path = join(root, 'jobs.json');
+        const document = JSON.parse(await readFile(path, 'utf8'));
+        const current = document.jobs[job.id];
+        assert.equal(current.status, 'applied');
+        current.status = 'in_progress';
+        current.closedOutcome = null;
+        current.revision++;
+        current.updatedAt = new Date().toISOString();
+        document.metadata.updatedAt = current.updatedAt;
+        await writeFile(path, JSON.stringify(document), { mode: 0o600 });
+      },
+    });
     const unsupported = await fetch(startup.origin + '/api/trash', { headers: { Authorization: `Bearer ${token}` } });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     releaseInitialClaim?.();
     if (browser) await browser.close();

--- a/tests_js/workspace_native_job_transition_adapters.test.mjs
+++ b/tests_js/workspace_native_job_transition_adapters.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, snapshot, cli, readyPacket, plain } from './workspace_native_claims_support.mjs';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { fromJSON, text } from '../runtime/contracts/workspace/values.js';
+
+test('native transition HTTP and Python-free CLI preserve revision and owner confirmation boundaries', {timeout:60000}, async () => {
+  const fixture = await nativeFixture();
+  try {
+    const {root,repository,jobs,claims} = await setup(fixture,'transition-adapters');
+    const post = payload => jobsHttp(jobs,repository,'POST','/api/jobs/job/transition',JSON.stringify(payload));
+    assert.equal((await post({status:'ready',expectedRevision:1})).status,200);
+    assert.equal((await post({status:'saved',expectedRevision:1})).status,409);
+    const acquired=plain(await claims.acquire('job',text('Owner'),2n));
+    const beforeClaimed=await snapshot(root);
+    assert.equal((await post({status:'closed',closedOutcome:'withdrawn',expectedRevision:3})).status,400);
+    assert.deepEqual(await snapshot(root),beforeClaimed);
+    await claims.handoff('job',text(acquired.token),'awaiting_review',fromJSON({status:'review',readinessInput:readyPacket(3)}),3n);
+    const before=await snapshot(root);
+    for(const payload of [
+      {status:'applied',expectedRevision:4},
+      {status:'applied',expectedRevision:4,userConfirmed:'true'},
+      {status:'closed',expectedRevision:4,closedOutcome:false},
+      {status:'closed',expectedRevision:true,closedOutcome:'withdrawn'},
+      {status:'closed',expectedRevision:4,closedOutcome:'withdrawn',extra:true},
+    ]) assert.equal((await post(payload)).status,400);
+    await assert.rejects(()=>cli(fixture,root,'job-transition',['--id','job','--status','applied','--expected-revision','4']),/confirmation/);
+    assert.deepEqual(await snapshot(root),before);
+    const applied=await cli(fixture,root,'job-transition',['--id','job','--status','applied','--expected-revision','4','--user-confirmed']);
+    assert.equal(applied.status,'applied');assert.equal(applied.revision,5);
+    const closed=await post({status:'closed',expectedRevision:5,closedOutcome:'withdrawn'});
+    assert.equal(closed.status,200);assert.equal(JSON.parse(closed.body).closedOutcome,'withdrawn');
+    const reopened=await cli(fixture,root,'job-transition',['--id','job','--status','saved','--expected-revision','6']);
+    assert.equal(reopened.closedOutcome,null);assert.equal(reopened.revision,7);
+    const after=await snapshot(root);
+    for(const name of Object.keys(before).filter(name=>name!=='jobs.json')) assert.equal(after[name],before[name],name);
+    assert.equal((await jobsHttp(jobs,repository,'POST','/api/jobs/missing/transition','{"status":"saved","expectedRevision":1}')).status,404);
+  } finally {await fixture.cleanup();}
+});

--- a/tests_js/workspace_native_job_transition_model.test.mjs
+++ b/tests_js/workspace_native_job_transition_model.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import ts from 'typescript';
+const emit = source => ts.transpileModule(source, { compilerOptions: {
+  target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022,
+} }).outputText;
+const data = source => `data:text/javascript;base64,${Buffer.from(source).toString('base64')}`;
+const contracts = data(emit(await readFile(new URL('../apps/companion/components/contracts.ts', import.meta.url), 'utf8')));
+const source = await readFile(new URL('../apps/companion/components/job-transition-model.ts', import.meta.url), 'utf8');
+const model = await import(data(emit(source).replaceAll("'./contracts'", JSON.stringify(contracts))));
+const job = { id: 'job-one', revision: 7, status: 'saved', url: 'https://example.org/job' };
+
+test('targets follow Python transitions without granting direct in_progress authority', () => {
+  for (const [status, expected] of [
+    ['saved', ['needs_info', 'ready', 'closed']],
+    ['needs_info', ['saved', 'ready', 'closed']],
+    ['ready', ['saved', 'needs_info', 'closed']],
+    ['in_progress', ['needs_info', 'awaiting_review', 'closed']],
+    ['awaiting_review', ['applied', 'closed']],
+    ['applied', ['closed']], ['closed', ['saved']], ['unknown', []], ['__proto__', []],
+  ]) assert.deepEqual(model.transitionTargets({ ...job, status }), expected);
+  assert.deepEqual(model.transitionTargets({ ...job, deletedAt: '2026-01-01' }), []);
+});
+
+test('payload binds current revision and rejects unsupported transitions or malformed identity', () => {
+  assert.deepEqual(JSON.parse(model.transitionBody(job, 'ready')), { status: 'ready', expectedRevision: 7 });
+  for (const target of ['saved', 'applied', 'in_progress', 'wat'])
+    assert.throws(() => model.transitionBody(job, target), /transition/i);
+  for (const revision of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, NaN])
+    assert.throws(() => model.transitionBody({ ...job, revision }, 'ready'), /revision/i);
+  assert.throws(() => model.transitionBody({ ...job, id: '' }, 'ready'), /identity/i);
+});
+
+test('applied requires explicit personal submission confirmation and omits consent elsewhere', () => {
+  const review = { ...job, status: 'awaiting_review' };
+  assert.throws(() => model.transitionBody(review, 'applied'), /personally submitted/i);
+  assert.deepEqual(JSON.parse(model.transitionBody(review, 'applied', '', true)), {
+    status: 'applied', expectedRevision: 7, userConfirmed: true,
+  });
+  assert.deepEqual(JSON.parse(model.transitionBody(job, 'ready', 'expired', true)), {
+    status: 'ready', expectedRevision: 7,
+  });
+  assert.match(model.transitionConfirmation(review, 'applied'), /personally submitted/i);
+  assert.match(model.transitionConfirmation(job, 'ready'), /local status/i);
+  assert.match(model.transitionConfirmation(job, 'ready'), /preflight/i);
+});
+
+test('closing requires one of the five canonical outcomes', () => {
+  for (const outcome of ['rejected', 'withdrawn', 'expired', 'duplicate', 'not_interested'])
+    assert.deepEqual(JSON.parse(model.transitionBody(job, 'closed', outcome)), {
+      status: 'closed', expectedRevision: 7, closedOutcome: outcome,
+    });
+  for (const outcome of ['', 'other', 'applied'])
+    assert.throws(() => model.transitionBody(job, 'closed', outcome), /outcome/i);
+});
+
+test('acknowledgement must decode a full job with matching identity, target, and advanced revision', () => {
+  const result = { ...job, revision: 8, status: 'ready', notes: 'Preserved' };
+  assert.deepEqual(model.transitionAcknowledgement(JSON.stringify(result), job, 'ready'), result);
+  for (const bad of [{ ...result, id: 'other' }, { ...result, revision: 7 },
+    { ...result, status: 'saved' }, { status: 'ready' }, { job: result }])
+    assert.throws(() => model.transitionAcknowledgement(JSON.stringify(bad), job, 'ready'));
+  assert.throws(() => model.transitionAcknowledgement('not json', job, 'ready'));
+});
+
+test('conflict and ambiguous failure require refresh without claiming a successful write', () => {
+  const conflict = model.transitionFailure({ status: 409, message: 'conflict' });
+  assert.match(conflict, /changed|claim/i);
+  assert.match(conflict, /refresh/i);
+  assert.match(model.transitionFailure(new Error('Timeout')), /refresh/i);
+  assert.match(model.transitionFailure(new Error('job is not ready')), /job is not ready/i);
+});

--- a/tests_js/workspace_native_job_transitions.test.mjs
+++ b/tests_js/workspace_native_job_transitions.test.mjs
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { cp, readFile, readdir, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, plain, read, write, snapshot } from './workspace_native_claims_support.mjs';
+import { NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { fromJSON, text } from '../runtime/contracts/workspace/values.js';
+import { atomicWritePointJson, createNativePointAtomicWriteIO } from '../runtime/store/point-persistence.js';
+
+const loaded = await import('../runtime/workspace-core/job-transitions.js').catch(() => ({}));
+const fixed = '2026-09-10T13:00:00Z';
+const statuses = ['saved', 'needs_info', 'ready', 'in_progress', 'awaiting_review', 'applied', 'closed'];
+const python = `
+import sys, json, importlib.util
+from pathlib import Path
+sys.path.insert(0, str(Path('scripts').resolve()))
+spec=importlib.util.spec_from_file_location('transition_reference','scripts/job-apply-store.py')
+m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+m.utc_now=lambda: '${fixed}'
+s=m.Store(Path(sys.argv[1])); s.initialize()
+base=json.loads(s.jobs_path.read_text()); out=[]
+profile_path=Path(sys.argv[1])/'profile.json'; profile=json.loads(profile_path.read_text())
+resumes_path=Path(sys.argv[1])/'resumes.json'; resumes=json.loads(resumes_path.read_text())
+for case in json.loads(sys.argv[2]):
+ current_profile=json.loads(json.dumps(profile)); current_resumes=json.loads(json.dumps(resumes))
+ if case.get('emptyProfile'): current_profile['profile']={}
+ if case.get('missingResume'): current_resumes['resumes']={}
+ profile_path.write_text(json.dumps(current_profile)); resumes_path.write_text(json.dumps(current_resumes))
+ document=json.loads(json.dumps(base)); job=document['jobs']['job']
+ job['status']=case['source']; job['closedOutcome']='expired' if case['source']=='closed' else None
+ job['deletedAt']=case.get('deletedAt')
+ s.jobs_path.write_text(json.dumps(document))
+ try:
+  value=s.transition_job(case.get('id','job'),case['target'],case.get('revision',1),case.get('outcome'),case.get('confirmed',False))
+  result={'value':value}
+ except (m.StoreError, TypeError) as error: result={'error':str(error)}
+ result['jobs']=json.loads(s.jobs_path.read_text()); out.append(result)
+print(json.dumps(out))
+`;
+
+async function unchanged(root, operation, pattern) {
+  const before = await snapshot(root);
+  await assert.rejects(operation, pattern);
+  assert.deepEqual(await snapshot(root), before);
+}
+
+test('native transitions preserve Python lifecycle and durable write boundaries', { timeout: 60000 }, async t => {
+  assert.equal(typeof loaded.JobTransitionsService, 'function');
+  const { JobTransitionsService } = loaded;
+  const fixture = await nativeFixture();
+  try {
+    const state = await setup(fixture, 'transitions');
+    const { root, repository } = state;
+    const service = new JobTransitionsService(repository, () => fixed);
+    await t.test('actual Python differential for every status pair, outcomes, revisions and invalid inputs', async () => {
+      const cases = statuses.flatMap(source => statuses.map(target => ({source, target, outcome:'rejected', confirmed:true})));
+      for (const outcome of [null, '', 'unknown', true, 3, 'withdrawn', 'expired', 'duplicate', 'not_interested']) {
+        cases.push({source:'saved',target:'closed',outcome});
+      }
+      cases.push({source:'saved',target:'ready',emptyProfile:true}, {source:'saved',target:'ready',missingResume:true},
+        {source:'ready',target:'ready',emptyProfile:true}, {source:'awaiting_review',target:'applied'}, {source:'saved',target:'saved',outcome:'invalid'},
+        {source:'closed',target:'closed',outcome:null}, {source:'saved',target:'closed',revision:2},
+        {source:'saved',target:'invalid'}, {source:'saved',target:'saved',id:'missing'},
+        {source:'saved',target:'saved',id:'../bad'}, {source:'saved',target:'saved',deletedAt:fixed});
+      const referenceRoot = join(fixture.root, 'python');
+      await cp(root, referenceRoot, { recursive:true, preserveTimestamps:true });
+      const expected = JSON.parse((await promisify(execFile)('python3', ['-c',python,referenceRoot,JSON.stringify(cases)])).stdout);
+      const base = await read(root, 'jobs.json');
+      const profile = await read(root,'profile.json'), resumes = await read(root,'resumes.json');
+      for (const [index, item] of cases.entries()) {
+        await write(root,'profile.json',item.emptyProfile ? {...profile,profile:{}} : profile);
+        await write(root,'resumes.json',item.missingResume ? {...resumes,resumes:{}} : resumes);
+        const document = structuredClone(base);
+        Object.assign(document.jobs.job, {status:item.source,closedOutcome:item.source === 'closed' ? 'expired' : null,deletedAt:item.deletedAt ?? null});
+        await write(root, 'jobs.json', document);
+        const before = await snapshot(root);
+        let actual;
+        try {
+          actual = {value:plain(await service.transition(item.id ?? 'job',item.target,BigInt(item.revision ?? 1),fromJSON(item.outcome ?? null),item.confirmed ?? false))};
+        } catch (error) { actual = {error:error.message}; }
+        actual.jobs = await read(root, 'jobs.json');
+        assert.deepEqual(actual, expected[index], JSON.stringify(item));
+        const after = await snapshot(root);
+        if (actual.error || item.source === item.target) assert.deepEqual(after, before);
+        else {
+          delete before['jobs.json']; delete after['jobs.json'];
+          assert.deepEqual(after, before, 'only jobs.json may change');
+        }
+      }
+      await write(root, 'jobs.json', base);
+      await write(root,'profile.json',profile);
+      await write(root,'resumes.json',resumes);
+    });
+    await t.test('strict revisions and confirmation reject ambiguous direct callers without writes', async () => {
+      for (const revision of [0n,-1n,1,1.0,true,'1',null,undefined]) {
+        await unchanged(root, () => service.transition('job','saved',revision), /job revision is invalid/);
+      }
+      for (const outcome of [[],{}]) {
+        await unchanged(root, () => service.transition('job','closed',1n,fromJSON(outcome)), /closed job requires a supported outcome/);
+      }
+      for (const confirmation of [1,'true',null,{}]) {
+        await unchanged(root, () => service.transition('job','saved',1n,null,confirmation), /confirmation.*boolean/);
+      }
+    });
+    await t.test('claim guards precede same-status noops, including expired claims; stale revisions precede guards', async () => {
+      await state.claims.select('job',1n,true);
+      await state.claims.acquire('job',text('Synthetic'),2n);
+      const guarded = new JobTransitionsService(repository, () => state.clock.now);
+      for (const at of [state.clock.now,'2026-09-10T12:05:00Z','2026-09-11T12:00:00Z']) {
+        state.clock.now = at;
+        await unchanged(root, () => guarded.transition('job','in_progress',3n), /claimed job requires/);
+        await unchanged(root, () => guarded.transition('job','closed',3n,text('expired')), /claimed job requires/);
+        await unchanged(root, () => guarded.transition('job','in_progress',2n), /revision conflict/);
+      }
+      const claimCases = [
+        {source:'in_progress',target:'in_progress',revision:3},
+        {source:'in_progress',target:'closed',revision:3,outcome:'expired'},
+        {source:'in_progress',target:'in_progress',revision:2},
+        {source:'in_progress',target:'saved',revision:1,id:'other'},
+      ];
+      const referenceRoot = join(fixture.root,'python-claims');
+      await cp(root,referenceRoot,{recursive:true,preserveTimestamps:true});
+      const expected = JSON.parse((await promisify(execFile)('python3',
+        ['-c',python,referenceRoot,JSON.stringify(claimCases)])).stdout);
+      for (const [index,item] of claimCases.entries()) {
+        let actual;
+        try {
+          actual = {value:plain(await guarded.transition(item.id ?? 'job',item.target,
+            BigInt(item.revision),fromJSON(item.outcome ?? null)))};
+        } catch (error) { actual = {error:error.message}; }
+        const {jobs,...reference} = expected[index];
+        assert.deepEqual(actual,reference);
+      }
+      assert.equal(plain(await service.transition('other','needs_info',1n)).revision,2);
+    });
+    await t.test('ready preflight rejects empty profile and changed managed resume, same ready remains no-op', async () => {
+      const isolated = await setup(fixture,'preflight');
+      const transitions = new JobTransitionsService(isolated.repository,() => fixed);
+      const profile = await read(isolated.root,'profile.json');
+      await write(isolated.root,'profile.json',{...profile,profile:{}});
+      await unchanged(isolated.root, () => transitions.transition('job','ready',1n), /job is not ready/);
+      await write(isolated.root,'profile.json',profile);
+      await transitions.transition('job','ready',1n);
+      await write(isolated.root,'profile.json',{...profile,profile:{}});
+      const before = await snapshot(isolated.root);
+      assert.equal(plain(await transitions.transition('job','ready',2n)).revision,2);
+      assert.deepEqual(await snapshot(isolated.root),before);
+      await write(isolated.root,'profile.json',profile);
+      const resumes = await read(isolated.root,'resumes.json');
+      resumes.resumes.resume.digest = '0'.repeat(64);
+      await write(isolated.root,'resumes.json',resumes);
+      await unchanged(isolated.root, () => transitions.transition('other','ready',1n), /job is not ready/);
+    });
+    await t.test('concurrent exact revision writers commit once and retain session/history bytes', async () => {
+      const isolated = await setup(fixture,'concurrent');
+      const before = await snapshot(isolated.root);
+      const results = await Promise.allSettled(Array.from({length:4}, () => new JobTransitionsService(
+        new NativeJobsRepository(isolated.root,isolated.provider),() => fixed).transition('job','needs_info',1n)));
+      assert.equal(results.filter(result => result.status === 'fulfilled').length,1);
+      for (const result of results.filter(result => result.status === 'rejected')) assert.match(result.reason.message,/revision conflict/);
+      const after = await snapshot(isolated.root);
+      delete before['jobs.json']; delete after['jobs.json'];
+      assert.deepEqual(after,before);
+    });
+    await t.test('revisions above JavaScript safe integer range remain exact', async () => {
+      const isolated = await setup(fixture,'large-revision');
+      const path = join(isolated.root,'jobs.json');
+      const document = await read(isolated.root,'jobs.json');
+      document.jobs.job.revision = 'EXACT_REVISION';
+      await writeFile(path,JSON.stringify(document).replace('\"EXACT_REVISION\"','900719925474099312345'));
+      const transitions = new JobTransitionsService(isolated.repository,() => fixed);
+      await unchanged(isolated.root,() => transitions.transition('job','needs_info',900719925474099312344n),/revision conflict/);
+      await transitions.transition('job','needs_info',900719925474099312345n);
+      assert.match(await readFile(path,'utf8'),/900719925474099312346/);
+      const before = await snapshot(isolated.root);
+      await transitions.transition('job','needs_info',900719925474099312346n);
+      assert.deepEqual(await snapshot(isolated.root),before);
+    });
+    await t.test('atomic replacement faults leave old bytes and release lock', async () => {
+      const isolated = await setup(fixture,'faults');
+      for (const stage of ['write','sync','replace']) {
+        const failing = new NativeJobsRepository(isolated.root,isolated.provider,async (path,value,options) => {
+          const io = createNativePointAtomicWriteIO(options.pathProfile);
+          if (stage === 'replace') io.replace = async () => { throw Error('transition fault'); };
+          else {
+            const original = io.createTemporary;
+            io.createTemporary = async (...args) => {
+              const handle = await original(...args);
+              handle[stage] = async () => { throw Error('transition fault'); };
+              return handle;
+            };
+          }
+          await atomicWritePointJson(path,value,options,io);
+        });
+        await unchanged(isolated.root,() => new JobTransitionsService(failing).transition('job','needs_info',1n),/transition fault/);
+        assert.equal((await readdir(isolated.root)).some(name => name.endsWith('.tmp')),false);
+      }
+      assert.equal(plain(await new JobTransitionsService(isolated.repository).transition('job','needs_info',1n)).revision,2);
+    });
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_job_transitions_browser_support.mjs
+++ b/tests_js/workspace_native_job_transitions_browser_support.mjs
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+import { readyPacket } from './workspace_native_claims_support.mjs';
+
+// Caller owns a disposable native fixture with a preflight-ready job and no claim.
+export async function jobTransitionsBrowser(page, { jobId, readJob, prepareInterrupted }) {
+  const authorization = await page.evaluate(() => `Bearer ${sessionStorage.getItem('jobApplyWorkspaceToken')}`);
+  async function api(path, body, method = body === undefined ? 'GET' : 'POST') {
+    const response = await page.request.fetch(new URL(path, page.url()).href, {
+      method, headers: { Authorization: authorization, Origin: new URL(page.url()).origin }, data: body,
+    });
+    assert.equal(response.status(), 200, await response.text());
+    return response.json();
+  }
+  const navigation = page.getByRole('navigation', { name: 'Workspace sections' });
+  const modal = page.getByRole('dialog', { name: 'Edit job', exact: true });
+  const status = modal.getByRole('region', { name: 'Job status', exact: true });
+  const close = modal.getByRole('button', { name: 'Close job details', exact: true });
+  async function open() {
+    await navigation.getByRole('button', { name: 'Jobs', exact: true }).click();
+    await page.locator('[data-job-create]:enabled').waitFor();
+    await page.getByRole('button', { name: /Native fixture role/ }).click();
+    await status.getByRole('group', { name: 'Change local status' }).waitFor();
+  }
+  const transitionResponse = () => page.waitForResponse(response =>
+    response.url().endsWith(`/api/jobs/${jobId}/transition`) && response.request().method() === 'POST');
+  async function change(label, target) {
+    const response = transitionResponse();
+    page.once('dialog', dialog => dialog.accept());
+    await status.getByRole('button', { name: label, exact: true }).click();
+    const result = await response;
+    assert.equal(result.status(), 200, await result.text());
+    const record = await result.json();
+    assert.equal(record.status, target);
+    assert.deepEqual(await readJob(), record);
+    await status.getByText(`Local status changed to ${target.replaceAll('_', ' ')}.`, { exact: true }).waitFor();
+    await modal.locator('fieldset:enabled').first().waitFor();
+    return record;
+  }
+  await page.setViewportSize({ width: 390, height: 844 });
+  await open();
+  assert.equal((await readJob()).status, 'ready');
+  assert.equal(await status.getByRole('button', { name: 'Close job', exact: true }).isDisabled(), true);
+  const originalNotes = await modal.locator('[name="notes"]').inputValue();
+  await modal.locator('[name="notes"]').fill(`${originalNotes} unsaved transition draft`);
+  assert.equal(await status.getByRole('button', { name: 'Mark saved', exact: true }).isDisabled(), true);
+  await modal.locator('[name="notes"]').fill(originalNotes);
+  await status.getByLabel('Closing outcome').selectOption('withdrawn');
+  let requests = 0;
+  const count = request => { if (request.url().endsWith(`/api/jobs/${jobId}/transition`)) requests++; };
+  page.on('request', count);
+  let confirmation;
+  const beforeCancel = await readJob();
+  page.once('dialog', async dialog => { confirmation = dialog.message(); await dialog.dismiss(); });
+  await status.getByRole('button', { name: 'Close job', exact: true }).click();
+  assert.match(confirmation, /local status only/i);
+  assert.equal(requests, 0);
+  assert.deepEqual(await readJob(), beforeCancel);
+  await change('Close job', 'closed');
+  assert.equal((await readJob()).closedOutcome, 'withdrawn');
+  await change('Reopen as saved', 'saved');
+  assert.equal((await readJob()).closedOutcome, null);
+  await change('Mark ready', 'ready');
+  assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), true);
+
+  // A concurrent canonical edit must not cause an automatic retry or lose the outcome choice.
+  await status.getByLabel('Closing outcome').selectOption('expired');
+  const stale = await readJob();
+  const latest = await api(`/api/jobs/${jobId}`, { expectedRevision: stale.revision, patch: { company: 'Transition conflict writer' } }, 'PATCH');
+  const conflict = transitionResponse();
+  const beforeConflictRequests = requests;
+  page.once('dialog', dialog => dialog.accept());
+  await status.getByRole('button', { name: 'Close job', exact: true }).click();
+  assert.equal((await conflict).status(), 409);
+  await status.getByRole('alert').filter({ hasText: /Refresh latest values/ }).waitFor();
+  assert.equal(await status.getByLabel('Closing outcome').inputValue(), 'expired');
+  assert.equal(requests, beforeConflictRequests + 1);
+  assert.deepEqual(await readJob(), latest);
+  await close.click();
+
+  // Prepare review through the real claim API; no browser or employer submission occurs.
+  const acquired = await api('/api/claims/acquire', { jobId, expectedRevision: latest.revision, ownerLabel: 'Transition fixture' });
+  const reviewed = await api('/api/claims/handoff', { jobId, token: acquired.token, status: 'awaiting_review',
+    expectedRevision: acquired.job.revision, session: { status: 'review', readinessInput: readyPacket(acquired.job.revision) } });
+  assert.equal(reviewed.job.status, 'awaiting_review');
+  await page.reload();
+  await open();
+  const beforeApplied = requests;
+  page.once('dialog', async dialog => { confirmation = dialog.message(); await dialog.dismiss(); });
+  await status.getByRole('button', { name: 'Mark applied', exact: true }).click();
+  assert.match(confirmation, /I personally submitted/i);
+  assert.equal(requests, beforeApplied);
+  assert.equal((await readJob()).status, 'awaiting_review');
+  const appliedResponse = transitionResponse();
+  await change('Mark applied', 'applied');
+  assert.equal((await appliedResponse).request().postDataJSON().userConfirmed, true);
+  await close.click();
+
+  // This explicitly synthetic crash fixture has an in_progress record and no live claim.
+  await prepareInterrupted();
+  await page.reload();
+  await open();
+  await status.getByText(/After an active claim is released/).waitFor();
+  await change('Mark needs info', 'needs_info');
+
+  // Hold a write, then hold only its background refresh: write guards must end at acknowledgement.
+  let releasePost, postSeen, releaseGet, getSeen;
+  const postGate = new Promise(resolve => { releasePost = resolve; });
+  const postStarted = new Promise(resolve => { postSeen = resolve; });
+  const getGate = new Promise(resolve => { releaseGet = resolve; });
+  const getStarted = new Promise(resolve => { getSeen = resolve; });
+  const postRoute = async route => { postSeen(); await postGate; await route.continue(); };
+  const getRoute = async route => { getSeen(); await getGate; await route.continue().catch(() => {}); };
+  await page.route(`**/api/jobs/${jobId}/transition`, postRoute);
+  try {
+    const acknowledged = transitionResponse();
+    page.once('dialog', dialog => dialog.accept());
+    await status.getByRole('button', { name: 'Mark saved', exact: true }).click();
+    await postStarted;
+    assert.equal(await close.isDisabled(), true);
+    await page.keyboard.press('Escape');
+    assert.equal(await modal.isVisible(), true);
+    assert.equal(await status.getByRole('button', { name: 'Mark saved', exact: true }).isDisabled(), true);
+    await page.route('**/api/state', getRoute);
+    releasePost();
+    assert.equal((await acknowledged).status(), 200);
+    await getStarted;
+    await modal.getByRole('button', { name: 'Close job details', exact: true }).waitFor();
+    await close.click();
+    let navigationPrompts = 0;
+    const dismiss = dialog => { navigationPrompts++; return dialog.dismiss(); };
+    page.on('dialog', dismiss);
+    try {
+      await navigation.getByRole('button', { name: 'Overview', exact: true }).click();
+      await page.getByRole('heading', { name: 'Your next step', exact: true }).waitFor();
+      assert.equal(navigationPrompts, 0);
+    } finally { page.off('dialog', dismiss); }
+    assert.equal((await readJob()).status, 'saved');
+  } finally {
+    releasePost(); releaseGet();
+    await page.unroute(`**/api/jobs/${jobId}/transition`, postRoute);
+    await page.unroute('**/api/state', getRoute);
+    page.off('request', count);
+  }
+  return { closeReopen: true, cancellation: true, dirtyDisabled: true, personallySubmitted: true,
+    claimlessRecovery: true, conflictPreserved: true, pendingGuard: true, acknowledgedRefreshClean: true, narrowViewport: true };
+}

--- a/tests_js/workspace_native_jobs.test.mjs
+++ b/tests_js/workspace_native_jobs.test.mjs
@@ -115,7 +115,8 @@ print(json.dumps(out))
       assert.equal((await jobsHttp(service, repository, 'PATCH', '/api/jobs/one', '{"patch":{"notes":"stale"},"expectedRevision":1}')).status, 409);
       assert.equal((await jobsHttp(service, repository, 'PATCH', '/api/jobs/one', '{"patch":{},"expectedRevision":true}')).status, 400);
       assert.equal((await jobsHttp(service, repository, 'GET', '/api/jobs/missing')).status, 404);
-      assert.equal((await jobsHttp(service, repository, 'POST', '/api/jobs/one/transition', '{}')).status, 501);
+      assert.equal((await jobsHttp(service, repository, 'POST', '/api/jobs/one/transition', '{}')).status, 400);
+      assert.equal((await jobsHttp(service, repository, 'GET', '/api/trash')).status, 501);
     });
     await t.test('independent CLI writers serialize revisions without Python', async () => {
       const cli = resolve('runtime/cli/native-jobs.js');

--- a/tests_js/workspace_native_projection_model.test.mjs
+++ b/tests_js/workspace_native_projection_model.test.mjs
@@ -29,12 +29,12 @@ test('activity rejects malformed revision and eligibility',()=>{
 });
 
 test('native recovery and review guidance describes only supported authority',()=>{
- assert.equal(model.recoveryGuidance.interrupted, 'This attempt was interrupted without an active claim. Recovery for this state is not available in the native workspace yet.');
+ assert.match(model.recoveryGuidance.interrupted, /change this interrupted attempt to Needs information/);
  assert.equal(model.attentionGuidance.claimless_interrupted_attempt, model.recoveryGuidance.interrupted);
  assert.doesNotMatch(model.attentionGuidance.claimless_interrupted_attempt, /job-transition/);
  assert.match(model.recoveryGuidance.expired, /claim-recover/);
- assert.match(model.attentionGuidance.awaiting_human_review, /personally review and submit on the third-party site/);
- assert.match(model.attentionGuidance.awaiting_human_review, /Recording Applied or Closed in the native workspace is deferred/);
+ assert.match(model.attentionGuidance.awaiting_human_review, /Personally review and submit on the third-party site/);
+ assert.match(model.attentionGuidance.awaiting_human_review, /confirm Applied in Job details/);
 });
 
 test('attention and activity allow a null unbound attempt revision but reject malformed bindings',()=>{

--- a/tests_js/workspace_next_security_support.mjs
+++ b/tests_js/workspace_next_security_support.mjs
@@ -19,7 +19,7 @@ export async function nextSecurity() {
                 await readFile(join(componentDirectory, name), 'utf8'));
         }
         const catalogs = ['browser-g02-next-surfaces.json', 'browser-native-answers-surfaces.json',
-            'browser-native-extractions-surfaces.json', 'browser-native-projections-surfaces.json'];
+            'browser-native-extractions-surfaces.json', 'browser-native-projections-surfaces.json', 'browser-native-job-transitions-surfaces.json'];
         const surfaces = (await Promise.all(catalogs.map(async name =>
             JSON.parse(await readFile(join(root, 'config/migration', name), 'utf8')).surfaces))).flat();
         assert.deepEqual(checkBrowserBindings(discoverNextBrowserExports(components), surfaces), []);


### PR DESCRIPTION
The native Companion could display interrupted and awaiting-review jobs but could not record their next status. This adds shared TypeScript, CLI, and authenticated HTTP transitions plus Job details controls for recovery, readiness, owner-confirmed Applied, closure outcomes, and reopening.

Transitions preserve Python ordering: exact revision and same-job claim checks precede no-ops; readiness runs preflight; Applied requires confirmation. Writes atomically update only the job record and preserve sessions/history. Companion retains draft protection, asks for confirmation, and releases write guards after acknowledgement. This remains an opt-in v9 synthetic fixture.

Validation includes Python differential across all 49 status pairs, claim/no-op/revision checks, concurrent writes, atomic faults, strict adapters, and the production native browser flow at 390px. Five independent focused reviews found no concrete defects. The installed Codex CLI baseline could not run its configured model; focused reviews covered correctness, tests, error handling, contracts/types, and guidance.

Local deep validation passed all required checks across 27 suites (Windows-only checks deferred to CI); normal commit and push hooks passed. The initial deep run found an obsolete 501 transition-endpoint expectation, which was corrected and independently reviewed before the full rerun passed. [Validate Plugin](https://github.com/neonwatty/job-apply-plugin/actions/runs/34533081604) and [Release Validation](https://github.com/neonwatty/job-apply-plugin/actions/runs/34533084641) passed on exact head `5b767a22219142d87dfe090693183a956e12aee4`, including Windows, macOS, browser/workspace and the PR gate.
