### PR TITLE
Add native job upsert preview and commit

### DIFF
--- a/config/migration/cli-native-job-upsert-surfaces.json
+++ b/config/migration/cli-native-job-upsert-surfaces.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:job-upsert-preview",
+      "kind": "cli",
+      "command": "job-upsert-preview",
+      "node": "JOB",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-job-upsert.ts",
+        "src/workspace-core/job-upsert.ts",
+        "src/workspace-core/job-upsert-plan.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:job-upsert-commit",
+      "kind": "cli",
+      "command": "job-upsert-commit",
+      "node": "JOB",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-job-upsert.ts",
+        "src/workspace-core/job-upsert.ts",
+        "src/workspace-core/job-upsert-plan.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -106,6 +106,10 @@
       "sha256": "3310d133626397a57545af50e70591523b906036cdf4a0d04884e4a1630f1c3b"
     },
     {
+      "path": "cli-native-job-upsert-surfaces.json",
+      "sha256": "6d98fac8d272d2552aebabab3d7468998b53adfe6f5777329785c28edd853197"
+    },
+    {
       "path": "cli-native-jobs-surfaces.json",
       "sha256": "8757138a819fd1166abfeb7e86aed548a42f3d2d6f832da404370f9c483e8963"
     },
@@ -310,8 +314,12 @@
       "sha256": "d3586b035af22d3f4b4fa3ba3aa7d9e1bc781632317005aff9d158ac78625772"
     },
     {
+      "path": "source-catalog-native-job-upsert.json",
+      "sha256": "46000867500a9b5e7492a7602af8369fc24ad3c7d2ba863174357d1e38f51864"
+    },
+    {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "38ef913d3e0ed7235a3ff4e81091f7e750e09fb68be7a39be4f51b85d0dec223"
+      "sha256": "c6f3bd835dcd6654205e198ca6090f2ddebd3590d6570d213266d7d8b709a178"
     },
     {
       "path": "source-catalog-native-pending-answers.json",

--- a/config/migration/source-catalog-native-job-upsert.json
+++ b/config/migration/source-catalog-native-job-upsert.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "runtime/cli/native-job-upsert.js",
+      "sha256": "0e6396e536552fa9297fb55b8a2e09cf5bc893b1525c4a90dd4a8afbf5ecc267",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/job-upsert-plan.js",
+      "sha256": "724a931bb32e9711894b91b494aeadb30b8c3e8bab34a1021f620194caf8e780",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/job-upsert.js",
+      "sha256": "906919dcec3acac8004b9140e7d2036c13315401bf3538696b2b0d143f760a83",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-job-upsert.ts",
+      "sha256": "b7e0d4ce18e8fe7e14d1ab2fcf90a2dbed1913ee7c9a89f6c1f224d33420b011",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/job-upsert-plan.ts",
+      "sha256": "7912f3b226487938298d997cd9bb8c291bf3cf176f09f1941a8ae2dec544b9a1",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/job-upsert.ts",
+      "sha256": "69e16d70b7c750a13e1b272d5bd77ba833ce043928e509a0f71595cbeffd555d",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "18f4d9122cbb3cc62c4cc8db2fab67bd54ec921a660eda16620c7119a5a7d262",
+      "sha256": "eed959ab8ab1a91ba9627c5a679579bf8034bde03b8eae4298e5409340a8b1be",
       "classification": "unreviewed"
     },
     {
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "8a87a16971fe888ab7ae32066b194a40497a1a68007aa9c57c1cbf3474905f40",
+      "sha256": "bbe6ea2d6d54297ed9b36faed293c4f2fa093bcea11c0279642cc7a5af457367",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "f93c2b682e9829eaa65783bf05710cf54b29460c6b3ad53245f9a60e9ea5b9f9",
+      "sha256": "7ff5b7f1095cbeb44334fe4a0b7ae716451edd34d55282e5dc1e165de63837ce",
       "classification": "unreviewed"
     },
     {
@@ -83,7 +83,7 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "46cb2cadfe59aab1ca2f921bc96adce98c271cf1317f5ef07eca7545b64ffcaa",
+      "sha256": "91efc4be73a8e91e0a93956af18ab9104caf2a261798ce1475f9fce622dfc91e",
       "classification": "unreviewed"
     },
     {

--- a/docs/local-testing-protocol.md
+++ b/docs/local-testing-protocol.md
@@ -119,3 +119,10 @@ The current deep runner serializes one invocation, not every worktree on a host;
 the coordinator must serialize heavy runs until the planned host lease lands.
 Existing receipts identify runtime versions, not every native executable byte;
 required native cells and child-test skips need the stricter acceptance receipts.
+
+
+Fresh native obligations at push use the same bounded execution timeout as deep
+validation: the configured suite timeout, or 15 minutes by default. Their
+browser, crash-recovery and cross-process tests still run freshly and must
+pass. Quick commit and focused push checks keep their two-minute per-suite
+timeout. A timeout remains a failure; it never counts as completed evidence.

--- a/docs/native-job-upsert-fixture.md
+++ b/docs/native-job-upsert-fixture.md
@@ -1,0 +1,86 @@
+# Native job upsert fixture
+
+The opt-in version 9 native fixture supports `job-upsert-preview` and
+`job-upsert-commit` through its CLI. Both use the native Jobs repository and
+shared Store lock. Committed records appear in Companion Jobs after Refresh or
+reload. This tranche adds no upsert HTTP route or browser batch editor.
+
+Use a new synthetic root initialized as described in
+[Native Jobs fixture](native-jobs-fixture.md). Do not use a live applicant Store
+or run Python writers against the native fixture.
+
+## Preview and commit
+
+The input must contain only a `jobs` array. For example:
+
+```json
+{
+  "jobs": [
+    {
+      "url": "https://example.invalid/careers/fixture-job",
+      "role": "Synthetic role",
+      "company": "Fixture company"
+    }
+  ]
+}
+```
+
+```sh
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node job-upsert-preview --input /absolute/synthetic-batch.json --origin agent
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node job-upsert-commit --input /absolute/synthetic-batch.json --origin agent --token PREVIEW_TOKEN
+```
+
+`--origin` is required and accepts `human` or `agent`; migration provenance is
+reserved for the separate legacy import workflow. Input may also be supplied
+through stdin using `--input -`.
+
+Both commands return a token, summary counts for `create`, `update`, `noop`,
+`conflict` and `invalid`, and an ordered decision for every input item. A
+decision includes its input index and action, plus an ID, changed fields or a
+reason where applicable. Preview reports `committed: false` and does not write
+the planned Jobs document. Commit reports `committed: true` only when at least
+one create or update is persisted.
+
+## Identity, provenance and drift
+
+The preview token binds the entire current Jobs document, origin and canonical
+input. Canonical input trims string values and ignores object key order, while
+preserving array order. Commit recalculates that binding under the Store lock;
+changed input, origin or Jobs state rejects the token before applying the plan.
+After drift, preview again and review the new decisions.
+
+Matching uses normalized URLs and source identities. Differing duplicate
+identities within the batch, ambiguous or deleted stored matches, incompatible
+identities and deterministic ID collisions become conflict decisions. Invalid
+items have their own decisions. Neither kind prevents other valid items in the
+same batch from being committed. Review every decision, not only the aggregate
+count or process exit status.
+
+Agent input may refresh fields already attributed to an agent or fill empty
+fields with no provenance. It preserves human and migration provenance, and
+nonempty unattributed fields. Human input can update supplied ingest fields.
+Empty incoming values do not clear stored fields. Accepted changes increment
+the record revision and stamp provenance; no-op items do neither. A batch with
+only no-op, conflict or invalid decisions leaves Jobs bytes unchanged and
+returns `committed: false`, including when called through commit.
+
+Upsert preserves the Python behavior for active claims: it does not add a
+claim-based write prohibition. It does not submit applications or change job
+status; newly captured jobs start saved.
+
+## Validation and remaining scope
+
+Native version 9 fixture validation remains strict across the existing Store
+inventory. A corrupt or unsupported fixture is rejected; this workflow does
+not adopt or repair legacy Stores. No new fixture marker or persisted journal
+is introduced by upsert.
+
+The browser walkthrough previews without creating a visible record, commits
+through the native CLI with Python absent from PATH, edits the record through
+Companion, and confirms a later agent batch preserves the human field while
+filling a new field. It checks preview/commit agreement, reload, clean
+navigation and a 390-pixel viewport. Service and CLI tests cover planning,
+token drift and persistence separately.
+
+Legacy import preview/commit and task intake remain later tranches. General
+writer activation and installable Python-free packaging are also deferred.

--- a/docs/native-jobs-fixture.md
+++ b/docs/native-jobs-fixture.md
@@ -11,7 +11,8 @@ metadata update, file replacement, legacy adoption, default selection, integrity
 check, content read and resolution are available through the same Store lock.
 Facts/profile operations, [active claims](native-claims-fixture.md),
 [workspace projections](native-projections-fixture.md), and
-[job status transitions](native-job-transitions-fixture.md) are also available. Other
+[job status transitions](native-job-transitions-fixture.md), and
+[CLI job upsert preview/commit](native-job-upsert-fixture.md) are also available. Other
 workflows return `unsupported_native_workflow`; they never fall back to Python.
 
 ## Run against a new synthetic root

--- a/runtime/cli/native-job-upsert.js
+++ b/runtime/cli/native-job-upsert.js
@@ -1,0 +1,20 @@
+import { JobUpsertService } from '../workspace-core/job-upsert.js';
+import { JobsError } from '../contracts/workspace/values.js';
+export const jobUpsertCommands = {
+    'job-upsert-preview': ['--input', '--origin'],
+    'job-upsert-commit': ['--input', '--origin', '--token'],
+};
+export async function runJobUpsertCommand(command, repository, options, payload) {
+    const required = (key) => {
+        const value = options.get(key);
+        if (!value)
+            throw new JobsError(`required option: ${key}`);
+        return value;
+    };
+    const author = required('--origin');
+    const service = new JobUpsertService(repository);
+    if (command === 'job-upsert-preview')
+        return service.preview(await payload(), author);
+    const token = required('--token');
+    return service.commit(await payload(), author, token);
+}

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,3 +1,4 @@
+import { jobUpsertCommands, runJobUpsertCommand } from './native-job-upsert.js';
 import { claimCommands, runClaimCommand } from './native-claims.js';
 import { jobTransitionCommands, runJobTransitionCommand } from './native-job-transitions.js';
 import { projectionCommands, runProjectionCommand } from './native-projections.js';
@@ -39,6 +40,7 @@ export async function runJobsCli(args, input) {
         }
     }
     const fields = {
+        ...jobUpsertCommands,
         ...jobTransitionCommands,
         ...projectionCommands,
         ...claimCommands,
@@ -76,9 +78,13 @@ export async function runJobsCli(args, input) {
         const file = required("--input");
         // Extraction candidates permit 256 KiB after normalization. Allow JSON
         // escaping and formatting overhead while keeping stdin bounded.
-        const limit = ["resume-proposal-create", "resume-extraction-request-complete"].includes(command) ? 2 * 1024 * 1024 : 65536;
+        // Bulk upsert accepts the same input domain through stdin and files, as Python does.
+        const limit = Object.hasOwn(jobUpsertCommands, command) ? Infinity
+            : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command) ? 2 * 1024 * 1024 : 65536;
         return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
     };
