### PR TITLE
Fix Companion shutdown and delayed input focus

### DIFF
--- a/companion/scripts/job_apply_workspace/connections.py
+++ b/companion/scripts/job_apply_workspace/connections.py
@@ -1,0 +1,43 @@
+"""Interruptible socket I/O without imposing a user-facing idle deadline."""
+
+import socket
+
+
+class WorkspaceConnection(socket.socket):
+    """Poll the server close event inside I/O, before SocketIO sees a timeout."""
+
+    def __init__(self, connection, closing):
+        super().__init__(connection.family, connection.type, connection.proto,
+                         fileno=connection.detach())
+        self.closing = closing
+        self.settimeout(0.2)
+
+    def recv_into(self, buffer, nbytes=0, flags=0):
+        while not self.closing.is_set():
+            try:
+                return super().recv_into(buffer, nbytes, flags)
+            except socket.timeout:
+                continue
+            except OSError:
+                if self.closing.is_set():
+                    return 0
+                raise
+        return 0
+
+    def sendall(self, data, flags=0):
+        with memoryview(data).cast('B') as pending:
+            offset = 0
+            while offset < len(pending):
+                if self.closing.is_set():
+                    raise BrokenPipeError("workspace connection is closing")
+                try:
+                    sent = super().send(pending[offset:], flags)
+                except socket.timeout:
+                    continue
+                except OSError:
+                    if self.closing.is_set():
+                        raise BrokenPipeError("workspace connection is closing") from None
+                    raise
+                if sent == 0:
+                    raise BrokenPipeError("workspace connection closed")
+                offset += sent

--- a/companion/scripts/job_apply_workspace/handler.py
+++ b/companion/scripts/job_apply_workspace/handler.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import secrets
+import socket
+import sys
+import threading
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -52,7 +55,7 @@ def degraded_boot_status(error: Exception) -> dict[str, str]:
 
 
 class WorkspaceServer(ThreadingHTTPServer):
-    daemon_threads = True
+    daemon_threads = False
     allow_reuse_address = False
 
     def __init__(self, root: Path, port: int, token: str | None = None):
@@ -80,8 +83,52 @@ class WorkspaceServer(ThreadingHTTPServer):
             self.store.initialize()
         runtime_secrets = runtime().get("secrets", secrets)
         self.token = token or runtime_secrets.token_urlsafe(32)
+        self._connections_lock = threading.Lock()
+        self._connections: set[socket.socket] = set()
+        self._closing = False
         super().__init__((LOOPBACK, port), WorkspaceHandler)
         self.origin, self.expected_host = loopback_authority(self.server_port)
