### PR TITLE
Fix false Facts conflicts and restore TXT preview focus

### DIFF
--- a/companion/workspace/features/facts.js
+++ b/companion/workspace/features/facts.js
@@ -21,6 +21,7 @@ export function installFacts(context) {
     shouldRetryFactSave,
   } = apiHelpers;
   const {
+    equalJson,
     pointerValue,
     patchForPaths,
     conflictingPaths,
@@ -33,7 +34,6 @@ export function installFacts(context) {
   const namedTopLevel = new Set(["firstName", "lastName", "email", "phone", "location", "linkedInUrl", "portfolioUrl", "githubUrl", "workHistory", "education", "skills", "preferences"]);
   const encodePointer = (value) => String(value).replaceAll("~", "~0").replaceAll("/", "~1");
   const decodePointer = (value) => String(value).replaceAll("~1", "/").replaceAll("~0", "~");
-  const equalJson = (left, right) => JSON.stringify(left) === JSON.stringify(right);
 
   function factPathLabel(control) {
     if (control.dataset.label) return control.dataset.label;

--- a/companion/workspace/features/resumes.js
+++ b/companion/workspace/features/resumes.js
@@ -59,6 +59,18 @@ export function installResumes(context) {
     pdfOpener = null;
   });
 
+  let textOpener = null;
+  let textResumeId = null;
+  const textDialog = $("#preview-dialog");
+  textDialog.addEventListener("close", () => {
+    if (textDialog.open) return;
+    const opener = textOpener?.isConnected ? textOpener
+      : document.querySelector(`[data-resume-preview="${CSS.escape(textResumeId || "")}"]`);
+    if (opener) opener.disabled = false;
+    if (opener?.getClientRects().length) opener.focus();
+    textOpener = null;
+  });
+
   async function openResumeContent(resume, button, inDetails = false) {
     if (!resume) return;
     const errorNode = $(inDetails ? "#resume-error" : "#resumes-error");
@@ -105,7 +117,8 @@ export function installResumes(context) {
         }
       } else if (resume.mediaType?.startsWith("text/plain")) {
         $("#resume-preview").textContent = await response.text();
-        $("#preview-dialog").showModal();
+        textOpener = button; textResumeId = resume.id;
+        textDialog.showModal();
       } else {
         const url = URL.createObjectURL(await response.blob());
         const link = document.createElement("a");

--- a/companion/workspace/lib/helpers.js
+++ b/companion/workspace/lib/helpers.js
@@ -60,7 +60,7 @@ export function answerApiPath(key, action = "") {
   return `/api/answers/by-key/${encoded}${action ? `/${action}` : ""}`;
 }
 
-export function sameAnswerScope(left, right) {
+export function equalJson(left, right) {
   const canonical = (value) => {
     if (Array.isArray(value)) return value.map(canonical);
     if (value && typeof value === "object") return Object.fromEntries(
@@ -68,7 +68,11 @@ export function sameAnswerScope(left, right) {
     );
     return value;
   };
-  return JSON.stringify(canonical(left || {})) === JSON.stringify(canonical(right || {}));
+  return JSON.stringify(canonical(left)) === JSON.stringify(canonical(right));
+}
+
+export function sameAnswerScope(left, right) {
+  return equalJson(left || {}, right || {});
 }
 
 export function formPatch(values) {
@@ -204,7 +208,7 @@ export function conflictingPaths(base, latest, drafts, atomicPaths = new Set()) 
     const before = base instanceof Map ? base.get(path) : pointerValue(base, path);
     const now = pointerValue(latest, path);
     const structured = atomicPaths.has(path) || typeof mine === "object" || typeof before === "object" || typeof now === "object";
-    return JSON.stringify(before) !== JSON.stringify(now) && (structured || JSON.stringify(mine) !== JSON.stringify(now));
+    return !equalJson(before, now) && (structured || !equalJson(mine, now));
   }).map(([path]) => path);
 }
 

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -188,3 +188,17 @@ An explicit download fallback remains available for unsupported or blank native
 PDF renderers. TXT and DOCX behavior is unchanged. Embedded readability requires
 owner acceptance; isolated headless tests verify wiring, not native rendering.
 Forward-port this presentation and cancellation behavior to TypeScript separately.
+
+### Desktop Facts conflicts and TXT preview focus
+
+Facts comparisons now ignore JSON object key order, including nested work-history
+objects. PATCH responses and subsequent canonical reads can serialize identical
+objects differently; this must not create a conflict on the next save. Array
+order, missing fields, and changed values still participate in conflict checks.
+TXT preview restores focus to its invoking button after Close or Escape, with a
+current-card fallback if the resume list was refreshed while the dialog was open.
+
+Migration follow-up: use semantic JSON comparisons for draft bases and restore
+focus by stable resume identity when preview triggers are replaced. These desktop
+regressions use isolated synthetic data; owner walkthrough acceptance and
+smaller-screen QA remain separate.

--- a/tests_js/workspace_desktop_regressions.test.mjs
+++ b/tests_js/workspace_desktop_regressions.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { openWorkspace } from './workspace_menu_support.mjs';
+import { createOwnerBetaScenario, startOwnerBetaScenario, cleanupOwnerBetaScenario } from './workspace_owner_beta_scenario_support.mjs';
+
+test('desktop facts can save then restore work and skills without a false conflict', { timeout: 60_000 }, async () => {
+  const context = await createOwnerBetaScenario();
+  try {
+    await context.cli('profile-replace', ['--expected-revision', '0', '--source', 'resume'], {
+      firstName: 'Synthetic', skills: ['Python'],
+      workHistory: [{ title: 'Engineer', company: 'Example', description: 'Original' }],
+    });
+    await startOwnerBetaScenario(context);
+    const page = await context.browser.newPage({ viewport: { width: 1280, height: 800 } });
+    await page.goto(context.running.startup.url);
+    await openWorkspace(page, 'facts');
+    for (const [description, skills, revision] of [['Updated', 'Python\nJavaScript', 2], ['Original', 'Python', 3]]) {
+      await page.getByRole('tab', { name: 'Work history', exact: true }).click();
+      await page.getByLabel('Description, item 1', { exact: true }).fill(description);
+      await page.getByRole('tab', { name: 'Skills', exact: true }).click();
+      await page.locator('[data-path="/skills"]').fill(skills);
+      await openWorkspace(page, 'answers');
+      await openWorkspace(page, 'facts');
+      if (revision === 2) await page.keyboard.press('ControlOrMeta+s');
+      else await page.locator('#facts-save').click();
+      await page.waitForFunction(() => !document.querySelector('#facts-save').disabled);
+      assert.equal(await page.locator('#facts-conflict').isVisible(), false, `unexpected conflict saving revision ${revision}`);
+      const saved = await context.cli('profile-inspect');
+      assert.equal(saved.revision, revision);
+      assert.equal(saved.profile.workHistory[0].description, description);
+      assert.deepEqual(saved.profile.skills, skills.split('\n'));
+    }
+    await page.getByRole('tab', { name: 'Work history', exact: true }).click();
+    await page.getByRole('button', { name: 'Add promotion after position 1', exact: true }).click();
+    await page.getByLabel('Title, item 2', { exact: true }).fill('Senior Engineer');
+    await page.getByLabel('Description, item 2', { exact: true }).fill('Promoted');
+    page.once('dialog', dialog => dialog.accept());
+    await page.getByRole('button', { name: 'Copy description from position 2 to other roles at this company', exact: true }).click();
+    await page.locator('#facts-save').click();
+    await page.waitForFunction(() => !document.querySelector('#facts-save').disabled);
+    assert.equal(await page.locator('#facts-conflict').isVisible(), false);
+    const promoted = await context.cli('profile-inspect');
+    assert.equal(promoted.revision, 4);
+    assert.equal(promoted.profile.workHistory.length, 2);
+    assert.ok(promoted.profile.workHistory.every(role => role.description === 'Promoted'));
+    await page.getByLabel('Description, item 1', { exact: true }).fill('My draft');
+    const concurrent = structuredClone(promoted.profile.workHistory);
+    concurrent[0].description = 'Concurrent writer';
+    await context.cli('profile-patch', ['--expected-revision', '4', '--source', 'user'], { workHistory: concurrent });
+    await page.locator('#facts-save').click();
+    await page.locator('#facts-conflict').waitFor();
+    assert.equal(await page.getByLabel('Description, item 1', { exact: true }).inputValue(), 'My draft');
+    const conflicted = await context.cli('profile-inspect');
+    assert.equal(conflicted.revision, 5);
+    assert.equal(conflicted.profile.workHistory[0].description, 'Concurrent writer');
+  } finally { await cleanupOwnerBetaScenario(context); }
+});
+
+test('desktop TXT preview restores focus after Escape', { timeout: 60_000 }, async () => {
+  const context = await createOwnerBetaScenario();
+  try {
+    await startOwnerBetaScenario(context);
+    const page = await context.browser.newPage({ viewport: { width: 1280, height: 800 } });
+    await page.goto(context.running.startup.url);
+    await openWorkspace(page, 'resumes');
+    await page.locator('#resume-import input[name=label]').fill('Synthetic TXT');
+    await page.locator('#resume-import input[type=file]').setInputFiles({ name: 'synthetic.txt', mimeType: 'text/plain', buffer: Buffer.from('Synthetic resume') });
+    await page.getByRole('button', { name: 'Import resume', exact: true }).click();
+    const opener = page.getByRole('button', { name: 'Preview text', exact: true });
+    await opener.click();
+    await page.locator('#preview-dialog').waitFor();
+    await page.keyboard.press('Escape');
+    await page.locator('#preview-dialog').waitFor({ state: 'hidden' });
+    await page.waitForFunction(() => document.activeElement?.matches('[data-resume-preview]'), { }, { timeout: 3000 });
+    assert.equal(await opener.evaluate(node => node === document.activeElement), true);
+    await opener.click();
+    await page.locator('#preview-dialog').waitFor();
+    const original = await opener.elementHandle();
+    await page.evaluate(() => document.querySelector('#resumes-refresh').click());
+    await page.waitForFunction(node => !node.isConnected, original);
+    await page.getByRole('button', { name: 'Close preview', exact: true }).click();
+    await page.waitForFunction(() => document.activeElement?.matches('[data-resume-preview]'));
+    assert.equal(await opener.evaluate(node => node === document.activeElement), true);
+    await page.getByRole('button', { name: 'Manage', exact: true }).click();
+    const details = page.locator('#resume-dialog');
+    await details.locator('input[name=label]').fill('Unsaved label');
+    await details.getByRole('button', { name: 'Preview text', exact: true }).click();
+    await page.locator('#preview-dialog').waitFor();
+    await page.keyboard.press('Escape');
+    await page.waitForFunction(() => document.activeElement?.id === 'resume-content');
+    assert.equal(await details.locator('input[name=label]').inputValue(), 'Unsaved label');
+
+  } finally { await cleanupOwnerBetaScenario(context); }
+});
+
+test('conflict comparison ignores object order but preserves real collection changes', async () => {
+  const { equalJson, conflictingPaths } = await import('../companion/workspace/lib/helpers.js');
+  const original = { company: 'Example', description: 'Original', details: { z: 1, a: 2 } };
+  const reordered = { details: { a: 2, z: 1 }, description: 'Original', company: 'Example' };
+  const base = new Map([['/workHistory', [original]]]);
+  const drafts = new Map([['/workHistory', [{ ...original, description: 'Mine' }]]]);
+  assert.deepEqual(conflictingPaths(base, { workHistory: [reordered] }, drafts), []);
+  assert.deepEqual(conflictingPaths(base, { workHistory: [{ ...reordered, description: 'Agent update' }] }, drafts), ['/workHistory']);
+  assert.equal(equalJson([original, reordered], [reordered, original]), true);
+  assert.equal(equalJson([1, 2], [2, 1]), false);
+  assert.equal(equalJson(null, undefined), false);
+  assert.equal(equalJson({}, { extra: null }), false);
+});


### PR DESCRIPTION
Saving and then restoring work history could report a conflict without another writer: the PATCH response and later GET serialize equivalent objects in different key orders. Facts now compare semantic JSON values, preserving array order and actual value changes. TXT preview also restores focus after Escape or Close, including when a refresh replaces the invoking resume card.

Both desktop defects reproduced before the fixes. Regressions cover cross-tab drafts, keyboard save followed by button restoration, promotion/shared-description persistence, real concurrent-write conflict protection, TXT card and Manage focus, refreshed-card fallback, and unsaved Manage label preservation.

Validation: all 11 affected suites passed, including 67 workspace tests. Independent final review found no blockers. Existing dogfooding installations, Stores, server at port 55836, and browser tabs were untouched. Owner acceptance remains separate; no merge or publication performed. This PR is independent of the shutdown changes in #72.