+    if (Object.hasOwn(jobUpsertCommands, command))
+        return serialize(await runJobUpsertCommand(command, repository, options, payload));
     if (Object.hasOwn(jobTransitionCommands, command))
         return serialize(await runJobTransitionCommand(repository, options));
     if (Object.hasOwn(projectionCommands, command))

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -205,6 +205,16 @@ export class NativeJobsRepository {
                 }, });
         }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
     }
+    async upsertTransaction(operation) {
+        return this.transaction(async ({ document }) => operation({ document,
+            // Python ingestion may update claimed jobs without changing claim/session evidence.
+            // Keep that authority separate from the ordinary Jobs save guard.
+            save: async (value) => {
+                validateJobsDocument(value);
+                await this.write(join(this.root, "jobs.json"), value, options);
+            },
+        }));
+    }
     async resumeTransaction(operation) {
         await this.validateRoot();
         return withExclusiveFileLock(join(this.root, ".store.lock"), async () => {

--- a/runtime/workspace-core/job-upsert-plan.js
+++ b/runtime/workspace-core/job-upsert-plan.js
@@ -1,0 +1,171 @@
+import { createHash } from 'node:crypto';
+import { PythonObject } from '../contracts/python-object.js';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { normalizeJobUrl, strip } from '../contracts/workspace/job-url.js';
+import { emptyObject, ingestFields, validateJob } from '../contracts/workspace/jobs.js';
+import { copy, get, has, set, object, string, text, integer, int, keys, same, fromJSON, parse, serialize, JobsError } from '../contracts/workspace/values.js';
+import { mayUpdate, nonempty, stamp } from './job-provenance.js';
+function normalizeItem(value) {
+    if (!(value instanceof PythonObject))
+        throw new JobsError('job upsert item must be a JSON object');
+    const item = value;
+    if (keys(item).some(field => !ingestFields.has(field)))
+        throw new JobsError('job upsert item contains unsupported fields');
+    if (!nonempty(get(item, 'url')))
+        throw new JobsError('job upsert item requires a URL');
+    for (const field of ingestFields) {
+        const value = get(item, field);
+        if (field !== 'priority' && value !== null && string(value) === null) {
+            throw new JobsError(`job upsert item.${field} must be a string`);
+        }
+    }
+    const priority = get(item, 'priority');
+    if (priority !== null && (int(priority) === null || int(priority) < 0n || int(priority) > 5n)) {
+        throw new JobsError('job upsert item.priority must be an integer from 0 to 5');
+    }
+    const normalized = emptyObject();
+    for (const field of keys(item)) {
+        const value = get(item, field);
+        if (nonempty(value))
+            set(normalized, field, string(value) === null ? value : text(strip(string(value))));
+    }
+    set(normalized, 'normalizedUrl', text(normalizeJobUrl(string(get(normalized, 'url')))));
+    return normalized;
+}
+const sourceName = (record) => strip(string(get(record, 'source')) ?? '').toLowerCase();
+function sourceIdentity(record) {
+    const source = sourceName(record), id = strip(string(get(record, 'sourceId')) ?? '');
+    return source && id ? JSON.stringify([source, id]) : null;
+}
+function batchConflicts(items) {
+    const identities = new Map(), conflicts = new Set();
+    items.forEach((item, index) => {
+        if (!item)
+            return;
+        const identityKeys = ['url:' + string(get(item, 'normalizedUrl'))];
+        const source = sourceIdentity(item);
+        if (source !== null)
+            identityKeys.push('source:' + source);
+        for (const key of identityKeys)
+            identities.set(key, [...(identities.get(key) ?? []), index]);
+    });
+    for (const indexes of identities.values()) {
+        if (new Set(indexes.map(index => canonicalJson(items[index]))).size > 1) {
+            for (const index of indexes)
+                conflicts.add(index);
+        }
+    }
+    return conflicts;
+}
+function incompatible(current, item) {
+    const previous = sourceIdentity(current), incoming = sourceIdentity(item);
+    const sourceChanged = nonempty(get(current, 'source')) && nonempty(get(item, 'source'))
+        && sourceName(current) !== sourceName(item);
+    const idChanged = nonempty(get(current, 'sourceId')) && nonempty(get(item, 'sourceId'))
+        && strip(string(get(current, 'sourceId'))) !== strip(string(get(item, 'sourceId')));
+    return !same(get(current, 'normalizedUrl'), get(item, 'normalizedUrl'))
+        || previous !== null && incoming !== null && previous !== incoming || sourceChanged || idChanged;
+}
+export function planJobUpsert(currentDocument, raw, author, now) {
+    const errors = [];
+    const normalized = raw.map(value => {
+        try {
+            const item = normalizeItem(value);
+            errors.push(null);
+            return item;
+        }
+        catch (error) {
+            if (!(error instanceof JobsError))
+                throw error;
+            errors.push(error.message);
+            return null;
+        }
+    });
+    const conflicts = batchConflicts(normalized);
+    const document = object(parse(serialize(currentDocument)), 'jobs');
+    const jobs = object(get(document, 'jobs'), 'jobs.jobs');
+    const decisions = [];
+    let changed = false;
+    const decide = (value) => { decisions.push(object(fromJSON(value), 'upsert decision')); };
+    normalized.forEach((item, index) => {
+        if (!item) {
+            decide({ index, action: 'invalid', reason: errors[index] });
+            return;
+        }
+        if (conflicts.has(index)) {
+            decide({ index, action: 'conflict', reason: 'differing duplicate identities in input' });
+            return;
+        }
+        const records = jobs.entries().map(([, value]) => object(value, 'job record'));
+        const urlMatches = records.filter(record => same(get(record, 'normalizedUrl'), get(item, 'normalizedUrl')));
+        const source = sourceIdentity(item);
+        const sourceMatches = source === null ? [] : records.filter(record => sourceIdentity(record) === source);
+        const matches = new Map([...urlMatches, ...sourceMatches].map(record => [string(get(record, 'id')), record]));
+        if (urlMatches.length > 1 || sourceMatches.length > 1 || matches.size > 1
+            || [...matches.values()].some(record => get(record, 'deletedAt') !== null)) {
+            decide({ index, action: 'conflict', reason: 'job identities do not resolve to one active record' });
+            return;
+        }
+        const current = matches.values().next().value;
+        if (current) {
+            const id = string(get(current, 'id'));
+            const provenance = has(current, 'provenance') ? object(get(current, 'provenance'), 'job provenance') : emptyObject();
+            if (incompatible(current, item)) {
+                decide({ index, action: 'conflict', id, reason: 'incoming identity is incompatible with stored identity' });
+                return;
+            }
+            const updated = copy(current), accepted = [];
+            for (const field of ingestFields) {
+                if (!has(item, field) || field === 'url' || author === 'agent' && !mayUpdate(current, provenance, field))
+                    continue;
+                if (!same(get(current, field), get(item, field))) {
+                    set(updated, field, get(item, field));
+                    accepted.push(field);
+                }
+            }
+            if (!accepted.length) {
+                decide({ index, action: 'noop', id });
+                return;
+            }
+            set(updated, 'provenance', stamp(provenance, accepted, author, updated, now));
+            set(updated, 'revision', integer(int(get(current, 'revision')) + 1n));
+            set(updated, 'updatedAt', text(now));
+            validateJob(id, updated);
+            set(jobs, id, updated);
+            decide({ index, action: 'update', id, fields: accepted.sort() });
+            changed = true;
+            return;
+        }
+        const id = 'job-' + createHash('sha256').update('url\0' + string(get(item, 'normalizedUrl'))).digest('hex').slice(0, 24);
+        if (has(jobs, id)) {
+            decide({ index, action: 'conflict', id, reason: 'deterministic job id is already in use' });
+            return;
+        }
+        const record = copy(item), fields = [...ingestFields].filter(field => has(item, field));
+        set(record, 'id', text(id));
+        if (!has(record, 'priority'))
+            set(record, 'priority', integer(0n));
+        set(record, 'status', text('saved'));
+        set(record, 'closedOutcome', null);
+        set(record, 'provenance', stamp(emptyObject(), fields, author, item, now));
+        set(record, 'revision', integer(1n));
+        set(record, 'createdAt', text(now));
+        set(record, 'updatedAt', text(now));
+        set(record, 'deletedAt', null);
+        try {
+            validateJob(id, record);
+        }
+        catch (error) {
+            if (!(error instanceof JobsError))
+                throw error;
+            decide({ index, action: 'invalid', reason: error.message });
+            return;
+        }
+        set(jobs, id, record);
+        decide({ index, action: 'create', id });
+        changed = true;
+    });
+    if (changed)
+        set(object(get(document, 'metadata'), 'jobs.metadata'), 'updatedAt', text(now));
+    return { document, decisions, changed };
+}

--- a/runtime/workspace-core/job-upsert.js
+++ b/runtime/workspace-core/job-upsert.js
@@ -1,0 +1,73 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { PythonObject } from '../contracts/python-object.js';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { strip } from '../contracts/workspace/job-url.js';
+import { copy, get, set, object, string, text, fromJSON, JobsError } from '../contracts/workspace/values.js';
+import { origin } from './job-provenance.js';
+import { planJobUpsert } from './job-upsert-plan.js';
+export function upsertItems(payload) {
+    if (!(payload instanceof PythonObject) || payload.size !== 1 || !payload.has(text('jobs'))) {
+        throw new JobsError('job upsert input must contain only a jobs array');
+    }
+    const jobs = get(payload, 'jobs');
+    if (!Array.isArray(jobs))
+        throw new JobsError('job upsert input.jobs must be an array');
+    return jobs;
+}
+function tokenFor(document, payload, author) {
+    const by = origin(author);
+    const items = upsertItems(payload).map(value => {
+        if (!(value instanceof PythonObject))
+            return value;
+        const normalized = copy(value);
+        for (const [key, value] of normalized.entries()) {
+            const field = string(value);
+            if (field !== null)
+                normalized.set(key, text(strip(field)));
+        }
+        return normalized;
+    });
+    const bound = object(fromJSON({ version: 1, origin: by, input: {}, jobsDocument: {} }), 'upsert token');
+    set(bound, 'input', set(new PythonObject(), 'jobs', items));
+    set(bound, 'jobsDocument', document);
+    return 'job-upsert-v1.' + createHash('sha256').update(canonicalJson(bound)).digest('hex');
+}
+function result(token, decisions, committed) {
+    const counts = { create: 0, update: 0, noop: 0, conflict: 0, invalid: 0 };
+    for (const decision of decisions)
+        counts[string(get(decision, 'action'))]++;
+    const value = object(fromJSON({ token, summary: counts, committed }), 'upsert result');
+    set(value, 'decisions', decisions);
+    return value;
+}
+/** Preview tokens bind all job records, the author, and trimmed input under the Store lock. */
+export class JobUpsertService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    async preview(payload, author) {
+        return this.repository.upsertTransaction(async ({ document }) => {
+            const token = tokenFor(document, payload, author);
+            const { decisions } = planJobUpsert(document, upsertItems(payload), origin(author), this.now());
+            return result(token, decisions, false);
+        });
+    }
+    async commit(payload, author, token) {
+        if (typeof token !== 'string' || !token)
+            throw new JobsError('job upsert commit requires a preview token');
+        return this.repository.upsertTransaction(async (transaction) => {
+            const expected = Buffer.from(tokenFor(transaction.document, payload, author));
+            const supplied = Buffer.from(token);
+            if (expected.length !== supplied.length || !timingSafeEqual(expected, supplied)) {
+                throw new JobsError('job upsert preview token rejected because the store or input drifted');
+            }
+            const { document, decisions, changed } = planJobUpsert(transaction.document, upsertItems(payload), origin(author), this.now());
+            if (changed)
+                await transaction.save(document);
+            return result(token, decisions, changed);
+        });
+    }
+}

--- a/src/cli/native-job-upsert.ts
+++ b/src/cli/native-job-upsert.ts
@@ -1,0 +1,20 @@
+import { JobUpsertService, type JobUpsertRepository } from '../workspace-core/job-upsert.js';
+import { JobsError, type Value } from '../contracts/workspace/values.js';
+
+export const jobUpsertCommands: Record<string, string[]> = {
+  'job-upsert-preview': ['--input', '--origin'],
+  'job-upsert-commit': ['--input', '--origin', '--token'],
+};
+export async function runJobUpsertCommand(command: string, repository: JobUpsertRepository,
+  options: Map<string, string>, payload: () => Promise<Value>): Promise<Value> {
+  const required = (key: string): string => {
+    const value = options.get(key);
+    if (!value) throw new JobsError(`required option: ${key}`);
+    return value;
+  };
+  const author = required('--origin');
+  const service = new JobUpsertService(repository);
+  if (command === 'job-upsert-preview') return service.preview(await payload(), author);
+  const token = required('--token');
+  return service.commit(await payload(), author, token);
+}

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,3 +1,4 @@
+import { jobUpsertCommands, runJobUpsertCommand } from './native-job-upsert.js';
 import { claimCommands, runClaimCommand } from './native-claims.js';
 import { jobTransitionCommands, runJobTransitionCommand } from './native-job-transitions.js';
 import { projectionCommands, runProjectionCommand } from './native-projections.js';
@@ -35,6 +36,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     }
   }
   const fields: Record<string, string[]> = {
+    ...jobUpsertCommands,
     ...jobTransitionCommands,
     ...projectionCommands,
     ...claimCommands,
@@ -68,9 +70,12 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     const file = required("--input");
     // Extraction candidates permit 256 KiB after normalization. Allow JSON
     // escaping and formatting overhead while keeping stdin bounded.
-    const limit = ["resume-proposal-create", "resume-extraction-request-complete"].includes(command!) ? 2 * 1024 * 1024 : 65536;
+    // Bulk upsert accepts the same input domain through stdin and files, as Python does.
+    const limit = Object.hasOwn(jobUpsertCommands, command!) ? Infinity
+      : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command!) ? 2 * 1024 * 1024 : 65536;
     return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
   };