+
+    def process_request(self, request, client_address):
+        # Register before starting the worker so close cannot miss an accepted socket.
+        with self._connections_lock:
+            closing = self._closing
+            if not closing:
+                self._connections.add(request)
+        if closing:
+            self.shutdown_request(request)
+            return
+        try:
+            super().process_request(request, client_address)
+        except Exception:
+            self.shutdown_request(request)
+            raise
+
+    def shutdown_request(self, request):
+        try:
+            super().shutdown_request(request)
+        finally:
+            with self._connections_lock:
+                self._connections.discard(request)
+
+    def server_close(self):
+        # Stop socket reads/writes, then join workers. Store operations already in
+        # progress finish normally before interpreter teardown can begin.
+        with self._connections_lock:
+            self._closing = True
+            connections = tuple(self._connections)
+        for connection in connections:
+            try:
+                connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass  # The peer or request worker already closed this socket.
+        super().server_close()
+
+    def handle_error(self, request, client_address):
+        # A browser disconnect (including shutdown above) is not an app failure.
+        if isinstance(sys.exc_info()[1], ConnectionError):
+            return
+        super().handle_error(request, client_address)
 
 
 class WorkspaceHandler(

--- a/companion/scripts/job_apply_workspace/handler.py
+++ b/companion/scripts/job_apply_workspace/handler.py
@@ -16,6 +16,7 @@ from . import (
     loopback_authority,
     runtime,
 )
+from .connections import WorkspaceConnection
 from .auth import AuthMixin
 from .domains.accounts import AccountMutationMixin
 from .domains.answers import AnswerMutationMixin
@@ -86,8 +87,13 @@ class WorkspaceServer(ThreadingHTTPServer):
         self._connections_lock = threading.Lock()
         self._connections: set[socket.socket] = set()
         self._closing = False
+        self._closing_event = threading.Event()
         super().__init__((LOOPBACK, port), WorkspaceHandler)
         self.origin, self.expected_host = loopback_authority(self.server_port)
+
+    def get_request(self):
+        connection, address = super().get_request()
+        return WorkspaceConnection(connection, self._closing_event), address
 
     def process_request(self, request, client_address):
         # Register before starting the worker so close cannot miss an accepted socket.
@@ -116,6 +122,7 @@ class WorkspaceServer(ThreadingHTTPServer):
         # progress finish normally before interpreter teardown can begin.
         with self._connections_lock:
             self._closing = True
+            self._closing_event.set()
             connections = tuple(self._connections)
         for connection in connections:
             try:

--- a/companion/workspace/features/answers.js
+++ b/companion/workspace/features/answers.js
@@ -88,7 +88,7 @@ export function installAnswers(context) {
   function showAnswerDetail(selected, opener, pendingJobId = null, pendingReference = null) {
     answerState.dialogGeneration += 1; answerState.opener = opener || document.activeElement;
     answerState.pendingJobId = pendingJobId; answerState.pendingReference = pendingReference; answerState.selected = selected; populateAnswerForm(selected);
-    $("#answer-kicker").textContent = `CANONICAL · REVISION ${selected.revision}`; $("#answer-dialog").showModal(); setTimeout(() => $("#answer-form").elements.question.focus(), 0);
+    $("#answer-kicker").textContent = `CANONICAL · REVISION ${selected.revision}`; $("#answer-dialog").showModal(); $("#answer-form").elements.question.focus();
   }
 
   async function openAnswer(answer, opener) {
@@ -100,7 +100,7 @@ export function installAnswers(context) {
       showAnswerDetail(selected, requestedOpener);
     } catch (error) { if (requestSequence === answerState.detailRequestSequence) answerError(error.message); }
   }
-  function newAnswer() { answerState.detailRequestSequence += 1; answerState.dialogGeneration += 1; answerState.selected = null; answerState.opener = document.activeElement; answerState.pendingJobId = null; answerState.pendingReference = null; populateAnswerForm(null); $("#answer-kicker").textContent = "NEW CANONICAL RECORD"; $("#answer-dialog").showModal(); setTimeout(() => $("#answer-form").elements.question.focus(), 0); }
+  function newAnswer() { answerState.detailRequestSequence += 1; answerState.dialogGeneration += 1; answerState.selected = null; answerState.opener = document.activeElement; answerState.pendingJobId = null; answerState.pendingReference = null; populateAnswerForm(null); $("#answer-kicker").textContent = "NEW CANONICAL RECORD"; $("#answer-dialog").showModal(); $("#answer-form").elements.question.focus(); }
 
   function answerFormPayload(onlyDirty = false) {
     const form = $("#answer-form"); let scope; try { scope = JSON.parse(form.elements.scope.value); } catch { throw new Error("Scope must be a valid JSON object."); } if (!scope || Array.isArray(scope) || typeof scope !== "object") throw new Error("Scope must be a JSON object.");

--- a/companion/workspace/features/navigation.js
+++ b/companion/workspace/features/navigation.js
@@ -118,15 +118,15 @@ export function installNavigation(context) {
   }
 
   async function navigateWorkspace(name) {
-    const generation = ++state.navigationGeneration;
+    state.navigationGeneration += 1;
     attentionState.detailRequestSequence += 1;
     closeNavigation();
-    await showWorkspace(name);
-    if (generation !== state.navigationGeneration) return;
+    const loading = showWorkspace(name);
     const heading = $(`#${name}-workspace .hero h2`);
     heading.setAttribute("tabindex", "-1");
     heading.focus({ preventScroll: true });
     window.scrollTo({ top: 0, behavior: "instant" });
+    await loading;
   }
 
   function attentionButton(jobId) { return document.querySelector(`[data-attention-id="${CSS.escape(jobId)}"]`); }

--- a/docs/python-release-readiness.md
+++ b/docs/python-release-readiness.md
@@ -1,6 +1,6 @@
 # Python release readiness spec
 
-Status: phase 2 re-scoped after owner dogfooding; availability hardening in progress. Baseline assessed: `c1b180b3` on 2026-09-09.
+Status (2026-09-11): PR #75 UX candidate passes CI and scoped installed Companion QA; PR #72 CI hardening continues. Fresh installed calling-agent acceptance is owner-skipped, not passed. Final integration/release acceptance remains open.
 
 ## Objective and scope
 
@@ -76,9 +76,9 @@ testing retains its explicit opt-in.
 | --- | --- | --- |
 | 1 | Complete | PR #57 merged; 20 repeated runs, full local/package tests, and CI run `34406170344` passed |
 | 2 | Re-scoped | Owner dogfooding completed; agent-first and optional-companion improvements required |
-| 3 | Planned | Actual prior-release upgrade and installed-agent sessions |
-| 4 | Planned | Observed workspace QA and refinements |
-| 5 | Planned | Installed-agent and owner acceptance |
+| 3 | Partial / scope revised | Isolated package smoke passes; actual prior-release upgrade remains open; fresh installed-agent sessions skipped by owner |
+| 4 | Refined / scoped QA | PR #75 CI and installed Companion receipts pass for recorded journeys; DOCX and uncaptured browser branches remain unqualified |
+| 5 | Scope revised | Recorded owner/browser journeys only; fresh installed calling-agent acceptance skipped, not completed |
 | 6 | Planned | Final candidate, review, and release |
 
 Record behavioral fixes and TypeScript follow-up in the
@@ -140,3 +140,23 @@ Phase 4 observation: Facts provenance is nested inside field labels, so an exact
 accessible name such as “First name” changes when provenance loads. Evaluate
 separating the field name from its provenance description in the accessibility
 walkthrough; the setup regression selects the stable field path after data loads.
+
+### Owner acceptance scope update — 2026-09-11
+
+The owner explicitly skipped fresh installed-plugin calling-agent acceptance for
+Claude and Codex because isolated sign-in could not be completed. Record this as
+**not completed**, not a pass. Do not pursue further sign-in or substitute package
+smoke for actual installed-agent acceptance. Keep the limitation in release notes
+and final review. Existing package, controlled browser and installed Companion
+receipts retain their narrower scope. DOCX browser-download confirmation remains
+unqualified under the host inspection restriction.
+
+Browser closeout for installed Companion candidate
+`5ccf85be700f3c4d080623dc8d755038f860425d`: normal-speed readiness action-window
+and actual Ready transition passed; changing/restoring the profile invalidated
+and recovered readiness with unchanged job revision. Answer Trash toast, restore
+view guidance and Automation copy passed. The synthetic answer was restored;
+settings and prior environments were preserved. Brief pending-disabled state,
+no-scroll and missing-resume-specific branches remain controlled-test evidence,
+not independent browser acceptance. This receipt does not qualify later PR #72
+changes or remove the skipped calling-agent/DOCX limitations above.

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -223,3 +223,16 @@ announcement. This fixes the demonstrated test race without weakening stale-data
 checks or adding sleeps/retries. The historical timeout alone cannot prove every
 previous failure had this cause. Forward-port the synchronization check to the
 migration walkthrough if it uses response headers as an application-ready signal.
+
+### Input focus during asynchronous work
+
+Controlled browser schedules reproduce two input hazards: navigation completion
+focused its heading after the owner had begun editing an employer override;
+answer-dialog opening queued a question-field focus that could redirect later
+value typing into the question. Navigation now focuses before awaiting initial
+loads, and answer dialogs focus synchronously when opened. Regressions hold the
+account-operation response and defer the old dialog callback, then verify focus,
+submitted override revision, and canonical answer value. Both fail before the fix.
+The CI timeout/null lookup alone does not prove every historical failure shared
+these causes. Forward-port focus-at-entry behavior, preserving user focus after
+async completion, into the TypeScript UI.

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -206,3 +206,10 @@ establish why any previously unavailable dogfooding process exited.
 Migration follow-up: preserve request draining and Store-operation completion in
 the TypeScript server lifecycle. A Store operation blocked on external work can
 still delay graceful exit; this change does not forcibly interrupt transactions.
+
+Windows shutdown correction: accepted sockets now poll the server close event
+inside read/write operations. This avoids relying on cross-thread socket
+shutdown to wake Windows reads. Poll timeouts remain internal and do not expire
+idle browser connections or interrupt Store operations. A regression disables
+the socket shutdown wakeup and still requires all workers to drain; another
+keeps a connection idle across multiple intervals before completing its request.

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -161,8 +161,8 @@ Forward-port these interaction details with the UX foundation.
 Verification follow-up: abandoning a response body and immediately stopping the
 server reproduced a request-thread stderr/finalization failure on Python 3.9 and
 3.12. The orderly-shutdown test now consumes the response before stopping.
-Abrupt-disconnect shutdown deserves a separate regression/fix before final release
-acceptance; this UX change does not alter server shutdown behavior.
+The subsequent request-draining fix below addresses worker lifetime separately
+from the UX changes.
 
 CI timing fixes: retire the attempt broker socket and PID before acknowledging a
 terminal request, so an immediate review restart cannot reach a retiring broker.
@@ -188,3 +188,21 @@ An explicit download fallback remains available for unsupported or blank native
 PDF renderers. TXT and DOCX behavior is unchanged. Embedded readability requires
 owner acceptance; isolated headless tests verify wiring, not native rendering.
 Forward-port this presentation and cancellation behavior to TypeScript separately.
+
+### Request draining during Companion shutdown
+
+The Python server now tracks accepted connections, interrupts pending socket I/O,
+and joins non-daemon request workers before the launcher exits. Work already
+running in the Store can finish before interpreter teardown; idle keepalive and
+incomplete requests do not hold shutdown open. Expected connection errors are
+quiet, while unexpected handler errors retain their traceback.
+
+Regression coverage holds an active handler through shutdown, leaves an
+incomplete request connected, and stops isolated launcher processes with idle,
+partial-body, and abandoned-response clients under supported stop signals.
+This fixes the request-worker lifetime defect recorded above; it does not
+establish why any previously unavailable dogfooding process exited.
+
+Migration follow-up: preserve request draining and Store-operation completion in
+the TypeScript server lifecycle. A Store operation blocked on external work can
+still delay graceful exit; this change does not forcibly interrupt transactions.

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -213,3 +213,13 @@ shutdown to wake Windows reads. Poll timeouts remain internal and do not expire
 idle browser connections or interrupt Store operations. A regression disables
 the socket shutdown wakeup and still requires all workers to drain; another
 keeps a connection idle across multiple intervals before completing its request.
+
+Shutdown CI follow-up: the owner-beta recovery test waited for `/api/state`
+response headers before retrying readiness. A controlled response-consumption
+gate reproduces the premature click: the client correctly refuses preflight
+while canonical state is pending. The walkthrough now waits for a new rendered
+Jobs refresh-complete announcement, even when its text matches the previous
+announcement. This fixes the demonstrated test race without weakening stale-data
+checks or adding sleeps/retries. The historical timeout alone cannot prove every
+previous failure had this cause. Forward-port the synchronization check to the
+migration walkthrough if it uses response headers as an application-ready signal.

--- a/tests/test_job_apply_workspace_shutdown.py
+++ b/tests/test_job_apply_workspace_shutdown.py
@@ -7,7 +7,7 @@ import threading
 import unittest
 from http.server import BaseHTTPRequestHandler
 
-from tests.support.workspace_case import WORKSPACE, tempfile, Path
+from tests.support.workspace_case import WORKSPACE, tempfile, Path, mock
 
 
 class ShutdownTests(unittest.TestCase):
@@ -79,11 +79,79 @@ class ShutdownTests(unittest.TestCase):
                 client.sendall(b"GET / HTTP/1.1")
                 self.assertTrue(entered.wait(2))
                 server.shutdown()
-                closer = threading.Thread(target=server.server_close, daemon=True)
-                closer.start()
-                closer.join(2)
+                # Model platforms where shutdown does not wake a blocked recv.
+                with mock.patch.object(type(next(iter(server._connections))), "shutdown", return_value=None):
+                    closer = threading.Thread(target=server.server_close, daemon=True)
+                    closer.start()
+                    closer.join(2)
                 self.assertFalse(closer.is_alive(), "idle client blocked shutdown")
                 self.assertTrue(finished.is_set(), "request worker survived shutdown")
+            finally:
+                client.close()
+                server.shutdown()
+                server.server_close()
+                serving.join(2)
+
+    def test_close_unblocks_response_to_client_that_is_not_reading(self):
+        entered = threading.Event()
+        finished = threading.Event()
+
+        class Handler(BaseHTTPRequestHandler):
+            def handle(self):
+                self.connection.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4096)
+                entered.set()
+                try:
+                    self.wfile.write(b"x" * (8 * 1024 * 1024))
+                finally:
+                    finished.set()
+
+        with tempfile.TemporaryDirectory() as temporary:
+            server = WORKSPACE.WorkspaceServer(Path(temporary), 0)
+            server.RequestHandlerClass = Handler
+            serving = threading.Thread(target=server.serve_forever)
+            serving.start()
+            client = socket.create_connection(server.server_address, timeout=2)
+            try:
+                self.assertTrue(entered.wait(2))
+                self.assertFalse(finished.wait(.3))
+                server.shutdown()
+                with mock.patch.object(type(next(iter(server._connections))), "shutdown", return_value=None):
+                    closer = threading.Thread(target=server.server_close, daemon=True)
+                    closer.start()
+                    closer.join(2)
+                self.assertFalse(closer.is_alive())
+                self.assertTrue(finished.is_set())
+            finally:
+                client.close()
+                server.shutdown()
+                server.server_close()
+                serving.join(2)
+
+    def test_idle_connection_survives_multiple_io_poll_intervals(self):
+        entered = threading.Event()
+        finished = threading.Event()
+        received = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def handle(self):
+                entered.set()
+                received.append(self.rfile.readline())
+                self.wfile.write(b"accepted")
+                finished.set()
+
+        with tempfile.TemporaryDirectory() as temporary:
+            server = WORKSPACE.WorkspaceServer(Path(temporary), 0)
+            server.RequestHandlerClass = Handler
+            serving = threading.Thread(target=server.serve_forever)
+            serving.start()
+            client = socket.create_connection(server.server_address, timeout=2)
+            try:
+                self.assertTrue(entered.wait(2))
+                self.assertFalse(finished.wait(.7))
+                client.sendall(b"delayed request\n")
+                self.assertEqual(client.recv(8), b"accepted")
+                self.assertTrue(finished.wait(2))
+                self.assertEqual(received, [b"delayed request\n"])
             finally:
                 client.close()
                 server.shutdown()

--- a/tests/test_job_apply_workspace_shutdown.py
+++ b/tests/test_job_apply_workspace_shutdown.py
@@ -101,7 +101,11 @@ class ShutdownTests(unittest.TestCase):
                 self.connection.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4096)
                 entered.set()
                 try:
-                    self.wfile.write(b"x" * (8 * 1024 * 1024))
+                    # Keep producing until shutdown: loopback stacks can absorb
+                    # a fixed payload despite constrained socket buffers.
+                    payload = b"x" * (64 * 1024)
+                    while True:
+                        self.wfile.write(payload)
                 finally:
                     finished.set()
 

--- a/tests/test_job_apply_workspace_shutdown.py
+++ b/tests/test_job_apply_workspace_shutdown.py
@@ -1,0 +1,177 @@
+"""Shutdown must drain request workers without waiting on idle clients."""
+
+import io
+import socket
+from contextlib import redirect_stderr
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler
+
+from tests.support.workspace_case import WORKSPACE, tempfile, Path
+
+
+class ShutdownTests(unittest.TestCase):
+    def test_close_waits_for_active_request_work(self):
+        entered = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        closed = threading.Event()
+
+        class Handler(BaseHTTPRequestHandler):
+            def handle(self):
+                entered.set()
+                release.wait(5)
+                self.server.store.patch_profile(
+                    {"contact": {"name": "Synthetic Shutdown Test"}},
+                    expected_revision=self.server.store.inspect_profile()["revision"],
+                    source="user",
+                )
+                finished.set()
+
+        with tempfile.TemporaryDirectory() as temporary:
+            server = WORKSPACE.WorkspaceServer(Path(temporary), 0)
+            server.RequestHandlerClass = Handler
+            serving = threading.Thread(target=server.serve_forever)
+            serving.start()
+            client = socket.create_connection(server.server_address, timeout=2)
+            closer = None
+            try:
+                self.assertTrue(entered.wait(2))
+                server.shutdown()
+                def close():
+                    server.server_close()
+                    closed.set()
+                closer = threading.Thread(target=close)
+                closer.start()
+                self.assertFalse(closed.wait(.2), "server_close abandoned an active worker")
+                release.set()
+                self.assertTrue(closed.wait(2))
+                self.assertTrue(finished.is_set())
+                self.assertEqual(server.store.get_profile()["contact"]["name"], "Synthetic Shutdown Test")
+            finally:
+                release.set()
+                client.close()
+                server.shutdown()
+                server.server_close()
+                serving.join(2)
+                if closer:
+                    closer.join(2)
+
+    def test_close_unblocks_incomplete_request(self):
+        entered = threading.Event()
+        finished = threading.Event()
+
+        class Handler(BaseHTTPRequestHandler):
+            def handle(self):
+                entered.set()
+                try:
+                    self.rfile.readline()
+                finally:
+                    finished.set()
+
+        with tempfile.TemporaryDirectory() as temporary:
+            server = WORKSPACE.WorkspaceServer(Path(temporary), 0)
+            server.RequestHandlerClass = Handler
+            serving = threading.Thread(target=server.serve_forever)
+            serving.start()
+            client = socket.create_connection(server.server_address, timeout=2)
+            try:
+                client.sendall(b"GET / HTTP/1.1")
+                self.assertTrue(entered.wait(2))
+                server.shutdown()
+                closer = threading.Thread(target=server.server_close, daemon=True)
+                closer.start()
+                closer.join(2)
+                self.assertFalse(closer.is_alive(), "idle client blocked shutdown")
+                self.assertTrue(finished.is_set(), "request worker survived shutdown")
+            finally:
+                client.close()
+                server.shutdown()
+                server.server_close()
+                serving.join(2)
+
+    def test_disconnect_is_quiet_but_unexpected_worker_error_is_reported(self):
+        for error in (BrokenPipeError("disconnected"), RuntimeError("synthetic defect")):
+            entered = threading.Event()
+
+            class Handler(BaseHTTPRequestHandler):
+                def handle(self):
+                    entered.set()
+                    raise error
+
+            with self.subTest(error=type(error).__name__), tempfile.TemporaryDirectory() as temporary:
+                server = WORKSPACE.WorkspaceServer(Path(temporary), 0)
+                server.RequestHandlerClass = Handler
+                serving = threading.Thread(target=server.serve_forever)
+                output = io.StringIO()
+                with redirect_stderr(output):
+                    serving.start()
+                    client = socket.create_connection(server.server_address, timeout=2)
+                    try:
+                        self.assertTrue(entered.wait(2))
+                    finally:
+                        server.shutdown()
+                        server.server_close()
+                        client.close()
+                        serving.join(2)
+                if isinstance(error, ConnectionError):
+                    self.assertEqual(output.getvalue(), "")
+                else:
+                    self.assertIn("RuntimeError: synthetic defect", output.getvalue())
+
+
+class LauncherShutdownTests(unittest.TestCase):
+    def test_signals_with_keepalive_partial_body_and_disconnected_clients(self):
+        import http.client
+        import json
+        import os
+        import signal
+        import subprocess
+        import sys
+        from tests.support.workspace_case import ROOT
+
+        signals = [signal.SIGINT, signal.SIGTERM] if os.name != "nt" else [signal.CTRL_BREAK_EVENT]
+        for stop_signal in signals:
+            for attempt in range(3):
+                with self.subTest(signal=stop_signal, attempt=attempt), tempfile.TemporaryDirectory() as temporary:
+                    process = subprocess.Popen(
+                        [sys.executable, str(ROOT / "companion/scripts/job-apply-workspace.py"),
+                         "--root", str(Path(temporary) / "store"), "--port", "0", "--no-open", "--json"],
+                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+                        creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0,
+                    )
+                    clients = []
+                    connection = None
+                    try:
+                        details = json.loads(process.stdout.readline())
+                        address = ("127.0.0.1", details["port"])
+                        host = f"127.0.0.1:{details['port']}"
+                        connection = http.client.HTTPConnection(*address, timeout=3)
+                        connection.request("GET", "/")
+                        response = connection.getresponse()
+                        self.assertEqual(response.status, 200)
+                        response.read()  # Leave HTTP/1.1 keepalive open.
+                        for request in (
+                            b"GET / HTTP/1.1\r\nHost: ",
+                            (f"POST /api/profile HTTP/1.1\r\nHost: {host}\r\n"
+                             f"Origin: http://{host}\r\nAuthorization: Bearer {details['url'].split('#token=')[1]}\r\n"
+                             "Content-Type: application/json\r\nContent-Length: 100\r\n\r\n{").encode(),
+                            f"GET / HTTP/1.1\r\nHost: {host}\r\n\r\n".encode(),
+                        ):
+                            client = socket.create_connection(address, timeout=3)
+                            clients.append(client)
+                            client.sendall(request)
+                        clients[-1].close()  # Abandon the response before shutdown.
+                        process.send_signal(stop_signal)
+                        _, errors = process.communicate(timeout=5)
+                        self.assertEqual(process.returncode, 0, errors)
+                        self.assertNotIn("Fatal Python error", errors)
+                        self.assertNotIn("Traceback", errors)
+                    finally:
+                        for client in clients:
+                            client.close()
+                        if connection:
+                            connection.close()
+                        if process.poll() is None:
+                            process.kill()
+                        process.communicate(timeout=5)

--- a/tests/test_job_apply_workspace_shutdown.py
+++ b/tests/test_job_apply_workspace_shutdown.py
@@ -110,7 +110,12 @@ class ShutdownTests(unittest.TestCase):
             server.RequestHandlerClass = Handler
             serving = threading.Thread(target=server.serve_forever)
             serving.start()
-            client = socket.create_connection(server.server_address, timeout=2)
+            # Constrain the receive window before connecting: Windows may otherwise
+            # buffer the entire payload even with a small server send buffer.
+            client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4096)
+            client.settimeout(2)
+            client.connect(server.server_address)
             try:
                 self.assertTrue(entered.wait(2))
                 self.assertFalse(finished.wait(.3))

