### PR TITLE
Add native legacy job import preview and commit

### DIFF
--- a/config/migration/cli-native-legacy-jobs-surfaces.json
+++ b/config/migration/cli-native-legacy-jobs-surfaces.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:legacy-jobs-preview",
+      "kind": "cli",
+      "command": "legacy-jobs-preview",
+      "node": "JOB",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-legacy-jobs.ts",
+        "src/contracts/workspace/legacy-job-report.ts",
+        "src/store/legacy-job-discovery.ts",
+        "src/store/posix-directory.ts",
+        "src/workspace-core/legacy-job-plan.ts",
+        "src/workspace-core/legacy-jobs.ts",
+        "src/store/native-jobs.ts",
+        "src/workspace-core/job-upsert-plan.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:legacy-jobs-commit",
+      "kind": "cli",
+      "command": "legacy-jobs-commit",
+      "node": "JOB",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-legacy-jobs.ts",
+        "src/contracts/workspace/legacy-job-report.ts",
+        "src/store/legacy-job-discovery.ts",
+        "src/store/posix-directory.ts",
+        "src/workspace-core/legacy-job-plan.ts",
+        "src/workspace-core/legacy-jobs.ts",
+        "src/store/native-jobs.ts",
+        "src/workspace-core/job-upsert-plan.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -114,6 +114,10 @@
       "sha256": "8757138a819fd1166abfeb7e86aed548a42f3d2d6f832da404370f9c483e8963"
     },
     {
+      "path": "cli-native-legacy-jobs-surfaces.json",
+      "sha256": "7a8156760cab566c3ff9d83abe668672987fc15139434773b12db17336e5fa34"
+    },
+    {
       "path": "cli-native-projections-surfaces.json",
       "sha256": "db44fabe54a6f0bfb360f02880cdc06fc2780f4f78c3c0a487492cb485344a06"
     },