+  if (Object.hasOwn(jobUpsertCommands, command!)) return serialize(await runJobUpsertCommand(command!, repository, options, payload));
   if (Object.hasOwn(jobTransitionCommands, command!)) return serialize(await runJobTransitionCommand(repository, options));
   if (Object.hasOwn(projectionCommands, command!)) return serialize(await runProjectionCommand(command!, repository, options));
   if (Object.hasOwn(claimCommands, command!)) return serialize(await runClaimCommand(command!,repository,options,payload));

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -205,6 +205,17 @@ export class NativeJobsRepository implements JobsRepository {
     }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
   }
 
+  async upsertTransaction<T>(operation: (transaction: Pick<JobsTransaction, "document" | "save">) => Promise<T>): Promise<T> {
+    return this.transaction(async ({ document }) => operation({ document,
+      // Python ingestion may update claimed jobs without changing claim/session evidence.
+      // Keep that authority separate from the ordinary Jobs save guard.
+      save: async value => {
+        validateJobsDocument(value);
+        await this.write(join(this.root, "jobs.json"), value, options);
+      },
+    }));
+  }
+
   async resumeTransaction<T>(operation: (transaction: ResumeTransaction) => Promise<T>): Promise<T> {
     await this.validateRoot();
     return withExclusiveFileLock(join(this.root, ".store.lock"), async () => {

--- a/src/workspace-core/job-upsert-plan.ts
+++ b/src/workspace-core/job-upsert-plan.ts
@@ -1,0 +1,165 @@
+import { createHash } from 'node:crypto';
+import { PythonObject } from '../contracts/python-object.js';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { normalizeJobUrl, strip } from '../contracts/workspace/job-url.js';
+import { emptyObject, ingestFields, validateJob } from '../contracts/workspace/jobs.js';
+import { copy, get, has, set, object, string, text, integer, int, keys, same, fromJSON, parse, serialize, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import { mayUpdate, nonempty, stamp } from './job-provenance.js';
+import type { Origin } from './job-provenance.js';
+
+function normalizeItem(value: Value): Document {
+  if (!(value instanceof PythonObject)) throw new JobsError('job upsert item must be a JSON object');
+  const item = value;
+  if (keys(item).some(field => !ingestFields.has(field))) throw new JobsError('job upsert item contains unsupported fields');
+  if (!nonempty(get(item, 'url'))) throw new JobsError('job upsert item requires a URL');
+  for (const field of ingestFields) {
+    const value = get(item, field);
+    if (field !== 'priority' && value !== null && string(value) === null) {
+      throw new JobsError(`job upsert item.${field} must be a string`);
+    }
+  }
+  const priority = get(item, 'priority');
+  if (priority !== null && (int(priority) === null || int(priority)! < 0n || int(priority)! > 5n)) {
+    throw new JobsError('job upsert item.priority must be an integer from 0 to 5');
+  }
+  const normalized = emptyObject();
+  for (const field of keys(item)) {
+    const value = get(item, field);
+    if (nonempty(value)) set(normalized, field, string(value) === null ? value : text(strip(string(value)!)));
+  }
+  set(normalized, 'normalizedUrl', text(normalizeJobUrl(string(get(normalized, 'url')))));
+  return normalized;
+}
+
+const sourceName = (record: Document): string => strip(string(get(record, 'source')) ?? '').toLowerCase();
+function sourceIdentity(record: Document): string | null {
+  const source = sourceName(record), id = strip(string(get(record, 'sourceId')) ?? '');
+  return source && id ? JSON.stringify([source, id]) : null;
+}
+
+function batchConflicts(items: (Document | null)[]): Set<number> {
+  const identities = new Map<string, number[]>(), conflicts = new Set<number>();
+  items.forEach((item, index) => {
+    if (!item) return;
+    const identityKeys = ['url:' + string(get(item, 'normalizedUrl'))];
+    const source = sourceIdentity(item);
+    if (source !== null) identityKeys.push('source:' + source);
+    for (const key of identityKeys) identities.set(key, [...(identities.get(key) ?? []), index]);
+  });
+  for (const indexes of identities.values()) {
+    if (new Set(indexes.map(index => canonicalJson(items[index]!))).size > 1) {
+      for (const index of indexes) conflicts.add(index);
+    }
+  }
+  return conflicts;
+}
+
+function incompatible(current: Document, item: Document): boolean {
+  const previous = sourceIdentity(current), incoming = sourceIdentity(item);
+  const sourceChanged = nonempty(get(current, 'source')) && nonempty(get(item, 'source'))
+    && sourceName(current) !== sourceName(item);
+  const idChanged = nonempty(get(current, 'sourceId')) && nonempty(get(item, 'sourceId'))
+    && strip(string(get(current, 'sourceId'))!) !== strip(string(get(item, 'sourceId'))!);
+  return !same(get(current, 'normalizedUrl'), get(item, 'normalizedUrl'))
+    || previous !== null && incoming !== null && previous !== incoming || sourceChanged || idChanged;
+}
+
+export function planJobUpsert(currentDocument: Document, raw: Value[], author: Origin, now: string): {
+  document: Document; decisions: Document[]; changed: boolean;
+} {
+  const errors: (string | null)[] = [];
+  const normalized = raw.map(value => {
+    try {
+      const item = normalizeItem(value);
+      errors.push(null);
+      return item;
+    } catch (error) {
+      if (!(error instanceof JobsError)) throw error;
+      errors.push(error.message);
+      return null;
+    }
+  });
+  const conflicts = batchConflicts(normalized);
+  const document = object(parse(serialize(currentDocument)), 'jobs');
+  const jobs = object(get(document, 'jobs'), 'jobs.jobs');
+  const decisions: Document[] = [];
+  let changed = false;
+  const decide = (value: unknown): void => {decisions.push(object(fromJSON(value), 'upsert decision'));};
+  normalized.forEach((item, index) => {
+    if (!item) {
+      decide({index, action:'invalid', reason:errors[index]});
+      return;
+    }
+    if (conflicts.has(index)) {
+      decide({index, action:'conflict', reason:'differing duplicate identities in input'});
+      return;
+    }
+    const records = jobs.entries().map(([, value]) => object(value, 'job record'));
+    const urlMatches = records.filter(record => same(get(record, 'normalizedUrl'), get(item, 'normalizedUrl')));
+    const source = sourceIdentity(item);
+    const sourceMatches = source === null ? [] : records.filter(record => sourceIdentity(record) === source);
+    const matches = new Map([...urlMatches, ...sourceMatches].map(record => [string(get(record, 'id'))!, record]));
+    if (urlMatches.length > 1 || sourceMatches.length > 1 || matches.size > 1
+      || [...matches.values()].some(record => get(record, 'deletedAt') !== null)) {
+      decide({index, action:'conflict', reason:'job identities do not resolve to one active record'});
+      return;
+    }
+    const current = matches.values().next().value;
+    if (current) {
+      const id = string(get(current, 'id'))!;
+      const provenance = has(current, 'provenance') ? object(get(current, 'provenance'), 'job provenance') : emptyObject();
+      if (incompatible(current, item)) {
+        decide({index, action:'conflict', id, reason:'incoming identity is incompatible with stored identity'});
+        return;
+      }
+      const updated = copy(current), accepted: string[] = [];
+      for (const field of ingestFields) {
+        if (!has(item, field) || field === 'url' || author === 'agent' && !mayUpdate(current, provenance, field)) continue;
+        if (!same(get(current, field), get(item, field))) {
+          set(updated, field, get(item, field));
+          accepted.push(field);
+        }
+      }
+      if (!accepted.length) {
+        decide({index, action:'noop', id});
+        return;
+      }
+      set(updated, 'provenance', stamp(provenance, accepted, author, updated, now));
+      set(updated, 'revision', integer(int(get(current, 'revision'))! + 1n));
+      set(updated, 'updatedAt', text(now));
+      validateJob(id, updated);
+      set(jobs, id, updated);
+      decide({index, action:'update', id, fields:accepted.sort()});
+      changed = true;
+      return;
+    }
+    const id = 'job-' + createHash('sha256').update('url\0' + string(get(item, 'normalizedUrl'))!).digest('hex').slice(0, 24);
+    if (has(jobs, id)) {
+      decide({index, action:'conflict', id, reason:'deterministic job id is already in use'});
+      return;
+    }
+    const record = copy(item), fields = [...ingestFields].filter(field => has(item, field));
+    set(record, 'id', text(id));
+    if (!has(record, 'priority')) set(record, 'priority', integer(0n));
+    set(record, 'status', text('saved'));
+    set(record, 'closedOutcome', null);
+    set(record, 'provenance', stamp(emptyObject(), fields, author, item, now));
+    set(record, 'revision', integer(1n));
+    set(record, 'createdAt', text(now));
+    set(record, 'updatedAt', text(now));
+    set(record, 'deletedAt', null);
+    try {
+      validateJob(id, record);
+    } catch (error) {
+      if (!(error instanceof JobsError)) throw error;
+      decide({index, action:'invalid', reason:error.message});
+      return;
+    }
+    set(jobs, id, record);
+    decide({index, action:'create', id});
+    changed = true;
+  });
+  if (changed) set(object(get(document, 'metadata'), 'jobs.metadata'), 'updatedAt', text(now));
+  return {document, decisions, changed};
+}

--- a/src/workspace-core/job-upsert.ts
+++ b/src/workspace-core/job-upsert.ts
@@ -1,0 +1,75 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { PythonObject } from '../contracts/python-object.js';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { strip } from '../contracts/workspace/job-url.js';
+import { copy, get, set, object, string, text, fromJSON, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import type { JobsTransaction } from './jobs.js';
+import { origin } from './job-provenance.js';
+import { planJobUpsert } from './job-upsert-plan.js';
+
+export interface JobUpsertRepository {
+  upsertTransaction<T>(operation: (transaction: Pick<JobsTransaction, 'document' | 'save'>) => Promise<T>): Promise<T>;
+}
+
+export function upsertItems(payload: Value): Value[] {
+  if (!(payload instanceof PythonObject) || payload.size !== 1 || !payload.has(text('jobs'))) {
+    throw new JobsError('job upsert input must contain only a jobs array');
+  }
+  const jobs = get(payload, 'jobs');
+  if (!Array.isArray(jobs)) throw new JobsError('job upsert input.jobs must be an array');
+  return jobs;
+}
+
+function tokenFor(document: Document, payload: Value, author: string): string {
+  const by = origin(author);
+  const items = upsertItems(payload).map(value => {
+    if (!(value instanceof PythonObject)) return value;
+    const normalized = copy(value);
+    for (const [key, value] of normalized.entries()) {
+      const field = string(value);
+      if (field !== null) normalized.set(key, text(strip(field)));
+    }
+    return normalized;
+  });
+  const bound = object(fromJSON({version:1, origin:by, input:{}, jobsDocument:{}}), 'upsert token');
+  set(bound, 'input', set(new PythonObject<Value>(), 'jobs', items));
+  set(bound, 'jobsDocument', document);
+  return 'job-upsert-v1.' + createHash('sha256').update(canonicalJson(bound)).digest('hex');
+}
+
+function result(token: string, decisions: Document[], committed: boolean): Value {
+  const counts: Record<string, number> = {create:0, update:0, noop:0, conflict:0, invalid:0};
+  for (const decision of decisions) counts[string(get(decision, 'action'))!]!++;
+  const value = object(fromJSON({token, summary:counts, committed}), 'upsert result');
+  set(value, 'decisions', decisions);
+  return value;
+}
+
+/** Preview tokens bind all job records, the author, and trimmed input under the Store lock. */
+export class JobUpsertService {
+  constructor(readonly repository: JobUpsertRepository,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+
+  async preview(payload: Value, author: string): Promise<Value> {
+    return this.repository.upsertTransaction(async ({document}) => {
+      const token = tokenFor(document, payload, author);
+      const {decisions} = planJobUpsert(document, upsertItems(payload), origin(author), this.now());
+      return result(token, decisions, false);
+    });
+  }
+
+  async commit(payload: Value, author: string, token: string): Promise<Value> {
+    if (typeof token !== 'string' || !token) throw new JobsError('job upsert commit requires a preview token');
+    return this.repository.upsertTransaction(async transaction => {
+      const expected = Buffer.from(tokenFor(transaction.document, payload, author));
+      const supplied = Buffer.from(token);
+      if (expected.length !== supplied.length || !timingSafeEqual(expected, supplied)) {
+        throw new JobsError('job upsert preview token rejected because the store or input drifted');
+      }
+      const {document, decisions, changed} = planJobUpsert(transaction.document, upsertItems(payload), origin(author), this.now());
+      if (changed) await transaction.save(document);
+      return result(token, decisions, changed);
+    });
+  }
+}

--- a/tests_js/local_checks_policy.test.mjs
+++ b/tests_js/local_checks_policy.test.mjs
@@ -192,3 +192,13 @@ test('P03 unknown deleted renamed global lock and policy changes retain complete
   assert.equal(selectLocalPlan(matrix, f.tracked(), ['README.md'], { closure, mode: 'deep' }).native.flatMap(s => s.include).length, 6);
   assert.equal(selectLocalPlan(matrix, f.tracked(), [], { closure, mode: 'commit' }).heavy.length, 0);
 });
+
+test('fresh native obligations keep the deep execution ceiling while quick checks stay bounded', async () => {
+  const { localSuiteTimeout } = await import('../tools/local-checks/run.mjs');
+  const native = {id:'native-posix-lock'};
+  assert.equal(localSuiteTimeout('push',native,[native]),localSuiteTimeout('deep',native,[]));
+  assert.equal(localSuiteTimeout('push',{...native,timeoutMs:240000},[native]),240000);
+  assert.equal(localSuiteTimeout('push',{id:'quick',timeoutMs:240000},[native]),120000);
+  assert.equal(localSuiteTimeout('commit',native,[]),120000);
+  assert.equal(localSuiteTimeout('push',native,[native]),900000);
+});

--- a/tests_js/workspace_job_upsert_model.test.mjs
+++ b/tests_js/workspace_job_upsert_model.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createHash } from 'node:crypto';
+import { fromJSON, parse, serialize } from '../runtime/contracts/workspace/values.js';
+const loaded = await import('../runtime/workspace-core/job-upsert.js').catch(() => ({}));
+const plain = value => JSON.parse(serialize(value));
+const now = '2026-09-10T15:00:00Z';
+
+function fixture() {
+  let document = fromJSON({schemaVersion:1, metadata:{updatedAt:'before'}, jobs:{}}), saves = 0;
+  const repository = {async upsertTransaction(operation) {
+    return operation({document, requireUnclaimed() {throw new Error('unexpected claim guard');},
+      async requireResume() {throw new Error('unexpected resume validation');},
+      async save(value) {document = value; saves++;}});
+  }};
+  return {repository, snapshot:() => plain(document), saves:() => saves};
+}
+
+test('upsert binds canonical input, plans without mutation and saves only changed jobs', async () => {
+  assert.equal(typeof loaded.JobUpsertService, 'function');
+  const store = fixture(), service = new loaded.JobUpsertService(store.repository, () => now);
+  const payload = fromJSON({jobs:[{url:' HTTPS://EXAMPLE.COM:443/job#top ',role:' Engineer ',priority:0}]});
+  const preview = plain(await service.preview(payload, 'agent'));
+  const id = 'job-' + createHash('sha256').update('url\0https://example.com/job').digest('hex').slice(0,24);
+  assert.deepEqual(preview.decisions,[{index:0,action:'create',id}]);
+  assert.equal(preview.committed,false); assert.equal(store.saves(),0);
+  assert.deepEqual(store.snapshot().jobs,{});
+  const trimmed = fromJSON({jobs:[{priority:0,role:'Engineer',url:'HTTPS://EXAMPLE.COM:443/job#top'}]});
+  assert.equal(plain(await service.preview(trimmed,'agent')).token,preview.token);
+  const committed = plain(await service.commit(trimmed,'agent',preview.token));
+  assert.equal(committed.committed,true); assert.equal(store.saves(),1);
+  assert.equal(store.snapshot().jobs[id].role,'Engineer');
+  assert.equal(store.snapshot().jobs[id].provenance['/priority'].origin,'agent');
+  await assert.rejects(service.commit(payload,'agent',preview.token),/store or input drifted/);
+  const noop = plain(await service.preview(payload,'agent'));
+  assert.equal(plain(await service.commit(payload,'agent',noop.token)).committed,false);
+  assert.equal(store.saves(),1);
+});
+
+test('upsert detects batch identity conflicts, invalid items and protected agent fields', async () => {
+  assert.equal(typeof loaded.JobUpsertService, 'function');
+  const store=fixture(), service=new loaded.JobUpsertService(store.repository,()=>now);
+  const initial=fromJSON({jobs:[{url:'https://example.com/job',role:'Owner',source:' Board ',sourceId:' id '}]});
+  await service.commit(initial,'human',plain(await service.preview(initial,'human')).token);
+  const changed=fromJSON({jobs:[{url:'https://example.com/job',role:'Agent',company:'New'}]});
+  const preview=plain(await service.preview(changed,'agent'));
+  assert.deepEqual(preview.decisions[0].fields,['company']);
+  await service.commit(changed,'agent',preview.token);
+  assert.equal(Object.values(store.snapshot().jobs)[0].role,'Owner');
+  const batch=fromJSON({jobs:[{url:'https://example.com/new',role:'A'},
+    {url:'https://example.com/new#fragment',role:'B'},null,{url:'https://example.com/other',priority:true}]});
+  const result=plain(await service.preview(batch,'human'));
+  assert.deepEqual(result.summary,{create:0,update:0,noop:0,conflict:2,invalid:2});
+  await assert.rejects(service.preview(parse('{"jobs":[],"extra":1}'),'human'),/only a jobs array/);
+  await assert.rejects(service.preview(fromJSON({jobs:[]}), 'migration'),/human or agent/);
+});

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,5 +1,6 @@
 import { claimsBrowser } from './workspace_native_claims_browser_support.mjs';
 import { jobTransitionsBrowser } from './workspace_native_job_transitions_browser_support.mjs';
+import { jobUpsertBrowser } from './workspace_native_job_upsert_browser_support.mjs';
 import { projectionsBrowser } from './workspace_native_projections_browser_support.mjs';
 import { nativeFactsBrowser } from './workspace_native_facts_browser_support.mjs';
 import { resumeDraftBrowser } from './workspace_native_resumes_browser_support.mjs';
@@ -153,10 +154,22 @@ export async function nativeJobsBrowser(buildRoot) {
         await writeFile(path, JSON.stringify(document), { mode: 0o600 });
       },
     });
+    const upsert = await jobUpsertBrowser(page, {
+      readDocument: () => readFile(join(root, 'jobs.json'), 'utf8'),
+      upsert: async (payload, origin, previewToken) => {
+        const input = join(fixture.root, 'browser-upsert.json');
+        await writeFile(input, JSON.stringify(payload), { mode: 0o600 });
+        const args = [cli, '--root', root, '--native-lock', fixture.receipt.artifact,
+          previewToken ? 'job-upsert-commit' : 'job-upsert-preview', '--input', input, '--origin', origin];
+        if (previewToken) args.push('--token', previewToken);
+        const result = await execute(process.execPath, args, { env: { PATH: '' } });
+        return JSON.parse(result.stdout);
+      },
+    });
     const unsupported = await fetch(startup.origin + '/api/trash', { headers: { Authorization: `Bearer ${token}` } });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     releaseInitialClaim?.();
     if (browser) await browser.close();

--- a/tests_js/workspace_native_job_upsert.test.mjs
+++ b/tests_js/workspace_native_job_upsert.test.mjs
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createHash } from 'node:crypto';
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, read, write, plain, snapshot } from './workspace_native_claims_support.mjs';
+import { fixed, item, batch, differential, unchanged } from './workspace_native_job_upsert_support.mjs';
+import { NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { fromJSON, get, object, set, text } from '../runtime/contracts/workspace/values.js';
+import { atomicWritePointJson, createNativePointAtomicWriteIO } from '../runtime/store/point-persistence.js';
+
+const loaded = await import('../runtime/workspace-core/job-upsert.js').catch(() => ({}));
+test('native upsert preserves Python previews, commits, identity and atomicity contracts', {timeout:60000}, async t => {
+  assert.equal(typeof loaded.JobUpsertService,'function');
+  const {JobUpsertService} = loaded;
+  const fixture = await nativeFixture();
+  try {
+    let serial = 0;
+    const isolated = async () => {
+      const state = await setup(fixture,`upsert-${++serial}`);
+      return {...state,service:new JobUpsertService(state.repository,() => fixed)};
+    };
+    await t.test('exact tokens and records across partial batches, duplicates and provenance',async () => {
+      const state = await isolated();
+      const human = batch(item('new',{source:'LinkedIn',sourceId:'42',role:'Human role',priority:4}));
+      const agent = batch(item('new',{source:'linkedin',sourceId:'42',role:'Agent role',company:'Agent company'}));
+      await differential(state.service,state.root,join(fixture.root,'python-sequence'),[
+        {payload:human}, {payload:human}, {payload:agent,origin:'agent'},
+        {payload:batch(item('new',{company:'Agent refresh'})),origin:'agent'},
+        {payload:batch(item('new',{company:'Human edit'}))},
+        {payload:batch(item('new',{company:'Ignored',description:'Added'})),origin:'agent'},
+        {payload:batch(item('identical'),item('identical'))},
+        {payload:batch(item('differing',{role:'One'}),item('differing',{role:'Two'}))},
+        {payload:batch(item('partial'),null,4,[],{},item('bad',{role:[]}))},
+        {payload:batch(...[true,1.5,-1,6,'2'].map(priority=>item('bad-priority',{priority})))},
+        {payload:batch(item('bad',{status:'ready'}),{url:'ftp://example.invalid/x'},item('nulls',{role:null,company:' ',priority:0}))},
+        {payload:batch({url:3},{url:true},item('source-invalid',{source:5}),item('ats-invalid',{ats:'not-an-ats'}))},
+        {payload:batch()}, {payload:{}}, {payload:{jobs:{}}}, {payload:{jobs:[],extra:true}},
+        {payload:batch(item('bad-origin')),origin:'migration'},
+        {payloadJson:'{"jobs":[{"url":"https://example.invalid/float-priority","priority":1.0},{"url":"https://example.invalid/huge-priority","priority":900719925474099312345}]}'},
+      ]);
+    });
+    await t.test('tokens trim strings but bind source case, item order, author and whole document',async () => {
+      const state = await isolated();
+      await differential(state.service,state.root,join(fixture.root,'python-tokens'),[
+        {payload:batch(item('trim',{role:'  Engineer  '})),commitPayload:batch(item('trim',{role:'Engineer'}))},
+        {payload:batch(item('case',{source:'LinkedIn'})),commitPayload:batch(item('case',{source:'linkedin'}))},
+        {payload:batch(item('a'),item('b')),commitPayload:batch(item('b'),item('a'))},
+        {payload:batch(item('origin')),commitOrigin:'agent'},
+        {payload:batch(item('forged')),token:'job-upsert-v1.'+'0'.repeat(64)},
+        {payload:batch(item('empty-token')),token:''},
+      ]);
+      const payload = fromJSON(batch(item('drift')));
+      const preview = plain(await state.service.preview(payload,'human'));
+      const document = await read(state.root,'jobs.json');
+      document.metadata.unknown = 'metadata drift';
+      await write(state.root,'jobs.json',document);
+      await unchanged(state.root,() => state.service.commit(payload,'human',preview.token),/drifted/);
+      await differential(state.service,state.root,join(fixture.root,'python-document-drift'),[
+        {payload:batch(item('drift')),token:preview.token},
+      ]);
+    });
+    await t.test('cross identities, incompatible sources, deleted matches and deterministic id collisions',async () => {
+      const state = await isolated();
+      const document = await read(state.root,'jobs.json');
+      Object.assign(document.jobs.job,{source:'LinkedIn',sourceId:'one'});
+      Object.assign(document.jobs.other,{source:'LinkedIn',sourceId:'two'});
+      const collision = 'job-'+createHash('sha256').update('url\0https://example.invalid/collision').digest('hex').slice(0,24);
+      document.jobs[collision] = {...document.jobs.other,id:collision,url:'https://example.invalid/occupied',normalizedUrl:'https://example.invalid/occupied',sourceId:'occupied'};
+      document.jobs.deleted = {...document.jobs.other,id:'deleted',url:'https://example.invalid/deleted',normalizedUrl:'https://example.invalid/deleted',sourceId:'deleted',deletedAt:fixed};
+      await write(state.root,'jobs.json',document);
+      await differential(state.service,state.root,join(fixture.root,'python-identities'),[
+        {payload:batch(item('job',{source:'linkedin',sourceId:'two'}))},
+        {payload:batch(item('job',{source:'Other'}))},
+        {payload:batch(item('job',{sourceId:'changed'}))},
+        {payload:batch(item('new-url',{source:'linkedin',sourceId:'one'}))},
+        {payload:batch(item('deleted'),item('collision'))},
+        {payload:batch(item('source-a',{source:'LinkedIn',sourceId:'new'}),item('source-b',{source:'linkedin',sourceId:'new'}))},
+      ]);
+    });
+    await t.test('ambiguous pre-existing URL and source identities remain conflicts',async () => {
+      const state = await isolated();
+      const document = await read(state.root,'jobs.json');
+      document.jobs.other.normalizedUrl = document.jobs.job.normalizedUrl;
+      document.jobs.other.url = document.jobs.job.url;
+      Object.assign(document.jobs.job,{source:'LinkedIn',sourceId:'duplicate'});
+      Object.assign(document.jobs.other,{source:'LinkedIn',sourceId:'duplicate'});
+      await write(state.root,'jobs.json',document);
+      await differential(state.service,state.root,join(fixture.root,'python-ambiguous'),[
+        {payload:batch(item('job'),item('different-url',{source:'linkedin',sourceId:'duplicate'}))},
+      ]);
+    });
+    await t.test('active claims do not add a guard absent from Python; unrelated files remain untouched',async () => {
+      const state = await isolated();
+      await state.claims.select('job',1n,true);
+      await state.claims.acquire('job',text('Synthetic'),2n);
+      await unchanged(state.root,() => state.jobs.update('job',fromJSON({description:'Guarded'}),3n),/claimed job requires/);
+      await unchanged(state.root,() => state.repository.transaction(async transaction => {
+        const record = object(get(object(get(transaction.document,'jobs'),'jobs'),'job'),'job');
+        set(record,'description',text('Must remain guarded'));
+        await transaction.save(transaction.document);
+      }),/claimed job requires/);
+      await differential(state.service,state.root,join(fixture.root,'python-claimed'),[
+        {payload:batch(item('job',{description:'Observed while claimed'})),origin:'agent'},
+      ]);
+    });
+    await t.test('large revisions and unknown numbers are preserved and included in Python token',async () => {
+      const state = await isolated();
+      const path = join(state.root,'jobs.json');
+      const document = await read(state.root,'jobs.json');
+      document.jobs.job.revision = 'EXACT';
+      document.metadata.opaque = 'OPAQUE';
+      await writeFile(path,JSON.stringify(document).replace('"EXACT"','900719925474099312345')
+        .replace('"OPAQUE"','{"integer":900719925474099312346,"float":1.0,"negativeZero":-0.0,"text":"😀"}'));
+      await differential(state.service,state.root,join(fixture.root,'python-large'),[
+        {payload:batch(item('job',{description:'Exact revision increment'}))},
+      ]);
+      assert.match(await readFile(path,'utf8'),/900719925474099312346/);
+      assert.match(await readFile(path,'utf8'),/"float": 1\.0/);
+    });
+    await t.test('independent repositories serialize one accepted token and reject concurrent stale commits',async () => {
+      const state = await isolated();
+      const payload = fromJSON(batch(item('concurrent')));
+      const {token} = plain(await state.service.preview(payload,'human'));
+      const outcomes = await Promise.allSettled(Array.from({length:4},() => new JobUpsertService(
+        new NativeJobsRepository(state.root,state.provider),() => fixed).commit(payload,'human',token)));
+      assert.equal(outcomes.filter(result=>result.status==='fulfilled').length,1);
+      for(const result of outcomes.filter(result=>result.status==='rejected')) assert.match(result.reason.message,/drifted/);
+      const replay = plain(await state.service.preview(payload,'human'));
+      const before = await snapshot(state.root);
+      assert.equal(plain(await state.service.commit(payload,'human',replay.token)).committed,false);
+      assert.deepEqual(await snapshot(state.root),before);
+    });
+    await t.test('atomic save faults preserve old bytes and allow retry with the same token',async () => {
+      const state = await isolated();
+      const payload = fromJSON(batch(item('fault')));
+      const {token} = plain(await state.service.preview(payload,'human'));
+      for(const stage of ['write','sync','replace']) {
+        const repository = new NativeJobsRepository(state.root,state.provider,async (path,value,options) => {
+          const io = createNativePointAtomicWriteIO(options.pathProfile);
+          if(stage==='replace') io.replace = async () => {throw Error('upsert injected fault');};
+          else {
+            const original = io.createTemporary;
+            io.createTemporary = async (...args) => {
+              const handle = await original(...args);
+              handle[stage] = async () => {throw Error('upsert injected fault');};
+              return handle;
+            };
+          }
+          await atomicWritePointJson(path,value,options,io);
+        });
+        await unchanged(state.root,()=>new JobUpsertService(repository,()=>fixed).commit(payload,'human',token),/upsert injected fault/);
+        assert.equal((await readdir(state.root)).some(name=>name.endsWith('.tmp')),false);
+      }
+      assert.equal(plain(await state.service.commit(payload,'human',token)).committed,true);
+    });
+  } finally {await fixture.cleanup();}
+});

--- a/tests_js/workspace_native_job_upsert_browser_support.mjs
+++ b/tests_js/workspace_native_job_upsert_browser_support.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+
+// The caller owns an isolated native fixture; every upsert uses the native CLI.
+export async function jobUpsertBrowser(page, { upsert, readDocument }) {
+  const navigation = page.getByRole('navigation', { name: 'Workspace sections' });
+  const modal = page.getByRole('dialog', { name: 'Edit job', exact: true });
+  const role = 'Native batch capture role';
+  const url = 'https://example.invalid/native-batch-capture';
+  const payload = { jobs: [{ url, role, company: 'Batch company' }] };
+  const expected = { create: 1, update: 0, noop: 0, conflict: 0, invalid: 0 };
+  let navigationPrompts = 0;
+  const dismiss = dialog => { navigationPrompts++; return dialog.dismiss(); };
+  page.on('dialog', dismiss);
+  try {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const before = await readDocument();
+    const preview = await upsert(payload, 'agent');
+    assert.equal(preview.committed, false);
+    assert.deepEqual(preview.summary, expected);
+    assert.match(preview.token, /^job-upsert-v1\.[a-f0-9]{64}$/);
+    assert.equal(await readDocument(), before, 'preview leaves canonical Jobs bytes unchanged');
+    await navigation.getByRole('button', { name: 'Jobs', exact: true }).click();
+    await page.locator('[data-job-create]:enabled').waitFor();
+    assert.equal(await page.getByRole('button', { name: new RegExp(role) }).count(), 0);
+
+    const committed = await upsert(payload, 'agent', preview.token);
+    assert.equal(committed.committed, true);
+    assert.deepEqual(committed.summary, preview.summary);
+    assert.deepEqual(committed.decisions, preview.decisions);
+    const id = committed.decisions[0].id;
+    await page.getByRole('button', { name: 'Refresh', exact: true }).click();
+    await page.getByRole('button', { name: new RegExp(role) }).click();
+    assert.equal(await modal.locator('[name="company"]').inputValue(), 'Batch company');
+    await modal.locator('[name="company"]').fill('Human-reviewed company');
+    await modal.getByRole('button', { name: 'Save job', exact: true }).click();
+    await modal.waitFor({ state: 'hidden' });
+    const humanRecord = JSON.parse(await readDocument()).jobs[id];
+    assert.equal(humanRecord.company, 'Human-reviewed company');
+    assert.equal(humanRecord.provenance['/company'].origin, 'human');
+
+    // ATS is not included in the browser's full editor patch, so it remains
+    // unattributed; explicitly human-stamped empty fields must stay protected.
+    const incoming = { jobs: [{ url, company: 'Agent replacement', ats: 'Fixture ATS' }] };
+    const beforeUpdate = await readDocument();
+    const updatePreview = await upsert(incoming, 'agent');
+    assert.deepEqual(updatePreview.summary, { create: 0, update: 1, noop: 0, conflict: 0, invalid: 0 });
+    assert.deepEqual(updatePreview.decisions, [{ index: 0, action: 'update', id, fields: ['ats'] }]);
+    assert.equal(await readDocument(), beforeUpdate);
+    const update = await upsert(incoming, 'agent', updatePreview.token);
+    assert.equal(update.committed, true);
+    assert.deepEqual(update.summary, updatePreview.summary);
+    assert.deepEqual(update.decisions, updatePreview.decisions);
+    const updated = JSON.parse(await readDocument()).jobs[id];
+    assert.equal(updated.company, humanRecord.company);
+    assert.deepEqual(updated.provenance['/company'], humanRecord.provenance['/company']);
+    assert.equal(updated.ats, 'Fixture ATS');
+    assert.equal(updated.provenance['/ats'].origin, 'agent');
+    assert.equal(updated.revision, humanRecord.revision + 1);
+
+    await navigation.getByRole('button', { name: 'Overview', exact: true }).click();
+    await page.getByRole('heading', { name: 'Your next step', exact: true }).waitFor();
+    await page.reload();
+    await navigation.getByRole('button', { name: 'Jobs', exact: true }).click();
+    await page.locator('[data-job-create]:enabled').waitFor();
+    await page.getByRole('button', { name: new RegExp(role) }).click();
+    assert.equal(await modal.locator('[name="company"]').inputValue(), 'Human-reviewed company');
+    assert.equal(await modal.locator('[name="role"]').inputValue(), role);
+    assert.equal(JSON.parse(await readDocument()).jobs[id].ats, 'Fixture ATS');
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), true);
+    await modal.getByRole('button', { name: 'Close job details', exact: true }).click();
+    await navigation.getByRole('button', { name: 'Overview', exact: true }).click();
+    await page.getByRole('heading', { name: 'Your next step', exact: true }).waitFor();
+    assert.equal(navigationPrompts, 0, 'acknowledged CLI/browser writes leave no false unsaved draft');
+    return { previewReadOnly: true, cliCommitVisible: true, humanProvenancePreserved: true,
+      agentFillsNewField: true, previewCommitAgreement: true, reload: true, cleanNavigation: true, narrowViewport: true };
+  } finally {
+    page.off('dialog', dismiss);
+  }
+}