--- a/tests_js/workspace_input_focus_races.test.mjs
+++ b/tests_js/workspace_input_focus_races.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { openWorkspace } from './workspace_menu_support.mjs';
+import { createOwnerBetaScenario, startOwnerBetaScenario, cleanupOwnerBetaScenario } from './workspace_owner_beta_scenario_support.mjs';
+
+test('late navigation loading does not take focus from an employer override draft', { timeout: 30_000 }, async () => {
+  const context = await createOwnerBetaScenario();
+  try {
+    await startOwnerBetaScenario(context);
+    const page = await context.browser.newPage();
+    await page.goto(context.running.startup.url);
+    let release;
+    const gate = new Promise(resolve => { release = resolve; });
+    await page.route('**/api/account-operation', async route => { await gate; await route.continue(); });
+    try {
+      await openWorkspace(page, 'automation');
+      await page.getByLabel('Exact employer portal URL').fill('https://acme.wd5.myworkdayjobs.com/en-US/jobs/one');
+      await page.getByRole('button', { name: 'Add resolved realm', exact: true }).click();
+      const input = page.getByRole('form', { name: /Edit signup email override/ }).getByLabel('Signup email override');
+      await input.fill('replacement@example.com');
+      await page.evaluate(() => { document.querySelector('#account-operation-status').textContent = 'Waiting for controlled response'; });
+      release();
+      await page.getByText('No protected account operation is pending.', { exact: true }).waitFor();
+      assert.equal(await input.evaluate(node => node === document.activeElement), true);
+      await page.getByRole('button', { name: 'Save override', exact: true }).click();
+      await page.getByText(/revision 2 · email override configured/).waitFor();
+    } finally { release(); }
+  } finally { await cleanupOwnerBetaScenario(context); }
+});
+
+test('answer dialog opening cannot redirect subsequent value input into its question', { timeout: 30_000 }, async () => {
+  const context = await createOwnerBetaScenario();
+  try {
+    await startOwnerBetaScenario(context);
+    const page = await context.browser.newPage();
+    await page.addInitScript(() => {
+      const timeout = globalThis.setTimeout;
+      globalThis.answerFocusCallbacks = [];
+      globalThis.setTimeout = (callback, delay, ...args) => {
+        if (delay === 0 && String(callback).includes('elements.question.focus')) {
+          globalThis.answerFocusCallbacks.push(callback);
+          return -1;
+        }
+        return timeout(callback, delay, ...args);
+      };
+    });
+    await page.goto(context.running.startup.url);
+    await openWorkspace(page, 'answers');
+    await page.getByRole('button', { name: 'New answer', exact: true }).click();
+    const dialog = page.locator('#answer-dialog');
+    await dialog.getByLabel('Question', { exact: true }).fill('Synthetic focus question?');
+    const value = dialog.getByLabel('Value', { exact: true });
+    await value.focus();
+    await page.evaluate(() => { for (const callback of globalThis.answerFocusCallbacks.splice(0)) callback(); });
+    await page.keyboard.insertText('Synthetic focus value');
+    assert.equal(await value.inputValue(), 'Synthetic focus value');
+    await dialog.getByRole('button', { name: 'Save answer', exact: true }).click();
+    await dialog.waitFor({ state: 'hidden' });
+    const answer = await context.cli('answer-find', ['--question', 'Synthetic focus question?', '--scope', '{}']);
+    assert.equal(answer?.value, 'Synthetic focus value');
+  } finally { await cleanupOwnerBetaScenario(context); }
+});

