### PR TITLE
Improve desktop readiness feedback, recovery focus, and clarity

### DIFF
--- a/companion/workspace/features/answers.js
+++ b/companion/workspace/features/answers.js
@@ -52,7 +52,7 @@ export function installAnswers(context) {
     $("#answers-clear-filters").classList.toggle("hidden", !filtered);
     const inTrash = $("#answer-view").value === "trash";
     $("#answers-empty h3").textContent = filtered ? "No matching answers" : inTrash ? "No answers in Trash" : "No answers in this view";
-    $("#answers-empty p").textContent = filtered ? "Clear your search or state filter to see more answers." : inTrash ? "Restored answers are back in your Library. Choose Library to see them." : "Create an answer or wait for an agent to observe a question.";
+    $("#answers-empty p").textContent = filtered ? "Clear your search or state filter to see more answers." : inTrash ? "Restored answers return to their previous view. Check Library, Observed inbox, or Declined." : "Create an answer or wait for an agent to observe a question.";
     $("#answers-empty").classList.toggle("hidden", answerState.items.length !== 0);
     for (const answer of answerState.items) {
       const item = document.createElement("div"); item.setAttribute("role", "listitem");

--- a/companion/workspace/features/answers.js
+++ b/companion/workspace/features/answers.js
@@ -39,8 +39,19 @@ export function installAnswers(context) {
     answerState.busyControls = null;
   }
 
+  $("#answers-clear-filters").addEventListener("click", async () => {
+    $("#answer-search").value = "";
+    $("#answer-state-filter").value = "";
+    await refreshAnswers({ reset: true });
+    $("#answer-search").focus();
+  });
+
   function renderAnswers() {
     const list = $("#answer-list"); list.replaceChildren();
+    const filtered = $("#answer-search").value.trim() || $("#answer-state-filter").value;
+    $("#answers-clear-filters").classList.toggle("hidden", !filtered);
+    $("#answers-empty h3").textContent = filtered ? "No matching answers" : "No answers in this view";
+    $("#answers-empty p").textContent = filtered ? "Clear your search or state filter to see more answers." : "Create an answer or wait for an agent to observe a question.";
     $("#answers-empty").classList.toggle("hidden", answerState.items.length !== 0);
     for (const answer of answerState.items) {
       const item = document.createElement("div"); item.setAttribute("role", "listitem");
@@ -143,7 +154,7 @@ export function installAnswers(context) {
       const currentDialog = canApplyAnswerDialogMutation(answerState.selected, answer.key, dialogGeneration, answerState.dialogGeneration, $("#answer-dialog").open);
       const pendingReturn = Boolean(answerState.pendingJobId && dialog.open);
       if (currentDialog) { if (!pendingReturn) answerState.opener = null; $("#answer-dialog").close(); }
-      await refreshAnswers({ reset: true }); if (currentDialog && !pendingReturn) $("#answer-new").focus(); toast(`Answer ${action === "accept" ? "accepted" : action === "decline" ? "declined" : `${action}d`}`);
+      await refreshAnswers({ reset: true }); if (currentDialog && !pendingReturn) $("#answer-new").focus(); toast(`Answer ${action === "accept" ? "accepted" : action === "decline" ? "declined" : action === "trash" ? "moved to trash" : "restored"}`);
     }
     catch (error) { if (!canApplyAnswerDialogMutation(answerState.selected, answer.key, dialogGeneration, answerState.dialogGeneration, $("#answer-dialog").open)) { toast(error.message); return; } if (error.code === "revision_conflict") { $("#answer-conflict").classList.remove("hidden"); $("#answer-conflict").focus(); } else answerError(lifecycleErrorText(error), true); }
     finally { if (canApplyAnswerDialogMutation(answerState.selected, answer.key, dialogGeneration, answerState.dialogGeneration, $("#answer-dialog").open)) setAnswerBusy(false); }

--- a/companion/workspace/features/answers.js
+++ b/companion/workspace/features/answers.js
@@ -50,8 +50,9 @@ export function installAnswers(context) {
     const list = $("#answer-list"); list.replaceChildren();
     const filtered = $("#answer-search").value.trim() || $("#answer-state-filter").value;
     $("#answers-clear-filters").classList.toggle("hidden", !filtered);
-    $("#answers-empty h3").textContent = filtered ? "No matching answers" : "No answers in this view";
-    $("#answers-empty p").textContent = filtered ? "Clear your search or state filter to see more answers." : "Create an answer or wait for an agent to observe a question.";
+    const inTrash = $("#answer-view").value === "trash";
+    $("#answers-empty h3").textContent = filtered ? "No matching answers" : inTrash ? "No answers in Trash" : "No answers in this view";
+    $("#answers-empty p").textContent = filtered ? "Clear your search or state filter to see more answers." : inTrash ? "Restored answers are back in your Library. Choose Library to see them." : "Create an answer or wait for an agent to observe a question.";
     $("#answers-empty").classList.toggle("hidden", answerState.items.length !== 0);
     for (const answer of answerState.items) {
       const item = document.createElement("div"); item.setAttribute("role", "listitem");

--- a/companion/workspace/features/automation.js
+++ b/companion/workspace/features/automation.js
@@ -34,14 +34,13 @@ export function installAutomation(context) {
     $("#automation-email-status").textContent = settings.signupEmailConfigured ? "Configured; value remains hidden" : "Not configured";
     const capability = projection.capability;
     const accountFlow = capability.accountFlowAutomation || {};
-    const capabilityReason = capability.reasonCode ? capability.reasonCode.replaceAll("_", " ") : capability.state;
     const workday = accountFlow.workdayPasswordAccountReady ? "Workday account setup supported; separate approval required" : "Workday account automation unavailable";
     const greenhouse = accountFlow.greenhouseAccountlessClassificationReady ? "ordinary Greenhouse applications are accountless" : "Greenhouse account status unresolved";
-    $("#automation-capability").textContent = `${workday} · ${greenhouse} · ${accountFlow.emailOnlyCandidateProfileReady ? "Oracle candidate profiles supported" : "Oracle candidate profiles unavailable"} · ${capabilityReason}. Settings and recovery remain available here; no live execution control is exposed.`;
+    $("#automation-capability").textContent = `${workday} · ${greenhouse} · ${accountFlow.emailOnlyCandidateProfileReady ? "Oracle candidate profiles supported" : "Oracle candidate profiles unavailable"}. Settings and recovery remain available here; no live execution control is exposed.`;
     const list = $("#automation-accounts"); list.replaceChildren();
     for (const account of projection.accounts) {
       const card = document.createElement("article"); card.className = "automation-account"; card.setAttribute("role", "listitem");
-      const realmLabel = account.adapterId === "oracle-recruiting" ? "Oracle Recruiting site" : "Workday realm";
+      const realmLabel = account.adapterId === "oracle-recruiting" ? "Oracle Recruiting site" : "Workday portal";
       const title = document.createElement("h3"); title.textContent = `${realmLabel} · ${account.realmRef.slice(0, 12)}…`;
       const detail = document.createElement("p"); detail.textContent = `${account.lifecycleState.replaceAll("_", " ")} · revision ${account.revision} · ${account.signupEmailOverrideConfigured ? "email override configured" : "global email setting"} · ${String(account.flowKind || "password_candidate_account").replaceAll("_", " ")}`;
       const status = document.createElement("p"); status.textContent = account.credentialRequired === false ? "Email-only candidate profile; no password is created or stored." : (account.providerAssigned ? "Protected credential metadata assigned; value remains inaccessible." : "Credential not provisioned.");
@@ -52,7 +51,7 @@ export function installAutomation(context) {
       const save = document.createElement("button"); save.type = "submit"; save.className = "button secondary"; save.textContent = "Save override";
       const clear = document.createElement("button"); clear.type = "button"; clear.className = "button secondary"; clear.textContent = "Clear override";
       const feedback = document.createElement("p"); feedback.className = "realm-override-feedback visually-hidden"; feedback.setAttribute("role", "status"); feedback.setAttribute("aria-live", "polite");
-      const conflict = document.createElement("div"); conflict.className = "conflict hidden"; conflict.setAttribute("role", "alert"); conflict.tabIndex = -1; conflict.textContent = "This realm changed elsewhere. Nothing was retried. Refresh and review the latest revision.";
+      const conflict = document.createElement("div"); conflict.className = "conflict hidden"; conflict.setAttribute("role", "alert"); conflict.tabIndex = -1; conflict.textContent = "This employer account changed elsewhere. Nothing was retried. Refresh and review the latest revision.";
       const submit = async (clearValue) => {
         conflict.classList.add("hidden"); feedback.classList.add("visually-hidden");
         if (!clearValue && !input.value.trim()) { feedback.textContent = "Enter an email override or choose Clear override."; feedback.classList.remove("visually-hidden"); return; }
@@ -68,7 +67,7 @@ export function installAutomation(context) {
       card.append(title, detail, status, form); list.append(card);
     }
     if (!projection.accounts.length) {
-      const empty = document.createElement("p"); empty.className = "empty-state compact-empty"; empty.textContent = "No employer realms recorded yet."; list.append(empty);
+      const empty = document.createElement("p"); empty.className = "empty-state compact-empty"; empty.textContent = "No employer accounts recorded yet."; list.append(empty);
     }
   }
 
@@ -149,7 +148,7 @@ export function installAutomation(context) {
     if (form.elements.signupEmailOverride.value.trim()) payload.signupEmailOverride = form.elements.signupEmailOverride.value.trim();
     try {
       await api("/api/employer-accounts", { method: "POST", body: JSON.stringify(payload) });
-      form.reset(); await refreshAutomation({ quiet: true }); toast("Resolved employer realm added");
+      form.reset(); await refreshAutomation({ quiet: true }); toast("Employer portal added");
     } catch (error) {
       $("#automation-error").textContent = error.message; $("#automation-error").classList.remove("hidden");
     }

--- a/companion/workspace/features/automation.js
+++ b/companion/workspace/features/automation.js
@@ -71,12 +71,17 @@ export function installAutomation(context) {
     }
   }
 
+  let automationRefreshSequence = 0;
   async function refreshAutomation({ quiet = false } = {}) {
+    const sequence = ++automationRefreshSequence;
     try {
-      const projection = await api("/api/automation"); renderAutomation(projection);
+      const projection = await api("/api/automation");
+      if (sequence !== automationRefreshSequence) return;
+      renderAutomation(projection);
       $("#automation-error").classList.add("hidden"); $("#automation-conflict").classList.add("hidden");
       if (!quiet) toast("Automation controls refreshed");
     } catch (error) {
+      if (sequence !== automationRefreshSequence) return;
       $("#automation-error").textContent = error.message; $("#automation-error").classList.remove("hidden");
     }
   }

--- a/companion/workspace/features/automation.js
+++ b/companion/workspace/features/automation.js
@@ -35,9 +35,9 @@ export function installAutomation(context) {
     const capability = projection.capability;
     const accountFlow = capability.accountFlowAutomation || {};
     const capabilityReason = capability.reasonCode ? capability.reasonCode.replaceAll("_", " ") : capability.state;
-    const workday = accountFlow.workdayPasswordAccountReady ? "Reviewed Workday seam ready; live execution disabled" : "Workday account automation unavailable";
+    const workday = accountFlow.workdayPasswordAccountReady ? "Workday account setup supported; separate approval required" : "Workday account automation unavailable";
     const greenhouse = accountFlow.greenhouseAccountlessClassificationReady ? "ordinary Greenhouse applications are accountless" : "Greenhouse account status unresolved";
-    $("#automation-capability").textContent = `${workday} · ${greenhouse} · ${accountFlow.emailOnlyCandidateProfileReady ? "Oracle candidate-profile seam ready" : "Oracle candidate-profile seam unavailable"} · ${capabilityReason}. Settings and recovery remain available here; no live execution control is exposed.`;
+    $("#automation-capability").textContent = `${workday} · ${greenhouse} · ${accountFlow.emailOnlyCandidateProfileReady ? "Oracle candidate profiles supported" : "Oracle candidate profiles unavailable"} · ${capabilityReason}. Settings and recovery remain available here; no live execution control is exposed.`;
     const list = $("#automation-accounts"); list.replaceChildren();
     for (const account of projection.accounts) {
       const card = document.createElement("article"); card.className = "automation-account"; card.setAttribute("role", "listitem");

--- a/companion/workspace/features/bindings.js
+++ b/companion/workspace/features/bindings.js
@@ -102,13 +102,15 @@ export function installBindings(context) {
   async function pollWorkspace() {
     refreshOverview({ quiet: true }); refreshAttention({ quiet: true });
     if (dialog.open && state.selected) loadActivity();
-    await refresh({ quiet: true });
+    const checkedDialog = dialog.open && !$("#preflight-panel").classList.contains("hidden")
+      ? state.jobDialogGeneration : null;
+    await refresh({ quiet: true, preserveReadiness: checkedDialog !== null });
     if (dialog.open && state.selected) {
       const listed = state.jobs.find((job) => job.id === state.selected.id);
-      if (state.canonicalStateCurrent && listed?.status === "ready" && !state.preflightPolling) {
+      if (state.canonicalStateCurrent && (listed?.status === "ready" || (listed && checkedDialog === state.jobDialogGeneration)) && !state.preflightPolling) {
         state.preflightPolling = true;
         try {
-          await preflight({ clearAtStart: false });
+          await preflight({ clearAtStart: false, scrollToResult: false });
         } finally {
           state.preflightPolling = false;
         }

--- a/companion/workspace/features/facts.js
+++ b/companion/workspace/features/facts.js
@@ -113,7 +113,7 @@ export function installFacts(context) {
     $("#facts-title").textContent = label;
     $("#facts-form-title").textContent = label;
     if (!$("#facts-workspace").classList.contains("hidden")) document.title = `${label} · Job Apply Workspace`;
-    if (announce) $("#fact-view-status").textContent = `Showing ${label}. ${visibleControls} fact field${visibleControls === 1 ? "" : "s"} available.`;
+    $("#fact-view-status").textContent = `Showing ${label}. ${visibleControls} fact field${visibleControls === 1 ? "" : "s"} available.`;
   }
 
   async function refreshFactGroups({ quiet = false } = {}) {

--- a/companion/workspace/features/facts.js
+++ b/companion/workspace/features/facts.js
@@ -21,6 +21,7 @@ export function installFacts(context) {
     shouldRetryFactSave,
   } = apiHelpers;
   const {
+    equalJson,
     pointerValue,
     patchForPaths,
     conflictingPaths,
@@ -33,7 +34,6 @@ export function installFacts(context) {
   const namedTopLevel = new Set(["firstName", "lastName", "email", "phone", "location", "linkedInUrl", "portfolioUrl", "githubUrl", "workHistory", "education", "skills", "preferences"]);
   const encodePointer = (value) => String(value).replaceAll("~", "~0").replaceAll("/", "~1");
   const decodePointer = (value) => String(value).replaceAll("~1", "/").replaceAll("~0", "~");
-  const equalJson = (left, right) => JSON.stringify(left) === JSON.stringify(right);
 
   function factPathLabel(control) {
     if (control.dataset.label) return control.dataset.label;

--- a/companion/workspace/features/facts.js
+++ b/companion/workspace/features/facts.js
@@ -238,7 +238,16 @@ export function installFacts(context) {
         else input.value = item?.[field] ?? "";
         input.setAttribute("aria-label", `${text}, item ${index + 1}`);
         if (field === "description") { label.className = "wide"; input.rows = 5; }
-        label.append(input); row.append(label);
+        label.append(input);
+        if (field === "startDate" || field === "endDate") {
+          input.placeholder = "e.g. 2020 or 2020-08";
+          const help = document.createElement("small");
+          help.id = `${container.id}-${index}-${field}-help`;
+          help.textContent = "Free-text date; partial dates are welcome. Use the detail available in your resume.";
+          input.setAttribute("aria-describedby", help.id);
+          label.append(help);
+        }
+        row.append(label);
       }
       const remove = document.createElement("button"); remove.type = "button"; remove.className = "button danger"; remove.textContent = `Remove ${container.dataset.repeater === "work" ? "position" : "education"}`;
       remove.addEventListener("click", () => {

--- a/companion/workspace/features/jobs.js
+++ b/companion/workspace/features/jobs.js
@@ -104,15 +104,17 @@ export function installJobs(context) {
     if (focusedJobId) jobButton(focusedJobId)?.focus();
   }
 
-  function refresh({ quiet = false } = {}) {
+  function refresh({ quiet = false, preserveReadiness = false } = {}) {
     if (state.refreshPromise) return state.refreshPromise;
     state.refreshEpoch += 1;
     state.canonicalStateCurrent = false;
     state.preflightRequestSequence += 1;
     const hadCheck = !$("#preflight-panel").classList.contains("hidden") || Boolean($("#ready-check-status").textContent);
-    clearPreflightReadiness();
+    clearPreflightReadiness({ hidePanel: !preserveReadiness, disableAction: preserveReadiness });
     if (hadCheck && dialog.open) {
-      $("#ready-check-status").textContent = "Workspace data refreshed. Run ready check again to see current results.";
+      $("#ready-check-status").textContent = preserveReadiness
+        ? "Checking for updates…"
+        : "Workspace data refreshed. Run ready check again to see current results.";
     }
     if (state.preflightError) {
       state.preflightError = null;
@@ -138,6 +140,7 @@ export function installJobs(context) {
         if (!quiet) toast("Jobs refreshed from the canonical store");
       } catch (error) {
         state.canonicalStateCurrent = false;
+        if (preserveReadiness) $("#ready-check-status").textContent = "Could not verify current data. Run ready check after reconnecting.";
         setConnection(false, error.message); if (!quiet) showFormError(error.message);
       }
     })().finally(() => { state.refreshPromise = null; });
@@ -217,7 +220,7 @@ export function installJobs(context) {
     } finally { $("#save-job").disabled = false; }
   }
 
-  async function preflight({ clearAtStart = true } = {}) {
+  async function preflight({ clearAtStart = true, scrollToResult = true } = {}) {
     if (!state.selected) return null;
     if (!state.canonicalStateCurrent) {
       $("#ready-check-status").textContent = "Workspace data is refreshing. Run ready check again when it finishes.";
@@ -261,7 +264,7 @@ export function installJobs(context) {
         $("#form-error").textContent = "";
         $("#form-error").classList.add("hidden");
       }
-      renderPreflight(result, { dialogGeneration, refreshEpoch, dependencyObservation }); return result;
+      renderPreflight(result, { dialogGeneration, refreshEpoch, dependencyObservation, scrollToResult }); return result;
     } catch (error) {
       if (
         requestSequence === state.preflightRequestSequence
@@ -281,7 +284,7 @@ export function installJobs(context) {
   }
 
   const issueText = { profile_empty: "Complete your applicant profile", resume_missing: "Assign an active resume", resume_file_missing: "The resume file cannot be found", resume_file_changed: "The resume file changed since it was added", role_missing: "Add a role for clearer handoff", company_missing: "Add a company for clearer handoff" };
-  function renderPreflight(result, { dialogGeneration, refreshEpoch, dependencyObservation }) {
+  function renderPreflight(result, { dialogGeneration, refreshEpoch, dependencyObservation, scrollToResult = true }) {
     $("#ready-check-status").textContent = "";
     const panel = $("#preflight-panel"), body = $("#preflight-results"); body.replaceChildren();
     const summary = document.createElement("p"); summary.textContent = result.ready ? "No blocking issues. This job can be handed to a Job Apply agent." : "Resolve the blocking issues before marking this job ready."; body.append(summary);
@@ -289,7 +292,8 @@ export function installJobs(context) {
     const current = freshestKnownJob(state.selected?.id);
     const currentStatus = current?.status;
     panel.classList.remove("hidden");
-    panel.scrollIntoView({ block: "center" });
+    if (scrollToResult) panel.scrollIntoView({ block: "center" });
+    $("#mark-ready").disabled = false;
     $("#mark-ready").classList.toggle("hidden", !result.ready || !canMarkReadyFrom(currentStatus));
     state.readyHandoffProof = result.ready && currentStatus === "ready" && result.revision === current?.revision
       ? { id: result.id, revision: result.revision, dialogGeneration, refreshEpoch, dependencyObservation }

--- a/companion/workspace/features/jobs.js
+++ b/companion/workspace/features/jobs.js
@@ -220,7 +220,7 @@ export function installJobs(context) {
   async function preflight({ clearAtStart = true } = {}) {
     if (!state.selected) return null;
     if (!state.canonicalStateCurrent) {
-      showFormError("Workspace data is refreshing. Run ready check again when it finishes.");
+      $("#ready-check-status").textContent = "Workspace data is refreshing. Run ready check again when it finishes.";
       return null;
     }
     const requestedId = state.selected.id;
@@ -247,10 +247,10 @@ export function installJobs(context) {
         || !current
       ) return null;
       if (current.revision !== requestedRevision || result.revision !== requestedRevision) {
-        $("#ready-check-status").textContent = "This job changed during the check. Refresh Jobs and run ready check again.";
         if (result.revision > current.revision) {
           clearPreflightReadiness({ hidePanel: false });
         }
+        $("#ready-check-status").textContent = "This job changed during the check. Refresh Jobs and run ready check again.";
         return null;
       }
       if (

--- a/companion/workspace/features/jobs.js
+++ b/companion/workspace/features/jobs.js
@@ -43,11 +43,21 @@ export function installJobs(context) {
     $("#metric-needs").textContent = state.jobs.filter((j) => j.status === "needs_info").length;
   }
 
+  $("#jobs-clear-filters").addEventListener("click", () => {
+    $("#search").value = ""; $("#status-filter").value = "";
+    render(); $("#search").focus();
+  });
+
   function render() {
     metrics(); $("#loading").classList.add("hidden");
     if (dialog.open) return;
     const focusedJobId = document.activeElement instanceof HTMLElement ? document.activeElement.dataset.id : null;
     const jobs = filterJobs(state.jobs, $("#search").value, $("#status-filter").value);
+    const filtered = $("#search").value.trim() || $("#status-filter").value;
+    $("#empty h3").textContent = filtered ? "No matching jobs" : "No jobs here yet";
+    $("#empty p").textContent = filtered ? "Clear your search or status filter to see more jobs." : "Capture one opportunity or paste a list of URLs to start your local pipeline.";
+    $("#jobs-clear-filters").classList.toggle("hidden", !filtered);
+    $("#empty-create").classList.toggle("hidden", Boolean(filtered));
     $("#empty").classList.toggle("hidden", jobs.length !== 0);
     $("#job-list").classList.toggle("hidden", jobs.length === 0);
     const list = $("#job-list");
@@ -73,7 +83,14 @@ export function installJobs(context) {
       if (jobCardRenderKeys.get(button) !== renderKey) {
         const title = document.createElement("div"); title.className = "job-title";
         const mark = document.createElement("span"); mark.className = "company-mark"; mark.textContent = escapeText(job.company || job.role || "J").slice(0, 1).toUpperCase(); mark.setAttribute("aria-hidden", "true");
-        const names = document.createElement("div"); const heading = document.createElement("h3"); heading.textContent = job.role || "Untitled opportunity"; const company = document.createElement("p"); company.textContent = job.company || "Company not set"; names.append(heading, company); title.append(mark, names);
+        const names = document.createElement("div"); const heading = document.createElement("h3"); heading.textContent = job.role || "Untitled opportunity"; const company = document.createElement("p"); company.textContent = job.company || "Company not set"; names.append(heading, company);
+        if (!job.role || !job.company) {
+          const source = document.createElement("p"); source.className = "job-source";
+          try { const url = new URL(job.url); source.textContent = `${url.hostname}${url.pathname}`; }
+          catch { source.textContent = "Saved job link"; }
+          names.append(source);
+        }
+        title.append(mark, names);
         const location = document.createElement("p"); location.textContent = job.location || job.workplaceType || "Location not set";
         const priority = document.createElement("span"); priority.className = "priority"; priority.textContent = job.priority ? "★".repeat(Math.min(job.priority, 5)) : "—"; priority.setAttribute("aria-label", `Priority ${job.priority || 0}`);
         const status = document.createElement("span"); status.className = `status ${job.status}`; status.textContent = statusLabel(job.status);
@@ -92,7 +109,11 @@ export function installJobs(context) {
     state.refreshEpoch += 1;
     state.canonicalStateCurrent = false;
     state.preflightRequestSequence += 1;
+    const hadCheck = !$("#preflight-panel").classList.contains("hidden") || Boolean($("#ready-check-status").textContent);
     clearPreflightReadiness();
+    if (hadCheck && dialog.open) {
+      $("#ready-check-status").textContent = "Workspace data refreshed. Run ready check again to see current results.";
+    }
     if (state.preflightError) {
       state.preflightError = null;
       $("#form-error").textContent = "";
@@ -173,7 +194,13 @@ export function installJobs(context) {
       $("#reload-latest").disabled = true; $("#rebase-draft").disabled = true;
       $("#conflict").classList.remove("hidden"); $("#conflict").focus(); return;
     }
-    for (const field of ["url", "role", "company", "location", "workplaceType", "employmentType", "compensation", "notes", "description", "resumeId", "priority", "status", "revision"]) { const span = document.createElement("span"); span.textContent = `${field}: ${state.latest[field] ?? "—"}`; holder.append(span); }
+    const labels = { url: "Job URL", role: "Role", company: "Company", location: "Location", workplaceType: "Work arrangement", employmentType: "Employment type", compensation: "Compensation", notes: "Notes", description: "Description", resumeId: "Resume", priority: "Priority", status: "Status", revision: "Revision" };
+    for (const [field, label] of Object.entries(labels)) {
+      const row = document.createElement("div"); row.className = "conflict-field";
+      const name = document.createElement("strong"); name.textContent = label;
+      const value = document.createElement("p"); value.textContent = state.latest[field] ?? "—";
+      row.append(name, value); holder.append(row);
+    }
     $("#conflict").classList.remove("hidden"); $("#conflict").focus();
   }
 
@@ -191,7 +218,11 @@ export function installJobs(context) {
   }
 
   async function preflight({ clearAtStart = true } = {}) {
-    if (!state.selected || !state.canonicalStateCurrent) return null;
+    if (!state.selected) return null;
+    if (!state.canonicalStateCurrent) {
+      showFormError("Workspace data is refreshing. Run ready check again when it finishes.");
+      return null;
+    }
     const requestedId = state.selected.id;
     const requestedRevision = freshestKnownJob(requestedId)?.revision;
     const refreshEpoch = state.refreshEpoch;
@@ -200,6 +231,7 @@ export function installJobs(context) {
     if (!Number.isInteger(requestedRevision)) return null;
     const requestSequence = ++state.preflightRequestSequence;
     if (clearAtStart) clearPreflightReadiness();
+    $("#ready-check-status").textContent = "Checking profile and resume…";
     try {
       const result = await api(`/api/jobs/${encodeURIComponent(requestedId)}/preflight`);
       const current = freshestKnownJob(requestedId);
@@ -215,6 +247,7 @@ export function installJobs(context) {
         || !current
       ) return null;
       if (current.revision !== requestedRevision || result.revision !== requestedRevision) {
+        $("#ready-check-status").textContent = "This job changed during the check. Refresh Jobs and run ready check again.";
         if (result.revision > current.revision) {
           clearPreflightReadiness({ hidePanel: false });
         }
@@ -249,12 +282,14 @@ export function installJobs(context) {
 
   const issueText = { profile_empty: "Complete your applicant profile", resume_missing: "Assign an active resume", resume_file_missing: "The resume file cannot be found", resume_file_changed: "The resume file changed since it was added", role_missing: "Add a role for clearer handoff", company_missing: "Add a company for clearer handoff" };
   function renderPreflight(result, { dialogGeneration, refreshEpoch, dependencyObservation }) {
+    $("#ready-check-status").textContent = "";
     const panel = $("#preflight-panel"), body = $("#preflight-results"); body.replaceChildren();
     const summary = document.createElement("p"); summary.textContent = result.ready ? "No blocking issues. This job can be handed to a Job Apply agent." : "Resolve the blocking issues before marking this job ready."; body.append(summary);
     for (const [label, items] of [["Blocking", result.errors], ["Warnings", result.warnings]]) if (items.length) { const h = document.createElement("strong"); h.textContent = label; const ul = document.createElement("ul"); for (const code of items) { const li = document.createElement("li"); li.textContent = issueText[code] || code; ul.append(li); } body.append(h, ul); }
     const current = freshestKnownJob(state.selected?.id);
     const currentStatus = current?.status;
     panel.classList.remove("hidden");
+    panel.scrollIntoView({ block: "center" });
     $("#mark-ready").classList.toggle("hidden", !result.ready || !canMarkReadyFrom(currentStatus));
     state.readyHandoffProof = result.ready && currentStatus === "ready" && result.revision === current?.revision
       ? { id: result.id, revision: result.revision, dialogGeneration, refreshEpoch, dependencyObservation }

--- a/companion/workspace/features/overview.js
+++ b/companion/workspace/features/overview.js
@@ -64,6 +64,7 @@ export function installOverview(context) {
   }
 
   function clearPreflightReadiness({ hidePanel = true } = {}) {
+    $("#ready-check-status").textContent = "";
     state.readyHandoffProof = null;
     $("#mark-ready").classList.add("hidden");
     $("#ready-handoff").classList.add("hidden");

--- a/companion/workspace/features/overview.js
+++ b/companion/workspace/features/overview.js
@@ -63,10 +63,11 @@ export function installOverview(context) {
     $("#ready-handoff").classList.toggle("hidden", !visible);
   }
 
-  function clearPreflightReadiness({ hidePanel = true } = {}) {
+  function clearPreflightReadiness({ hidePanel = true, disableAction = false } = {}) {
     $("#ready-check-status").textContent = "";
     state.readyHandoffProof = null;
-    $("#mark-ready").classList.add("hidden");
+    if (!disableAction) $("#mark-ready").classList.add("hidden");
+    $("#mark-ready").disabled = disableAction;
     $("#ready-handoff").classList.add("hidden");
     if (hidePanel) {
       $("#preflight-panel").classList.add("hidden");

--- a/companion/workspace/features/resumes.js
+++ b/companion/workspace/features/resumes.js
@@ -59,6 +59,18 @@ export function installResumes(context) {
     pdfOpener = null;
   });
 
+  let textOpener = null;
+  let textResumeId = null;
+  const textDialog = $("#preview-dialog");
+  textDialog.addEventListener("close", () => {
+    if (textDialog.open) return;
+    const opener = textOpener?.isConnected ? textOpener
+      : document.querySelector(`[data-resume-preview="${CSS.escape(textResumeId || "")}"]`);
+    if (opener) opener.disabled = false;
+    if (opener?.getClientRects().length) opener.focus();
+    textOpener = null;
+  });
+
   async function openResumeContent(resume, button, inDetails = false) {
     if (!resume) return;
     const errorNode = $(inDetails ? "#resume-error" : "#resumes-error");
@@ -105,7 +117,8 @@ export function installResumes(context) {
         }
       } else if (resume.mediaType?.startsWith("text/plain")) {
         $("#resume-preview").textContent = await response.text();
-        $("#preview-dialog").showModal();
+        textOpener = button; textResumeId = resume.id;
+        textDialog.showModal();
       } else {
         const url = URL.createObjectURL(await response.blob());
         const link = document.createElement("a");

--- a/companion/workspace/features/trash.js
+++ b/companion/workspace/features/trash.js
@@ -37,6 +37,9 @@ export function installTrash(context) {
     $("#trash-nav-count").textContent = String(trashState.items.length);
     $("#trash-counts").textContent = `${trashState.counts.job} jobs · ${trashState.counts.resume} resumes · ${trashState.counts.answer} answers`;
     $("#trash-status").textContent = `${items.length} trashed ${type || "record"}${items.length === 1 ? "" : "s"} in this view.`;
+    const filteredEmpty = Boolean(type && trashState.items.length);
+    $("#trash-empty h3").textContent = filteredEmpty ? "No matching records in Trash" : "Trash is empty";
+    $("#trash-empty p").textContent = filteredEmpty ? "Choose All types to see other trashed records." : "Records moved to trash remain recoverable until you explicitly delete them.";
     $("#trash-empty").classList.toggle("hidden", items.length !== 0);
     const list = $("#trash-list"); list.replaceChildren();
     for (const item of items) {
@@ -67,6 +70,9 @@ export function installTrash(context) {
     try {
       await api(trashActionPath(item, "restore"), { method: "POST", body: JSON.stringify({ expectedRevision: item.revision }) });
       await Promise.all([refresh({ quiet: true }), refreshTrash({ quiet: true })]); toast(`${item.type} restored`);
+      if (!$("#trash-workspace").classList.contains("hidden")) {
+        ($("#trash-list button") || $("#trash-refresh")).focus();
+      }
     } catch (error) {
       const node = $("#trash-error"); node.textContent = lifecycleErrorText(error); node.classList.remove("hidden");
       if (error.code === "revision_conflict") await refreshTrash({ quiet: true });

--- a/companion/workspace/features/trash.js
+++ b/companion/workspace/features/trash.js
@@ -35,7 +35,7 @@ export function installTrash(context) {
     const type = $("#trash-type-filter").value;
     const items = filterTrashItems(trashState.items, type);
     $("#trash-nav-count").textContent = String(trashState.items.length);
-    $("#trash-counts").textContent = `${trashState.counts.job} jobs · ${trashState.counts.resume} resumes · ${trashState.counts.answer} answers`;
+    $("#trash-counts").textContent = ["job", "resume", "answer"].map(type => `${trashState.counts[type]} ${type}${trashState.counts[type] === 1 ? "" : "s"}`).join(" · ");
     $("#trash-status").textContent = `${items.length} trashed ${type || "record"}${items.length === 1 ? "" : "s"} in this view.`;
     const filteredEmpty = Boolean(type && trashState.items.length);
     $("#trash-empty h3").textContent = filteredEmpty ? "No matching records in Trash" : "Trash is empty";

--- a/companion/workspace/index.html
+++ b/companion/workspace/index.html
@@ -286,7 +286,7 @@
           <label><span><input name="enabled" type="checkbox"> Enable companion automation controls</span></label>
           <label><span><input name="automaticAccountCreation" type="checkbox"> Allow protected account preparation</span><small>Live Workday execution still requires a separate one-shot owner approval.</small></label>
           <label>Global signup email <input name="signupEmail" type="email" autocomplete="email" placeholder="Leave blank to keep the current setting"><small id="automation-email-status">Not configured</small></label>
-          <label>Password strategy <select name="passwordStrategy"><option value="unique_per_realm">Unique per employer realm</option><option value="shared">Shared credential version</option><option value="custom">Custom per realm</option><option value="ask_each_time">Ask each time</option></select></label>
+          <label>Password strategy <select name="passwordStrategy"><option value="unique_per_realm">Unique per employer</option><option value="shared">Shared credential version</option><option value="custom">Custom per employer</option><option value="ask_each_time">Ask each time</option></select></label>
           <div class="button-row"><button class="button primary" type="submit">Save settings</button><button id="automation-copy-profile-email" class="button secondary" type="button">Copy profile email once</button><button id="automation-clear-email" class="button secondary" type="button">Clear signup email</button></div>
           <p class="safety-note">Copying is an explicit one-time snapshot. Later profile edits do not change the signup email, and the copied value is never returned by this action.</p>
         </form>
@@ -294,7 +294,7 @@
         <p id="automation-error" class="error hidden" role="alert"></p>
       </section>
       <section class="automation-panel" aria-labelledby="realm-heading">
-        <div class="panel-heading"><div><p class="eyebrow">EMPLOYER REALMS</p><h2 id="realm-heading">Employer accounts</h2></div></div>
+        <div class="panel-heading"><div><p class="eyebrow">EMPLOYER ACCOUNTS</p><h2 id="realm-heading">Employer accounts</h2></div></div>
         <form id="realm-form" class="automation-form">
           <label>Exact employer portal URL <input name="url" type="url" required placeholder="https://tenant.wd5.myworkdayjobs.com/… or an Oracle Recruiting job URL"></label>
           <label>Optional signup email override <input name="signupEmailOverride" type="email" autocomplete="email"></label>
@@ -305,9 +305,9 @@
       </section>
       <section class="automation-panel" aria-labelledby="account-operation-heading">
         <div class="panel-heading"><div><p class="eyebrow">PROTECTED OPERATION</p><h2 id="account-operation-heading">Account operation recovery</h2></div></div>
-        <p class="safety-note">Recovery never infers success. A stranded operation becomes permanently ambiguous and cannot retry, rotate, or provision again.</p>
+        <p class="safety-note">If account setup was interrupted, record its outcome as unknown. This prevents another setup attempt or credential change; it does not assume the account was created.</p>
         <div id="account-operation-status" class="notice" role="status" aria-live="polite">No operation status loaded.</div>
-        <div class="button-row"><button id="account-operation-refresh" class="button secondary" type="button">Refresh operation status</button><button id="account-operation-recover" class="button danger" type="button" disabled>Mark stranded operation ambiguous</button></div>
+        <div class="button-row"><button id="account-operation-refresh" class="button secondary" type="button">Refresh operation status</button><button id="account-operation-recover" class="button danger" type="button" disabled>Record interrupted setup as unknown</button></div>
         <p id="account-operation-error" class="error hidden" role="alert"></p>
       </section>
       <section class="automation-panel" aria-labelledby="trusted-fill-heading">

--- a/companion/workspace/index.html
+++ b/companion/workspace/index.html
@@ -136,6 +136,7 @@
       <div id="empty" class="empty-state hidden">
         <span class="empty-icon" aria-hidden="true">◎</span><h3>No jobs here yet</h3>
         <p>Capture one opportunity or paste a list of URLs to start your local pipeline.</p>
+        <button id="jobs-clear-filters" class="button secondary hidden" type="button">Clear filters</button>
         <button id="empty-create" class="button primary" type="button">Capture a job</button>
       </div>
       <div id="job-list" class="job-list hidden" role="list"></div>
@@ -251,7 +252,7 @@
       <section class="answers-panel" aria-labelledby="answer-library-heading">
         <div class="panel-heading"><div><p class="eyebrow">CANONICAL LIBRARY</p><h2 id="answer-library-heading">Answers</h2></div><div class="filters"><label>Search <input id="answer-search" type="search" placeholder="Question or alias"></label><label>View <select id="answer-view"><option value="accepted">Library</option><option value="pending">Observed inbox</option><option value="declined">Declined</option><option value="trash">Trash</option></select></label><label>State <select id="answer-state-filter"><option value="">All states</option><option value="confirmed">Confirmed</option><option value="inferred">Inferred</option><option value="missing">Missing</option><option value="sensitive">Sensitive</option></select></label></div></div>
         <p id="answers-status" class="notice" role="status" aria-live="polite">Open Answers to load the canonical library.</p>
-        <div id="answers-empty" class="empty-state hidden"><h3>No answers in this view</h3><p>Create an answer or wait for an agent to observe a question.</p></div>
+        <div id="answers-empty" class="empty-state hidden"><h3>No answers in this view</h3><p>Create an answer or wait for an agent to observe a question.</p><button id="answers-clear-filters" class="button secondary hidden" type="button">Clear filters</button></div>
         <div id="answer-list" class="answer-list" role="list"></div>
         <div class="button-row pagination"><button id="answers-previous" class="button secondary" type="button">Previous</button><button id="answers-next" class="button secondary" type="button">Next</button></div>
         <p id="answers-error" class="error hidden" role="alert"></p>
@@ -275,7 +276,7 @@
 
     <div id="automation-workspace" class="hidden">
       <section class="hero" aria-labelledby="automation-title">
-        <div><p class="eyebrow">Companion Automation</p><h2 id="automation-title">Automation settings</h2><p>This surface shows redacted settings, tenant metadata, and protected-operation recovery. The reviewed macOS Workday seam remains disabled until a separate one-shot owner approval; ordinary Greenhouse applications need no account. No live execution control or final application action is reachable here.</p></div>
+        <div><p class="eyebrow">Companion Automation</p><h2 id="automation-title">Automation settings</h2><p>Manage account preferences and review agent permissions. Workday account setup requires your separate approval each time. Ordinary Greenhouse applications need no account. These controls do not submit applications.</p></div>
         <div class="hero-actions"><button id="automation-refresh" class="button secondary" type="button">Refresh</button></div>
       </section>
       <section class="automation-panel" aria-labelledby="automation-settings-title">
@@ -293,11 +294,11 @@
         <p id="automation-error" class="error hidden" role="alert"></p>
       </section>
       <section class="automation-panel" aria-labelledby="realm-heading">
-        <div class="panel-heading"><div><p class="eyebrow">EMPLOYER REALMS</p><h2 id="realm-heading">Tenant-scoped account metadata</h2></div></div>
+        <div class="panel-heading"><div><p class="eyebrow">EMPLOYER REALMS</p><h2 id="realm-heading">Employer accounts</h2></div></div>
         <form id="realm-form" class="automation-form">
           <label>Exact employer portal URL <input name="url" type="url" required placeholder="https://tenant.wd5.myworkdayjobs.com/… or an Oracle Recruiting job URL"></label>
           <label>Optional signup email override <input name="signupEmailOverride" type="email" autocomplete="email"></label>
-          <button class="button primary" type="submit">Add resolved realm</button>
+          <button class="button primary" type="submit">Add employer portal</button>
         </form>
         <p class="safety-note">Unknown hosts and unproven tenant paths are rejected. Employer names and ATS families are never used as a fallback.</p>
         <div id="automation-accounts" class="automation-accounts" role="list"></div>
@@ -310,8 +311,9 @@
         <p id="account-operation-error" class="error hidden" role="alert"></p>
       </section>
       <section class="automation-panel" aria-labelledby="trusted-fill-heading">
-        <div class="panel-heading"><div><p class="eyebrow">GROUNDED TRUSTED FILL</p><h2 id="trusted-fill-heading">Approve exact non-final field operations</h2></div></div>
-        <p class="safety-note">This inert authority evaluates fingerprints only. It cannot operate a browser, authenticate, accept consent, enter credentials, navigate, or activate Submit, Send, Apply, or any equivalent final control.</p>
+        <div class="panel-heading"><div><p class="eyebrow">GROUNDED TRUSTED FILL</p><h2 id="trusted-fill-heading">Advanced agent permissions</h2></div></div>
+        <p class="safety-note">Review an agent-provided request for specific form fields. Approval alone does not run the browser, enter credentials, accept consent, or submit an application. Technical identifiers below bind approval to the exact job and form.</p>
+        <details class="advanced-permissions"><summary>Review agent-provided permission details</summary>
         <form id="trusted-fill-form" class="automation-form">
           <div class="form-grid">
             <label>Claimed job ID <input name="jobId" required></label>
@@ -324,12 +326,13 @@
             <label>Duration in minutes <input name="durationMinutes" type="number" min="1" max="60" value="30" required></label>
           </div>
           <fieldset><legend>Allowed non-final operations</legend><label><span><input name="allowedOperations" value="fill_text" type="checkbox"> Fill text</span></label><label><span><input name="allowedOperations" value="select_option" type="checkbox"> Select option</span></label><label><span><input name="allowedOperations" value="toggle_non_consent" type="checkbox"> Toggle a non-consent field</span></label><label><span><input name="allowedOperations" value="upload_approved_resume" type="checkbox"> Upload the approved resume</span></label></fieldset>
-          <button class="button primary" type="submit">Approve exact packet</button>
+          <button class="button primary" type="submit">Approve these field permissions</button>
         </form>
         <form id="trusted-fill-status-form" class="automation-form">
           <label>Job ID for status or revocation <input name="jobId" required></label>
           <div class="button-row"><button class="button secondary" type="submit">Check approval status</button><button id="trusted-fill-revoke" class="button secondary" type="button" disabled>Revoke approval</button></div>
         </form>
+        </details>
         <div id="trusted-fill-status" class="notice" role="status" aria-live="polite">No approval loaded.</div>
         <div id="trusted-fill-conflict" class="conflict hidden" role="alert" tabindex="-1"><h3>Approval changed elsewhere</h3><p>Nothing was retried. Refresh its exact status before another action.</p></div>
         <p id="trusted-fill-error" class="error hidden" role="alert"></p>
@@ -464,7 +467,7 @@
         </div>
       </section>
       <section id="preflight-panel" class="preflight hidden" aria-labelledby="preflight-heading">
-        <h3 id="preflight-heading">Ready check</h3><div id="preflight-results"></div>
+        <h3 id="preflight-heading">Ready check</h3><div id="preflight-results" role="status" aria-live="polite"></div>
       </section>
       <section id="ready-handoff" class="handoff-card compact-handoff hidden" aria-labelledby="ready-handoff-heading">
         <p class="eyebrow">READY FOR AN AGENT</p><h3 id="ready-handoff-heading">Continue outside this workspace</h3>
@@ -473,7 +476,8 @@
         <label class="clipboard-fallback hidden" role="alert">Clipboard unavailable. Select and copy this invocation manually. <input class="clipboard-fallback-value" readonly aria-label="Invocation to copy"></label>
       </section>
       <p id="form-error" class="error hidden" role="alert"></p>
-      <div class="dialog-footer">
+      <div class="dialog-footer job-footer">
+        <p id="ready-check-status" role="status" aria-live="polite"></p>
         <div class="danger-zone"><button id="trash-job" class="button danger hidden" type="button">Move to trash</button></div>
         <div class="button-row">
           <button id="preflight-job" class="button secondary hidden" type="button">Run ready check</button>

--- a/companion/workspace/lib/helpers.js
+++ b/companion/workspace/lib/helpers.js
@@ -239,7 +239,7 @@ export function fileToBase64(file) {
 export function resumeAssignmentText(resume) {
   const explicit = Number.isInteger(resume?.assignedJobCount) ? resume.assignedJobCount : 0;
   const implicit = Number.isInteger(resume?.implicitJobCount) ? resume.implicitJobCount : 0;
-  return `${explicit} explicitly assigned active job${explicit === 1 ? "" : "s"}${implicit ? `; ${implicit} active job${implicit === 1 ? "" : "s"} use this default` : ""}.`;
+  return `${explicit} explicitly assigned active job${explicit === 1 ? "" : "s"}${implicit ? `; ${implicit} active job${implicit === 1 ? " uses" : "s use"} this default` : ""}.`;
 }
 
 export function extractionRequestView(request, proposalSummary) {

--- a/companion/workspace/lib/helpers.js
+++ b/companion/workspace/lib/helpers.js
@@ -60,7 +60,7 @@ export function answerApiPath(key, action = "") {
   return `/api/answers/by-key/${encoded}${action ? `/${action}` : ""}`;
 }
 
-export function sameAnswerScope(left, right) {
+export function equalJson(left, right) {
   const canonical = (value) => {
     if (Array.isArray(value)) return value.map(canonical);
     if (value && typeof value === "object") return Object.fromEntries(
@@ -68,7 +68,11 @@ export function sameAnswerScope(left, right) {
     );
     return value;
   };
-  return JSON.stringify(canonical(left || {})) === JSON.stringify(canonical(right || {}));
+  return JSON.stringify(canonical(left)) === JSON.stringify(canonical(right));
+}
+
+export function sameAnswerScope(left, right) {
+  return equalJson(left || {}, right || {});
 }
 
 export function formPatch(values) {
@@ -204,7 +208,7 @@ export function conflictingPaths(base, latest, drafts, atomicPaths = new Set()) 
     const before = base instanceof Map ? base.get(path) : pointerValue(base, path);
     const now = pointerValue(latest, path);
     const structured = atomicPaths.has(path) || typeof mine === "object" || typeof before === "object" || typeof now === "object";
-    return JSON.stringify(before) !== JSON.stringify(now) && (structured || JSON.stringify(mine) !== JSON.stringify(now));
+    return !equalJson(before, now) && (structured || !equalJson(mine, now));
   }).map(([path]) => path);
 }
 

--- a/companion/workspace/styles.css
+++ b/companion/workspace/styles.css
@@ -363,3 +363,15 @@ dialog::backdrop { background: #10182865; backdrop-filter: blur(2px); }
 #pdf-fallback { flex-shrink: 0; font-size: .85rem; }
 #pdf-preview-dialog [hidden] { display: none; }
 @media (max-width: 760px) { #pdf-preview-dialog { width: 100vw; height: 100dvh; margin: 0; border-radius: 0; } }
+
+.job-source { overflow-wrap: anywhere; font-size: .8rem; }
+.conflict-field { padding: .65rem; border: 1px solid currentColor; border-radius: 6px; }
+.conflict-field p { margin: .3rem 0 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+
+.advanced-permissions summary { cursor: pointer; padding: .8rem 0; font-weight: 600; }
+.advanced-permissions[open] summary { margin-bottom: .6rem; }
+
+.job-footer { flex-wrap: wrap; }
+#ready-check-status { flex-basis: 100%; margin: 0; color: var(--ink); }
+#ready-check-status:empty { display: none; }
+#preflight-panel { scroll-margin-block: 90px; }

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -188,3 +188,17 @@ An explicit download fallback remains available for unsupported or blank native
 PDF renderers. TXT and DOCX behavior is unchanged. Embedded readability requires
 owner acceptance; isolated headless tests verify wiring, not native rendering.
 Forward-port this presentation and cancellation behavior to TypeScript separately.
+
+### Desktop Facts conflicts and TXT preview focus
+
+Facts comparisons now ignore JSON object key order, including nested work-history
+objects. PATCH responses and subsequent canonical reads can serialize identical
+objects differently; this must not create a conflict on the next save. Array
+order, missing fields, and changed values still participate in conflict checks.
+TXT preview restores focus to its invoking button after Close or Escape, with a
+current-card fallback if the resume list was refreshed while the dialog was open.
+
+Migration follow-up: use semantic JSON comparisons for draft bases and restore
+focus by stable resume identity when preview triggers are replaced. These desktop
+regressions use isolated synthetic data; owner walkthrough acceptance and
+smaller-screen QA remain separate.

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -222,3 +222,7 @@ filter recovery, and progressive disclosure. The reported education date format
 and DOCX download-event timeout remain separate investigations. The observed
 ready-check disappearance was reproduced via refresh invalidation; the original
 walkthrough timing has not been established. Desktop owner retest remains open.
+
+Work and education date fields explicitly describe the existing free-text
+contract, with year and year-month examples. Existing partial dates remain
+valid; this is guidance, not a new parser or Store migration.

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -202,3 +202,23 @@ Migration follow-up: use semantic JSON comparisons for draft bases and restore
 focus by stable resume identity when preview triggers are replaced. These desktop
 regressions use isolated synthetic data; owner walkthrough acceptance and
 smaller-screen QA remain separate.
+
+### Desktop readiness and recovery feedback
+
+Workspace refresh still invalidates readiness proof, but now leaves a visible
+instruction to rerun the check instead of silently removing its result. Pending
+checks announce progress. Restoring a Trash record returns focus to a remaining
+Restore button or Refresh when the list is empty, without pulling focus back
+from another workspace.
+
+Incomplete job cards show hostname/path (excluding URL credentials, query and
+fragment). Empty search views offer Clear filters. Answer trash grammar, custom
+Facts view summaries, job conflict field labels, and Automation wording are
+clearer; technical field-permission inputs are behind an advanced disclosure.
+Authorization, revision checks, and final-submission boundaries are unchanged.
+
+Migration follow-up: preserve stale-readiness explanations, contextual focus,
+filter recovery, and progressive disclosure. The reported education date format
+and DOCX download-event timeout remain separate investigations. The observed
+ready-check disappearance was reproduced via refresh invalidation; the original
+walkthrough timing has not been established. Desktop owner retest remains open.

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -293,3 +293,21 @@ submitted override revision, and canonical answer value. Both fail before the fi
 The CI timeout/null lookup alone does not prove every historical failure shared
 these causes. Forward-port focus-at-entry behavior, preserving user focus after
 async completion, into the TypeScript UI.
+
+
+### Outdated Automation responses and deterministic comparison clocks
+
+A controlled browser schedule reproduces a second Automation draft hazard:
+an older initial load can render after the add-portal refresh and detach an
+in-progress override input. Automation refreshes now discard both successes and
+errors superseded by a newer refresh. Regression tests hold the initial response
+until an override draft exists, then verify draft identity/value, successful
+revision-2 save, and absence of an obsolete error. The observed CI timeout alone
+does not establish that every prior override failure had this cause.
+
+The Store overview equivalence test also left its trash comparison outside the
+fixed wall-clock patch; executions across a second boundary produced unequal
+timestamps. Both trash operations now use the same explicit clock, retaining full
+record/tree equality and an exact deletedAt assertion. Runtime timestamp behavior
+is unchanged. Forward-port the Automation response-order guard and deterministic
+comparison-clock setup to the TypeScript lane where applicable.

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -237,3 +237,11 @@ continuity, review-fixture preparation, and review handoff using allowlisted,
 value-free stages. This improves diagnosis without exposing applicant data or
 weakening acceptance; an intermittent second-acquisition-stage CI failure remains
 unattributed until those diagnostics identify it or reproduction establishes it.
+
+UX-10 follow-up: the four-second background poll previously discarded Saved-job
+readiness results and rechecked only Ready jobs. Polling now keeps an open result
+visible, disables its action while canonical data is refreshed, and rechecks the
+current dialog before enabling it again. Poll rechecks do not scroll the page.
+Explicit refresh still clears proof. A regression removes the managed resume file
+without changing the job revision and verifies that revalidation revokes readiness.
+Forward-port this distinction between visible results and current actionable proof.

--- a/docs/python-release.md
+++ b/docs/python-release.md
@@ -226,3 +226,14 @@ walkthrough timing has not been established. Desktop owner retest remains open.
 Work and education date fields explicitly describe the existing free-text
 contract, with year and year-month examples. Existing partial dates remain
 valid; this is guidance, not a new parser or Store migration.
+
+Review follow-up: a ready-check attempt during an in-flight refresh now uses the
+transient readiness status, so a successful retry clears its explanation. Answer
+Trash guidance identifies the previous view rather than promising Library for
+pending or declined answers. Preserve these behaviors in the migration UX.
+
+Package oracle failures now distinguish second acquisition, managed-resume
+continuity, review-fixture preparation, and review handoff using allowlisted,
+value-free stages. This improves diagnosis without exposing applicant data or
+weakening acceptance; an intermittent second-acquisition-stage CI failure remains
+unattributed until those diagnostics identify it or reproduction establishes it.

--- a/qa/unified_task_spine_diagnostics.mjs
+++ b/qa/unified_task_spine_diagnostics.mjs
@@ -1,0 +1,27 @@
+const PUBLIC_STAGES = new Set([
+  "setup", "ux_intake", "agent_intake", "selection", "first_acquisition",
+  "attention_open", "answer_open", "answer_save", "answer_recheck",
+  "second_acquisition", "resume_continuity", "review_fixture", "review_handoff",
+  "final_verification", "cleanup",
+  "answer_save_response", "answer_save_closed", "answer_save_activity",
+  "answer_save_draft", "answer_save_focus_wait",
+]);
+
+export class OracleFailure extends Error {
+  constructor(code, stage = "cleanup") {
+    super(code);
+    this.stage = stage;
+  }
+}
+
+export function publicFailureReport(error) {
+  return {
+    schemaVersion: 1,
+    oracle: "unified_task_spine",
+    result: "fail",
+    closed: true,
+    error: "oracle_failed",
+    stage: PUBLIC_STAGES.has(error?.stage) ? error.stage : "unknown",
+  };
+}
+

--- a/qa/unified_task_spine_oracle.mjs
+++ b/qa/unified_task_spine_oracle.mjs
@@ -9,6 +9,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
 import { waitForLinkedAnswerReturn } from "./unified_task_spine_answer.mjs";
+import { OracleFailure, publicFailureReport } from "./unified_task_spine_diagnostics.mjs";
+export { publicFailureReport } from "./unified_task_spine_diagnostics.mjs";
 
 const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const PYTHON = process.env.PYTHON || "python3";
@@ -57,32 +59,6 @@ const PASS_REPORT = Object.freeze({
     "closed_without_final_action",
   ],
 });
-
-const PUBLIC_STAGES = new Set([
-  "setup", "ux_intake", "agent_intake", "selection", "first_acquisition",
-  "attention_open", "answer_open", "answer_save", "answer_recheck",
-  "second_acquisition", "final_verification", "cleanup",
-  "answer_save_response", "answer_save_closed", "answer_save_activity",
-  "answer_save_draft", "answer_save_focus_wait",
-]);
-
-class OracleFailure extends Error {
-  constructor(code, stage = "cleanup") {
-    super(code);
-    this.stage = stage;
-  }
-}
-
-export function publicFailureReport(error) {
-  return {
-    schemaVersion: 1,
-    oracle: "unified_task_spine",
-    result: "fail",
-    closed: true,
-    error: "oracle_failed",
-    stage: PUBLIC_STAGES.has(error?.stage) ? error.stage : "unknown",
-  };
-}
 
 function check(condition, code) {
   if (!condition) throw new OracleFailure(code);
@@ -430,13 +406,17 @@ export async function runOracle({ configurePage = async () => {} } = {}) {
     );
     attempts.push(secondSession);
     const second = await secondSession.start();
+    stage = "resume_continuity";
     for (const field of ["id", "revision", "contentRevision", "digest"]) {
       check(second.resume[field] === first.resume[field], "resume_identity_changed");
     }
     check(Buffer.compare(await readFile(second.resume.path), resumeBytesBefore) === 0, "resume_bytes_changed");
+    stage = "review_fixture";
+    const reviewSession = await liveReviewSession(second.job.revision);
+    stage = "review_handoff";
     await secondSession.send({
       command: "handoff", status: "awaiting_review",
-      session: await liveReviewSession(second.job.revision),
+      session: reviewSession,
     });
     await secondSession.completed();
 

--- a/tests/test_store_jobs_overview_domain.py
+++ b/tests/test_store_jobs_overview_domain.py
@@ -162,9 +162,13 @@ class JobOverviewDomainTests(unittest.TestCase):
             self.assertEqual(noop["action"], "noop")
             self.assertEqual(before, [snapshot_tree(store.root) for store in stores])
         self.assertEqual(write.call_count, 2)
-        trashed = self.both(stores, lambda store: store.trash_job(
-            created["job"]["id"], created["job"]["revision"]
-        ))
+        # Both implementations must see the same wall clock, even if execution
+        # crosses a second boundary. The injected coordinator clock is separate.
+        with mock.patch.object(self.facade, "utc_now", return_value="2026-09-04T18:00:01Z"):
+            trashed = self.both(stores, lambda store: store.trash_job(
+                created["job"]["id"], created["job"]["revision"]
+            ))
+        self.assertEqual(trashed["deletedAt"], "2026-09-04T18:00:01Z")
         self.assertEqual(trashed["id"], created["job"]["id"])
         self.assertEqual(
             self.both_error(stores, lambda store: store.intake_task_job({

--- a/tests_js/unified_task_spine_oracle.test.mjs
+++ b/tests_js/unified_task_spine_oracle.test.mjs
@@ -20,7 +20,7 @@ test("oracle failures expose only allowlisted diagnostic stages", () => {
     error: "oracle_failed",
     stage: "answer_save",
   });
-  for (const stage of ["answer_save_response", "answer_save_closed", "answer_save_activity", "answer_save_draft", "answer_save_focus_wait"]) {
+  for (const stage of ["second_acquisition", "resume_continuity", "review_fixture", "review_handoff", "answer_save_response", "answer_save_closed", "answer_save_activity", "answer_save_draft", "answer_save_focus_wait"]) {
     sensitive.stage = stage;
     assert.equal(publicFailureReport(sensitive).stage, stage);
   }

--- a/tests_js/workspace_automation.test.mjs
+++ b/tests_js/workspace_automation.test.mjs
@@ -8,7 +8,7 @@ import {
 
 test("automation UI describes reviewed ATS support without exposing live execution", async () => {
   const html = await readFile(join(REPO_ROOT, "companion", "workspace", "index.html"), "utf8");
-  assert.match(html, /Workday seam remains disabled/);
+  assert.match(html, /Workday account setup requires your separate approval each time/);
   assert.match(html, /Greenhouse applications need no account/);
   assert.doesNotMatch(html, /id="[^\"]*(?:execute|run-live|create-account)[^\"]*"/i);
 });

--- a/tests_js/workspace_browser_crud_trash_phase.mjs
+++ b/tests_js/workspace_browser_crud_trash_phase.mjs
@@ -22,7 +22,7 @@ export async function runBrowserCrudTrashShutdownPhase(context) {
 
     await openWorkspace(page, "trash");
     await page.locator("#trash-refresh").click();
-    await page.getByText("1 jobs · 1 resumes · 2 answers").waitFor();
+    await page.getByText("1 job · 1 resume · 2 answers").waitFor();
     const trashWorkspaceText = await page.locator("#trash-workspace").innerText();
     for (const privateValue of ["private.example", "private-trash-answer", "protected-private-answer", "private-trash-resume.txt"]) {
       assert.equal(trashWorkspaceText.includes(privateValue), false);

--- a/tests_js/workspace_desktop_feedback.test.mjs
+++ b/tests_js/workspace_desktop_feedback.test.mjs
@@ -39,6 +39,10 @@ test('desktop readiness refresh explains invalidation and final trash restore ke
     await page.locator('#trash-empty').waitFor();
     await page.waitForFunction(() => document.activeElement?.id === 'trash-refresh', null, { timeout: 3000 });
     await openWorkspace(page, 'answers');
+    await page.locator('#answer-view').selectOption('trash');
+    await page.getByRole('heading', { name: 'No answers in Trash', exact: true }).waitFor();
+    assert.match(await page.locator('#answers-empty').innerText(), /Choose Library/);
+    await page.locator('#answer-view').selectOption('accepted');
     await page.locator('#answer-search').fill('No matching synthetic answer');
     await page.getByRole('heading', { name: 'No matching answers', exact: true }).waitFor();
     await page.getByRole('button', { name: 'Clear filters', exact: true }).click();

--- a/tests_js/workspace_desktop_feedback.test.mjs
+++ b/tests_js/workspace_desktop_feedback.test.mjs
@@ -25,6 +25,27 @@ test('desktop readiness refresh explains invalidation and final trash restore ke
     await page.waitForResponse(response => response.url().endsWith('/api/state'));
     await page.getByText('Workspace data refreshed. Run ready check again to see current results.', { exact: true }).waitFor({ timeout: 3000 });
     assert.equal(await page.locator('#mark-ready').isVisible(), false);
+    let releaseRefresh;
+    const gate = new Promise(resolve => { releaseRefresh = resolve; });
+    await page.route('**/api/state', async route => { await gate; await route.continue(); });
+    try {
+      const requested = page.waitForRequest(request => request.url().endsWith('/api/state'));
+      await page.evaluate(() => document.querySelector('#refresh').click());
+      await requested;
+      await dialog.getByRole('button', { name: 'Run ready check', exact: true }).click();
+      await page.getByText('Workspace data is refreshing. Run ready check again when it finishes.', { exact: true }).waitFor();
+      const refreshed = page.waitForResponse(response => response.url().endsWith('/api/state'));
+      releaseRefresh();
+      await refreshed;
+    } finally {
+      releaseRefresh();
+      await page.unroute('**/api/state');
+    }
+    await dialog.getByRole('button', { name: 'Run ready check', exact: true }).click();
+    await page.locator('#preflight-panel').waitFor();
+    assert.equal(await page.locator('#form-error').isVisible(), false);
+    assert.equal(await page.locator('#ready-check-status').textContent(), '');
+
     page.once('dialog', dialog => dialog.accept());
     await page.locator('#trash-job').click();
     await dialog.waitFor({ state: 'hidden' });
@@ -41,7 +62,7 @@ test('desktop readiness refresh explains invalidation and final trash restore ke
     await openWorkspace(page, 'answers');
     await page.locator('#answer-view').selectOption('trash');
     await page.getByRole('heading', { name: 'No answers in Trash', exact: true }).waitFor();
-    assert.match(await page.locator('#answers-empty').innerText(), /Choose Library/);
+    assert.match(await page.locator('#answers-empty').innerText(), /previous view.*Library, Observed inbox, or Declined/);
     await page.locator('#answer-view').selectOption('accepted');
     await page.locator('#answer-search').fill('No matching synthetic answer');
     await page.getByRole('heading', { name: 'No matching answers', exact: true }).waitFor();

--- a/tests_js/workspace_desktop_feedback.test.mjs
+++ b/tests_js/workspace_desktop_feedback.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { openWorkspace } from './workspace_menu_support.mjs';
+import { createOwnerBetaScenario, startOwnerBetaScenario, cleanupOwnerBetaScenario } from './workspace_owner_beta_scenario_support.mjs';
+
+test('desktop readiness refresh explains invalidation and final trash restore keeps focus', { timeout: 60_000 }, async () => {
+  const context = await createOwnerBetaScenario();
+  try {
+    await startOwnerBetaScenario(context);
+    const page = await context.browser.newPage({ viewport: { width: 1280, height: 900 }, reducedMotion: 'reduce' });
+    await page.goto(context.running.startup.url);
+    await openWorkspace(page, 'jobs');
+    await page.getByRole('button', { name: 'New job', exact: true }).click();
+    const dialog = page.locator('#job-dialog');
+    await dialog.getByLabel('Job URL', { exact: true }).fill('https://example.invalid/jobs/feedback');
+    await dialog.getByLabel('Role', { exact: true }).fill('Feedback Engineer');
+    await dialog.getByRole('button', { name: 'Save job', exact: true }).click();
+    await dialog.waitFor({ state: 'hidden' });
+    await page.getByRole('button', { name: /Feedback Engineer/ }).click();
+    await dialog.getByRole('button', { name: 'Run ready check', exact: true }).click();
+    await page.locator('#preflight-panel').waitFor();
+    await page.screenshot({ path: '/tmp/desktop-feedback-readiness.png' });
+    // A canonical refresh invalidates proof, but must leave an explanation.
+    await page.evaluate(() => document.querySelector('#refresh').click());
+    await page.waitForResponse(response => response.url().endsWith('/api/state'));
+    await page.getByText('Workspace data refreshed. Run ready check again to see current results.', { exact: true }).waitFor({ timeout: 3000 });
+    assert.equal(await page.locator('#mark-ready').isVisible(), false);
+    page.once('dialog', dialog => dialog.accept());
+    await page.locator('#trash-job').click();
+    await dialog.waitFor({ state: 'hidden' });
+    await openWorkspace(page, 'trash');
+    await page.getByRole('button', { name: 'Restore', exact: true }).click();
+    await page.locator('#trash-empty').waitFor();
+    await page.waitForFunction(() => document.activeElement?.id === 'trash-refresh', null, { timeout: 3000 });
+    const answer = await context.cli('answer-put', [], { question: 'Synthetic restore?', state: 'confirmed', value: 'Synthetic' });
+    await context.cli('answer-trash', ['--key', answer.key, '--expected-revision', String(answer.revision)]);
+    await page.locator('#trash-refresh').click();
+    await page.getByRole('button', { name: 'Restore', exact: true }).click();
+    await page.locator('#trash-empty').waitFor();
+    await page.waitForFunction(() => document.activeElement?.id === 'trash-refresh', null, { timeout: 3000 });
+    await openWorkspace(page, 'answers');
+    await page.locator('#answer-search').fill('No matching synthetic answer');
+    await page.getByRole('heading', { name: 'No matching answers', exact: true }).waitFor();
+    await page.getByRole('button', { name: 'Clear filters', exact: true }).click();
+    assert.equal(await page.locator('#answer-search').inputValue(), '');
+    await openWorkspace(page, 'automation');
+    assert.equal(await page.locator('#trusted-fill-form').isVisible(), false);
+    await page.getByText('Review agent-provided permission details', { exact: true }).click();
+    assert.equal(await page.locator('#trusted-fill-form').isVisible(), true);
+    await page.screenshot({ path: '/tmp/desktop-feedback-automation.png' });
+  } finally { await cleanupOwnerBetaScenario(context); }
+});

--- a/tests_js/workspace_desktop_regressions.test.mjs
+++ b/tests_js/workspace_desktop_regressions.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { openWorkspace } from './workspace_menu_support.mjs';
+import { createOwnerBetaScenario, startOwnerBetaScenario, cleanupOwnerBetaScenario } from './workspace_owner_beta_scenario_support.mjs';
+
+test('desktop facts can save then restore work and skills without a false conflict', { timeout: 60_000 }, async () => {
+  const context = await createOwnerBetaScenario();
+  try {
+    await context.cli('profile-replace', ['--expected-revision', '0', '--source', 'resume'], {
+      firstName: 'Synthetic', skills: ['Python'],
+      workHistory: [{ title: 'Engineer', company: 'Example', description: 'Original' }],
+    });
+    await startOwnerBetaScenario(context);
+    const page = await context.browser.newPage({ viewport: { width: 1280, height: 800 } });
+    await page.goto(context.running.startup.url);
+    await openWorkspace(page, 'facts');
+    for (const [description, skills, revision] of [['Updated', 'Python\nJavaScript', 2], ['Original', 'Python', 3]]) {
+      await page.getByRole('tab', { name: 'Work history', exact: true }).click();
+      await page.getByLabel('Description, item 1', { exact: true }).fill(description);
+      await page.getByRole('tab', { name: 'Skills', exact: true }).click();
+      await page.locator('[data-path="/skills"]').fill(skills);
+      await openWorkspace(page, 'answers');
+      await openWorkspace(page, 'facts');
+      if (revision === 2) await page.keyboard.press('ControlOrMeta+s');
+      else await page.locator('#facts-save').click();
+      await page.waitForFunction(() => !document.querySelector('#facts-save').disabled);
+      assert.equal(await page.locator('#facts-conflict').isVisible(), false, `unexpected conflict saving revision ${revision}`);
+      const saved = await context.cli('profile-inspect');
+      assert.equal(saved.revision, revision);
+      assert.equal(saved.profile.workHistory[0].description, description);
+      assert.deepEqual(saved.profile.skills, skills.split('\n'));
+    }
+    await page.getByRole('tab', { name: 'Work history', exact: true }).click();
+    await page.getByRole('button', { name: 'Add promotion after position 1', exact: true }).click();
+    await page.getByLabel('Title, item 2', { exact: true }).fill('Senior Engineer');
+    await page.getByLabel('Description, item 2', { exact: true }).fill('Promoted');
+    page.once('dialog', dialog => dialog.accept());
+    await page.getByRole('button', { name: 'Copy description from position 2 to other roles at this company', exact: true }).click();
+    await page.locator('#facts-save').click();
+    await page.waitForFunction(() => !document.querySelector('#facts-save').disabled);
+    assert.equal(await page.locator('#facts-conflict').isVisible(), false);
+    const promoted = await context.cli('profile-inspect');
+    assert.equal(promoted.revision, 4);
+    assert.equal(promoted.profile.workHistory.length, 2);
+    assert.ok(promoted.profile.workHistory.every(role => role.description === 'Promoted'));
+    await page.getByLabel('Description, item 1', { exact: true }).fill('My draft');
+    const concurrent = structuredClone(promoted.profile.workHistory);
+    concurrent[0].description = 'Concurrent writer';
+    await context.cli('profile-patch', ['--expected-revision', '4', '--source', 'user'], { workHistory: concurrent });
+    await page.locator('#facts-save').click();
+    await page.locator('#facts-conflict').waitFor();
+    assert.equal(await page.getByLabel('Description, item 1', { exact: true }).inputValue(), 'My draft');
+    const conflicted = await context.cli('profile-inspect');
+    assert.equal(conflicted.revision, 5);
+    assert.equal(conflicted.profile.workHistory[0].description, 'Concurrent writer');
+  } finally { await cleanupOwnerBetaScenario(context); }
+});
+
+test('desktop TXT preview restores focus after Escape', { timeout: 60_000 }, async () => {
+  const context = await createOwnerBetaScenario();
+  try {
+    await startOwnerBetaScenario(context);
+    const page = await context.browser.newPage({ viewport: { width: 1280, height: 800 } });
+    await page.goto(context.running.startup.url);
+    await openWorkspace(page, 'resumes');
+    await page.locator('#resume-import input[name=label]').fill('Synthetic TXT');
+    await page.locator('#resume-import input[type=file]').setInputFiles({ name: 'synthetic.txt', mimeType: 'text/plain', buffer: Buffer.from('Synthetic resume') });
+    await page.getByRole('button', { name: 'Import resume', exact: true }).click();
+    const opener = page.getByRole('button', { name: 'Preview text', exact: true });
+    await opener.click();
+    await page.locator('#preview-dialog').waitFor();
+    await page.keyboard.press('Escape');
+    await page.locator('#preview-dialog').waitFor({ state: 'hidden' });
+    await page.waitForFunction(() => document.activeElement?.matches('[data-resume-preview]'), { }, { timeout: 3000 });
+    assert.equal(await opener.evaluate(node => node === document.activeElement), true);
+    await opener.click();
+    await page.locator('#preview-dialog').waitFor();
+    const original = await opener.elementHandle();
+    await page.evaluate(() => document.querySelector('#resumes-refresh').click());
+    await page.waitForFunction(node => !node.isConnected, original);
+    await page.getByRole('button', { name: 'Close preview', exact: true }).click();
+    await page.waitForFunction(() => document.activeElement?.matches('[data-resume-preview]'));
+    assert.equal(await opener.evaluate(node => node === document.activeElement), true);
+    await page.getByRole('button', { name: 'Manage', exact: true }).click();
+    const details = page.locator('#resume-dialog');
+    await details.locator('input[name=label]').fill('Unsaved label');
+    await details.getByRole('button', { name: 'Preview text', exact: true }).click();
+    await page.locator('#preview-dialog').waitFor();
+    await page.keyboard.press('Escape');
+    await page.waitForFunction(() => document.activeElement?.id === 'resume-content');
+    assert.equal(await details.locator('input[name=label]').inputValue(), 'Unsaved label');
+
+  } finally { await cleanupOwnerBetaScenario(context); }
+});
+
+test('conflict comparison ignores object order but preserves real collection changes', async () => {
+  const { equalJson, conflictingPaths } = await import('../companion/workspace/lib/helpers.js');
+  const original = { company: 'Example', description: 'Original', details: { z: 1, a: 2 } };
+  const reordered = { details: { a: 2, z: 1 }, description: 'Original', company: 'Example' };
+  const base = new Map([['/workHistory', [original]]]);
+  const drafts = new Map([['/workHistory', [{ ...original, description: 'Mine' }]]]);
+  assert.deepEqual(conflictingPaths(base, { workHistory: [reordered] }, drafts), []);
+  assert.deepEqual(conflictingPaths(base, { workHistory: [{ ...reordered, description: 'Agent update' }] }, drafts), ['/workHistory']);
+  assert.equal(equalJson([original, reordered], [reordered, original]), true);
+  assert.equal(equalJson([1, 2], [2, 1]), false);
+  assert.equal(equalJson(null, undefined), false);
+  assert.equal(equalJson({}, { extra: null }), false);
+});

--- a/tests_js/workspace_helpers.test.mjs
+++ b/tests_js/workspace_helpers.test.mjs
@@ -165,7 +165,7 @@ test("resume tag drafts are trimmed without inventing durable browser state", ()
 test("resume assignment copy uses canonical projection counts", () => {
   assert.equal(
     resumeAssignmentText({ assignedJobCount: 2, implicitJobCount: 1 }),
-    "2 explicitly assigned active jobs; 1 active job use this default.",
+    "2 explicitly assigned active jobs; 1 active job uses this default.",
   );
   assert.equal(resumeAssignmentText({ assignedJobCount: 0, implicitJobCount: 0 }), "0 explicitly assigned active jobs.");
 });

--- a/tests_js/workspace_input_focus_races.test.mjs
+++ b/tests_js/workspace_input_focus_races.test.mjs
@@ -60,3 +60,73 @@ test('answer dialog opening cannot redirect subsequent value input into its ques
     assert.equal(answer?.value, 'Synthetic focus value');
   } finally { await cleanupOwnerBetaScenario(context); }
 });
+
+for (const lateFailure of [false, true]) {
+  test(`older automation ${lateFailure ? 'failure' : 'refresh'} cannot replace an employer override draft`, { timeout: 30_000 }, async () => {
+    const context = await createOwnerBetaScenario();
+    let release;
+    const gate = new Promise(resolve => { release = resolve; });
+    try {
+      await startOwnerBetaScenario(context);
+      const page = await context.browser.newPage();
+      await page.addInitScript(() => {
+        const fetch = globalThis.fetch;
+        let firstAutomation = true;
+        globalThis.fetch = async (...args) => {
+          const first = firstAutomation && String(args[0]).endsWith('/api/automation');
+          if (first) firstAutomation = false;
+          const response = await fetch(...args);
+          if (first) {
+            const json = response.json.bind(response);
+            response.json = async () => {
+              const payload = await json();
+              setTimeout(() => { globalThis.initialAutomationConsumed = true; }, 0);
+              return payload;
+            };
+          }
+          return response;
+        };
+      });
+      await page.goto(context.running.startup.url);
+      let first = true;
+      let delivered;
+      const delivery = new Promise(resolve => { delivered = resolve; });
+      await page.route('**/api/automation', async route => {
+        if (!first) return route.continue();
+        first = false;
+        await gate;
+        if (lateFailure) {
+          await route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: { message: 'Obsolete load failure' } }) });
+        } else {
+          const response = await route.fetch();
+          await route.fulfill({ response });
+        }
+        delivered();
+      });
+      await openWorkspace(page, 'automation');
+      await page.getByLabel('Exact employer portal URL').fill('https://acme.wd5.myworkdayjobs.com/en-US/jobs/one');
+      await page.getByLabel('Optional signup email override').fill('realm@example.com');
+      await page.getByRole('button', { name: 'Add employer portal', exact: true }).click();
+      const input = page.getByRole('form', { name: /Edit signup email override/ }).getByLabel('Signup email override');
+      await input.fill('replacement@example.com');
+      // A late initial load must neither detach the draft nor reset its value.
+      await input.evaluate(node => { globalThis.originalOverrideInput = node; });
+      release();
+      await delivery;
+      // Wait for the initial refresh continuation, not merely response headers.
+      await page.waitForFunction(() => globalThis.initialAutomationConsumed);
+      assert.equal(await input.inputValue(), 'replacement@example.com');
+      assert.equal(await input.evaluate(node => node === globalThis.originalOverrideInput), true);
+      assert.equal(await page.locator('#automation-error').isVisible(), false);
+      await page.getByRole('button', { name: 'Save override', exact: true }).click();
+      await page.getByText(/revision 2 · email override configured/).waitFor();
+      const account = (await context.cli('employer-account-list'))[0];
+      assert.equal(account.signupEmailOverrideConfigured, true);
+      assert.equal(account.revision, 2);
+      assert.equal(await page.locator('#automation-error').isVisible(), false);
+    } finally {
+      release();
+      await cleanupOwnerBetaScenario(context);
+    }
+  });
+}

--- a/tests_js/workspace_owner_beta_overview_phases.mjs
+++ b/tests_js/workspace_owner_beta_overview_phases.mjs
@@ -24,7 +24,7 @@ export async function runOwnerBetaOverviewAndPreflightPhase(context) {
     await page.getByLabel("Exact employer portal URL").fill("https://acme.wd5.myworkdayjobs.com/en-US/jobs/one");
     await page.getByLabel("Optional signup email override").fill("realm@example.com");
     await page.getByRole("button", { name: "Add employer portal" }).click();
-    const overrideForm = page.getByRole("form", { name: /Edit signup email override for Workday realm/ });
+    const overrideForm = page.getByRole("form", { name: /Edit signup email override for Workday portal/ });
     await overrideForm.waitFor();
     await overrideForm.getByLabel("Signup email override").fill("replacement@example.com");
     await overrideForm.getByRole("button", { name: "Save override" }).click();

--- a/tests_js/workspace_owner_beta_overview_phases.mjs
+++ b/tests_js/workspace_owner_beta_overview_phases.mjs
@@ -23,7 +23,7 @@ export async function runOwnerBetaOverviewAndPreflightPhase(context) {
     await page.locator("#automation-title").waitFor();
     await page.getByLabel("Exact employer portal URL").fill("https://acme.wd5.myworkdayjobs.com/en-US/jobs/one");
     await page.getByLabel("Optional signup email override").fill("realm@example.com");
-    await page.getByRole("button", { name: "Add resolved realm" }).click();
+    await page.getByRole("button", { name: "Add employer portal" }).click();
     const overrideForm = page.getByRole("form", { name: /Edit signup email override for Workday realm/ });
     await overrideForm.waitFor();
     await overrideForm.getByLabel("Signup email override").fill("replacement@example.com");

--- a/tests_js/workspace_readiness_poll.test.mjs
+++ b/tests_js/workspace_readiness_poll.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { writeFile, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { openWorkspace } from './workspace_menu_support.mjs';
+import { minimalSyntheticPdf } from './workspace_test_support.mjs';
+import { createOwnerBetaScenario, startOwnerBetaScenario, cleanupOwnerBetaScenario } from './workspace_owner_beta_scenario_support.mjs';
+
+test('poll revalidates a Saved job without removing its result or scrolling, and revokes changed dependencies', { timeout: 60_000 }, async () => {
+  const context = await createOwnerBetaScenario();
+  try {
+    await startOwnerBetaScenario(context);
+    const profile = await context.cli('profile-inspect');
+    await context.cli('profile-replace', ['--expected-revision', String(profile.revision), '--source', 'user'], { firstName: 'Synthetic' });
+    const path = join(context.temporary, 'synthetic.pdf');
+    await writeFile(path, minimalSyntheticPdf());
+    const resume = await context.cli('resume-create', [], { id: 'poll-resume', label: 'Synthetic', path });
+    await context.cli('job-create', [], { id: 'poll-job', url: 'https://example.invalid/jobs/poll', role: 'Poll Engineer' });
+    const page = await context.browser.newPage();
+    await page.addInitScript(() => {
+      globalThis.setInterval = (callback, delay) => {
+        if (delay === 4000) globalThis.pollWorkspace = callback;
+        return 1;
+      };
+      globalThis.resultScrolls = 0;
+      const original = Element.prototype.scrollIntoView;
+      Element.prototype.scrollIntoView = function (...args) {
+        if (this.id === 'preflight-panel') globalThis.resultScrolls++;
+        return original.apply(this, args);
+      };
+    });
+    await page.goto(context.running.startup.url);
+    await openWorkspace(page, 'jobs');
+    await page.getByRole('button', { name: /Poll Engineer/ }).click();
+    await page.getByRole('button', { name: 'Run ready check', exact: true }).click();
+    const mark = page.locator('#mark-ready');
+    await mark.waitFor();
+    assert.equal(await mark.isEnabled(), true);
+    const scrolls = await page.evaluate(() => globalThis.resultScrolls);
+    let release;
+    const gate = new Promise(resolve => { release = resolve; });
+    await page.route('**/api/state', async route => { await gate; await route.continue(); });
+    try {
+      const requested = page.waitForRequest(request => request.url().endsWith('/api/state'));
+      await page.evaluate(() => { globalThis.pendingPoll = globalThis.pollWorkspace(); });
+      await requested;
+      assert.equal(await page.locator('#preflight-panel').isVisible(), true);
+      assert.equal(await mark.isVisible(), true);
+      assert.equal(await mark.isDisabled(), true);
+      release();
+      await page.evaluate(() => globalThis.pendingPoll);
+    } finally { release(); await page.unroute('**/api/state'); }
+    assert.equal(await mark.isEnabled(), true);
+    assert.equal(await mark.isVisible(), true);
+    await page.evaluate(() => globalThis.pollWorkspace());
+    assert.equal(await mark.isEnabled(), true);
+    assert.equal(await page.evaluate(() => globalThis.resultScrolls), scrolls);
+    await page.route('**/api/state', route => route.abort());
+    await page.evaluate(() => globalThis.pollWorkspace());
+    assert.equal(await mark.isVisible(), true);
+    assert.equal(await mark.isDisabled(), true);
+    await page.getByText('Could not verify current data. Run ready check after reconnecting.', { exact: true }).waitFor();
+    await page.unroute('**/api/state');
+    await page.evaluate(() => globalThis.pollWorkspace());
+    assert.equal(await mark.isEnabled(), true);
+    // Job revision remains unchanged; only the managed file disappears.
+    const resolved = await context.cli('resume-resolve', ['--id', resume.id]);
+    await unlink(resolved.path);
+    await page.evaluate(() => globalThis.pollWorkspace());
+    assert.equal(await mark.isVisible(), false);
+    await page.getByText('The resume file cannot be found', { exact: true }).waitFor();
+    assert.equal((await context.cli('job-get', ['--id', 'poll-job'])).revision, 1);
+  } finally { await cleanupOwnerBetaScenario(context); }
+});


### PR DESCRIPTION
The Companion keeps readiness results available across polling, explains pending or invalidated checks, and preserves draft/focus behavior during recovery. Facts use semantic comparisons to avoid false conflicts; TXT preview and Trash restore return focus appropriately; filtering, date guidance, and Automation copy are clearer. Stale revision guards, manual submission, and URL redaction remain enforced.

This includes the merged shutdown and synchronous focus fixes from PR #72. An additional controlled regression demonstrates that a late initial Automation response can erase an employer override draft after a newer refresh. Superseded successes and errors are now ignored. The Store equivalence test fixes its trash-operation wall clock so a second boundary cannot create false timestamp differences; runtime timestamp behavior is unchanged.

Validation: focused browser regressions and Store domain tests pass, as do package/release checks with isolated installs and browser/CLI walkthroughs. All 11 affected suites and both release suites passed with these changes. The four focused browser regressions were rerun after strengthening the obsolete-error assertion. CI is running on 47579e849a6f59640c5a6af2711177b16c4ac8ce. Independent review previously confirmed fixes for stale retry feedback and answer-restoration guidance. Native codex review was unavailable because the installed CLI did not support its configured model.

Independent desktop QA covers historical candidate 5ccf85be, including readiness polling and recovery. It is not final combined-candidate acceptance. Fresh installed-plugin calling-agent acceptance is owner-skipped/not completed; DOCX browser download confirmation remains unqualified. Prior opaque CI timeouts are not all attributed to the newly reproduced race.

Targets codex/python-release and includes PR #73. Release integration to main and publication remain separate.