--- a/tests_js/workspace_native_job_upsert_cli.test.mjs
+++ b/tests_js/workspace_native_job_upsert_cli.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, snapshot, cli } from './workspace_native_claims_support.mjs';
+
+test('Python-free upsert CLI previews without writes and commits only the reviewed batch', {timeout:60000}, async () => {
+  const fixture = await nativeFixture();
+  try {
+    const {root} = await setup(fixture,'upsert-cli');
+    const payload={jobs:[{url:'https://example.invalid/upsert-cli',role:'Native upsert role',source:'Search'}, {url:''}]};
+    const before=await snapshot(root);
+    const preview=await cli(fixture,root,'job-upsert-preview',['--origin','agent'],payload);
+    assert.equal(preview.committed,false);
+    assert.deepEqual(preview.summary,{create:1,update:0,noop:0,conflict:0,invalid:1});
+    assert.deepEqual(await snapshot(root),before);
+    for(const args of [[],['--origin','migration'],['--origin','agent','--token','extra'],['--origin','agent','--unknown','x']]) {
+      await assert.rejects(()=>cli(fixture,root,'job-upsert-preview',args,payload));
+    }
+    await assert.rejects(()=>cli(fixture,root,'job-upsert-commit',['--origin','agent'],payload),/token/);
+    await assert.rejects(()=>cli(fixture,root,'job-upsert-commit',['--origin','agent','--token','forged'],payload),/drifted/);
+    assert.deepEqual(await snapshot(root),before);
+    const committed=await cli(fixture,root,'job-upsert-commit',['--origin','agent','--token',preview.token],payload);
+    assert.equal(committed.committed,true);
+    assert.deepEqual(committed.decisions,preview.decisions);
+    const saved=await cli(fixture,root,'job-get',['--id',preview.decisions[0].id]);
+    assert.equal(saved.role,'Native upsert role');
+    assert.equal(saved.status,'saved');
+    assert.equal(saved.provenance['/role'].origin,'agent');
+    await assert.rejects(()=>cli(fixture,root,'job-upsert-commit',['--origin','agent','--token',preview.token],payload),/drifted/);
+    const again=await cli(fixture,root,'job-upsert-preview',['--origin','agent'],payload);
+    assert.equal(again.summary.noop,1);
+    const settled=await snapshot(root);
+    assert.equal((await cli(fixture,root,'job-upsert-commit',['--origin','agent','--token',again.token],payload)).committed,false);
+    assert.deepEqual(await snapshot(root),settled);
+    for(const name of Object.keys(before).filter(name=>name!=='jobs.json')) assert.equal(settled[name],before[name],name);
+  } finally {await fixture.cleanup();}
+});
+
+test('bulk upsert stdin accepts the same reviewed batch as file input', {timeout:60000}, async () => {
+  const {spawn} = await import('node:child_process');
+  const fixture = await nativeFixture();
+  try {
+    const {root} = await setup(fixture,'upsert-stdin');
+    const payload = {jobs:Array.from({length:10},(_,index)=>({url:`https://example.invalid/bulk-${index}`,description:'a'.repeat(8192)}))};
+    const stdin = (command,token) => new Promise((resolve,reject) => {
+      const child = spawn(process.execPath,['runtime/cli/native-jobs.js','--root',root,'--native-lock',fixture.receipt.artifact,
+        command,'--origin','agent','--input','-',...(token?['--token',token]:[])],{cwd:new URL('../',import.meta.url),env:{PATH:''}});
+      let stdout='',stderr='';
+      child.stdout.on('data',bytes=>{stdout+=bytes;});
+      child.stderr.on('data',bytes=>{stderr+=bytes;});
+      child.on('error',reject);
+      child.on('close',code=>{
+        if(code!==0) return reject(Error(stderr));
+        try {resolve(JSON.parse(stdout));} catch(error){reject(error);}
+      });
+      child.stdin.on('error',()=>{});
+      child.stdin.end(JSON.stringify(payload));
+    });
+    const file = await cli(fixture,root,'job-upsert-preview',['--origin','agent'],payload);
+    assert.equal(file.summary.create,10);
+    const before = await snapshot(root);
+    assert.deepEqual(await stdin('job-upsert-preview'),file);
+    assert.deepEqual(await snapshot(root),before);
+    const committed=await stdin('job-upsert-commit',file.token);
+    assert.equal(committed.committed,true);
+    assert.deepEqual(committed.decisions,file.decisions);
+  } finally {await fixture.cleanup();}
+});