@@ -263,7 +267,7 @@
     },
     {
       "path": "source-catalog-06.json",
-      "sha256": "ddc83cc609b3d33d56f2793d4d87db257782a7d276a8c62fe5ff4719df72ab0b"
+      "sha256": "2120acf4272d562eaba575c830999030e4ff0732adac676a05102d07a9d3ee95"
     },
     {
       "path": "source-catalog-g02-hybrid.json",
@@ -315,11 +319,15 @@
     },
     {
       "path": "source-catalog-native-job-upsert.json",
-      "sha256": "46000867500a9b5e7492a7602af8369fc24ad3c7d2ba863174357d1e38f51864"
+      "sha256": "31e6b6cc554c6c19e54f262b1e83834483a11a18577e954d696e7dacb0633f31"
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "c6f3bd835dcd6654205e198ca6090f2ddebd3590d6570d213266d7d8b709a178"
+      "sha256": "7bc32c04ed6daba6bb8b0b5c74d3b12ec353cc4106916d47ab8631f266029c7e"
+    },
+    {
+      "path": "source-catalog-native-legacy-jobs.json",
+      "sha256": "3e0066d9196b88f93260f2368cac0c08d11f8496969c8b020db2174798839786"
     },
     {
       "path": "source-catalog-native-pending-answers.json",

--- a/config/migration/source-catalog-06.json
+++ b/config/migration/source-catalog-06.json
@@ -103,7 +103,7 @@
     },
     {
       "path": "native/posix/flock.c",
-      "sha256": "511590e191f8764402e9bf2b03ee8307716bf79f2801d411667d3423ca444907",
+      "sha256": "a8955e79286e9f529aea51246e2158ad7cfd45b410a18cb8403fe7611ba2fff9",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-job-upsert.json
+++ b/config/migration/source-catalog-native-job-upsert.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/workspace-core/job-upsert-plan.js",
-      "sha256": "724a931bb32e9711894b91b494aeadb30b8c3e8bab34a1021f620194caf8e780",
+      "sha256": "4122bdc6aefe2f471fc8f8dc4feed72732ae24bad781bedb098fe2123e82fc48",
       "classification": "unreviewed"
     },
     {
@@ -23,7 +23,7 @@
     },
     {
       "path": "src/workspace-core/job-upsert-plan.ts",
-      "sha256": "7912f3b226487938298d997cd9bb8c291bf3cf176f09f1941a8ae2dec544b9a1",
+      "sha256": "c0f81818c0b9bef6eb5dac36acab43df8006585bf9f4a8451fa2f4a63d1f193e",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "eed959ab8ab1a91ba9627c5a679579bf8034bde03b8eae4298e5409340a8b1be",
+      "sha256": "1cf062245626d508844e7edfef0f176e4ff97619a345da9d475761276b85afd2",
       "classification": "unreviewed"
     },
     {
@@ -33,12 +33,12 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "bbe6ea2d6d54297ed9b36faed293c4f2fa093bcea11c0279642cc7a5af457367",
+      "sha256": "b7ddccad762802242cf56d1bf3bfcd6d30d6b0351fb1708f1c33e54e41535fb1",
       "classification": "unreviewed"
     },
     {
       "path": "runtime/workspace-core/job-provenance.js",
-      "sha256": "0eee632303d41334822ac5f4c21637431ed8f3f1a5c7cb901dcd33616a0af210",
+      "sha256": "a1dd15767febe050d9909db2109b91a6d2ce92226ec42b52192ecfe33f266ee1",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "7ff5b7f1095cbeb44334fe4a0b7ae716451edd34d55282e5dc1e165de63837ce",
+      "sha256": "b04a04c0a883b3f30831585b24cedfa7d7edad9f0f48bfe28770f9f16ac02aa7",
       "classification": "unreviewed"
     },
     {
@@ -83,12 +83,12 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "91efc4be73a8e91e0a93956af18ab9104caf2a261798ce1475f9fce622dfc91e",
+      "sha256": "ab7223c28daa31565260ec9c9321a21db8df77de3644bb2e6e07ace8967710eb",
       "classification": "unreviewed"
     },
     {
       "path": "src/workspace-core/job-provenance.ts",
-      "sha256": "b3d03ed0fca2c6780d4f58bbb40c20352a3ee53c709d7feb6214131a575d33dd",
+      "sha256": "c971eec9c07009bbc90c00687eb2f8d6390ac4941f2ef114274546058b8e3472",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-legacy-jobs.json
+++ b/config/migration/source-catalog-native-legacy-jobs.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "runtime/cli/native-legacy-jobs.js",
+      "sha256": "2bf502c91f06339b6f9a59069aae8094e77c23b393b1efa244037215fa15ccab",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/legacy-job-report.js",
+      "sha256": "5b2eb5d0693a9d00d76b86c80c2df942a9edd09c57a8a3a76758714176c173cb",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/store/legacy-job-discovery.js",
+      "sha256": "07b6375c4c4af61e97fc010f3280fa0895510bb24c21c9318f024407b9d7757e",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/store/posix-directory.js",
+      "sha256": "5b4f3a12549c4b1c0a15458267d97b0cfc64269318e6ae1cd4cdad6ae8aaaa34",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/legacy-job-plan.js",
+      "sha256": "83f3eb5b237204e5898c6146843fb58a8300c02d838362fdc071bf2dd5658af8",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/legacy-jobs.js",
+      "sha256": "f3663a0db8758f47835b0f2fbeed6f63025dab3e0c1473fe118bbc2c27a3e613",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-legacy-jobs.ts",
+      "sha256": "6352a0afed2588d89358047bd8cf152d9c3919c06fed4559bbd3d6e1a3bf88bb",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/legacy-job-report.ts",
+      "sha256": "4f6cce5d914485a530480878386b1d90518fd3429b7c59ba4f7358f032b04215",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/store/legacy-job-discovery.ts",
+      "sha256": "108a6714406ac4e34f216fc284f6caa38802a265606208762a7089bac3dced4b",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/store/posix-directory.ts",
+      "sha256": "dde19669d21d9ac515784dceaa36ea90692f48a53b4850dc732b377115bb3dd0",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/legacy-job-plan.ts",
+      "sha256": "6e58ecfd01f1eee0d3f77e458702eab58db57a855489c51f423af6888b904a6d",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/legacy-jobs.ts",
+      "sha256": "7a0f001d26b633596a3a8846519d394374de19af9caa0ac34b42bbbd0ac2c709",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/docs/native-job-upsert-fixture.md
+++ b/docs/native-job-upsert-fixture.md
@@ -82,5 +82,6 @@ filling a new field. It checks preview/commit agreement, reload, clean
 navigation and a 390-pixel viewport. Service and CLI tests cover planning,
 token drift and persistence separately.
 
-Legacy import preview/commit and task intake remain later tranches. General
-writer activation and installable Python-free packaging are also deferred.
+[Legacy import preview/commit](native-legacy-jobs-fixture.md) is available through
+its separate guided CLI workflow. Task intake, general writer activation and
+installable Python-free packaging remain deferred.

--- a/docs/native-jobs-fixture.md
+++ b/docs/native-jobs-fixture.md
@@ -11,8 +11,9 @@ metadata update, file replacement, legacy adoption, default selection, integrity
 check, content read and resolution are available through the same Store lock.
 Facts/profile operations, [active claims](native-claims-fixture.md),
 [workspace projections](native-projections-fixture.md), and
-[job status transitions](native-job-transitions-fixture.md), and
-[CLI job upsert preview/commit](native-job-upsert-fixture.md) are also available. Other
+[job status transitions](native-job-transitions-fixture.md),
+[CLI job upsert preview/commit](native-job-upsert-fixture.md), and
+[CLI legacy job import](native-legacy-jobs-fixture.md) are also available. Other
 workflows return `unsupported_native_workflow`; they never fall back to Python.
 
 ## Run against a new synthetic root

--- a/docs/native-legacy-jobs-fixture.md
+++ b/docs/native-legacy-jobs-fixture.md
@@ -1,0 +1,107 @@
+# Native legacy job import fixture
+
+The opt-in version 9 native fixture supports `legacy-jobs-preview` and
+`legacy-jobs-commit` through its CLI. The workflow discovers timestamped search
+reports, previews selected entries and commits reviewed migration decisions
+under the shared Store lock. Imported jobs appear in Companion Jobs after
+Refresh or reload. It adds no legacy import HTTP route or browser selection UI.
+
+Use a new synthetic Store initialized as described in
+[Native Jobs fixture](native-jobs-fixture.md), plus a separate synthetic home
+directory. Do not use an applicant's live Store or search reports, and do not
+run Python writers against the native fixture.
+
+## Discover, select and confirm
+
+Discovery reads only immediate files named `search-*.md` within
+`~/.claude-job-searches`. The CLI derives that path from its process home
+directory. For a POSIX fixture, point only the CLI subprocess at a synthetic
+home containing `.claude-job-searches`; keep the Store root separate. For
+example, create `search-fixture.md` there with this synthetic content:
+
+```markdown
+### 1. Synthetic engineer — Fixture company
+- **URL**: https://example.invalid/careers/fixture-job
+- **Source**: Synthetic board
+- **Location**: Fixture city
+```
+
+The native addon must include directory discovery support. Build the addon from
+this checkout using the command in the Native Jobs fixture guide; an older
+addon without that capability cannot perform discovery safely.
+
+```sh
+env HOME=/private/tmp/synthetic-legacy-home node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node legacy-jobs-preview
+env HOME=/private/tmp/synthetic-legacy-home node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node legacy-jobs-preview --select ITEM_ID
+env HOME=/private/tmp/synthetic-legacy-home node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node legacy-jobs-commit --select ITEM_ID --confirm PREVIEW_TOKEN
+```
+
+The first preview returns the root label, manifest and discovered items without
+reading or initializing Jobs. Items include a stable item ID, source locator
+and `valid` or `invalid` state; valid items contain parsed job fields. A missing
+search directory produces an empty discovery result.
+
+Repeat `--select ITEM_ID` for multiple entries, preserving selection order
+between preview and commit. Selecting duplicate IDs, unknown items or invalid
+items fails. A selected preview adds a token, per-item decisions and summary
+counts for `create`, `update`, `noop`, `conflict` and `invalid`. It does not write
+the planned Jobs document. Review all decisions before passing the token to
+`--confirm`; conflict or invalid decisions do not prevent other valid selected
+items from being committed. Commit reports `committed: true` only when Jobs
+actually changes.
+
+## Reports and source safety
+
+The parser accepts numbered third-level headings in the form
+`### 1. Role — Company`, with optional company score text, and supported labeled
+fields. A plain HTTP or HTTPS `URL` or `Apply` value must resolve to one
+normalized URL. Unsupported headings, duplicate labels, missing URLs and
+ambiguous URLs are reported as invalid entries. Source, location, salary and
+description labels map to the corresponding job fields.
+
+Discovery is bounded to 100 matching files, 2 MiB per file, 20 MiB total and
+5,000 entries. Reports must decode as UTF-8. The search root must be a regular
+directory and matching entries must be regular files. Symlink roots and reports
+are rejected. Discovery pins the root directory descriptor and inspects and
+opens entries relative to it, checking file identity and size around reads.
+Safety or limit failures reject discovery rather than silently omitting a
+matching report. Reports are read only; import never rewrites them.
+
+## Drift, provenance and refresh
+
+The token binds the ordered selection, selected payloads and locators, the
+entire discovered file manifest and the Jobs snapshot. Commit repeats discovery
+and token validation while holding the Store lock. Report changes, selection
+changes or Store changes reject a stale token. Preview again and review the
+current decisions before retrying.
+
+Imported fields receive migration provenance, and each successful record stores
+its source locator in `legacySources`. Locator identity uses the report path and
+entry ID, allowing an existing import to be found when report bytes change.
+Migration can update fields still attributed to migration or fill empty fields;
+it preserves nonempty human, agent and unattributed values. An imported URL can
+refresh through a matching locator when its field remains eligible for migration
+updates. Ambiguous identities and deleted matches remain conflicts.
+
+A changed locator digest alone updates `legacySources` and increments the job
+revision. Repeating an unchanged import is a no-op. New jobs start saved;
+existing statuses are preserved. As in Python legacy import, an active claim
+does not add a write prohibition for this operation. Import does not submit an
+application or modify coordinator claims.
+
+## Fixture boundary and remaining scope
+
+Only this narrow repository operation may preview an absent `jobs.json` using
+an empty epoch snapshot and persist it on a changed commit. The existing native
+fixture marker and other inventory validation still apply. Pending recovery
+operations must complete before import; previews do not replay journals. This is not a
+mechanism to adopt an arbitrary legacy Store, repair damaged state or activate
+native writes against live data. No new marker version or journal is introduced.
+
+Model, differential, native CLI and discovery checks cover planning and safety
+separately. Browser coverage verifies that CLI-imported records are visible in
+Companion; it does not add a browser import workflow. Passing checks and CI are
+recorded with the change's validation evidence.
+
+Task intake, general writer activation and installable Python-free packaging
+remain later work.

--- a/native/posix/flock.c
+++ b/native/posix/flock.c
@@ -1,6 +1,17 @@
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#else
+#define _POSIX_C_SOURCE 200809L
+#define _DEFAULT_SOURCE
+#endif
 #define NAPI_VERSION 8
 #include <node_api.h>
 #include <sys/file.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <limits.h>
 #include <math.h>
@@ -16,6 +27,13 @@
 
 static const char *errno_code(int number) {
     switch (number) {
+        case ENOENT: return "ENOENT";
+        case ENOTDIR: return "ENOTDIR";
+        case ELOOP: return "ELOOP";
+        case ENAMETOOLONG: return "ENAMETOOLONG";
+        case EOVERFLOW: return "EOVERFLOW";
+        case EMFILE: return "EMFILE";
+        case ENFILE: return "ENFILE";
         case EBADF: return "EBADF";
         case EINTR: return "EINTR";
         case EAGAIN: return "EAGAIN";
@@ -96,12 +114,124 @@ static napi_value unlock(napi_env env, napi_callback_info info) {
     return result;
 }
 
+/* Directory descriptors are caller-owned. No operation resolves the root path again. */
+static int entry_arguments(napi_env env, napi_callback_info info, int *fd, char **name) {
+    size_t count = 3, length = 0;
+    napi_value arguments[3];
+    napi_valuetype type;
+    double value;
+    if (napi_get_cb_info(env, info, &count, arguments, NULL, NULL) != napi_ok
+        || count != 2 || napi_typeof(env, arguments[0], &type) != napi_ok || type != napi_number
+        || napi_get_value_double(env, arguments[0], &value) != napi_ok
+        || !isfinite(value) || value < 0 || value > INT_MAX || floor(value) != value
+        || napi_typeof(env, arguments[1], &type) != napi_ok || type != napi_string
+        || napi_get_value_string_utf8(env, arguments[1], NULL, 0, &length) != napi_ok) {
+        napi_throw_type_error(env, NULL, "directory operation requires descriptor and basename");
+        return 0;
+    }
+    if (length == 0 || length > NAME_MAX) {
+        napi_throw_range_error(env, NULL, "directory basename length is invalid");
+        return 0;
+    }
+    *name = malloc(length + 1);
+    if (!*name) { throw_errno(env, ENOMEM); return 0; }
+    size_t written;
+    if (napi_get_value_string_utf8(env, arguments[1], *name, length + 1, &written) != napi_ok
+        || written != length || strlen(*name) != length || strchr(*name, '/')
+        || strcmp(*name, ".") == 0 || strcmp(*name, "..") == 0) {
+        free(*name);
+        napi_throw_type_error(env, NULL, "directory basename is invalid");
+        return 0;
+    }
+    napi_value roundtrip;
+    bool identical;
+    if (napi_create_string_utf8(env, *name, length, &roundtrip) != napi_ok
+        || napi_strict_equals(env, arguments[1], roundtrip, &identical) != napi_ok || !identical) {
+        free(*name);
+        napi_throw_type_error(env, NULL, "directory basename must be valid UTF-8");
+        return 0;
+    }
+    *fd = (int)value;
+    return 1;
+}
+
+static napi_value list_names(napi_env env, napi_callback_info info) {
+    int fd;
+    napi_value result;
+    if (!descriptor_argument(env, info, &fd)) return NULL;
+    CHECK_NAPI(env, napi_create_array(env, &result));
+    int scanfd = openat(fd, ".", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (scanfd < 0) return throw_errno(env, errno);
+    DIR *directory = fdopendir(scanfd);
+    if (!directory) { int number = errno; close(scanfd); return throw_errno(env, number); }
+    uint32_t index = 0;
+    int number = 0;
+    for (;;) {
+        errno = 0;
+        struct dirent *entry = readdir(directory);
+        if (!entry) { number = errno; break; }
+        if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..")) continue;
+        napi_value name;
+        if (napi_create_buffer_copy(env, strlen(entry->d_name), entry->d_name, NULL, &name) != napi_ok
+            || napi_set_element(env, result, index++, name) != napi_ok) {
+            closedir(directory);
+            napi_throw_error(env, NULL, "Cannot create directory listing");
+            return NULL;
+        }
+    }
+    if (closedir(directory) < 0 && !number) number = errno;
+    if (number) return throw_errno(env, number);
+    return result;
+}
+
+static napi_value inspect_entry(napi_env env, napi_callback_info info) {
+    int fd;
+    char *name;
+    struct stat metadata;
+    napi_value result, value;
+    if (!entry_arguments(env, info, &fd, &name)) return NULL;
+    int status = fstatat(fd, name, &metadata, AT_SYMLINK_NOFOLLOW);
+    int number = errno;
+    free(name);
+    if (status < 0) return throw_errno(env, number);
+    CHECK_NAPI(env, napi_create_object(env, &result));
+    CHECK_NAPI(env, napi_create_bigint_uint64(env, (uint64_t)metadata.st_dev, &value));
+    CHECK_NAPI(env, napi_set_named_property(env, result, "dev", value));
+    CHECK_NAPI(env, napi_create_bigint_uint64(env, (uint64_t)metadata.st_ino, &value));
+    CHECK_NAPI(env, napi_set_named_property(env, result, "ino", value));
+    CHECK_NAPI(env, napi_create_bigint_int64(env, (int64_t)metadata.st_size, &value));
+    CHECK_NAPI(env, napi_set_named_property(env, result, "size", value));
+    CHECK_NAPI(env, napi_create_uint32(env, (uint32_t)metadata.st_mode, &value));
+    CHECK_NAPI(env, napi_set_named_property(env, result, "mode", value));
+    return result;
+}
+
+static napi_value open_entry(napi_env env, napi_callback_info info) {
+    int fd;
+    char *name;
+    napi_value result;
+    if (!entry_arguments(env, info, &fd, &name)) return NULL;
+    int opened = openat(fd, name, O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC);
+    int number = errno;
+    free(name);
+    if (opened < 0) return throw_errno(env, number);
+    if (napi_create_int32(env, opened, &result) != napi_ok) {
+        close(opened);
+        napi_throw_error(env, NULL, "Cannot return opened descriptor");
+        return NULL;
+    }
+    return result;
+}
+
 static napi_value initialize(napi_env env, napi_value exports) {
     napi_property_descriptor properties[] = {
         { "tryLock", NULL, try_lock, NULL, NULL, NULL, napi_default, NULL },
         { "unlock", NULL, unlock, NULL, NULL, NULL, napi_default, NULL },
+        { "listNames", NULL, list_names, NULL, NULL, NULL, napi_default, NULL },
+        { "inspect", NULL, inspect_entry, NULL, NULL, NULL, napi_default, NULL },
+        { "openFile", NULL, open_entry, NULL, NULL, NULL, napi_default, NULL },
     };
-    CHECK_NAPI(env, napi_define_properties(env, exports, 2, properties));
+    CHECK_NAPI(env, napi_define_properties(env, exports, 5, properties));
     return exports;
 }
 

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,3 +1,4 @@
+import { legacyJobCommands, runLegacyJobCommand } from './native-legacy-jobs.js';
 import { jobUpsertCommands, runJobUpsertCommand } from './native-job-upsert.js';
 import { claimCommands, runClaimCommand } from './native-claims.js';
 import { jobTransitionCommands, runJobTransitionCommand } from './native-job-transitions.js';
@@ -19,6 +20,7 @@ import { NativeResumeFiles } from "../store/native-resume-files.js";
 export async function runJobsCli(args, input) {
     const options = new Map();
     let command;
+    const selected = [];
     for (let index = 0; index < args.length; index++) {
         const key = args[index];
         if (!key.startsWith("--")) {
@@ -27,7 +29,7 @@ export async function runJobsCli(args, input) {
             command = key;
         }
         else {
-            if (options.has(key))
+            if (options.has(key) && key !== "--select")
                 throw new JobsError("duplicate CLI option");
             if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses", "--summary-only", "--owner-confirmed", "--owner-confirmed-not-submitted", "--user-confirmed"].includes(key))
                 options.set(key, "true");
@@ -36,10 +38,13 @@ export async function runJobsCli(args, input) {
                 if (!value || value.startsWith("--"))
                     throw new JobsError("missing CLI option value");
                 options.set(key, value);
+                if (key === "--select")
+                    selected.push(value);
             }
         }
     }
     const fields = {
+        ...legacyJobCommands,
         ...jobUpsertCommands,
         ...jobTransitionCommands,
         ...projectionCommands,
@@ -83,6 +88,8 @@ export async function runJobsCli(args, input) {
             : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command) ? 2 * 1024 * 1024 : 65536;
         return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
     };
+    if (Object.hasOwn(legacyJobCommands, command))
+        return serialize(await runLegacyJobCommand(command, repository, options, selected));
     if (Object.hasOwn(jobUpsertCommands, command))
         return serialize(await runJobUpsertCommand(command, repository, options, payload));
     if (Object.hasOwn(jobTransitionCommands, command))

--- a/runtime/cli/native-legacy-jobs.js
+++ b/runtime/cli/native-legacy-jobs.js
@@ -1,0 +1,21 @@
+import { homedir } from 'node:os';
+import { LegacyJobsService } from '../workspace-core/legacy-jobs.js';
+import { discoverLegacyJobs } from '../store/legacy-job-discovery.js';
+import { loadPosixDirectoryProvider } from '../store/posix-directory.js';
+import { JobsError } from '../contracts/workspace/values.js';
+export const legacyJobCommands = {
+    'legacy-jobs-preview': ['--select'],
+    'legacy-jobs-commit': ['--select', '--confirm'],
+};
+export async function runLegacyJobCommand(command, repository, options, selected) {
+    const provider = loadPosixDirectoryProvider(options.get('--native-lock'));
+    const service = new LegacyJobsService(repository, () => discoverLegacyJobs(homedir(), provider));
+    if (command === 'legacy-jobs-preview')
+        return service.preview(selected);
+    if (!selected.length)
+        throw new JobsError('required option: --select');
+    const token = options.get('--confirm');
+    if (!token)
+        throw new JobsError('required option: --confirm');
+    return service.commit(selected, token);
+}

--- a/runtime/contracts/workspace/legacy-job-report.js
+++ b/runtime/contracts/workspace/legacy-job-report.js
@@ -1,0 +1,85 @@
+import { createHash } from 'node:crypto';
+import { normalizeJobUrl, strip } from './job-url.js';
+import { fromJSON, object, JobsError } from './values.js';
+const whitespace = '[\\u0009-\\u000d\\u001c-\\u0020\\u0085\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000]';
+// CPython 3.12 uses Unicode 15.0 decimal digits; host ICU versions must not change item identity.
+const decimalDigits = '[' + [
+    String.raw `\u{30}-\u{39}\u{660}-\u{669}\u{6f0}-\u{6f9}\u{7c0}-\u{7c9}\u{966}-\u{96f}`,
+    String.raw `\u{9e6}-\u{9ef}\u{a66}-\u{a6f}\u{ae6}-\u{aef}\u{b66}-\u{b6f}\u{be6}-\u{bef}`,
+    String.raw `\u{c66}-\u{c6f}\u{ce6}-\u{cef}\u{d66}-\u{d6f}\u{de6}-\u{def}\u{e50}-\u{e59}`,
+    String.raw `\u{ed0}-\u{ed9}\u{f20}-\u{f29}\u{1040}-\u{1049}\u{1090}-\u{1099}\u{17e0}-\u{17e9}`,
+    String.raw `\u{1810}-\u{1819}\u{1946}-\u{194f}\u{19d0}-\u{19d9}\u{1a80}-\u{1a89}\u{1a90}-\u{1a99}`,
+    String.raw `\u{1b50}-\u{1b59}\u{1bb0}-\u{1bb9}\u{1c40}-\u{1c49}\u{1c50}-\u{1c59}\u{a620}-\u{a629}`,
+    String.raw `\u{a8d0}-\u{a8d9}\u{a900}-\u{a909}\u{a9d0}-\u{a9d9}\u{a9f0}-\u{a9f9}\u{aa50}-\u{aa59}`,
+    String.raw `\u{abf0}-\u{abf9}\u{ff10}-\u{ff19}\u{104a0}-\u{104a9}\u{10d30}-\u{10d39}\u{11066}-\u{1106f}`,
+    String.raw `\u{110f0}-\u{110f9}\u{11136}-\u{1113f}\u{111d0}-\u{111d9}\u{112f0}-\u{112f9}\u{11450}-\u{11459}`,
+    String.raw `\u{114d0}-\u{114d9}\u{11650}-\u{11659}\u{116c0}-\u{116c9}\u{11730}-\u{11739}\u{118e0}-\u{118e9}`,
+    String.raw `\u{11950}-\u{11959}\u{11c50}-\u{11c59}\u{11d50}-\u{11d59}\u{11da0}-\u{11da9}\u{11f50}-\u{11f59}`,
+    String.raw `\u{16a60}-\u{16a69}\u{16ac0}-\u{16ac9}\u{16b50}-\u{16b59}\u{1d7ce}-\u{1d7ff}\u{1e140}-\u{1e149}`,
+    String.raw `\u{1e2f0}-\u{1e2f9}\u{1e4f0}-\u{1e4f9}\u{1e950}-\u{1e959}\u{1fbf0}-\u{1fbf9}`,
+].join('') + ']';
+const pattern = (source) => new RegExp(source.replaceAll('\\s', whitespace).replaceAll('\\d', decimalDigits), 'u');
+const digest = (value) => createHash('sha256').update(value).digest('hex').slice(0, 24);
+/** Parse only the historical numbered report format, retaining invalid entries for preview. */
+export function parseLegacyJobReport(relativePath, sourceSha256, content) {
+    const lines = content.split(/\r\n|[\n\r\v\f\u001c-\u001e\u0085\u2028\u2029]/u);
+    if (lines.at(-1) === '')
+        lines.pop();
+    const starts = lines.flatMap((line, index) => line.startsWith('###') ? [index] : []);
+    const identities = starts.map(start => strip(lines[start].replace(pattern('^###\\s+\\d+\\.\\s*'), '')));
+    const totals = new Map();
+    for (const identity of identities)
+        totals.set(identity, (totals.get(identity) ?? 0) + 1);
+    const occurrences = new Map();
+    return starts.map((start, index) => {
+        const body = lines.slice(start + 1, starts[index + 1] ?? lines.length);
+        const identity = identities[index];
+        const contentIdentity = totals.get(identity) > 1 ? strip([identity, ...body].join('\n')) : identity;
+        const occurrence = (occurrences.get(contentIdentity) ?? 0) + 1;
+        occurrences.set(contentIdentity, occurrence);
+        const entryId = 'legacy-entry-' + digest(`${relativePath}\0${contentIdentity}\0${occurrence}`);
+        const itemId = 'legacy-item-' + digest(entryId);
+        const source = { sourceKind: 'timestamped-search-report', relativePath, entryId, sourceSha256 };
+        const invalid = (reason) => object(fromJSON({ itemId, state: 'invalid', reason, source }), 'legacy item');
+        const heading = pattern('^###\\s+\\d+\\.\\s+(.+?)\\s+—\\s+(.+)$').exec(lines[start]);
+        if (!heading)
+            return invalid('unsupported_heading');
+        const role = strip(heading[1]);
+        const company = strip(heading[2].replace(pattern('\\s+\\(Score:\\s*[^)]*\\)\\s*$'), ''));
+        if (!role || !company)
+            return invalid('incomplete_heading');
+        const labels = new Map();
+        for (const line of body) {
+            const field = pattern('^- \\*\\*([^*]+)\\*\\*:\\s*(.*)$').exec(line);
+            if (!field)
+                continue;
+            const label = strip(field[1]).toLowerCase();
+            if (labels.has(label))
+                return invalid('duplicate_field');
+            labels.set(label, strip(field[2]));
+        }
+        const candidates = [];
+        for (const label of ['url', 'apply']) {
+            const value = labels.get(label) ?? '';
+            if (!value.startsWith('http://') && !value.startsWith('https://') || pattern('\\s').test(value))
+                continue;
+            try {
+                candidates.push([value, normalizeJobUrl(value)]);
+            }
+            catch (error) {
+                if (!(error instanceof JobsError))
+                    throw error;
+            }
+        }
+        if (!candidates.length)
+            return invalid('missing_url');
+        if (new Set(candidates.map(([, url]) => url)).size !== 1)
+            return invalid('ambiguous_url');
+        const job = { url: candidates[0][0], role, company };
+        for (const [label, field] of [['source', 'source'], ['location', 'location'], ['salary', 'compensation'], ['description', 'description']]) {
+            if (labels.get(label))
+                job[field] = labels.get(label);
+        }
+        return object(fromJSON({ itemId, state: 'valid', source, job }), 'legacy item');
+    });
+}

--- a/runtime/store/legacy-job-discovery.js
+++ b/runtime/store/legacy-job-discovery.js
@@ -1,0 +1,129 @@
+import { constants, read, fstat, close } from 'node:fs';
+import { lstat, open } from 'node:fs/promises';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { createHash } from 'node:crypto';
+import { parseLegacyJobReport } from '../contracts/workspace/legacy-job-report.js';
+import { fromJSON, object, set, JobsError } from '../contracts/workspace/values.js';
+const rootName = '.claude-job-searches';
+const maxFile = 2 * 1024 * 1024;
+const statDescriptor = promisify(fstat), closeDescriptor = promisify(close), readDescriptor = promisify(read);
+const fail = (message) => { throw new JobsError(message); };
+async function report(provider, root, name, metadata) {
+    let descriptor;
+    try {
+        descriptor = provider.openFile(root, name);
+    }
+    catch {
+        return fail('legacy search report cannot be opened safely');
+    }
+    try {
+        const opened = await statDescriptor(descriptor, { bigint: true });
+        if (!opened.isFile() || opened.dev !== metadata.dev || opened.ino !== metadata.ino || opened.size !== metadata.size) {
+            return fail('legacy search report changed during discovery');
+        }
+        const chunks = [];
+        let total = 0;
+        while (true) {
+            const buffer = Buffer.alloc(Math.min(65536, maxFile + 1 - total));
+            const { bytesRead } = await readDescriptor(descriptor, buffer, 0, buffer.length, null);
+            if (!bytesRead)
+                break;
+            total += bytesRead;
+            if (total > maxFile)
+                return fail('legacy search report exceeds the per-file byte limit');
+            chunks.push(buffer.subarray(0, bytesRead));
+        }
+        if ((await statDescriptor(descriptor, { bigint: true })).size !== opened.size)
+            return fail('legacy search report changed during discovery');
+        return Buffer.concat(chunks);
+    }
+    finally {
+        await closeDescriptor(descriptor);
+    }
+}
+/** All entry inspection and opens resolve against the pinned directory, never a replaced path. */
+export async function discoverLegacyJobs(home, provider) {
+    const root = join(home, rootName);
+    const result = object(fromJSON({ root: `~/${rootName}`, manifest: [], items: [] }), 'legacy discovery');
+    let metadata;
+    try {
+        metadata = await lstat(root, { bigint: true });
+    }
+    catch (error) {
+        if (error.code === 'ENOENT')
+            return result;
+        return fail('legacy search root cannot be inspected');
+    }
+    if (!metadata.isDirectory() || metadata.isSymbolicLink())
+        return fail('legacy search root must be a regular directory');
+    let handle;
+    try {
+        handle = await open(root, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+    }
+    catch {
+        return fail('legacy search root cannot be opened safely');
+    }
+    try {
+        const opened = await handle.stat({ bigint: true });
+        if (!opened.isDirectory() || opened.dev !== metadata.dev || opened.ino !== metadata.ino)
+            return fail('legacy search root changed during discovery');
+        // Python sorts Unicode code points rather than UTF-16 code units.
+        const names = provider.listNames(handle.fd)
+            .filter(name => name.subarray(0, 7).equals(Buffer.from('search-')) && name.subarray(-3).equals(Buffer.from('.md')))
+            .map(name => {
+            try {
+                return new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(name);
+            }
+            catch {
+                return fail('legacy search report name is not valid UTF-8');
+            }
+        });
+        names.sort((a, b) => {
+            const left = Array.from(a, c => c.codePointAt(0)), right = Array.from(b, c => c.codePointAt(0));
+            for (let i = 0; i < Math.min(left.length, right.length); i++)
+                if (left[i] !== right[i])
+                    return left[i] - right[i];
+            return left.length - right.length;
+        });
+        if (names.length > 100)
+            return fail('legacy search discovery exceeds the file limit');
+        const manifest = [], items = [];
+        let aggregate = 0n;
+        for (const name of names) {
+            let entry;
+            try {
+                entry = provider.inspect(handle.fd, name);
+            }
+            catch {
+                return fail('legacy search report cannot be inspected');
+            }
+            if ((entry.mode & constants.S_IFMT) !== constants.S_IFREG)
+                return fail('legacy search reports must be regular files');
+            if (entry.size > BigInt(maxFile))
+                return fail('legacy search report exceeds the per-file byte limit');
+            aggregate += entry.size;
+            if (aggregate > 20n * 1024n * 1024n)
+                return fail('legacy search discovery exceeds the aggregate byte limit');
+            const raw = await report(provider, handle.fd, name, entry);
+            let decoded;
+            try {
+                decoded = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(raw);
+            }
+            catch {
+                return fail('legacy search report is not valid UTF-8');
+            }
+            const digest = createHash('sha256').update(raw).digest('hex');
+            manifest.push(object(fromJSON({ relativePath: name, sourceSha256: digest, size: raw.length }), 'legacy manifest'));
+            items.push(...parseLegacyJobReport(name, digest, decoded));
+            if (items.length > 5000)
+                return fail('legacy search discovery exceeds the entry limit');
+        }
+        set(result, 'manifest', manifest);
+        set(result, 'items', items);
+        return result;
+    }
+    finally {
+        await handle.close();
+    }
+}

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -98,7 +98,7 @@ export class NativeJobsRepository {
             await handle.close();
         }
     }
-    async validateRoot(locked = false) {
+    async validateRoot(locked = false, allowMissingJobs = false) {
         if (!isAbsolute(this.root) || this.root !== resolve(this.root) || await realpath(this.root) !== this.root) {
             throw new JobsError("native fixture root must be a real absolute directory");
         }
@@ -107,7 +107,7 @@ export class NativeJobsRepository {
             throw new JobsError("native fixture root must be private and owned");
         }
         const entries = await readdir(this.root);
-        if (locked && entries.some(name => !allowed.has(name)) || [...allowed].some(name => !entries.includes(name))) {
+        if (locked && entries.some(name => !allowed.has(name)) || [...allowed].some(name => !(allowMissingJobs && name === "jobs.json") && !entries.includes(name))) {
             throw new JobsError("native Jobs cannot open unsupported state or recovery journals");
         }
         if ((await this.read(".native-jobs-fixture")).toString("utf8") !== marker) {
@@ -214,6 +214,38 @@ export class NativeJobsRepository {
                 await this.write(join(this.root, "jobs.json"), value, options);
             },
         }));
+    }
+    async legacyTransaction(operation) {
+        await this.validateRoot(false, true);
+        return withExclusiveFileLock(join(this.root, ".store.lock"), async () => {
+            await this.validateRoot(true, true);
+            // A preview must stay read-only; defer imports until existing recovery work is complete.
+            for (const name of [journalName, extractionJournalName, answerJournalName]) {
+                if (get(await this.journal(name), "operation") !== null) {
+                    throw new JobsError("native legacy import requires completed fixture recovery");
+                }
+            }
+            return operation({
+                snapshot: async () => {
+                    try {
+                        const document = validateJobsDocument(await this.document("jobs"));
+                        return { document, snapshot: document };
+                    }
+                    catch (error) {
+                        if (error.code !== 'ENOENT')
+                            throw error;
+                        const document = object(fromJSON({ schemaVersion: 1, jobs: {}, metadata: {
+                                createdAt: '1970-01-01T00:00:00Z', updatedAt: '1970-01-01T00:00:00Z',
+                            } }), 'jobs');
+                        return { document, snapshot: fromJSON({ state: 'missing' }) };
+                    }
+                },
+                save: async (document) => {
+                    validateJobsDocument(document);
+                    await this.write(join(this.root, "jobs.json"), document, options);
+                },
+            });
+        }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
     }
     async resumeTransaction(operation) {
         await this.validateRoot();

--- a/runtime/store/posix-directory.js
+++ b/runtime/store/posix-directory.js
@@ -1,0 +1,43 @@
+import { createRequire } from 'node:module';
+import { isAbsolute } from 'node:path';
+function basename(name) {
+    if (typeof name !== 'string' || !name || name === '.' || name === '..' || /[\0/]/u.test(name)
+        || Buffer.from(name, 'utf8').toString('utf8') !== name)
+        throw new TypeError('Directory basename is invalid');
+}
+/** Explicit artifact only; operations remain relative to the caller's pinned fd. */
+export function loadPosixDirectoryProvider(absoluteAddonPath) {
+    if (!['darwin', 'linux'].includes(process.platform))
+        throw new Error('POSIX directory access is unavailable');
+    if (!isAbsolute(absoluteAddonPath))
+        throw new TypeError('Native directory artifact path must be absolute');
+    const native = createRequire(import.meta.url)(absoluteAddonPath);
+    if (native === null || typeof native !== 'object' || !('listNames' in native) || typeof native.listNames !== 'function'
+        || !('inspect' in native) || typeof native.inspect !== 'function' || !('openFile' in native) || typeof native.openFile !== 'function')
+        throw new TypeError('Native directory artifact has an invalid interface');
+    const { listNames, inspect, openFile } = native;
+    return {
+        listNames(descriptor) {
+            const result = listNames(descriptor);
+            if (!Array.isArray(result) || result.some(name => !Buffer.isBuffer(name)))
+                throw new TypeError('Native directory listing is invalid');
+            return result;
+        },
+        inspect(descriptor, name) {
+            basename(name);
+            const result = inspect(descriptor, name);
+            if (result === null || typeof result !== 'object' || !('dev' in result) || typeof result.dev !== 'bigint'
+                || !('ino' in result) || typeof result.ino !== 'bigint' || !('size' in result) || typeof result.size !== 'bigint'
+                || !('mode' in result) || typeof result.mode !== 'number')
+                throw new TypeError('Native directory metadata is invalid');
+            return result;
+        },
+        openFile(descriptor, name) {
+            basename(name);
+            const result = openFile(descriptor, name);
+            if (typeof result !== 'number' || !Number.isInteger(result) || result < 0)
+                throw new TypeError('Native directory descriptor is invalid');
+            return result;
+        },
+    };
+}

--- a/runtime/workspace-core/job-provenance.js
+++ b/runtime/workspace-core/job-provenance.js
@@ -27,3 +27,10 @@ export function stamp(provenance, fields, author, record, now) {
         set(result, `/${field}`, fromJSON({ origin: author, observationSource, updatedAt: now }));
     return result;
 }
+/** Only guided legacy imports can refresh previously imported or empty fields. */
+export function migrationMayUpdate(record, provenance, field) {
+    if (!nonempty(get(record, field)))
+        return true;
+    const authored = get(provenance, `/${field}`);
+    return authored instanceof PythonObject && string(get(authored, "origin")) === "migration";
+}

--- a/runtime/workspace-core/job-upsert-plan.js
+++ b/runtime/workspace-core/job-upsert-plan.js
@@ -4,7 +4,7 @@ import { canonicalJson } from '../contracts/workspace/canonical-json.js';
 import { normalizeJobUrl, strip } from '../contracts/workspace/job-url.js';
 import { emptyObject, ingestFields, validateJob } from '../contracts/workspace/jobs.js';
 import { copy, get, has, set, object, string, text, integer, int, keys, same, fromJSON, parse, serialize, JobsError } from '../contracts/workspace/values.js';
-import { mayUpdate, nonempty, stamp } from './job-provenance.js';
+import { mayUpdate, migrationMayUpdate, nonempty, stamp } from './job-provenance.js';
 function normalizeItem(value) {
     if (!(value instanceof PythonObject))
         throw new JobsError('job upsert item must be a JSON object');
@@ -57,16 +57,16 @@ function batchConflicts(items) {
     }
     return conflicts;
 }
-function incompatible(current, item) {
+function incompatible(current, item, identityRefresh, urlRefresh) {
     const previous = sourceIdentity(current), incoming = sourceIdentity(item);
     const sourceChanged = nonempty(get(current, 'source')) && nonempty(get(item, 'source'))
         && sourceName(current) !== sourceName(item);
     const idChanged = nonempty(get(current, 'sourceId')) && nonempty(get(item, 'sourceId'))
         && strip(string(get(current, 'sourceId'))) !== strip(string(get(item, 'sourceId')));
-    return !same(get(current, 'normalizedUrl'), get(item, 'normalizedUrl'))
-        || previous !== null && incoming !== null && previous !== incoming || sourceChanged || idChanged;
+    return !same(get(current, 'normalizedUrl'), get(item, 'normalizedUrl')) && !urlRefresh
+        || (previous !== null && incoming !== null && previous !== incoming || sourceChanged || idChanged) && !identityRefresh;
 }
-export function planJobUpsert(currentDocument, raw, author, now) {
+export function planJobUpsert(currentDocument, raw, author, now, targetIds) {
     const errors = [];
     const normalized = raw.map(value => {
         try {
@@ -100,7 +100,9 @@ export function planJobUpsert(currentDocument, raw, author, now) {
         const urlMatches = records.filter(record => same(get(record, 'normalizedUrl'), get(item, 'normalizedUrl')));
         const source = sourceIdentity(item);
         const sourceMatches = source === null ? [] : records.filter(record => sourceIdentity(record) === source);
-        const matches = new Map([...urlMatches, ...sourceMatches].map(record => [string(get(record, 'id')), record]));
+        const targetId = targetIds?.[index] ?? null;
+        const targetMatches = targetId !== null && has(jobs, targetId) ? [object(get(jobs, targetId), 'job record')] : [];
+        const matches = new Map([...urlMatches, ...sourceMatches, ...targetMatches].map(record => [string(get(record, 'id')), record]));
         if (urlMatches.length > 1 || sourceMatches.length > 1 || matches.size > 1
             || [...matches.values()].some(record => get(record, 'deletedAt') !== null)) {
             decide({ index, action: 'conflict', reason: 'job identities do not resolve to one active record' });
@@ -110,13 +112,18 @@ export function planJobUpsert(currentDocument, raw, author, now) {
         if (current) {
             const id = string(get(current, 'id'));
             const provenance = has(current, 'provenance') ? object(get(current, 'provenance'), 'job provenance') : emptyObject();
-            if (incompatible(current, item)) {
+            const identityRefresh = author === 'migration'
+                && (same(get(current, 'normalizedUrl'), get(item, 'normalizedUrl')) || targetId === id);
+            const urlRefresh = author === 'migration' && targetId === id && migrationMayUpdate(current, provenance, 'url');
+            if (incompatible(current, item, identityRefresh, urlRefresh)) {
                 decide({ index, action: 'conflict', id, reason: 'incoming identity is incompatible with stored identity' });
                 return;
             }
             const updated = copy(current), accepted = [];
             for (const field of ingestFields) {
-                if (!has(item, field) || field === 'url' || author === 'agent' && !mayUpdate(current, provenance, field))
+                if (!has(item, field) || field === 'url' && !urlRefresh
+                    || author === 'agent' && !mayUpdate(current, provenance, field)
+                    || author === 'migration' && !migrationMayUpdate(current, provenance, field))
                     continue;
                 if (!same(get(current, field), get(item, field))) {
                     set(updated, field, get(item, field));
@@ -127,6 +134,8 @@ export function planJobUpsert(currentDocument, raw, author, now) {
                 decide({ index, action: 'noop', id });
                 return;
             }
+            if (accepted.includes('url'))
+                set(updated, 'normalizedUrl', get(item, 'normalizedUrl'));
             set(updated, 'provenance', stamp(provenance, accepted, author, updated, now));
             set(updated, 'revision', integer(int(get(current, 'revision')) + 1n));
             set(updated, 'updatedAt', text(now));

--- a/runtime/workspace-core/legacy-job-plan.js
+++ b/runtime/workspace-core/legacy-job-plan.js
@@ -1,0 +1,72 @@
+import { get, has, set, object, string, text, integer, int, same, JobsError } from '../contracts/workspace/values.js';
+import { validateJob } from '../contracts/workspace/jobs.js';
+import { planJobUpsert } from './job-upsert-plan.js';
+function sources(record) {
+    return has(record, 'legacySources') ? get(record, 'legacySources') : [];
+}
+function identity(value) {
+    const source = object(value, 'legacy source');
+    return JSON.stringify(['sourceKind', 'relativePath', 'entryId'].map(key => string(get(source, key))));
+}
+function compareSources(left, right) {
+    const a = object(left, 'legacy source'), b = object(right, 'legacy source');
+    for (const key of ['relativePath', 'entryId']) {
+        const result = text(string(get(a, key))).compare(text(string(get(b, key))));
+        if (result)
+            return result;
+    }
+    return 0;
+}
+/** Locators identify an imported entry even when its URL or report bytes later change. */
+export function planLegacyJobs(document, chosen, now) {
+    const records = object(get(document, 'jobs'), 'jobs.jobs').entries().map(([, value]) => object(value, 'job'));
+    const targets = chosen.map(item => {
+        const locator = identity(get(item, 'source'));
+        const matches = records.filter(record => sources(record).some(source => identity(source) === locator));
+        if (matches.length > 1)
+            throw new JobsError('legacy source locator resolves to multiple jobs');
+        return matches.length ? string(get(matches[0], 'id')) : null;
+    });
+    const planned = planJobUpsert(document, chosen.map(item => get(item, 'job')), 'migration', now, targets);
+    const jobs = object(get(planned.document, 'jobs'), 'jobs.jobs');
+    chosen.forEach((item, index) => {
+        const decision = planned.decisions[index];
+        set(decision, 'itemId', get(item, 'itemId'));
+        const action = string(get(decision, 'action'));
+        if (action === 'conflict' || action === 'invalid')
+            return;
+        const id = string(get(decision, 'id'));
+        const record = object(get(jobs, id), 'job');
+        const previous = sources(record), locator = get(item, 'source'), locatorIdentity = identity(locator);
+        let replaced = false;
+        const merged = previous.map(source => {
+            if (identity(source) !== locatorIdentity)
+                return source;
+            replaced = true;
+            return locator;
+        });
+        if (!replaced)
+            merged.push(locator);
+        merged.sort(compareSources);
+        if (same(merged, previous))
+            return;
+        set(record, 'legacySources', merged);
+        if (action === 'noop') {
+            set(record, 'revision', integer(int(get(record, 'revision')) + 1n));
+            set(record, 'updatedAt', text(now));
+            set(decision, 'action', text('update'));
+            set(decision, 'fields', [text('legacySources')]);
+        }
+        else if (action === 'update') {
+            const fields = get(decision, 'fields').map(value => string(value));
+            set(decision, 'fields', [...new Set([...fields, 'legacySources'])].sort().map(text));
+        }
+        planned.changed = true;
+        set(object(get(planned.document, 'metadata'), 'jobs.metadata'), 'updatedAt', text(now));
+        validateJob(id, record);
+    });
+    if (planned.changed && string(get(object(get(document, 'metadata'), 'jobs.metadata'), 'createdAt')) === '1970-01-01T00:00:00Z') {
+        set(object(get(planned.document, 'metadata'), 'jobs.metadata'), 'createdAt', text(now));
+    }
+    return planned;
+}

--- a/runtime/workspace-core/legacy-jobs.js
+++ b/runtime/workspace-core/legacy-jobs.js
@@ -1,0 +1,83 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { get, set, object, string, fromJSON, JobsError } from '../contracts/workspace/values.js';
+import { planLegacyJobs } from './legacy-job-plan.js';
+const drift = 'legacy job preview token rejected because the source, selection, input, or store drifted';
+function select(discovery, selected, committing = false) {
+    if (new Set(selected).size !== selected.length)
+        throw new JobsError('legacy job selection contains duplicate item ids');
+    const indexed = new Map(get(discovery, 'items').map(value => {
+        const item = object(value, 'legacy item');
+        return [string(get(item, 'itemId')), item];
+    }));
+    return selected.map(id => {
+        const item = indexed.get(id);
+        if (!item)
+            throw new JobsError(committing ? drift : 'legacy job selection contains an unknown item id');
+        if (string(get(item, 'state')) !== 'valid')
+            throw new JobsError(committing ? drift : 'legacy job selection contains an invalid item');
+        return item;
+    });
+}
+function tokenFor(discovery, selected, chosen, snapshot) {
+    const bound = object(fromJSON({ version: 1, origin: 'migration', selection: selected }), 'legacy token');
+    set(bound, 'payloads', chosen.map(item => get(item, 'job')));
+    set(bound, 'selectedLocators', chosen.map(item => get(item, 'source')));
+    set(bound, 'manifest', get(discovery, 'manifest'));
+    set(bound, 'jobsSnapshot', snapshot);
+    return 'legacy-jobs-v1.' + createHash('sha256').update(canonicalJson(bound)).digest('hex');
+}
+function result(discovery, selected, decisions, token, committed = false) {
+    const value = object(fromJSON({ selected, committed }), 'legacy result');
+    for (const key of ['root', 'manifest', 'items'])
+        set(value, key, get(discovery, key));
+    if (decisions !== undefined) {
+        const summary = { create: 0, update: 0, noop: 0, conflict: 0, invalid: 0 };
+        for (const decision of decisions)
+            summary[string(get(decision, 'action'))]++;
+        set(value, 'token', fromJSON(token ?? null));
+        set(value, 'summary', fromJSON(summary));
+        set(value, 'decisions', decisions);
+    }
+    return value;
+}
+/** Discovery-only previews never read or initialize the jobs document. */
+export class LegacyJobsService {
+    repository;
+    discover;
+    now;
+    constructor(repository, discover, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.discover = discover;
+        this.now = now;
+    }
+    async preview(selected) {
+        const discovery = await this.discover();
+        if (!selected.length)
+            return result(discovery, []);
+        const chosen = select(discovery, selected);
+        return this.repository.legacyTransaction(async (transaction) => {
+            const { document, snapshot } = await transaction.snapshot();
+            const token = tokenFor(discovery, selected, chosen, snapshot);
+            const { decisions } = planLegacyJobs(document, chosen, this.now());
+            return result(discovery, selected, decisions, token);
+        });
+    }
+    async commit(selected, token) {
+        if (!selected.length || typeof token !== 'string' || !token) {
+            throw new JobsError('legacy job commit requires selection and a preview token');
+        }
+        return this.repository.legacyTransaction(async (transaction) => {
+            const discovery = await this.discover(), chosen = select(discovery, selected, true);
+            const { document, snapshot } = await transaction.snapshot();
+            const expected = Buffer.from(tokenFor(discovery, selected, chosen, snapshot));
+            const supplied = Buffer.from(token);
+            if (expected.length !== supplied.length || !timingSafeEqual(expected, supplied))
+                throw new JobsError(drift);
+            const planned = planLegacyJobs(document, chosen, this.now());
+            if (planned.changed)
+                await transaction.save(planned.document);
+            return result(discovery, selected, planned.decisions, token, planned.changed);
+        });
+    }
+}

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,3 +1,4 @@
+import { legacyJobCommands, runLegacyJobCommand } from './native-legacy-jobs.js';
 import { jobUpsertCommands, runJobUpsertCommand } from './native-job-upsert.js';
 import { claimCommands, runClaimCommand } from './native-claims.js';
 import { jobTransitionCommands, runJobTransitionCommand } from './native-job-transitions.js';
@@ -20,22 +21,25 @@ import { NativeResumeFiles } from "../store/native-resume-files.js";
 export async function runJobsCli(args: string[], input: (limit?: number) => Promise<string>): Promise<string> {
   const options = new Map<string, string>();
   let command: string | undefined;
+  const selected: string[] = [];
   for (let index = 0; index < args.length; index++) {
     const key = args[index]!;
     if (!key.startsWith("--")) {
       if (command) throw new JobsError("unexpected CLI argument");
       command = key;
     } else {
-      if (options.has(key)) throw new JobsError("duplicate CLI option");
+      if (options.has(key) && key !== "--select") throw new JobsError("duplicate CLI option");
       if (["--include-trashed", "--trashed-only", "--replace", "--remember-sensitive", "--all-review-statuses", "--summary-only", "--owner-confirmed", "--owner-confirmed-not-submitted", "--user-confirmed"].includes(key)) options.set(key, "true");
       else {
         const value = args[++index];
         if (!value || value.startsWith("--")) throw new JobsError("missing CLI option value");
         options.set(key, value);
+        if (key === "--select") selected.push(value);
       }
     }
   }
   const fields: Record<string, string[]> = {
+    ...legacyJobCommands,
     ...jobUpsertCommands,
     ...jobTransitionCommands,
     ...projectionCommands,
@@ -75,6 +79,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
       : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command!) ? 2 * 1024 * 1024 : 65536;
     return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
   };
+  if (Object.hasOwn(legacyJobCommands, command!)) return serialize(await runLegacyJobCommand(command!, repository, options, selected));
   if (Object.hasOwn(jobUpsertCommands, command!)) return serialize(await runJobUpsertCommand(command!, repository, options, payload));
   if (Object.hasOwn(jobTransitionCommands, command!)) return serialize(await runJobTransitionCommand(repository, options));
   if (Object.hasOwn(projectionCommands, command!)) return serialize(await runProjectionCommand(command!, repository, options));

--- a/src/cli/native-legacy-jobs.ts
+++ b/src/cli/native-legacy-jobs.ts
@@ -1,0 +1,20 @@
+import { homedir } from 'node:os';
+import { LegacyJobsService, type LegacyJobsRepository } from '../workspace-core/legacy-jobs.js';
+import { discoverLegacyJobs } from '../store/legacy-job-discovery.js';
+import { loadPosixDirectoryProvider } from '../store/posix-directory.js';
+import { JobsError, type Value } from '../contracts/workspace/values.js';
+
+export const legacyJobCommands: Record<string,string[]> = {
+  'legacy-jobs-preview':['--select'],
+  'legacy-jobs-commit':['--select','--confirm'],
+};
+export async function runLegacyJobCommand(command:string, repository:LegacyJobsRepository,
+  options:Map<string,string>, selected:string[]):Promise<Value> {
+  const provider = loadPosixDirectoryProvider(options.get('--native-lock')!);
+  const service = new LegacyJobsService(repository, () => discoverLegacyJobs(homedir(),provider));
+  if (command === 'legacy-jobs-preview') return service.preview(selected);
+  if (!selected.length) throw new JobsError('required option: --select');
+  const token = options.get('--confirm');
+  if (!token) throw new JobsError('required option: --confirm');
+  return service.commit(selected,token);
+}

--- a/src/contracts/workspace/legacy-job-report.ts
+++ b/src/contracts/workspace/legacy-job-report.ts
@@ -1,0 +1,72 @@
+import { createHash } from 'node:crypto';
+import { normalizeJobUrl, strip } from './job-url.js';
+import { fromJSON, object, JobsError, type Document } from './values.js';
+
+const whitespace = '[\\u0009-\\u000d\\u001c-\\u0020\\u0085\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000]';
+// CPython 3.12 uses Unicode 15.0 decimal digits; host ICU versions must not change item identity.
+const decimalDigits = '[' + [
+  String.raw`\u{30}-\u{39}\u{660}-\u{669}\u{6f0}-\u{6f9}\u{7c0}-\u{7c9}\u{966}-\u{96f}`,
+  String.raw`\u{9e6}-\u{9ef}\u{a66}-\u{a6f}\u{ae6}-\u{aef}\u{b66}-\u{b6f}\u{be6}-\u{bef}`,
+  String.raw`\u{c66}-\u{c6f}\u{ce6}-\u{cef}\u{d66}-\u{d6f}\u{de6}-\u{def}\u{e50}-\u{e59}`,
+  String.raw`\u{ed0}-\u{ed9}\u{f20}-\u{f29}\u{1040}-\u{1049}\u{1090}-\u{1099}\u{17e0}-\u{17e9}`,
+  String.raw`\u{1810}-\u{1819}\u{1946}-\u{194f}\u{19d0}-\u{19d9}\u{1a80}-\u{1a89}\u{1a90}-\u{1a99}`,
+  String.raw`\u{1b50}-\u{1b59}\u{1bb0}-\u{1bb9}\u{1c40}-\u{1c49}\u{1c50}-\u{1c59}\u{a620}-\u{a629}`,
+  String.raw`\u{a8d0}-\u{a8d9}\u{a900}-\u{a909}\u{a9d0}-\u{a9d9}\u{a9f0}-\u{a9f9}\u{aa50}-\u{aa59}`,
+  String.raw`\u{abf0}-\u{abf9}\u{ff10}-\u{ff19}\u{104a0}-\u{104a9}\u{10d30}-\u{10d39}\u{11066}-\u{1106f}`,
+  String.raw`\u{110f0}-\u{110f9}\u{11136}-\u{1113f}\u{111d0}-\u{111d9}\u{112f0}-\u{112f9}\u{11450}-\u{11459}`,
+  String.raw`\u{114d0}-\u{114d9}\u{11650}-\u{11659}\u{116c0}-\u{116c9}\u{11730}-\u{11739}\u{118e0}-\u{118e9}`,
+  String.raw`\u{11950}-\u{11959}\u{11c50}-\u{11c59}\u{11d50}-\u{11d59}\u{11da0}-\u{11da9}\u{11f50}-\u{11f59}`,
+  String.raw`\u{16a60}-\u{16a69}\u{16ac0}-\u{16ac9}\u{16b50}-\u{16b59}\u{1d7ce}-\u{1d7ff}\u{1e140}-\u{1e149}`,
+  String.raw`\u{1e2f0}-\u{1e2f9}\u{1e4f0}-\u{1e4f9}\u{1e950}-\u{1e959}\u{1fbf0}-\u{1fbf9}`,
+].join('') + ']';
+const pattern = (source: string): RegExp => new RegExp(source.replaceAll('\\s', whitespace).replaceAll('\\d', decimalDigits), 'u');
+const digest = (value: string): string => createHash('sha256').update(value).digest('hex').slice(0, 24);
+
+/** Parse only the historical numbered report format, retaining invalid entries for preview. */
+export function parseLegacyJobReport(relativePath: string, sourceSha256: string, content: string): Document[] {
+  const lines = content.split(/\r\n|[\n\r\v\f\u001c-\u001e\u0085\u2028\u2029]/u);
+  if (lines.at(-1) === '') lines.pop();
+  const starts = lines.flatMap((line, index) => line.startsWith('###') ? [index] : []);
+  const identities = starts.map(start => strip(lines[start]!.replace(pattern('^###\\s+\\d+\\.\\s*'), '')));
+  const totals = new Map<string, number>();
+  for (const identity of identities) totals.set(identity, (totals.get(identity) ?? 0) + 1);
+  const occurrences = new Map<string, number>();
+  return starts.map((start, index) => {
+    const body = lines.slice(start + 1, starts[index + 1] ?? lines.length);
+    const identity = identities[index]!;
+    const contentIdentity = totals.get(identity)! > 1 ? strip([identity, ...body].join('\n')) : identity;
+    const occurrence = (occurrences.get(contentIdentity) ?? 0) + 1;
+    occurrences.set(contentIdentity, occurrence);
+    const entryId = 'legacy-entry-' + digest(`${relativePath}\0${contentIdentity}\0${occurrence}`);
+    const itemId = 'legacy-item-' + digest(entryId);
+    const source = {sourceKind:'timestamped-search-report', relativePath, entryId, sourceSha256};
+    const invalid = (reason: string): Document => object(fromJSON({itemId,state:'invalid',reason,source}), 'legacy item');
+    const heading = pattern('^###\\s+\\d+\\.\\s+(.+?)\\s+—\\s+(.+)$').exec(lines[start]!);
+    if (!heading) return invalid('unsupported_heading');
+    const role = strip(heading[1]!);
+    const company = strip(heading[2]!.replace(pattern('\\s+\\(Score:\\s*[^)]*\\)\\s*$'), ''));
+    if (!role || !company) return invalid('incomplete_heading');
+    const labels = new Map<string, string>();
+    for (const line of body) {
+      const field = pattern('^- \\*\\*([^*]+)\\*\\*:\\s*(.*)$').exec(line);
+      if (!field) continue;
+      const label = strip(field[1]!).toLowerCase();
+      if (labels.has(label)) return invalid('duplicate_field');
+      labels.set(label, strip(field[2]!));
+    }
+    const candidates: [string, string][] = [];
+    for (const label of ['url', 'apply']) {
+      const value = labels.get(label) ?? '';
+      if (!value.startsWith('http://') && !value.startsWith('https://') || pattern('\\s').test(value)) continue;
+      try { candidates.push([value, normalizeJobUrl(value)]); }
+      catch (error) { if (!(error instanceof JobsError)) throw error; }
+    }
+    if (!candidates.length) return invalid('missing_url');
+    if (new Set(candidates.map(([,url]) => url)).size !== 1) return invalid('ambiguous_url');
+    const job: Record<string,string> = {url:candidates[0]![0],role,company};
+    for (const [label,field] of [['source','source'],['location','location'],['salary','compensation'],['description','description']] as const) {
+      if (labels.get(label)) job[field] = labels.get(label)!;
+    }
+    return object(fromJSON({itemId,state:'valid',source,job}), 'legacy item');
+  });
+}

--- a/src/store/legacy-job-discovery.ts
+++ b/src/store/legacy-job-discovery.ts
@@ -1,0 +1,92 @@
+import { constants, read, fstat, close } from 'node:fs';
+import { lstat, open } from 'node:fs/promises';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { createHash } from 'node:crypto';
+import { parseLegacyJobReport } from '../contracts/workspace/legacy-job-report.js';
+import { fromJSON, object, set, JobsError, type Document } from '../contracts/workspace/values.js';
+import type { PosixDirectoryProvider } from './posix-directory.js';
+
+const rootName = '.claude-job-searches';
+const maxFile = 2 * 1024 * 1024;
+const statDescriptor = promisify(fstat), closeDescriptor = promisify(close), readDescriptor = promisify(read);
+const fail = (message: string): never => { throw new JobsError(message); };
+
+async function report(provider: PosixDirectoryProvider, root: number, name: string,
+  metadata: {dev:bigint;ino:bigint;size:bigint}): Promise<Buffer> {
+  let descriptor: number;
+  try { descriptor = provider.openFile(root,name); }
+  catch { return fail('legacy search report cannot be opened safely'); }
+  try {
+    const opened = await statDescriptor(descriptor, {bigint:true});
+    if (!opened.isFile() || opened.dev !== metadata.dev || opened.ino !== metadata.ino || opened.size !== metadata.size) {
+      return fail('legacy search report changed during discovery');
+    }
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      const buffer = Buffer.alloc(Math.min(65536, maxFile + 1 - total));
+      const {bytesRead} = await readDescriptor(descriptor, buffer, 0, buffer.length, null);
+      if (!bytesRead) break;
+      total += bytesRead;
+      if (total > maxFile) return fail('legacy search report exceeds the per-file byte limit');
+      chunks.push(buffer.subarray(0,bytesRead));
+    }
+    if ((await statDescriptor(descriptor, {bigint:true})).size !== opened.size) return fail('legacy search report changed during discovery');
+    return Buffer.concat(chunks);
+  } finally { await closeDescriptor(descriptor); }
+}
+
+/** All entry inspection and opens resolve against the pinned directory, never a replaced path. */
+export async function discoverLegacyJobs(home: string, provider: PosixDirectoryProvider): Promise<Document> {
+  const root = join(home,rootName);
+  const result = object(fromJSON({root:`~/${rootName}`,manifest:[],items:[]}), 'legacy discovery');
+  let metadata;
+  try { metadata = await lstat(root, {bigint:true}); }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return result;
+    return fail('legacy search root cannot be inspected');
+  }
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) return fail('legacy search root must be a regular directory');
+  let handle;
+  try { handle = await open(root,constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW); }
+  catch { return fail('legacy search root cannot be opened safely'); }
+  try {
+    const opened = await handle.stat({bigint:true});
+    if (!opened.isDirectory() || opened.dev !== metadata.dev || opened.ino !== metadata.ino) return fail('legacy search root changed during discovery');
+    // Python sorts Unicode code points rather than UTF-16 code units.
+    const names = provider.listNames(handle.fd)
+      .filter(name => name.subarray(0,7).equals(Buffer.from('search-')) && name.subarray(-3).equals(Buffer.from('.md')))
+      .map(name => {
+        try { return new TextDecoder('utf-8',{fatal:true,ignoreBOM:true}).decode(name); }
+        catch { return fail('legacy search report name is not valid UTF-8'); }
+      });
+    names.sort((a,b) => {
+      const left = Array.from(a, c => c.codePointAt(0)!), right = Array.from(b, c => c.codePointAt(0)!);
+      for (let i=0;i<Math.min(left.length,right.length);i++) if (left[i] !== right[i]) return left[i]! - right[i]!;
+      return left.length-right.length;
+    });
+    if (names.length > 100) return fail('legacy search discovery exceeds the file limit');
+    const manifest: Document[] = [], items: Document[] = [];
+    let aggregate = 0n;
+    for (const name of names) {
+      let entry;
+      try { entry = provider.inspect(handle.fd,name); }
+      catch { return fail('legacy search report cannot be inspected'); }
+      if ((entry.mode & constants.S_IFMT) !== constants.S_IFREG) return fail('legacy search reports must be regular files');
+      if (entry.size > BigInt(maxFile)) return fail('legacy search report exceeds the per-file byte limit');
+      aggregate += entry.size;
+      if (aggregate > 20n * 1024n * 1024n) return fail('legacy search discovery exceeds the aggregate byte limit');
+      const raw = await report(provider,handle.fd,name,entry);
+      let decoded: string;
+      try { decoded = new TextDecoder('utf-8',{fatal:true,ignoreBOM:true}).decode(raw); }
+      catch { return fail('legacy search report is not valid UTF-8'); }
+      const digest = createHash('sha256').update(raw).digest('hex');
+      manifest.push(object(fromJSON({relativePath:name,sourceSha256:digest,size:raw.length}), 'legacy manifest'));
+      items.push(...parseLegacyJobReport(name,digest,decoded));
+      if (items.length > 5000) return fail('legacy search discovery exceeds the entry limit');
+    }
+    set(result,'manifest',manifest); set(result,'items',items);
+    return result;
+  } finally { await handle.close(); }
+}

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -96,7 +96,7 @@ export class NativeJobsRepository implements JobsRepository {
     } finally { await handle.close(); }
   }
 
-  private async validateRoot(locked = false): Promise<void> {
+  private async validateRoot(locked = false, allowMissingJobs = false): Promise<void> {
     if (!isAbsolute(this.root) || this.root !== resolve(this.root) || await realpath(this.root) !== this.root) {
       throw new JobsError("native fixture root must be a real absolute directory");
     }
@@ -105,7 +105,7 @@ export class NativeJobsRepository implements JobsRepository {
       throw new JobsError("native fixture root must be private and owned");
     }
     const entries = await readdir(this.root);
-    if (locked && entries.some(name => !allowed.has(name)) || [...allowed].some(name => !entries.includes(name))) {
+    if (locked && entries.some(name => !allowed.has(name)) || [...allowed].some(name => !(allowMissingJobs && name === "jobs.json") && !entries.includes(name))) {
       throw new JobsError("native Jobs cannot open unsupported state or recovery journals");
     }
     if ((await this.read(".native-jobs-fixture")).toString("utf8") !== marker) {
@@ -214,6 +214,40 @@ export class NativeJobsRepository implements JobsRepository {
         await this.write(join(this.root, "jobs.json"), value, options);
       },
     }));
+  }
+
+  async legacyTransaction<T>(operation: (transaction: {
+    snapshot(): Promise<{document: Document; snapshot: Value}>;
+    save(document: Document): Promise<void>;
+  }) => Promise<T>): Promise<T> {
+    await this.validateRoot(false, true);
+    return withExclusiveFileLock(join(this.root, ".store.lock"), async () => {
+      await this.validateRoot(true, true);
+      // A preview must stay read-only; defer imports until existing recovery work is complete.
+      for (const name of [journalName, extractionJournalName, answerJournalName]) {
+        if (get(await this.journal(name), "operation") !== null) {
+          throw new JobsError("native legacy import requires completed fixture recovery");
+        }
+      }
+      return operation({
+        snapshot: async () => {
+          try {
+            const document = validateJobsDocument(await this.document("jobs"));
+            return {document, snapshot: document};
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+            const document = object(fromJSON({schemaVersion:1,jobs:{},metadata:{
+              createdAt:'1970-01-01T00:00:00Z',updatedAt:'1970-01-01T00:00:00Z',
+            }}), 'jobs');
+            return {document,snapshot:fromJSON({state:'missing'})};
+          }
+        },
+        save: async document => {
+          validateJobsDocument(document);
+          await this.write(join(this.root, "jobs.json"), document, options);
+        },
+      });
+    }, {provider:this.provider,pathProfile:"3.12",signal:AbortSignal.timeout(30_000)});
   }
 
   async resumeTransaction<T>(operation: (transaction: ResumeTransaction) => Promise<T>): Promise<T> {

--- a/src/store/posix-directory.ts
+++ b/src/store/posix-directory.ts
@@ -1,0 +1,45 @@
+import { createRequire } from 'node:module';
+import { isAbsolute } from 'node:path';
+
+export interface PosixDirectoryMetadata { dev:bigint; ino:bigint; size:bigint; mode:number }
+export interface PosixDirectoryProvider {
+  /** Raw POSIX basenames; callers filter bytes before decoding relevant entries. */
+  listNames(descriptor:number):Buffer[];
+  inspect(descriptor:number,name:string):PosixDirectoryMetadata;
+  /** Caller owns the returned fd and must fstat, read with bounds, and close it. */
+  openFile(descriptor:number,name:string):number;
+}
+function basename(name:string):void {
+  if (typeof name !== 'string' || !name || name === '.' || name === '..' || /[\0/]/u.test(name)
+    || Buffer.from(name,'utf8').toString('utf8') !== name) throw new TypeError('Directory basename is invalid');
+}
+/** Explicit artifact only; operations remain relative to the caller's pinned fd. */
+export function loadPosixDirectoryProvider(absoluteAddonPath:string):PosixDirectoryProvider {
+  if (!['darwin','linux'].includes(process.platform)) throw new Error('POSIX directory access is unavailable');
+  if (!isAbsolute(absoluteAddonPath)) throw new TypeError('Native directory artifact path must be absolute');
+  const native:unknown = createRequire(import.meta.url)(absoluteAddonPath);
+  if (native === null || typeof native !== 'object' || !('listNames' in native) || typeof native.listNames !== 'function'
+    || !('inspect' in native) || typeof native.inspect !== 'function' || !('openFile' in native) || typeof native.openFile !== 'function') throw new TypeError('Native directory artifact has an invalid interface');
+  const { listNames, inspect, openFile } = native;
+  return {
+    listNames(descriptor) {
+      const result:unknown = listNames(descriptor);
+      if (!Array.isArray(result) || result.some(name=>!Buffer.isBuffer(name))) throw new TypeError('Native directory listing is invalid');
+      return result;
+    },
+    inspect(descriptor,name) {
+      basename(name);
+      const result:unknown = inspect(descriptor,name);
+      if (result === null || typeof result !== 'object' || !('dev' in result) || typeof result.dev !== 'bigint'
+        || !('ino' in result) || typeof result.ino !== 'bigint' || !('size' in result) || typeof result.size !== 'bigint'
+        || !('mode' in result) || typeof result.mode !== 'number') throw new TypeError('Native directory metadata is invalid');
+      return result as PosixDirectoryMetadata;
+    },
+    openFile(descriptor,name) {
+      basename(name);
+      const result:unknown = openFile(descriptor,name);
+      if (typeof result !== 'number' || !Number.isInteger(result) || result < 0) throw new TypeError('Native directory descriptor is invalid');
+      return result;
+    },
+  };
+}

--- a/src/workspace-core/job-provenance.ts
+++ b/src/workspace-core/job-provenance.ts
@@ -22,9 +22,16 @@ export function protectMigration(current: Document, replacement: Document): void
     }
   }
 }
-export function stamp(provenance: Document, fields: Iterable<string>, author: Origin, record: Document, now: string): Document {
+export function stamp(provenance: Document, fields: Iterable<string>, author: Origin | "migration", record: Document, now: string): Document {
   const result = copy(provenance);
   const observationSource = strip(string(get(record, "source")) ?? "").toLowerCase() || "manual";
   for (const field of fields) set(result, `/${field}`, fromJSON({ origin: author, observationSource, updatedAt: now }));
   return result;
+}
+
+/** Only guided legacy imports can refresh previously imported or empty fields. */
+export function migrationMayUpdate(record: Document, provenance: Document, field: string): boolean {
+  if (!nonempty(get(record, field))) return true;
+  const authored = get(provenance, `/${field}`);
+  return authored instanceof PythonObject && string(get(authored, "origin")) === "migration";
 }

--- a/src/workspace-core/job-upsert-plan.ts
+++ b/src/workspace-core/job-upsert-plan.ts
@@ -5,7 +5,7 @@ import { normalizeJobUrl, strip } from '../contracts/workspace/job-url.js';
 import { emptyObject, ingestFields, validateJob } from '../contracts/workspace/jobs.js';
 import { copy, get, has, set, object, string, text, integer, int, keys, same, fromJSON, parse, serialize, JobsError } from '../contracts/workspace/values.js';
 import type { Document, Value } from '../contracts/workspace/values.js';
-import { mayUpdate, nonempty, stamp } from './job-provenance.js';
+import { mayUpdate, migrationMayUpdate, nonempty, stamp } from './job-provenance.js';
 import type { Origin } from './job-provenance.js';
 
 function normalizeItem(value: Value): Document {
@@ -55,17 +55,18 @@ function batchConflicts(items: (Document | null)[]): Set<number> {
   return conflicts;
 }
 
-function incompatible(current: Document, item: Document): boolean {
+function incompatible(current: Document, item: Document, identityRefresh: boolean, urlRefresh: boolean): boolean {
   const previous = sourceIdentity(current), incoming = sourceIdentity(item);
   const sourceChanged = nonempty(get(current, 'source')) && nonempty(get(item, 'source'))
     && sourceName(current) !== sourceName(item);
   const idChanged = nonempty(get(current, 'sourceId')) && nonempty(get(item, 'sourceId'))
     && strip(string(get(current, 'sourceId'))!) !== strip(string(get(item, 'sourceId'))!);
-  return !same(get(current, 'normalizedUrl'), get(item, 'normalizedUrl'))
-    || previous !== null && incoming !== null && previous !== incoming || sourceChanged || idChanged;
+  return !same(get(current, 'normalizedUrl'), get(item, 'normalizedUrl')) && !urlRefresh
+    || (previous !== null && incoming !== null && previous !== incoming || sourceChanged || idChanged) && !identityRefresh;
 }
 
-export function planJobUpsert(currentDocument: Document, raw: Value[], author: Origin, now: string): {
+export function planJobUpsert(currentDocument: Document, raw: Value[], author: Origin | 'migration', now: string,
+  targetIds?: (string | null)[]): {
   document: Document; decisions: Document[]; changed: boolean;
 } {
   const errors: (string | null)[] = [];
@@ -99,7 +100,9 @@ export function planJobUpsert(currentDocument: Document, raw: Value[], author: O
     const urlMatches = records.filter(record => same(get(record, 'normalizedUrl'), get(item, 'normalizedUrl')));
     const source = sourceIdentity(item);
     const sourceMatches = source === null ? [] : records.filter(record => sourceIdentity(record) === source);
-    const matches = new Map([...urlMatches, ...sourceMatches].map(record => [string(get(record, 'id'))!, record]));
+    const targetId = targetIds?.[index] ?? null;
+    const targetMatches = targetId !== null && has(jobs, targetId) ? [object(get(jobs, targetId), 'job record')] : [];
+    const matches = new Map([...urlMatches, ...sourceMatches, ...targetMatches].map(record => [string(get(record, 'id'))!, record]));
     if (urlMatches.length > 1 || sourceMatches.length > 1 || matches.size > 1
       || [...matches.values()].some(record => get(record, 'deletedAt') !== null)) {
       decide({index, action:'conflict', reason:'job identities do not resolve to one active record'});
@@ -109,13 +112,18 @@ export function planJobUpsert(currentDocument: Document, raw: Value[], author: O
     if (current) {
       const id = string(get(current, 'id'))!;
       const provenance = has(current, 'provenance') ? object(get(current, 'provenance'), 'job provenance') : emptyObject();
-      if (incompatible(current, item)) {
+      const identityRefresh = author === 'migration'
+        && (same(get(current, 'normalizedUrl'), get(item, 'normalizedUrl')) || targetId === id);
+      const urlRefresh = author === 'migration' && targetId === id && migrationMayUpdate(current, provenance, 'url');
+      if (incompatible(current, item, identityRefresh, urlRefresh)) {
         decide({index, action:'conflict', id, reason:'incoming identity is incompatible with stored identity'});
         return;
       }
       const updated = copy(current), accepted: string[] = [];
       for (const field of ingestFields) {
-        if (!has(item, field) || field === 'url' || author === 'agent' && !mayUpdate(current, provenance, field)) continue;
+        if (!has(item, field) || field === 'url' && !urlRefresh
+          || author === 'agent' && !mayUpdate(current, provenance, field)
+          || author === 'migration' && !migrationMayUpdate(current, provenance, field)) continue;
         if (!same(get(current, field), get(item, field))) {
           set(updated, field, get(item, field));
           accepted.push(field);
@@ -125,6 +133,7 @@ export function planJobUpsert(currentDocument: Document, raw: Value[], author: O
         decide({index, action:'noop', id});
         return;
       }
+      if (accepted.includes('url')) set(updated, 'normalizedUrl', get(item, 'normalizedUrl'));
       set(updated, 'provenance', stamp(provenance, accepted, author, updated, now));
       set(updated, 'revision', integer(int(get(current, 'revision'))! + 1n));
       set(updated, 'updatedAt', text(now));

--- a/src/workspace-core/legacy-job-plan.ts
+++ b/src/workspace-core/legacy-job-plan.ts
@@ -1,0 +1,70 @@
+import { get, has, set, object, string, text, integer, int, same, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import { validateJob } from '../contracts/workspace/jobs.js';
+import { planJobUpsert } from './job-upsert-plan.js';
+
+function sources(record: Document): Value[] {
+  return has(record, 'legacySources') ? get(record, 'legacySources') as Value[] : [];
+}
+function identity(value: Value): string {
+  const source = object(value, 'legacy source');
+  return JSON.stringify(['sourceKind', 'relativePath', 'entryId'].map(key => string(get(source, key))));
+}
+function compareSources(left: Value, right: Value): number {
+  const a = object(left, 'legacy source'), b = object(right, 'legacy source');
+  for (const key of ['relativePath', 'entryId']) {
+    const result = text(string(get(a, key))!).compare(text(string(get(b, key))!));
+    if (result) return result;
+  }
+  return 0;
+}
+
+/** Locators identify an imported entry even when its URL or report bytes later change. */
+export function planLegacyJobs(document: Document, chosen: Document[], now: string): {
+  document: Document; decisions: Document[]; changed: boolean;
+} {
+  const records = object(get(document, 'jobs'), 'jobs.jobs').entries().map(([, value]) => object(value, 'job'));
+  const targets = chosen.map(item => {
+    const locator = identity(get(item, 'source'));
+    const matches = records.filter(record => sources(record).some(source => identity(source) === locator));
+    if (matches.length > 1) throw new JobsError('legacy source locator resolves to multiple jobs');
+    return matches.length ? string(get(matches[0]!, 'id'))! : null;
+  });
+  const planned = planJobUpsert(document, chosen.map(item => get(item, 'job')), 'migration', now, targets);
+  const jobs = object(get(planned.document, 'jobs'), 'jobs.jobs');
+  chosen.forEach((item, index) => {
+    const decision = planned.decisions[index]!;
+    set(decision, 'itemId', get(item, 'itemId'));
+    const action = string(get(decision, 'action'));
+    if (action === 'conflict' || action === 'invalid') return;
+    const id = string(get(decision, 'id'))!;
+    const record = object(get(jobs, id), 'job');
+    const previous = sources(record), locator = get(item, 'source'), locatorIdentity = identity(locator);
+    let replaced = false;
+    const merged = previous.map(source => {
+      if (identity(source) !== locatorIdentity) return source;
+      replaced = true;
+      return locator;
+    });
+    if (!replaced) merged.push(locator);
+    merged.sort(compareSources);
+    if (same(merged, previous)) return;
+    set(record, 'legacySources', merged);
+    if (action === 'noop') {
+      set(record, 'revision', integer(int(get(record, 'revision'))! + 1n));
+      set(record, 'updatedAt', text(now));
+      set(decision, 'action', text('update'));
+      set(decision, 'fields', [text('legacySources')]);
+    } else if (action === 'update') {
+      const fields = (get(decision, 'fields') as Value[]).map(value => string(value)!);
+      set(decision, 'fields', [...new Set([...fields, 'legacySources'])].sort().map(text));
+    }
+    planned.changed = true;
+    set(object(get(planned.document, 'metadata'), 'jobs.metadata'), 'updatedAt', text(now));
+    validateJob(id, record);
+  });
+  if (planned.changed && string(get(object(get(document, 'metadata'), 'jobs.metadata'), 'createdAt')) === '1970-01-01T00:00:00Z') {
+    set(object(get(planned.document, 'metadata'), 'jobs.metadata'), 'createdAt', text(now));
+  }
+  return planned;
+}

--- a/src/workspace-core/legacy-jobs.ts
+++ b/src/workspace-core/legacy-jobs.ts
@@ -1,0 +1,82 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { get, set, object, string, fromJSON, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import { planLegacyJobs } from './legacy-job-plan.js';
+
+export interface LegacyJobsTransaction {
+  snapshot(): Promise<{document: Document; snapshot: Value}>;
+  save(document: Document): Promise<void>;
+}
+export interface LegacyJobsRepository {
+  legacyTransaction<T>(operation: (transaction: LegacyJobsTransaction) => Promise<T>): Promise<T>;
+}
+const drift = 'legacy job preview token rejected because the source, selection, input, or store drifted';
+
+function select(discovery: Document, selected: string[], committing = false): Document[] {
+  if (new Set(selected).size !== selected.length) throw new JobsError('legacy job selection contains duplicate item ids');
+  const indexed = new Map((get(discovery, 'items') as Value[]).map(value => {
+    const item = object(value, 'legacy item');
+    return [string(get(item, 'itemId'))!, item];
+  }));
+  return selected.map(id => {
+    const item = indexed.get(id);
+    if (!item) throw new JobsError(committing ? drift : 'legacy job selection contains an unknown item id');
+    if (string(get(item, 'state')) !== 'valid') throw new JobsError(committing ? drift : 'legacy job selection contains an invalid item');
+    return item;
+  });
+}
+function tokenFor(discovery: Document, selected: string[], chosen: Document[], snapshot: Value): string {
+  const bound = object(fromJSON({version:1, origin:'migration', selection:selected}), 'legacy token');
+  set(bound, 'payloads', chosen.map(item => get(item, 'job')));
+  set(bound, 'selectedLocators', chosen.map(item => get(item, 'source')));
+  set(bound, 'manifest', get(discovery, 'manifest'));
+  set(bound, 'jobsSnapshot', snapshot);
+  return 'legacy-jobs-v1.' + createHash('sha256').update(canonicalJson(bound)).digest('hex');
+}
+function result(discovery: Document, selected: string[], decisions?: Document[], token?: string, committed = false): Document {
+  const value = object(fromJSON({selected, committed}), 'legacy result');
+  for (const key of ['root', 'manifest', 'items']) set(value, key, get(discovery, key));
+  if (decisions !== undefined) {
+    const summary: Record<string, number> = {create:0, update:0, noop:0, conflict:0, invalid:0};
+    for (const decision of decisions) summary[string(get(decision, 'action'))!]!++;
+    set(value, 'token', fromJSON(token ?? null));
+    set(value, 'summary', fromJSON(summary));
+    set(value, 'decisions', decisions);
+  }
+  return value;
+}
+
+/** Discovery-only previews never read or initialize the jobs document. */
+export class LegacyJobsService {
+  constructor(readonly repository: LegacyJobsRepository, private readonly discover: () => Promise<Document>,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+
+  async preview(selected: string[]): Promise<Value> {
+    const discovery = await this.discover();
+    if (!selected.length) return result(discovery, []);
+    const chosen = select(discovery, selected);
+    return this.repository.legacyTransaction(async transaction => {
+      const {document, snapshot} = await transaction.snapshot();
+      const token = tokenFor(discovery, selected, chosen, snapshot);
+      const {decisions} = planLegacyJobs(document, chosen, this.now());
+      return result(discovery, selected, decisions, token);
+    });
+  }
+
+  async commit(selected: string[], token: string): Promise<Value> {
+    if (!selected.length || typeof token !== 'string' || !token) {
+      throw new JobsError('legacy job commit requires selection and a preview token');
+    }
+    return this.repository.legacyTransaction(async transaction => {
+      const discovery = await this.discover(), chosen = select(discovery, selected, true);
+      const {document, snapshot} = await transaction.snapshot();
+      const expected = Buffer.from(tokenFor(discovery, selected, chosen, snapshot));
+      const supplied = Buffer.from(token);
+      if (expected.length !== supplied.length || !timingSafeEqual(expected, supplied)) throw new JobsError(drift);
+      const planned = planLegacyJobs(document, chosen, this.now());
+      if (planned.changed) await transaction.save(planned.document);
+      return result(discovery, selected, planned.decisions, token, planned.changed);
+    });
+  }
+}

--- a/tests_js/workspace_legacy_jobs_model.test.mjs
+++ b/tests_js/workspace_legacy_jobs_model.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {fromJSON, serialize} from '../runtime/contracts/workspace/values.js';
+const loaded = await import('../runtime/workspace-core/legacy-jobs.js').catch(() => ({}));
+const plain = value => JSON.parse(serialize(value));
+const fixed = '2026-09-11T12:00:00Z';
+const locator = {sourceKind:'timestamped-search-report',relativePath:'search-one.md',
+  entryId:'legacy-entry-'+'a'.repeat(24),sourceSha256:'b'.repeat(64)};
+const item = {itemId:'one',state:'valid',source:locator,job:{url:'https://example.com/job',role:'Engineer'}};
+function fixture() {
+  let current=null, discovery={root:'~/.jobs',manifest:[],items:[item]}, saves=0, snapshots=0;
+  const repository={async legacyTransaction(operation) {return operation({
+    async snapshot() {snapshots++; return {document:fromJSON(current ?? {schemaVersion:1,jobs:{},metadata:{
+      createdAt:'1970-01-01T00:00:00Z',updatedAt:'1970-01-01T00:00:00Z'}}),snapshot:fromJSON(current ?? {state:'missing'})};},
+    async save(document) {saves++; current=plain(document);}
+  });}};
+  return {repository, discover:async()=>fromJSON(discovery), discovery:value=>{discovery=value;},
+    current:()=>current, saves:()=>saves, snapshots:()=>snapshots};
+}
+
+test('legacy import previews without initializing and binds missing state and selection',async()=>{
+  assert.equal(typeof loaded.LegacyJobsService,'function');
+  const state=fixture(), service=new loaded.LegacyJobsService(state.repository,state.discover,()=>fixed);
+  const discovered=plain(await service.preview([]));
+  assert.equal(discovered.token,undefined); assert.equal(state.snapshots(),0);
+  const preview=plain(await service.preview(['one']));
+  assert.equal(state.saves(),0); assert.equal(preview.decisions[0].action,'create');
+  assert.equal(preview.decisions[0].itemId,'one');
+  await service.commit(['one'],preview.token);
+  const record=Object.values(state.current().jobs)[0];
+  assert.equal(record.provenance['/role'].origin,'migration');
+  assert.deepEqual(record.legacySources,[locator]);
+  assert.equal(state.current().metadata.createdAt,fixed);
+  await assert.rejects(service.commit(['one'],preview.token),/drifted/);
+  const noop=plain(await service.preview(['one']));
+  assert.equal(plain(await service.commit(['one'],noop.token)).committed,false);
+  assert.equal(state.saves(),1);
+  await assert.rejects(service.preview(['one','one']),/duplicate item ids/);
+  await assert.rejects(service.preview(['missing']),/unknown item id/);
+  await assert.rejects(service.commit(['missing'],'bad'),/drifted/);
+});
+
+test('migration locator permits URL refresh and locator-only update preserves provenance',async()=>{
+  assert.equal(typeof loaded.LegacyJobsService,'function');
+  const state=fixture(), service=new loaded.LegacyJobsService(state.repository,state.discover,()=>fixed);
+  await service.commit(['one'],plain(await service.preview(['one'])).token);
+  state.discovery({root:'~/.jobs',manifest:[],items:[{...item,source:{...locator,sourceSha256:'c'.repeat(64)},
+    job:{...item.job,url:'https://example.com/moved'}}]});
+  const refreshed=plain(await service.preview(['one']));
+  assert.deepEqual(refreshed.decisions[0].fields,['legacySources','url']);
+  await service.commit(['one'],refreshed.token);
+  const record=Object.values(state.current().jobs)[0];
+  assert.equal(record.url,'https://example.com/moved'); assert.equal(record.revision,2);
+  state.discovery({root:'~/.jobs',manifest:[],items:[{...item,source:{...locator,sourceSha256:'d'.repeat(64)},
+    job:{...item.job,url:'https://example.com/moved'}}]});
+  const locatorOnly=plain(await service.preview(['one']));
+  assert.deepEqual(locatorOnly.decisions[0].fields,['legacySources']);
+  await service.commit(['one'],locatorOnly.token);
+  assert.equal(Object.values(state.current().jobs)[0].revision,3);
+});

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,3 +1,4 @@
+import { legacyJobsBrowser } from './workspace_native_legacy_jobs_browser_support.mjs';
 import { claimsBrowser } from './workspace_native_claims_browser_support.mjs';
 import { jobTransitionsBrowser } from './workspace_native_job_transitions_browser_support.mjs';
 import { jobUpsertBrowser } from './workspace_native_job_upsert_browser_support.mjs';
@@ -10,7 +11,7 @@ import assert from 'node:assert/strict';
 import { chromium } from 'playwright';
 import { spawn, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { realpath, readFile } from 'node:fs/promises';
+import { realpath, readFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { nativeFixture } from './exclusive_file_lock_support.mjs';
 import { initializeJobsFixture } from '../runtime/store/native-jobs.js';
@@ -166,10 +167,24 @@ export async function nativeJobsBrowser(buildRoot) {
         return JSON.parse(result.stdout);
       },
     });
+    const legacyHome = join(fixture.root, 'legacy-browser-home');
+    const legacyReports = join(legacyHome, '.claude-job-searches');
+    await mkdir(legacyReports, { recursive: true });
+    const legacyJobs = await legacyJobsBrowser(page, {
+      readDocument: () => readFile(join(root, 'jobs.json'), 'utf8'),
+      writeReport: report => writeFile(join(legacyReports, 'search-browser.md'), report),
+      legacy: async (command, selected, previewToken) => {
+        const args = [cli, '--root', root, '--native-lock', fixture.receipt.artifact, command];
+        for (const id of selected) args.push('--select', id);
+        if (previewToken) args.push('--confirm', previewToken);
+        const result = await execute(process.execPath, args, { env: { PATH: '', HOME: legacyHome } });
+        return JSON.parse(result.stdout);
+      },
+    });
     const unsupported = await fetch(startup.origin + '/api/trash', { headers: { Authorization: `Bearer ${token}` } });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     releaseInitialClaim?.();
     if (browser) await browser.close();

--- a/tests_js/workspace_native_legacy_directory.test.mjs
+++ b/tests_js/workspace_native_legacy_directory.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+import { constants, closeSync, fstatSync, readFileSync } from 'node:fs';
+import { mkdir, open, rename, symlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+
+// Exercise the exact addon directly, including argument safety beneath TS callers.
+test('directory-relative discovery stays pinned through root replacement and rejects entry symlinks',async()=>{
+  const fixture=await nativeFixture();
+  const native=createRequire(import.meta.url)(fixture.receipt.artifact);
+  let root;
+  try {
+    const source=join(fixture.root,'reports'), moved=join(fixture.root,'moved'), other=join(fixture.root,'other');
+    await mkdir(source);await mkdir(other);
+    await writeFile(join(source,'report.md'),'original');await writeFile(join(other,'report.md'),'substituted');
+    root=await open(source,constants.O_RDONLY|constants.O_DIRECTORY|constants.O_NOFOLLOW);
+    const metadata=native.inspect(root.fd,'report.md');
+    assert.equal(typeof metadata.dev,'bigint');assert.equal(metadata.size,8n);
+    assert.deepEqual(native.listNames(root.fd),[Buffer.from('report.md')]);
+    assert.deepEqual(native.listNames(root.fd),[Buffer.from('report.md')],'repeated listing must rewind independently');
+    await rename(source,moved);await symlink(other,source);
+    assert.deepEqual(native.listNames(root.fd),[Buffer.from('report.md')]);
+    const fd=native.openFile(root.fd,'report.md');
+    try {
+      const stat=fstatSync(fd,{bigint:true});
+      assert.equal(stat.dev,metadata.dev);assert.equal(stat.ino,metadata.ino);
+      assert.equal(readFileSync(fd,'utf8'),'original');
+    } finally { closeSync(fd); }
+    await symlink(join(other,'report.md'),join(moved,'link.md'));
+    assert.equal(native.inspect(root.fd,'link.md').mode & constants.S_IFMT,constants.S_IFLNK);
+    assert.throws(()=>native.openFile(root.fd,'link.md'),{code:'ELOOP'});
+    await rename(join(moved,'report.md'),join(moved,'old.md'));
+    await writeFile(join(moved,'report.md'),'new file');
+    assert.notEqual(native.inspect(root.fd,'report.md').ino,metadata.ino,'entry replacement is observable to caller');
+    for(const name of ['','.', '..','../report.md','a/b','report.md\0suffix','\ud800']) {
+      assert.throws(()=>native.inspect(root.fd,name));assert.throws(()=>native.openFile(root.fd,name));
+    }
+    for(const descriptor of [-1,1.5,NaN,Infinity,'0']) assert.throws(()=>native.listNames(descriptor));
+    assert.throws(()=>native.inspect(root.fd,'missing'),{code:'ENOENT'});
+    const closed=root.fd;await root.close();root=null;
+    assert.throws(()=>native.listNames(closed),{code:'EBADF'});
+  } finally { await root?.close();await fixture.cleanup(); }
+});
+
+test('Linux directory listing preserves arbitrary filename bytes',{skip:process.platform!=='linux'},async()=>{
+  const fixture=await nativeFixture();
+  const native=createRequire(import.meta.url)(fixture.receipt.artifact);
+  let root;
+  try {
+    const source=join(fixture.root,'reports');
+    await mkdir(source);
+    const name=Buffer.from([0x75,0x6e,0x72,0x65,0x6c,0x61,0x74,0x65,0x64,0xff]);
+    await writeFile(Buffer.concat([Buffer.from(`${source}/`),name]),'unrelated');
+    root=await open(source,constants.O_RDONLY|constants.O_DIRECTORY|constants.O_NOFOLLOW);
+    assert.deepEqual(native.listNames(root.fd),[name]);
+  } finally { await root?.close();await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_legacy_jobs.test.mjs
+++ b/tests_js/workspace_native_legacy_jobs.test.mjs
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { spawnSync } from 'node:child_process';
+import { appendFile, readFile, unlink, writeFile, symlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, oracle, native, report, reportRoot, snapshot } from './workspace_native_legacy_jobs_support.mjs';
+async function parity(f,op,selected=[],token) {
+  const expected=oracle(f,op,selected,token),actual=await native(f,op,selected,token);
+  assert.deepEqual(actual,expected);
+  return actual;
+}
+test('native legacy discovery and selection preserve Python identities, errors and preview tokens', {timeout:60000},async()=>{
+  const fixture=await nativeFixture();
+  try {
+    const f=await setup(fixture,'discovery');
+    const {value:discovery}=await parity(f,'preview');
+    assert.equal(discovery.manifest.length,1);
+    assert.equal(discovery.items.length,6);
+    assert.deepEqual(discovery.items.slice(2).map(item=>item.reason),['unsupported_heading','duplicate_field','missing_url','ambiguous_url']);
+    const [a,b]=discovery.items.map(item=>item.itemId);
+    const before=await snapshot(f.root);
+    const first=await parity(f,'preview',[a,b]);
+    const reversed=await parity(f,'preview',[b,a]);
+    assert.notEqual(first.value.token,reversed.value.token);
+    for(const selected of [[a,a],['unknown'],[discovery.items[2].itemId]]) assert.ok((await parity(f,'preview',selected)).error);
+    assert.equal(await snapshot(f.root),before);
+    assert.ok(!JSON.stringify(discovery).includes(f.home));
+  } finally {await fixture.cleanup();}
+});
+test('native legacy commits preserve provenance, noop reimport and stable-locator URL refresh', {timeout:60000},async()=>{
+  const fixture=await nativeFixture();
+  try {
+    const f=await setup(fixture,'reimport');
+    const {value:discovery}=await parity(f,'preview');
+    const selected=[discovery.items[0].itemId];
+    let preview=await parity(f,'preview',selected);
+    let committed=await parity(f,'commit',selected,preview.value.token);
+    assert.equal(committed.value.committed,true);
+    assert.deepEqual(JSON.parse(await snapshot(f.root)),JSON.parse(await snapshot(f.pythonRoot)));
+    const initial=JSON.parse(await snapshot(f.root)),id=committed.value.decisions[0].id;
+    assert.equal(initial.jobs[id].legacySources.length,1);
+    preview=await parity(f,'preview',selected);
+    assert.equal(preview.value.decisions[0].action,'noop');
+    const before=await snapshot(f.root);
+    committed=await parity(f,'commit',selected,preview.value.token);
+    assert.equal(committed.value.committed,false);
+    assert.equal(await snapshot(f.root),before);
+    const path=join(f.home,reportRoot,'search-2026-09-10.md');
+    await writeFile(path,(await readFile(path,'utf8')).replace('jobs/one?utm_source=synthetic','jobs/refreshed'));
+    preview=await parity(f,'preview',selected);
+    committed=await parity(f,'commit',selected,preview.value.token);
+    assert.equal(committed.value.decisions[0].id,id);
+    const updated=JSON.parse(await snapshot(f.root));
+    assert.equal(updated.jobs[id].legacySources.length,1);
+    assert.equal(updated.jobs[id].url,'https://example.invalid/jobs/refreshed');
+    assert.deepEqual(updated,JSON.parse(await snapshot(f.pythonRoot)));
+  } finally {await fixture.cleanup();}
+});
+test('source, selection and Store drift reject commits without writing jobs', {timeout:60000},async t=>{
+  const fixture=await nativeFixture();
+  try {
+    for(const drift of ['source','unselected-source','store','selection']) await t.test(drift,async()=>{
+      const f=await setup(fixture,drift),{value:discovery}=await parity(f,'preview');
+      const selected=[discovery.items[0].itemId],preview=await parity(f,'preview',selected);
+      if(drift==='source') await appendFile(join(f.home,reportRoot,'search-2026-09-10.md'),'\nsource changed');
+      if(drift==='unselected-source') await writeFile(join(f.home,reportRoot,'search-extra.md'),'# no selected entries');
+      if(drift==='store') for(const root of [f.root,f.pythonRoot]) {
+        const value=JSON.parse(await snapshot(root));value.metadata.updatedAt='2026-09-11T00:00:00Z';
+        await writeFile(join(root,'jobs.json'),JSON.stringify(value),{mode:0o600});
+      }
+      const before=await snapshot(f.root);
+      const result=await parity(f,'commit',drift==='selection'?[discovery.items[1].itemId]:selected,preview.value.token);
+      assert.match(result.error,/drifted/);
+      assert.equal(await snapshot(f.root),before);
+    });
+  } finally {await fixture.cleanup();}
+});
+test('missing jobs snapshot previews read-only then imports identically to Python', {timeout:60000},async()=>{
+  const fixture=await nativeFixture();
+  try {
+    const f=await setup(fixture,'missing');
+    await unlink(join(f.root,'jobs.json'));await unlink(join(f.pythonRoot,'jobs.json'));
+    const {value:discovery}=await parity(f,'preview'),selected=[discovery.items[0].itemId];
+    const preview=await parity(f,'preview',selected);
+    assert.equal(await snapshot(f.root),null);
+    await parity(f,'commit',selected,preview.value.token);
+    assert.deepEqual(JSON.parse(await snapshot(f.root)),JSON.parse(await snapshot(f.pythonRoot)));
+  } finally {await fixture.cleanup();}
+});
+test('legacy discovery rejects symlink reports and invalid UTF8 without mutating jobs', {timeout:60000},async t=>{
+  const fixture=await nativeFixture();
+  try {
+    for(const kind of ['symlink','utf8']) await t.test(kind,async()=>{
+      const f=await setup(fixture,kind),path=join(f.home,reportRoot,'search-unsafe.md');
+      if(kind==='symlink') await symlink(join(f.home,reportRoot,'search-2026-09-10.md'),path);
+      else await writeFile(path,Buffer.from([0xff]));
+      const before=await snapshot(f.root),result=await parity(f,'preview');
+      assert.ok(result.error);
+      assert.equal(await snapshot(f.root),before);
+    });
+  } finally {await fixture.cleanup();}
+});
+
+test('duplicate source URLs coalesce while preserving both source locators', {timeout:60000},async()=>{
+  const fixture=await nativeFixture();
+  try {
+    const f=await setup(fixture,'duplicate-url');
+    await writeFile(join(f.home,reportRoot,'search-second.md'),report.split('### 2.')[0]);
+    const {value:discovery}=await parity(f,'preview');
+    const selected=[discovery.items[0].itemId,discovery.items.at(-1).itemId];
+    const preview=await parity(f,'preview',selected);
+    const committed=await parity(f,'commit',selected,preview.value.token);
+    assert.equal(committed.value.decisions[0].id,committed.value.decisions[1].id);
+    const jobs=JSON.parse(await snapshot(f.root)).jobs;
+    assert.equal(Object.keys(jobs).length,1);
+    assert.equal(Object.values(jobs)[0].legacySources.length,2);
+    assert.deepEqual(JSON.parse(await snapshot(f.root)),JSON.parse(await snapshot(f.pythonRoot)));
+  } finally {await fixture.cleanup();}
+});
+
+test('legacy CLI supports repeatable selection, token confirmation and rejects duplicates', {timeout:60000},async()=>{
+  const fixture=await nativeFixture();
+  try {
+    const f=await setup(fixture,'cli');
+    const cli=(command,args=[])=>spawnSync(process.execPath,['runtime/cli/native-jobs.js',command,
+      '--root',f.root,'--native-lock',fixture.receipt.artifact,...args],{
+      env:{...process.env,HOME:f.home},encoding:'utf8',timeout:10000,
+    });
+    let result=cli('legacy-jobs-preview');
+    assert.equal(result.status,0,result.stderr);
+    const discovery=JSON.parse(result.stdout),selected=discovery.items.slice(0,2).map(item=>item.itemId);
+    const selection=selected.flatMap(id=>['--select',id]);
+    result=cli('legacy-jobs-preview',selection);
+    assert.equal(result.status,0,result.stderr);
+    const preview=JSON.parse(result.stdout);
+    assert.deepEqual(preview.selected,selected);
+    const duplicate=cli('legacy-jobs-preview',['--select',selected[0],'--select',selected[0]]);
+    assert.notEqual(duplicate.status,0);
+    assert.match(duplicate.stderr,/duplicate item ids/);
+    const missingToken=cli('legacy-jobs-commit',selection);
+    assert.notEqual(missingToken.status,0);
+    result=cli('legacy-jobs-commit',[...selection,'--confirm',preview.token]);
+    assert.equal(result.status,0,result.stderr);
+    assert.equal(JSON.parse(result.stdout).committed,true);
+    assert.equal(Object.keys(JSON.parse(await snapshot(f.root)).jobs).length,2);
+  } finally {await fixture.cleanup();}
+});
+
+test('legacy heading digits use the supported Python Unicode database rather than the Node version', async () => {
+  const fixture=await nativeFixture();
+  try {
+    const f=await setup(fixture,'unicode-digits');
+    const digits=['1','١','𝟘','𑽐','𞓰','𐵀','\ufeff1'];
+    const content=digits.map((digit,index)=>`### ${digit}. Role ${index} — Fixture\n- **URL**: https://example.invalid/unicode/${index}`).join('\n');
+    await writeFile(join(f.home,reportRoot,'search-2026-09-10.md'),content);
+    const {value}=await parity(f,'preview');
+    assert.deepEqual(value.items.map(item=>item.state),['valid','valid','valid','valid','valid','invalid','invalid']);
+  } finally {await fixture.cleanup();}
+});

--- a/tests_js/workspace_native_legacy_jobs_browser_support.mjs
+++ b/tests_js/workspace_native_legacy_jobs_browser_support.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+
+// All report mutations and CLI calls are scoped to the caller's synthetic HOME.
+export async function legacyJobsBrowser(page, { legacy, writeReport, readDocument }) {
+  const navigation = page.getByRole('navigation', { name: 'Workspace sections' });
+  const modal = page.getByRole('dialog', { name: 'Edit job', exact: true });
+  const role = 'Native legacy report role';
+  const originalUrl = 'https://example.invalid/native-legacy-original';
+  const report = url => `# Synthetic legacy report\n### 1. ${role} — Legacy company\n- **URL**: ${url}\n`;
+  await writeReport(report(originalUrl));
+  const before = await readDocument();
+  const discovery = await legacy('legacy-jobs-preview', []);
+  assert.equal(discovery.items.length, 1);
+  const itemId = discovery.items[0].itemId;
+  const preview = await legacy('legacy-jobs-preview', [itemId]);
+  assert.equal(preview.committed, false);
+  assert.equal(preview.summary.create, 1);
+  assert.match(preview.token, /^legacy-jobs-v1\.[a-f0-9]{64}$/);
+  assert.equal(await readDocument(), before, 'discovery and selected preview are read-only');
+  await navigation.getByRole('button', { name: 'Jobs', exact: true }).click();
+  await page.locator('[data-job-create]:enabled').waitFor();
+  assert.equal(await page.getByRole('button', { name: new RegExp(role) }).count(), 0);
+  const committed = await legacy('legacy-jobs-commit', [itemId], preview.token);
+  assert.equal(committed.committed, true);
+  assert.deepEqual(committed.decisions, preview.decisions);
+  const id = committed.decisions[0].id;
+  await page.getByRole('button', { name: 'Refresh', exact: true }).click();
+  await page.getByRole('button', { name: new RegExp(role) }).click();
+  assert.equal(await modal.locator('[name="company"]').inputValue(), 'Legacy company');
+  await modal.locator('[name="company"]').fill('Human legacy company');
+  await modal.getByRole('button', { name: 'Save job', exact: true }).click();
+  await modal.waitFor({ state: 'hidden' });
+  const human = JSON.parse(await readDocument()).jobs[id];
+  assert.equal(human.provenance['/company'].origin, 'human');
+  assert.equal(human.provenance['/url'].origin, 'migration');
+
+  await writeReport(report('https://example.invalid/native-legacy-refreshed'));
+  const beforeRefresh = await readDocument();
+  const refreshPreview = await legacy('legacy-jobs-preview', [itemId]);
+  assert.equal(refreshPreview.decisions[0].id, id, 'stable locator survives report URL changes');
+  assert.equal(await readDocument(), beforeRefresh);
+  const refresh = await legacy('legacy-jobs-commit', [itemId], refreshPreview.token);
+  assert.equal(refresh.committed, true);
+  const updated = JSON.parse(await readDocument()).jobs[id];
+  assert.equal(updated.company, 'Human legacy company');
+  assert.deepEqual(updated.provenance['/company'], human.provenance['/company']);
+  // Only changed fields transfer ownership; the imported URL remains refreshable.
+  assert.equal(updated.url, 'https://example.invalid/native-legacy-refreshed');
+  assert.equal(updated.provenance['/url'].origin, 'migration');
+  assert.equal(updated.legacySources.length, 1);
+  assert.equal(updated.legacySources[0].entryId, human.legacySources[0].entryId);
+  assert.notEqual(updated.legacySources[0].sourceSha256, human.legacySources[0].sourceSha256);
+  const stale = await legacy('legacy-jobs-preview', [itemId]);
+  await writeReport(report('https://example.invalid/native-legacy-refreshed') + '\nReport changed after preview\n');
+  const beforeRejected = await readDocument();
+  await assert.rejects(legacy('legacy-jobs-commit', [itemId], stale.token), /drifted/);
+  assert.equal(await readDocument(), beforeRejected);
+
+  await page.getByRole('button', { name: 'Refresh', exact: true }).click();
+  await page.getByRole('button', { name: new RegExp(role) }).click();
+  assert.equal(await modal.locator('[name="company"]').inputValue(), 'Human legacy company');
+  assert.equal(await modal.locator('[name="url"]').inputValue(), updated.url);
+  await modal.locator('[name="url"]').fill('https://example.invalid/human-legacy-url');
+  await modal.getByRole('button', { name: 'Save job', exact: true }).click();
+  await modal.waitFor({state:'hidden'});
+  const humanUrlBytes = await readDocument();
+  const conflictPreview = await legacy('legacy-jobs-preview', [itemId]);
+  assert.equal(conflictPreview.decisions[0].action, 'conflict');
+  const conflict = await legacy('legacy-jobs-commit', [itemId], conflictPreview.token);
+  assert.equal(conflict.committed, false);
+  assert.equal(await readDocument(), humanUrlBytes, 'human-owned URL conflicts leave Jobs unchanged');
+  await navigation.getByRole('button', { name: 'Overview', exact: true }).click();
+  await page.getByRole('heading', { name: 'Your next step', exact: true }).waitFor();
+  return { discoveryReadOnly: true, previewReadOnly: true, cliCommitVisible: true,
+    humanProvenancePreserved: true, sourceLocatorRefreshed: true, humanUrlConflict: true, staleTokenRejected: true };
+}

--- a/tests_js/workspace_native_legacy_jobs_support.mjs
+++ b/tests_js/workspace_native_legacy_jobs_support.mjs
@@ -1,0 +1,54 @@
+import { execFileSync } from 'node:child_process';
+import { mkdir, readFile, writeFile, cp, realpath } from 'node:fs/promises';
+import { join } from 'node:path';
+import { initializeJobsFixture, NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { loadPosixDirectoryProvider } from '../runtime/store/posix-directory.js';
+import { loadPosixFlockProvider } from '../runtime/store/posix-flock.js';
+import { LegacyJobsService } from '../runtime/workspace-core/legacy-jobs.js';
+import { discoverLegacyJobs } from '../runtime/store/legacy-job-discovery.js';
+import { serialize } from '../runtime/contracts/workspace/values.js';
+export const now='2026-09-10T12:00:00Z';
+export const reportRoot='.claude-job-searches';
+export const report=`# Synthetic search
+### 1. Engineer — Fixture Corp (Score: 90)
+- **URL**: https://example.invalid/jobs/one?utm_source=synthetic
+- **Location**: Remote
+- **Salary**: 100
+### 2. Other Engineer — Fixture Corp
+- **Apply**: https://example.invalid/jobs/two
+### Unsupported heading
+- **URL**: https://example.invalid/unsupported
+### 4. Duplicate field — Fixture
+- **URL**: https://example.invalid/a
+- **url**: https://example.invalid/b
+### 5. Missing URL — Fixture
+- **Description**: No URL
+### 6. Ambiguous URL — Fixture
+- **URL**: https://example.invalid/a
+- **Apply**: https://example.invalid/b
+`;
+export const plain=value=>JSON.parse(serialize(value));
+export async function snapshot(root) {
+  try {return await readFile(join(root,'jobs.json'),'utf8');}
+  catch(error) {if(error.code==='ENOENT') return null;throw error;}
+}
+export async function setup(fixture,name) {
+  const base=join(await realpath(fixture.root),name),home=join(base,'home'),root=join(base,'native'),pythonRoot=join(base,'python');
+  await mkdir(join(home,reportRoot),{recursive:true});
+  await writeFile(join(home,reportRoot,'search-2026-09-10.md'),report);
+  await writeFile(join(home,reportRoot,'ignored.md'),'### unrelated');
+  await initializeJobsFixture(root);
+  await cp(root,pythonRoot,{recursive:true});
+  const repository=new NativeJobsRepository(root,loadPosixFlockProvider(fixture.receipt.artifact));
+  const service=new LegacyJobsService(repository,()=>discoverLegacyJobs(home,loadPosixDirectoryProvider(fixture.receipt.artifact)),()=>now);
+  return {base,home,root,pythonRoot,repository,service};
+}
+export function oracle(fixture,op,selected=[],token) {
+  return JSON.parse(execFileSync('python3',['tools/contracts/legacy-jobs/reference.py'],{
+    input:JSON.stringify({root:fixture.pythonRoot,home:fixture.home,now,op,selected,token}),encoding:'utf8',maxBuffer:1024*1024,
+  }));
+}
+export async function native(fixture,op,selected=[],token) {
+  try {return {value:plain(await (op==='preview'?fixture.service.preview(selected):fixture.service.commit(selected,token)))};}
+  catch(error) {return {error:error.message};}
+}

--- a/tests_js/workspace_native_legacy_safety.test.mjs
+++ b/tests_js/workspace_native_legacy_safety.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { writeFile, readFile, truncate, rename, symlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, reportRoot, snapshot, plain } from './workspace_native_legacy_jobs_support.mjs';
+import { discoverLegacyJobs } from '../runtime/store/legacy-job-discovery.js';
+import { loadPosixDirectoryProvider } from '../runtime/store/posix-directory.js';
+
+test('legacy preview and commit reject pending recovery without overwriting jobs or journals', async () => {
+  const fixture = await nativeFixture();
+  try {
+    const f = await setup(fixture,'pending');
+    const discovery = plain(await f.service.preview([])), selected = [discovery.items[0].itemId];
+    const preview = plain(await f.service.preview(selected));
+    for (const name of ['resume-operation.json','resume-extraction-journal.json','coordinator-journal.json']) {
+      const path = join(f.root,name), original = await readFile(path,'utf8');
+      const pending = JSON.stringify({schemaVersion:1,operation:{kind:'pending'}});
+      await writeFile(path,pending);
+      const before = await snapshot(f.root);
+      await assert.rejects(f.service.preview(selected),/requires completed fixture recovery/);
+      await assert.rejects(f.service.commit(selected,preview.token),/requires completed fixture recovery/);
+      assert.equal(await snapshot(f.root),before);
+      assert.equal(await readFile(path,'utf8'),pending);
+      await writeFile(path,original);
+    }
+  } finally { await fixture.cleanup(); }
+});
+
+test('legacy discovery rejects entry replacement between inspection and open', async () => {
+  const fixture = await nativeFixture();
+  try {
+    const f = await setup(fixture,'replacement');
+    const provider = loadPosixDirectoryProvider(fixture.receipt.artifact);
+    const file = join(f.home,reportRoot,'search-2026-09-10.md');
+    const originalInspect = provider.inspect;
+    let swapped = false;
+    // Synchronous native callbacks let this interleaving replace the inspected inode.
+    const {renameSync,writeFileSync} = await import('node:fs');
+    provider.inspect = (fd,name) => {
+      const value = originalInspect(fd,name);
+      if (!swapped) {swapped=true;renameSync(file,file+'.old');writeFileSync(file,'replacement');}
+      return value;
+    };
+    await assert.rejects(discoverLegacyJobs(f.home,provider),/changed during discovery/);
+  } finally { await fixture.cleanup(); }
+});
+
+test('legacy discovery enforces source byte and file bounds before parsing', async () => {
+  const fixture = await nativeFixture();
+  try {
+    const f = await setup(fixture,'limits'), provider = loadPosixDirectoryProvider(fixture.receipt.artifact);
+    const file = join(f.home,reportRoot,'search-2026-09-10.md');
+    await truncate(file,2*1024*1024+1);
+    await assert.rejects(discoverLegacyJobs(f.home,provider),/per-file byte limit/);
+    await writeFile(file,'');
+    provider.listNames = () => Array.from({length:101},(_,index)=>Buffer.from(`search-${index}.md`));
+    await assert.rejects(discoverLegacyJobs(f.home,provider),/file limit/);
+    const root = join(f.home,reportRoot);
+    await rename(root,root+'-moved'); await symlink(root+'-moved',root);
+    await assert.rejects(discoverLegacyJobs(f.home,provider),/root must be a regular directory/);
+  } finally { await fixture.cleanup(); }
+});
+
+
+test('legacy discovery ignores unrelated undecodable filename bytes before decoding report names', async () => {
+  const fixture = await nativeFixture();
+  try {
+    const f = await setup(fixture,'filename-bytes'), provider = loadPosixDirectoryProvider(fixture.receipt.artifact);
+    const expected = plain(await discoverLegacyJobs(f.home,provider));
+    const original = provider.listNames;
+    provider.listNames = fd => [...original(fd),Buffer.from([0xff]),Buffer.from([0x78,0xff,0x2e,0x6d,0x64])];
+    assert.deepEqual(plain(await discoverLegacyJobs(f.home,provider)),expected);
+  } finally { await fixture.cleanup(); }
+});

--- a/tools/contracts/legacy-jobs/reference.py
+++ b/tools/contracts/legacy-jobs/reference.py
@@ -1,0 +1,25 @@
+"""Synthetic-root Python oracle for legacy report import parity."""
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / 'scripts'))
+spec = importlib.util.spec_from_file_location('legacy_reference_store', ROOT / 'scripts/job-apply-store.py')
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+request = json.load(sys.stdin)
+store = module.Store(Path(request['root']))
+with patch.object(Path, 'home', return_value=Path(request['home'])), patch.object(module, 'utc_now', return_value=request['now']):
+    try:
+        if request['op'] == 'preview':
+            result = store.preview_legacy_jobs(request['selected'])
+        elif request['op'] == 'commit':
+            result = store.commit_legacy_jobs(request['selected'], request['token'])
+        else:
+            raise ValueError('unsupported synthetic oracle operation')
+        print(json.dumps({'value': result}, ensure_ascii=True))
+    except Exception as error:
+        print(json.dumps({'error': str(error)}, ensure_ascii=True))


### PR DESCRIPTION
Adds native legacy-jobs-preview and legacy-jobs-commit to the opt-in synthetic fixture. Discovery, ordered selection and token-confirmed commit preserve Python source locators, migration provenance and partial decisions. Changed reports, selection or Jobs state reject stale tokens before writes.

Directory-relative POSIX access protects report discovery against path replacement. Existing marked-fixture boundaries remain in place; pending recovery is rejected. Companion displays CLI imports through its existing Jobs interface.

Validation: focused Python/native/model tests passed (30 passes, one Linux-only skip on macOS); real Companion/CLI walkthrough passed, including human ownership and stale-token rejection. Five independent review roles completed; a Unicode digit parity defect was fixed and the pinned table verified against Python 3.12. Normal commit and deep/push gates passed. The first deep run hit a tar error; unchanged package diagnostics and the complete gate rerun passed.

Standalone codex review was unavailable because the installed CLI was too old for the configured model. Independent reviews completed. No live applicant Store or reports were used; general writer activation remains deferred.

CI completed successfully on 7c06ec8c4a4df5905b44e423133f43113f2e99e7: Validate run 34598774168 (including Windows, Linux browser and macOS checks) and Release run 34598776263.