--- a/tests_js/workspace_owner_beta_recovery_phase.mjs
+++ b/tests_js/workspace_owner_beta_recovery_phase.mjs
@@ -1,3 +1,4 @@
+import { refreshJobsAndWait } from "./workspace_refresh_support.mjs";
 import { openWorkspace, openWorkspaceMenu } from "./workspace_menu_support.mjs";
 import {
   assert, join, writeFile,
@@ -42,7 +43,7 @@ export async function runOwnerBetaFreshnessRestartPhase(context) {
     const newerDependencyState = page.waitForResponse((response) => (
       new URL(response.url()).pathname === "/api/state" && response.ok()
     ));
-    await page.locator("#refresh").evaluate((button) => button.click());
+    await refreshJobsAndWait(page);
     await newerDependencyState;
     const dependencyStalePreflightResponse = page.waitForResponse((response) => (
       new URL(response.url()).pathname === `/api/jobs/${job.id}/preflight`
@@ -83,7 +84,7 @@ export async function runOwnerBetaFreshnessRestartPhase(context) {
     const newerStateResponse = page.waitForResponse((response) => (
       new URL(response.url()).pathname === "/api/state" && response.ok()
     ));
-    await page.evaluate(() => document.querySelector("#refresh").click());
+    await refreshJobsAndWait(page);
     await newerStateResponse;
     await jobDialog.getByLabel("Role", { exact: true }).fill("Stale preflight draft");
     await jobDialog.getByRole("button", { name: "Save job" }).click();
@@ -127,7 +128,7 @@ export async function runOwnerBetaFreshnessRestartPhase(context) {
     const changedResumeStateResponse = page.waitForResponse((response) => (
       new URL(response.url()).pathname === "/api/state" && response.ok()
     ));
-    await page.evaluate(() => document.querySelector("#refresh").click());
+    await refreshJobsAndWait(page);
     await changedResumeStateResponse;
 
     await page.getByRole("button", { name: "Close job details" }).click();

--- a/tests_js/workspace_refresh_completion.test.mjs
+++ b/tests_js/workspace_refresh_completion.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { openWorkspace } from './workspace_menu_support.mjs';
+import { refreshJobsAndWait } from './workspace_refresh_support.mjs';
+import { createOwnerBetaScenario, startOwnerBetaScenario, cleanupOwnerBetaScenario } from './workspace_owner_beta_scenario_support.mjs';
+
+test('manual refresh completion waits for consumed state before retrying readiness', { timeout: 30_000 }, async () => {
+  const context = await createOwnerBetaScenario();
+  try {
+    await startOwnerBetaScenario(context);
+    await context.cli('job-create', [], { id: 'refresh-job', role: 'Refresh Engineer', url: 'https://example.invalid/refresh' });
+    const page = await context.browser.newPage();
+    await page.addInitScript(() => {
+      globalThis.setInterval = () => 1;
+      const json = Response.prototype.json;
+      Response.prototype.json = async function (...args) {
+        const data = await json.apply(this, args);
+        if (globalThis.holdState && new URL(this.url).pathname === '/api/state') {
+          globalThis.stateBodyHeld = true;
+          await new Promise(resolve => { globalThis.releaseState = resolve; });
+        }
+        return data;
+      };
+    });
+    await page.goto(context.running.startup.url);
+    await openWorkspace(page, 'jobs');
+    await page.getByRole('button', { name: /Refresh Engineer/ }).click();
+    await refreshJobsAndWait(page);
+    await page.evaluate(() => { globalThis.holdState = true; });
+    let preflightRequests = 0;
+    page.on("request", request => { if (request.url().endsWith("/preflight")) preflightRequests++; });
+    let completed = false;
+    const refreshed = refreshJobsAndWait(page).then(() => { completed = true; });
+    await page.waitForFunction(() => globalThis.stateBodyHeld);
+    try {
+      assert.equal(completed, false, 'headers must not count as completed refresh');
+      await page.getByRole('button', { name: 'Run ready check', exact: true }).click();
+      assert.equal(preflightRequests, 0, 'readiness is rejected while state consumption is pending');
+      assert.equal(await page.locator('#preflight-panel').isVisible(), false);
+    } finally {
+      await page.evaluate(() => { globalThis.holdState = false; globalThis.releaseState(); });
+      await refreshed;
+    }
+    await page.getByRole('button', { name: 'Run ready check', exact: true }).click();
+    await page.getByText('Assign an active resume', { exact: true }).waitFor();
+  } finally { await cleanupOwnerBetaScenario(context); }
+});

--- a/tests_js/workspace_refresh_support.mjs
+++ b/tests_js/workspace_refresh_support.mjs
@@ -1,0 +1,19 @@
+// Headers can arrive before Response.json() and the refresh coordinator finish.
+// Observe a new completion announcement, including when its text is unchanged.
+export async function refreshJobsAndWait(page) {
+  await page.evaluate(() => new Promise((resolve, reject) => {
+    const toast = document.querySelector('#toast');
+    const observer = new MutationObserver(() => {
+      if (toast.textContent !== 'Jobs refreshed from the canonical store') return;
+      observer.disconnect();
+      clearTimeout(timer);
+      resolve();
+    });
+    const timer = setTimeout(() => {
+      observer.disconnect();
+      reject(new Error('Jobs refresh did not complete'));
+    }, 10_000);
+    observer.observe(toast, { childList: true, characterData: true, subtree: true });
+    document.querySelector('#refresh').click();
+  }));
+}


### PR DESCRIPTION
The Companion now drains request workers during shutdown and prevents delayed focus changes from redirecting user input. Socket polling cancels pending I/O across platforms while active Store work finishes. Expected disconnects stay quiet; unexpected errors remain visible.

Controlled browser schedules reproduce two input hazards: navigation completion steals focus from an employer-override draft, and a queued answer-dialog focus redirects value typing into the question. Focus now moves at navigation/dialog entry, before later user interaction. Both regressions fail before the fix and pass after it, including canonical override/answer verification.

The recovery walkthrough also waits for rendered refresh completion rather than HTTP headers. A response-consumption gate reproduces the client correctly refusing premature preflight. These demonstrated races do not establish the cause of every historical CI timeout.

Validation at 02fdae18: all 11 affected suites and both release/package suites pass, including the packaged browser CRUD journey. Source-size, matrix, and diff checks pass. Windows shutdown passed at runtime-equivalent 8c04ab92; new-head CI remains required. Earlier focused independent review covered shutdown; the latest focus fixes have controlled regression and local validation, with final integration review still open.

The release checklist records the owner's decision to skip fresh Claude/Codex installed calling-agent acceptance as NOT COMPLETED. Existing installed Companion browser receipts retain their exact candidate scope; DOCX remains unqualified. No further sign-in work. Protected installations, Stores, processes and tabs were untouched. External Store lock waits may still delay graceful exit; transactions are not forcibly interrupted. TypeScript follow-up is recorded in docs/python-release.md. No merge/publication authorized.