--- a/tests_js/workspace_native_job_upsert_support.mjs
+++ b/tests_js/workspace_native_job_upsert_support.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { cp, readFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join } from 'node:path';
+import { parse } from '../runtime/contracts/workspace/values.js';
+import { canonicalJson } from '../runtime/contracts/workspace/canonical-json.js';
+import { plain, snapshot } from './workspace_native_claims_support.mjs';
+export const fixed = '2026-09-10T14:00:00Z';
+export const item = (name, extra = {}) => ({url:`https://example.invalid/${name}`, ...extra});
+export const batch = (...jobs) => ({jobs});
+export async function differential(service, root, referenceRoot, operations) {
+  await cp(root, referenceRoot, {recursive:true, preserveTimestamps:true});
+  const reference = JSON.parse((await promisify(execFile)('python3', [
+    'tools/contracts/job-upsert/reference.py', referenceRoot, JSON.stringify(operations),
+  ], {maxBuffer:8 * 1024 * 1024})).stdout);
+  for (const [index, operation] of operations.entries()) {
+    const input = parse(operation.payloadJson ?? JSON.stringify(operation.payload));
+    const origin = operation.origin ?? 'human';
+    let result;
+    const before = await snapshot(root);
+    try {
+      const preview = plain(await service.preview(input, origin));
+      assert.deepEqual(await snapshot(root), before, 'preview must preserve canonical bytes');
+      result = {preview};
+      try {
+        result.commit = plain(await service.commit(operation.commitPayload ? parse(JSON.stringify(operation.commitPayload)) : input,
+          operation.commitOrigin ?? origin, operation.token ?? preview.token));
+      } catch (error) { result.error = error.message; }
+    } catch (error) { result = {error:error.message}; }
+    const {document, ...expected} = reference[index];
+    assert.deepEqual(result, expected, `operation ${index}: ${JSON.stringify(operation)}`);
+    assert.equal(canonicalJson(parse(await readFile(join(root,'jobs.json'),'utf8'))), canonicalJson(parse(document)), `durable operation ${index}`);
+    const after = await snapshot(root);
+    if (!result.commit?.committed) assert.deepEqual(after,before,'rejected/noop commit must preserve bytes');
+    delete before['jobs.json']; delete after['jobs.json'];
+    assert.deepEqual(after,before,'upsert may only change jobs.json');
+  }
+}
+export async function unchanged(root, operation, pattern) {
+  const before = await snapshot(root);
+  await assert.rejects(operation,pattern);
+  assert.deepEqual(await snapshot(root),before);
+}

--- a/tools/contracts/job-upsert/reference.py
+++ b/tools/contracts/job-upsert/reference.py
@@ -1,0 +1,32 @@
+"""Independent Python upsert oracle for synthetic native fixture comparisons."""
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path('scripts').resolve()))
+spec = importlib.util.spec_from_file_location('upsert_reference', 'scripts/job-apply-store.py')
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+module.utc_now = lambda: '2026-09-10T14:00:00Z'
+store = module.Store(Path(sys.argv[1]))
+store.initialize()
+results = []
+for operation in json.loads(sys.argv[2]):
+    try:
+        payload = json.loads(operation['payloadJson']) if 'payloadJson' in operation else operation['payload']
+        origin = operation.get('origin', 'human')
+        preview = store.preview_job_upsert(payload, origin)
+        result = {'preview': preview}
+        commit_payload = operation.get('commitPayload', payload)
+        commit_origin = operation.get('commitOrigin', origin)
+        token = operation.get('token', preview['token'])
+        try:
+            result['commit'] = store.commit_job_upsert(commit_payload, commit_origin, token)
+        except module.StoreError as error:
+            result['error'] = str(error)
+    except module.StoreError as error:
+        result = {'error': str(error)}
+    result['document'] = store.jobs_path.read_text()
+    results.append(result)
+print(json.dumps(results))

--- a/tools/local-checks/run.mjs
+++ b/tools/local-checks/run.mjs
@@ -52,6 +52,11 @@ async function environmentIdentity(root) {
     installedLock: hash(await readFile(join(root, 'node_modules/.package-lock.json'))) };
 }
 
+export function localSuiteTimeout(mode, suite, nativeSuites) {
+  const native = nativeSuites.some(candidate => candidate.id === suite.id);
+  return mode === 'deep' || native ? (suite.timeoutMs ?? 900_000) : 120_000;
+}
+
 export async function runTarget(root, target, { mode, paths }) {
   return withSnapshot(root, target.commit, async (snapshot) => {
     const matrix = await loadMatrix(snapshot);
@@ -107,7 +112,7 @@ export async function runTarget(root, target, { mode, paths }) {
     const suites = selected.map((suite) => ({
       ...suite,
       ...(suite.id === 'source-size' ? { command: ['npm', 'run', 'check:size', '--', '--base', target.base] } : {}),
-      timeoutMs: mode === 'deep' ? (suite.timeoutMs ?? 900_000) : 120_000,
+      timeoutMs: localSuiteTimeout(mode, suite, plan.native),
     }));
     const startedAt = Date.now();
     let log = '';


### PR DESCRIPTION
Native job capture lacked the existing preview-and-commit batch workflow. This adds shared TypeScript planning and native CLI commands, preserving deterministic identity matching, whole-document preview tokens, human/agent provenance, partial-batch decisions and no-op persistence. Committed jobs appear in the existing Companion after refresh or reload.

The dedicated repository path preserves Python ingestion behavior for claimed jobs while ordinary claimed-job edit guards remain intact. Commits atomically update only jobs.json. Bulk stdin accepts the same inputs as files. The opt-in v9 synthetic fixture boundary remains unchanged.

Validation: 25 focused model, CLI, native fixture, Python differential and Jobs regression tests passed, plus the production standalone Companion walkthrough at 390px. Five independent focused reviews completed; the bulk-stdin mismatch was independently validated, fixed with a red/green subprocess test, and reviewed again. Native Codex CLI review could not run its configured model because the installed CLI is too old.

The initial deep run passed, but the fresh native push suite exceeded its hardcoded two-minute timeout after the same suite passed deep in three minutes. Fresh native checks now use their configured/deep finite timeout; quick checks keep two minutes. Selection, freshness, assertions and receipt acceptance are unchanged. The timeout fix passed 21 policy/hook tests and independent review. Final deep validation passed all required checks across 27 suites (Windows-only checks deferred to CI). [Validate Plugin](https://github.com/neonwatty/job-apply-plugin/actions/runs/34543865119) and [Release Validation](https://github.com/neonwatty/job-apply-plugin/actions/runs/34543867123) passed on exact head `e59bc555efbc030d1a2f95fc93a65baad7d5a901`. Release attempt 1 timed out in an unchanged compatibility Trash browser test; attempt 2 passed without source changes. Inspection identified a plausible existing asynchronous refresh/old-revision race in that fixture, outside native upsert. The initial failure is retained in the local evidence record.
