### PR TITLE
Add native single-job task intake

### DIFF
--- a/config/migration/cli-native-task-intake-surfaces.json
+++ b/config/migration/cli-native-task-intake-surfaces.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:task-intake",
+      "kind": "cli",
+      "command": "task-intake",
+      "node": "JOB",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-task-intake.ts",
+        "src/workspace-core/task-intake.ts",
+        "src/workspace-core/task-job-projection.ts",
+        "src/workspace-core/job-upsert-plan.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -126,6 +126,10 @@
       "sha256": "23b9fd1e5a29720b5b4143d59a9767dfb9ee98a00e09ef3962f9112c9cda4e5c"
     },
     {
+      "path": "cli-native-task-intake-surfaces.json",
+      "sha256": "f02dfdea3805c56058502e394c9c8fbcb320bb7001e925c5639d664f0e7b28df"
+    },
+    {
       "path": "cli-root-01-surfaces.json",
       "sha256": "12f7e2a79b07b0f67b299487ac7d0a06d967a0d373e3da336a91b06fc040695a"
     },
@@ -323,7 +327,7 @@
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "7bc32c04ed6daba6bb8b0b5c74d3b12ec353cc4106916d47ab8631f266029c7e"
+      "sha256": "c324551966506da7d3105d6bef9a27ad82083f2b1abaf9255cf824f55b59f76b"
     },
     {
       "path": "source-catalog-native-legacy-jobs.json",
@@ -335,11 +339,15 @@
     },
     {
       "path": "source-catalog-native-projections.json",
-      "sha256": "9547436e8a2bdb0556915f4e87687aa65f3bee908312b3f461301476e9bcc421"
+      "sha256": "a78ee13b41a59fbe409c647d88721f62bf986db60bcdd94bc71e938c88456488"
     },
     {
       "path": "source-catalog-native-resumes.json",
       "sha256": "29dd7f8508a7d203df336e2dad4c4b643daf4c4441f4cbee96d4ea0f5d15cc17"
+    },
+    {
+      "path": "source-catalog-native-task-intake.json",
+      "sha256": "ecc9ad11a7d4d3cf6258e0b93ddbac8224a1fd7207af36542a1a4d533b164973"
     },
     {
       "path": "source-catalog-s01.json",

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "1cf062245626d508844e7edfef0f176e4ff97619a345da9d475761276b85afd2",
+      "sha256": "40d1c71beffced194a6484d69e2c5cacc64f678b274607fac72ee9b88ad5bef7",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "b04a04c0a883b3f30831585b24cedfa7d7edad9f0f48bfe28770f9f16ac02aa7",
+      "sha256": "dfa51598fcf41132fa296391e81a33079873a1d8236d560d95f837a7f5d668ef",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-projections.json
+++ b/config/migration/source-catalog-native-projections.json
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/workspace-core/workspace-projections.js",
-      "sha256": "b86a78120ffd7b45c9bca0ce47b10b42af59b7a55acfc3f1e33c323f8e5809b1",
+      "sha256": "eeea048d2440ba2fd4dfaeb5b00edafaf1578bf65c9d7199a61dd1028eafddf4",
       "classification": "unreviewed"
     },
     {
@@ -48,7 +48,7 @@
     },
     {
       "path": "src/workspace-core/workspace-projections.ts",
-      "sha256": "718afe784743c9a107ce781469ed90723af22ecae1f032014ce85a5a540876f5",
+      "sha256": "843b95fdf2061c0fbe6739fd2c85c1392eccc8ddda4e6dcf928463699a22a494",
       "classification": "unreviewed"
     }
   ]

--- a/config/migration/source-catalog-native-task-intake.json
+++ b/config/migration/source-catalog-native-task-intake.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "runtime/cli/native-task-intake.js",
+      "sha256": "1aedd2f8ca1f4d5a5594485d7f9151ab6cf88133ff63be35709e1361859b08d3",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/task-intake.js",
+      "sha256": "8b461b1774ebb08e1652e5898e41e17481e294fb1ed8476266b1434424995c84",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/task-job-projection.js",
+      "sha256": "57d48d38ae68395f64bb4e2422efeab140e9de2b76779f4dffae8b07d3166a42",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-task-intake.ts",
+      "sha256": "3e9035101b418337a1366fe8dd4556a8d4757e662a13f01165401b5c93c9a924",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/task-intake.ts",
+      "sha256": "cfd10e85ff248df5e96f1c89f85ff32a485c12cb58d781912456c378369475d3",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/task-job-projection.ts",
+      "sha256": "7bd65a09c81cc6700b7bebcc00887d3f9c972994c350f409a59bfc4deee3fc61",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/docs/native-jobs-fixture.md
+++ b/docs/native-jobs-fixture.md
@@ -13,7 +13,8 @@ Facts/profile operations, [active claims](native-claims-fixture.md),
 [workspace projections](native-projections-fixture.md), and
 [job status transitions](native-job-transitions-fixture.md),
 [CLI job upsert preview/commit](native-job-upsert-fixture.md), and
-[CLI legacy job import](native-legacy-jobs-fixture.md) are also available. Other
+[CLI legacy job import](native-legacy-jobs-fixture.md) and
+[CLI single-job task intake](native-task-intake-fixture.md) are also available. Other
 workflows return `unsupported_native_workflow`; they never fall back to Python.
 
 ## Run against a new synthetic root

--- a/docs/native-legacy-jobs-fixture.md
+++ b/docs/native-legacy-jobs-fixture.md
@@ -103,5 +103,6 @@ separately. Browser coverage verifies that CLI-imported records are visible in
 Companion; it does not add a browser import workflow. Passing checks and CI are
 recorded with the change's validation evidence.
 
-Task intake, general writer activation and installable Python-free packaging
-remain later work.
+[Single-job task intake](native-task-intake-fixture.md) is also available through
+the native fixture CLI. General writer activation and installable Python-free
+packaging remain later work.

--- a/docs/native-task-intake-fixture.md
+++ b/docs/native-task-intake-fixture.md
@@ -1,0 +1,68 @@
+# Native single-job task intake fixture
+
+The opt-in version 9 native fixture supports `task-intake` through its CLI.
+It atomically resolves one incoming job to a canonical active record using the
+same identity and provenance rules as [job upsert](native-job-upsert-fixture.md).
+The operation creates, updates or returns an unchanged job while holding the
+shared Store lock. There is no separate intake preview or confirmation token.
+Captured jobs appear in Companion Jobs after Refresh or reload; this adds no
+new HTTP endpoint or browser intake form.
+
+## Capture a synthetic job
+
+Initialize a new synthetic Store and build the native addon as described in
+[Native Jobs fixture](native-jobs-fixture.md). Keep Python writers and real
+applicant data away from this fixture. Create a JSON file containing one job
+object, rather than the `jobs` array wrapper used by batch upsert:
+
+```json
+{"url":"https://example.invalid/task-fixture","role":"Synthetic engineer","company":"Fixture company"}
+```
+
+```sh
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node task-intake --input /absolute/synthetic-job.json
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node task-intake --input /absolute/synthetic-job.json --origin human
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node task-snapshot
+```
+
+`--input -` reads JSON from stdin. Origin defaults to `agent`; only `human` and
+`agent` are accepted. Agent intake preserves human-authored fields. Human intake
+may replace the supplied editable fields according to the existing upsert rules.
+Intake does not select the job as ready, acquire a claim or submit an application.
+The existing `task-select` operation still requires explicit owner confirmation
+and the exact revision.
+
+## Result and failure behavior
+
+The fixture CLI returns the service result directly: an object with `action`
+(`create`, `update` or `noop`) and `job`. The job is the same restricted projection
+used in `task-snapshot`: identity, role, company, location, workplace and employment
+types, status, priority, revision and timestamps when present. It excludes URL,
+description, notes, provenance and claim credentials. This narrow native result
+does not replace the full compatibility task CLI envelope or its handoff workflow.
+
+Repeated equivalent intake converges on the same job and returns `noop` without
+rewriting Jobs or incrementing its revision. Conflicting identities, deleted
+matches and invalid incoming jobs fail as `task intake conflict` or
+`task intake invalid`. They do not partially apply the incoming job. Invalid
+origins and malformed JSON are rejected at their existing validation boundaries.
+
+As in the Python intake operation, an active claim does not prohibit ingestion
+updates. Intake preserves status and does not alter coordinator claims, sessions
+or application history. Ordinary editing retains its existing claim restrictions.
+
+## Fixture boundary and validation
+
+The existing version 9 marker, inventory validation and recovery rules apply.
+Intake does not adopt a legacy Store, activate general native writes or change
+the installed launcher default. Use a newly initialized fixture; no marker
+upgrade or new journal is introduced.
+
+Differential tests compare the native result and persisted Jobs against an
+independent Python fixture. The production browser walkthrough captures through
+the native CLI with Python absent from PATH, checks visibility in Companion,
+preserves a human company edit on subsequent agent intake, verifies no-op
+convergence and compares redacted intake output with the task snapshot.
+
+General task lifecycle parity, writer handoff and installable Python-free
+packaging remain later work.

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,3 +1,4 @@
+import { taskIntakeCommands, runTaskIntakeCommand } from './native-task-intake.js';
 import { legacyJobCommands, runLegacyJobCommand } from './native-legacy-jobs.js';
 import { jobUpsertCommands, runJobUpsertCommand } from './native-job-upsert.js';
 import { claimCommands, runClaimCommand } from './native-claims.js';
@@ -44,6 +45,7 @@ export async function runJobsCli(args, input) {
         }
     }
     const fields = {
+        ...taskIntakeCommands,
         ...legacyJobCommands,
         ...jobUpsertCommands,
         ...jobTransitionCommands,
@@ -84,10 +86,12 @@ export async function runJobsCli(args, input) {
         // Extraction candidates permit 256 KiB after normalization. Allow JSON
         // escaping and formatting overhead while keeping stdin bounded.
         // Bulk upsert accepts the same input domain through stdin and files, as Python does.
-        const limit = Object.hasOwn(jobUpsertCommands, command) ? Infinity
+        const limit = (Object.hasOwn(jobUpsertCommands, command) || Object.hasOwn(taskIntakeCommands, command)) ? Infinity
             : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command) ? 2 * 1024 * 1024 : 65536;
         return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
     };
+    if (Object.hasOwn(taskIntakeCommands, command))
+        return serialize(await runTaskIntakeCommand(repository, options, payload));
     if (Object.hasOwn(legacyJobCommands, command))
         return serialize(await runLegacyJobCommand(command, repository, options, selected));
     if (Object.hasOwn(jobUpsertCommands, command))

--- a/runtime/cli/native-task-intake.js
+++ b/runtime/cli/native-task-intake.js
@@ -1,0 +1,7 @@
+import { TaskIntakeService } from '../workspace-core/task-intake.js';
+export const taskIntakeCommands = {
+    'task-intake': ['--input', '--origin'],
+};
+export async function runTaskIntakeCommand(repository, options, payload) {
+    return new TaskIntakeService(repository).intake(await payload(), options.get('--origin'));
+}

--- a/runtime/workspace-core/task-intake.js
+++ b/runtime/workspace-core/task-intake.js
@@ -1,0 +1,35 @@
+import { get, object, set, string, text, fromJSON, JobsError } from '../contracts/workspace/values.js';
+import { origin } from './job-provenance.js';
+import { planJobUpsert } from './job-upsert-plan.js';
+import { taskJobProjection } from './task-job-projection.js';
+/** Resolve one canonical job under the same lock that protects ingestion writes. */
+export class TaskIntakeService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    async intake(incoming, author = 'agent') {
+        const by = origin(author);
+        return this.repository.upsertTransaction(async (transaction) => {
+            const planned = planJobUpsert(transaction.document, [incoming], by, this.now());
+            if (planned.decisions.length !== 1)
+                throw new JobsError('task intake did not resolve exactly one job');
+            const decision = planned.decisions[0], action = string(get(decision, 'action'));
+            if (action === 'conflict' || action === 'invalid')
+                throw new JobsError(`task intake ${action}`);
+            const id = string(get(decision, 'id'));
+            const record = id === null ? null : get(object(get(planned.document, 'jobs'), 'jobs'), id);
+            if (record === null || get(object(record, 'job'), 'deletedAt') !== null) {
+                throw new JobsError('task intake did not resolve one active job');
+            }
+            if (planned.changed)
+                await transaction.save(planned.document);
+            const result = object(fromJSON({}), 'task intake result');
+            set(result, 'action', text(action));
+            set(result, 'job', taskJobProjection(object(record, 'job')));
+            return result;
+        });
+    }
+}

--- a/runtime/workspace-core/task-job-projection.js
+++ b/runtime/workspace-core/task-job-projection.js
@@ -1,0 +1,11 @@
+import { get, has, set, object, fromJSON } from '../contracts/workspace/values.js';
+/** Shared task view excludes URLs, notes, provenance and claim credentials. */
+export function taskJobProjection(record) {
+    const result = object(fromJSON({}), 'task job');
+    for (const field of ['id', 'role', 'company', 'location', 'workplaceType', 'employmentType',
+        'status', 'priority', 'revision', 'createdAt', 'updatedAt']) {
+        if (has(record, field))
+            set(result, field, get(record, field));
+    }
+    return result;
+}

--- a/runtime/workspace-core/workspace-projections.js
+++ b/runtime/workspace-core/workspace-projections.js
@@ -1,3 +1,4 @@
+import { taskJobProjection } from './task-job-projection.js';
 import { createHash } from 'node:crypto';
 import { canonicalJson } from '../contracts/workspace/canonical-json.js';
 import { claimExpired } from '../contracts/workspace/claims.js';
@@ -40,7 +41,6 @@ function selectedClaim(tx, id) {
     const claim = object(raw, 'claim');
     return label(claim, 'jobId') === id ? claim : null;
 }
-const jobFields = ['id', 'role', 'company', 'location', 'workplaceType', 'employmentType', 'status', 'priority', 'revision', 'createdAt', 'updatedAt'];
 const sessionFields = ['attemptRevision', 'readiness', 'blockers', 'browserHandoff'];
 const reasons = [
     ['expired_agent_attempt', 'Expired agent attempt', 'Resume this attempt with the CLI claim-recover command for this job.'],
@@ -165,7 +165,7 @@ export class WorkspaceProjectionsService {
             const now = this.now(), overview = await overviewLocked(tx, now), attention = attentionLocked(tx, now);
             const jobs = active(records(tx.jobs, 'jobs')).sort((a, b) => comparePriority(a, b)
                 || compareText(label(a, 'createdAt'), label(b, 'createdAt')) || compareText(label(a, 'id'), label(b, 'id')))
-                .map(job => select(job, jobFields));
+                .map(job => taskJobProjection(job));
             const signatureInput = set(set(doc({}), 'overview', overview), 'jobs', jobs);
             set(signatureInput, 'attentionSignature', get(attention, 'snapshotSignature'));
             const result = doc({ snapshotSignature: digest(signatureInput) });

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,3 +1,4 @@
+import { taskIntakeCommands, runTaskIntakeCommand } from './native-task-intake.js';
 import { legacyJobCommands, runLegacyJobCommand } from './native-legacy-jobs.js';
 import { jobUpsertCommands, runJobUpsertCommand } from './native-job-upsert.js';
 import { claimCommands, runClaimCommand } from './native-claims.js';
@@ -39,6 +40,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     }
   }
   const fields: Record<string, string[]> = {
+    ...taskIntakeCommands,
     ...legacyJobCommands,
     ...jobUpsertCommands,
     ...jobTransitionCommands,
@@ -75,10 +77,11 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     // Extraction candidates permit 256 KiB after normalization. Allow JSON
     // escaping and formatting overhead while keeping stdin bounded.
     // Bulk upsert accepts the same input domain through stdin and files, as Python does.
-    const limit = Object.hasOwn(jobUpsertCommands, command!) ? Infinity
+    const limit = (Object.hasOwn(jobUpsertCommands, command!) || Object.hasOwn(taskIntakeCommands, command!)) ? Infinity
       : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command!) ? 2 * 1024 * 1024 : 65536;
     return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
   };
+  if (Object.hasOwn(taskIntakeCommands, command!)) return serialize(await runTaskIntakeCommand(repository, options, payload));
   if (Object.hasOwn(legacyJobCommands, command!)) return serialize(await runLegacyJobCommand(command!, repository, options, selected));
   if (Object.hasOwn(jobUpsertCommands, command!)) return serialize(await runJobUpsertCommand(command!, repository, options, payload));
   if (Object.hasOwn(jobTransitionCommands, command!)) return serialize(await runJobTransitionCommand(repository, options));

--- a/src/cli/native-task-intake.ts
+++ b/src/cli/native-task-intake.ts
@@ -1,0 +1,11 @@
+import { TaskIntakeService } from '../workspace-core/task-intake.js';
+import type { JobUpsertRepository } from '../workspace-core/job-upsert.js';
+import type { Value } from '../contracts/workspace/values.js';
+
+export const taskIntakeCommands: Record<string, string[]> = {
+  'task-intake': ['--input', '--origin'],
+};
+export async function runTaskIntakeCommand(repository: JobUpsertRepository,
+  options: Map<string, string>, payload: () => Promise<Value>): Promise<Value> {
+  return new TaskIntakeService(repository).intake(await payload(), options.get('--origin'));
+}

--- a/src/workspace-core/task-intake.ts
+++ b/src/workspace-core/task-intake.ts
@@ -1,0 +1,31 @@
+import { get, object, set, string, text, fromJSON, JobsError, type Value } from '../contracts/workspace/values.js';
+import { origin } from './job-provenance.js';
+import { planJobUpsert } from './job-upsert-plan.js';
+import type { JobUpsertRepository } from './job-upsert.js';
+import { taskJobProjection } from './task-job-projection.js';
+
+/** Resolve one canonical job under the same lock that protects ingestion writes. */
+export class TaskIntakeService {
+  constructor(readonly repository: JobUpsertRepository,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+
+  async intake(incoming: Value, author = 'agent'): Promise<Value> {
+    const by = origin(author);
+    return this.repository.upsertTransaction(async transaction => {
+      const planned = planJobUpsert(transaction.document, [incoming], by, this.now());
+      if (planned.decisions.length !== 1) throw new JobsError('task intake did not resolve exactly one job');
+      const decision = planned.decisions[0]!, action = string(get(decision, 'action'));
+      if (action === 'conflict' || action === 'invalid') throw new JobsError(`task intake ${action}`);
+      const id = string(get(decision, 'id'));
+      const record = id === null ? null : get(object(get(planned.document, 'jobs'), 'jobs'), id);
+      if (record === null || get(object(record, 'job'), 'deletedAt') !== null) {
+        throw new JobsError('task intake did not resolve one active job');
+      }
+      if (planned.changed) await transaction.save(planned.document);
+      const result = object(fromJSON({}), 'task intake result');
+      set(result, 'action', text(action!));
+      set(result, 'job', taskJobProjection(object(record, 'job')));
+      return result;
+    });
+  }
+}

--- a/src/workspace-core/task-job-projection.ts
+++ b/src/workspace-core/task-job-projection.ts
@@ -1,0 +1,11 @@
+import { get, has, set, object, fromJSON, type Document } from '../contracts/workspace/values.js';
+
+/** Shared task view excludes URLs, notes, provenance and claim credentials. */
+export function taskJobProjection(record: Document): Document {
+  const result = object(fromJSON({}), 'task job');
+  for (const field of ['id', 'role', 'company', 'location', 'workplaceType', 'employmentType',
+    'status', 'priority', 'revision', 'createdAt', 'updatedAt']) {
+    if (has(record, field)) set(result, field, get(record, field));
+  }
+  return result;
+}

--- a/src/workspace-core/workspace-projections.ts
+++ b/src/workspace-core/workspace-projections.ts
@@ -1,3 +1,4 @@
+import { taskJobProjection } from './task-job-projection.js';
 import { createHash } from 'node:crypto';
 import { canonicalJson } from '../contracts/workspace/canonical-json.js';
 import { claimExpired } from '../contracts/workspace/claims.js';
@@ -44,7 +45,6 @@ function selectedClaim(tx: ProjectionTransaction, id: string): Document | null {
   const claim = object(raw, 'claim');
   return label(claim, 'jobId') === id ? claim : null;
 }
-const jobFields = ['id', 'role', 'company', 'location', 'workplaceType', 'employmentType', 'status', 'priority', 'revision', 'createdAt', 'updatedAt'];
 const sessionFields = ['attemptRevision', 'readiness', 'blockers', 'browserHandoff'];
 const reasons = [
   ['expired_agent_attempt', 'Expired agent attempt', 'Resume this attempt with the CLI claim-recover command for this job.'],
@@ -156,7 +156,7 @@ export class WorkspaceProjectionsService {
       const now = this.now(), overview = await overviewLocked(tx, now), attention = attentionLocked(tx, now);
       const jobs = active(records(tx.jobs, 'jobs')).sort((a, b) => comparePriority(a, b)
         || compareText(label(a, 'createdAt'), label(b, 'createdAt')) || compareText(label(a, 'id'), label(b, 'id')))
-        .map(job => select(job, jobFields));
+        .map(job => taskJobProjection(job));
       const signatureInput = set(set(doc({}), 'overview', overview), 'jobs', jobs);
       set(signatureInput, 'attentionSignature', get(attention, 'snapshotSignature'));
       const result = doc({snapshotSignature:digest(signatureInput)});

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,4 +1,5 @@
 import { legacyJobsBrowser } from './workspace_native_legacy_jobs_browser_support.mjs';
+import { taskIntakeBrowser } from './workspace_native_task_intake_browser_support.mjs';
 import { claimsBrowser } from './workspace_native_claims_browser_support.mjs';
 import { jobTransitionsBrowser } from './workspace_native_job_transitions_browser_support.mjs';
 import { jobUpsertBrowser } from './workspace_native_job_upsert_browser_support.mjs';
@@ -181,10 +182,27 @@ export async function nativeJobsBrowser(buildRoot) {
         return JSON.parse(result.stdout);
       },
     });
+    const taskIntake = await taskIntakeBrowser(page, {
+      readDocument: () => readFile(join(root, 'jobs.json'), 'utf8'),
+      intake: async (payload, origin) => {
+        const input = join(fixture.root, 'browser-task-intake.json');
+        await writeFile(input, JSON.stringify(payload), { mode: 0o600 });
+        const args = [cli, '--root', root, '--native-lock', fixture.receipt.artifact,
+          'task-intake', '--input', input];
+        if (origin) args.push('--origin', origin);
+        const result = await execute(process.execPath, args, { env: { PATH: '' } });
+        return JSON.parse(result.stdout);
+      },
+      snapshot: async () => {
+        const result = await execute(process.execPath, [cli, '--root', root,
+          '--native-lock', fixture.receipt.artifact, 'task-snapshot'], { env: { PATH: '' } });
+        return JSON.parse(result.stdout);
+      },
+    });
     const unsupported = await fetch(startup.origin + '/api/trash', { headers: { Authorization: `Bearer ${token}` } });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { taskIntake, legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     releaseInitialClaim?.();
     if (browser) await browser.close();

--- a/tests_js/workspace_native_legacy_jobs_browser_support.mjs
+++ b/tests_js/workspace_native_legacy_jobs_browser_support.mjs
@@ -57,7 +57,9 @@ export async function legacyJobsBrowser(page, { legacy, writeReport, readDocumen
   assert.equal(await readDocument(), beforeRejected);
 
   await page.getByRole('button', { name: 'Refresh', exact: true }).click();
-  await page.getByRole('button', { name: new RegExp(role) }).click();
+  // Refresh retains old cards while loading. Open only the acknowledged CLI revision.
+  await page.getByRole('button', { name: new RegExp(role) })
+    .filter({hasText: new RegExp(`revision ${updated.revision}$`)}).click();
   assert.equal(await modal.locator('[name="company"]').inputValue(), 'Human legacy company');
   assert.equal(await modal.locator('[name="url"]').inputValue(), updated.url);
   await modal.locator('[name="url"]').fill('https://example.invalid/human-legacy-url');

--- a/tests_js/workspace_native_task_intake.test.mjs
+++ b/tests_js/workspace_native_task_intake.test.mjs
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, read, write, plain, snapshot, cli } from './workspace_native_claims_support.mjs';
+import { fixed, item, differential, unchanged, stdin } from './workspace_native_task_intake_support.mjs';
+import { NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { fromJSON, text } from '../runtime/contracts/workspace/values.js';
+import { atomicWritePointJson, createNativePointAtomicWriteIO } from '../runtime/store/point-persistence.js';
+
+const loaded = await import('../runtime/workspace-core/task-intake.js').catch(()=>({}));
+test('native task intake matches Python single-job resolution and durable boundaries',{timeout:60000},async t=>{
+  assert.equal(typeof loaded.TaskIntakeService,'function');
+  const {TaskIntakeService} = loaded;
+  const fixture = await nativeFixture();
+  try {
+    let serial=0;
+    const isolated = async()=>{
+      const state=await setup(fixture,`intake-${++serial}`);
+      return {...state,service:new TaskIntakeService(state.repository,()=>fixed)};
+    };
+    await t.test('create, noop, refresh and human provenance protection',async()=>{
+      const state=await isolated();
+      await differential(state.service,state.root,join(fixture.root,'python-sequence'),[
+        {payload:item('new',{role:'Agent role',source:'LinkedIn',sourceId:'42',priority:4,location:'Remote',workplaceType:'remote',employmentType:'full_time'})},
+        {payload:item('new',{role:'Agent role',source:'LinkedIn',sourceId:'42',priority:4,location:'Remote',workplaceType:'remote',employmentType:'full_time'})},
+        {payload:item('new',{role:'Agent refresh',company:'Agent company'})},
+        {payload:item('new',{role:'Human role'}),origin:'human'},
+        {payload:item('new',{role:'Ignored agent role',description:'PRIVATE DESCRIPTION'})},
+        {payload:item('new',{description:'Human description'}),origin:'human'},
+      ]);
+      const result=plain(await state.service.intake(fromJSON(item('new'))));
+      assert.equal(result.job.role,'Human role');
+      assert.equal(result.action,'noop');
+      assert.deepEqual(Object.keys(result.job).sort(),[
+        'company','createdAt','employmentType','id','location','priority','revision','role','status','updatedAt','workplaceType',
+      ].sort());
+      assert.doesNotMatch(JSON.stringify(result),/PRIVATE|https:|provenance|sourceId|description|resume/);
+    });
+    await t.test('invalid input and identity conflicts expose only generic decision errors',async()=>{
+      const state=await isolated();
+      const doc=await read(state.root,'jobs.json');
+      Object.assign(doc.jobs.job,{source:'LinkedIn',sourceId:'one'});
+      Object.assign(doc.jobs.other,{source:'LinkedIn',sourceId:'two'});
+      doc.jobs.deleted={...doc.jobs.job,id:'deleted',url:'https://example.invalid/deleted',normalizedUrl:'https://example.invalid/deleted',sourceId:'deleted',deletedAt:fixed};
+      await write(state.root,'jobs.json',doc);
+      await differential(state.service,state.root,join(fixture.root,'python-errors'),[
+        ...[null,4,true,[],{}, {jobs:[]},item('invalid',{role:[]}),item('invalid',{status:'PRIVATE'})].map(payload=>({payload})),
+        {payload:item('invalid',{priority:true})},
+        {payloadJson:'{"url":"https://example.invalid/float","priority":1.0}'},
+        {payload:item('new'),origin:'migration'},
+        {payload:item('job',{source:'LinkedIn',sourceId:'two'})},
+        {payload:item('job',{source:'Other'})},
+        {payload:item('moved',{source:'LinkedIn',sourceId:'one'})},
+        {payload:item('deleted')},
+      ]);
+      await unchanged(state.root,()=>state.service.intake(fromJSON({url:'PRIVATE INVALID URL'})),/^Error: task intake invalid$/);
+      await unchanged(state.root,()=>state.service.intake(fromJSON(item('deleted'))),/^Error: task intake conflict$/);
+    });
+    await t.test('claimed jobs remain resolvable without modifying coordinator or session',async()=>{
+      const state=await isolated();
+      await state.claims.select('job',1n,true);
+      await state.claims.acquire('job',text('Synthetic'),2n);
+      await differential(state.service,state.root,join(fixture.root,'python-claimed'),[
+        {payload:item('job',{description:'PRIVATE CLAIMED DESCRIPTION'})},
+        {payload:item('job',{description:'PRIVATE CLAIMED DESCRIPTION'})},
+      ]);
+    });
+    await t.test('concurrent duplicate intake converges on one creation without stale-token failures',async()=>{
+      const state=await isolated();
+      const incoming=fromJSON(item('concurrent',{role:'Concurrent role'}));
+      const results=await Promise.all(Array.from({length:4},()=>new TaskIntakeService(
+        new NativeJobsRepository(state.root,state.provider),()=>fixed).intake(incoming)));
+      const values=results.map(plain);
+      assert.equal(values.filter(value=>value.action==='create').length,1);
+      assert.equal(values.filter(value=>value.action==='noop').length,3);
+      assert.equal(new Set(values.map(value=>value.job.id)).size,1);
+      const jobs=Object.values((await read(state.root,'jobs.json')).jobs);
+      assert.equal(jobs.filter(job=>job.url==='https://example.invalid/concurrent').length,1);
+      assert.equal(jobs.find(job=>job.url==='https://example.invalid/concurrent').revision,1);
+    });
+    await t.test('atomic write, sync and replacement failures retain old data and permit retry',async()=>{
+      const state=await isolated();
+      const incoming=fromJSON(item('fault'));
+      for(const stage of ['write','sync','replace']) {
+        const repository=new NativeJobsRepository(state.root,state.provider,async(path,value,options)=>{
+          const io=createNativePointAtomicWriteIO(options.pathProfile);
+          if(stage==='replace') io.replace=async()=>{throw Error('intake injected fault');};
+          else {
+            const original=io.createTemporary;
+            io.createTemporary=async(...args)=>{
+              const handle=await original(...args);
+              handle[stage]=async()=>{throw Error('intake injected fault');};
+              return handle;
+            };
+          }
+          await atomicWritePointJson(path,value,options,io);
+        });
+        await unchanged(state.root,()=>new TaskIntakeService(repository,()=>fixed).intake(incoming),/intake injected fault/);
+        assert.equal((await readdir(state.root)).some(name=>name.endsWith('.tmp')),false);
+      }
+      assert.equal(plain(await state.service.intake(incoming)).action,'create');
+    });
+  } finally {await fixture.cleanup();}
+});
+
+test('Python-free task intake CLI defaults to agent, redacts output and accepts large stdin',{timeout:60000},async()=>{
+  const fixture=await nativeFixture();
+  try {
+    const {root}=await setup(fixture,'intake-cli');
+    const payload=item('cli',{role:'CLI role',description:'PRIVATE '+ 'x'.repeat(81920)});
+    const result=await stdin(fixture,root,payload);
+    assert.equal(result.action,'create');
+    assert.equal(result.job.role,'CLI role');
+    assert.doesNotMatch(JSON.stringify(result),/PRIVATE|https:|description|provenance/);
+    const saved=await cli(fixture,root,'job-get',['--id',result.job.id]);
+    assert.equal(saved.description,payload.description);
+    assert.equal(saved.provenance['/role'].origin,'agent');
+    const before=await snapshot(root);
+    const file=await cli(fixture,root,'task-intake',[],payload);
+    assert.equal(file.action,'noop');
+    assert.deepEqual(file.job,result.job);
+    assert.deepEqual(await snapshot(root),before);
+    for(const args of [['--origin','migration'],['--unknown','x'],['--origin','agent','--origin','human']]) {
+      await assert.rejects(()=>cli(fixture,root,'task-intake',args,payload));
+    }
+    await assert.rejects(()=>cli(fixture,root,'task-intake'),/input/);
+    assert.deepEqual(await snapshot(root),before);
+    assert.equal((await cli(fixture,root,'task-intake',['--origin','human'],item('cli',{role:'Human role'}))).action,'update');
+    assert.equal((await cli(fixture,root,'task-intake',[],item('cli',{role:'Agent role'}))).job.role,'Human role');
+  } finally {await fixture.cleanup();}
+});

--- a/tests_js/workspace_native_task_intake_browser_support.mjs
+++ b/tests_js/workspace_native_task_intake_browser_support.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+
+// The caller owns a synthetic Store and invokes intake through the native CLI.
+export async function taskIntakeBrowser(page, { intake, snapshot, readDocument }) {
+  const navigation = page.getByRole('navigation', { name: 'Workspace sections' });
+  const modal = page.getByRole('dialog', { name: 'Edit job', exact: true });
+  const role = 'Native single-task capture role';
+  const url = 'https://example.invalid/native-task-capture?private=fixture';
+  const payload = { url, role, company: 'Task company', description: 'Private fixture description' };
+  let navigationPrompts = 0;
+  const dismiss = dialog => { navigationPrompts++; return dialog.dismiss(); };
+  page.on('dialog', dismiss);
+  try {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const created = await intake(payload);
+    assert.equal(created.action, 'create');
+    assert.deepEqual(Object.keys(created).sort(), ['action', 'job']);
+    const id = created.job.id;
+    const checkProjection = async result => {
+      assert.deepEqual((await snapshot()).jobs.find(job => job.id === id), result.job);
+      for (const key of ['url', 'normalizedUrl', 'description', 'notes', 'provenance', 'legacySources', 'claimToken']) {
+        assert.equal(Object.hasOwn(result.job, key), false, `${key} must not appear in task output`);
+      }
+      assert.equal(JSON.stringify(result).includes('Private fixture description'), false);
+      assert.equal(JSON.stringify(result).includes('private=fixture'), false);
+    };
+    await checkProjection(created);
+    const beforeRepeat = await readDocument();
+    const repeated = await intake(payload);
+    assert.equal(repeated.action, 'noop');
+    assert.deepEqual(repeated.job, created.job);
+    assert.equal(await readDocument(), beforeRepeat);
+
+    await navigation.getByRole('button', { name: 'Jobs', exact: true }).click();
+    await page.locator('[data-job-create]:enabled').waitFor();
+    await page.getByRole('button', { name: 'Refresh', exact: true }).click();
+    await page.getByRole('button', { name: new RegExp(role) }).click();
+    assert.equal(await modal.locator('[name="company"]').inputValue(), 'Task company');
+    await modal.locator('[name="company"]').fill('Human task company');
+    await modal.getByRole('button', { name: 'Save job', exact: true }).click();
+    await modal.waitFor({ state: 'hidden' });
+    const human = JSON.parse(await readDocument()).jobs[id];
+    assert.equal(human.provenance['/company'].origin, 'human');
+
+    // ATS is absent from the editor patch and remains eligible for agent intake.
+    const incoming = { url, company: 'Agent task replacement', ats: 'Task fixture ATS' };
+    const updated = await intake(incoming, 'agent');
+    assert.equal(updated.action, 'update');
+    assert.equal(updated.job.id, id);
+    assert.equal(updated.job.company, human.company);
+    await checkProjection(updated);
+    const stored = JSON.parse(await readDocument()).jobs[id];
+    assert.equal(stored.ats, 'Task fixture ATS');
+    assert.equal(stored.revision, human.revision + 1);
+    assert.deepEqual(stored.provenance['/company'], human.provenance['/company']);
+    const beforeNoop = await readDocument();
+    assert.equal((await intake(incoming)).action, 'noop');
+    assert.equal(await readDocument(), beforeNoop);
+    assert.equal(Object.values(JSON.parse(beforeNoop).jobs).filter(job => job.id === id).length, 1);
+
+    await page.reload();
+    await navigation.getByRole('button', { name: 'Jobs', exact: true }).click();
+    await page.locator('[data-job-create]:enabled').waitFor();
+    await page.getByRole('button', { name: new RegExp(role) }).click();
+    assert.equal(await modal.locator('[name="company"]').inputValue(), 'Human task company');
+    assert.equal(await modal.locator('[name="role"]').inputValue(), role);
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), true);
+    await modal.getByRole('button', { name: 'Close job details', exact: true }).click();
+    await navigation.getByRole('button', { name: 'Overview', exact: true }).click();
+    await page.getByRole('heading', { name: 'Your next step', exact: true }).waitFor();
+    assert.equal(navigationPrompts, 0);
+    return { cliIntakeVisible: true, duplicateNoop: true, humanProvenancePreserved: true,
+      redactedSnapshotAgreement: true, reload: true, cleanNavigation: true, narrowViewport: true };
+  } finally {
+    page.off('dialog', dismiss);
+  }
+}

--- a/tests_js/workspace_native_task_intake_support.mjs
+++ b/tests_js/workspace_native_task_intake_support.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { cp, readFile } from 'node:fs/promises';
+import { execFile, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join } from 'node:path';
+import { parse } from '../runtime/contracts/workspace/values.js';
+import { canonicalJson } from '../runtime/contracts/workspace/canonical-json.js';
+import { plain, snapshot } from './workspace_native_claims_support.mjs';
+export { fixed, item, unchanged } from './workspace_native_job_upsert_support.mjs';
+export async function differential(service, root, referenceRoot, operations) {
+  await cp(root,referenceRoot,{recursive:true,preserveTimestamps:true});
+  const reference = JSON.parse((await promisify(execFile)('python3',[
+    'tools/contracts/task-intake/reference.py',referenceRoot,JSON.stringify(operations),
+  ],{maxBuffer:8*1024*1024})).stdout);
+  for(const [index,operation] of operations.entries()) {
+    const before = await snapshot(root);
+    let actual;
+    try {
+      actual = {result:plain(await service.intake(parse(operation.payloadJson ?? JSON.stringify(operation.payload)),operation.origin))};
+    } catch(error) { actual = {error:error.message}; }
+    const {document,...expected} = reference[index];
+    assert.deepEqual(actual,expected,`intake operation ${index}: ${JSON.stringify(operation)}`);
+    assert.equal(canonicalJson(parse(await readFile(join(root,'jobs.json'),'utf8'))),canonicalJson(parse(document)));
+    const after = await snapshot(root);
+    if(actual.error || actual.result.action==='noop') assert.deepEqual(after,before,'rejection and noop preserve canonical bytes');
+    delete before['jobs.json']; delete after['jobs.json'];
+    assert.deepEqual(after,before,'intake changes only jobs.json');
+  }
+}
+export function stdin(fixture,root,payload,args=[]) {
+  return new Promise((resolve,reject) => {
+    const child = spawn(process.execPath,['runtime/cli/native-jobs.js','--root',root,'--native-lock',fixture.receipt.artifact,
+      'task-intake','--input','-',...args],{cwd:new URL('../',import.meta.url),env:{PATH:''}});
+    let stdout='',stderr='';
+    child.stdout.on('data',bytes=>{stdout+=bytes;});
+    child.stderr.on('data',bytes=>{stderr+=bytes;});
+    child.on('error',reject);
+    child.on('close',code=>{
+      if(code!==0 || stderr) return reject(Error(stderr || `exit ${code}`));
+      try {resolve(JSON.parse(stdout));} catch(error){reject(error);}
+    });
+    child.stdin.on('error',()=>{});
+    child.stdin.end(JSON.stringify(payload));
+  });
+}

--- a/tests_js/workspace_task_intake_model.test.mjs
+++ b/tests_js/workspace_task_intake_model.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { TaskIntakeService } from '../runtime/workspace-core/task-intake.js';
+import { fromJSON, serialize } from '../runtime/contracts/workspace/values.js';
+const empty = () => fromJSON({schemaVersion:1,jobs:{},metadata:{updatedAt:'2026-09-11T00:00:00Z'}});
+
+test('task intake reports persistence failure without returning a successful action', async () => {
+  const document=empty(); let saves=0;
+  const service=new TaskIntakeService({upsertTransaction:operation=>operation({document,save:async()=>{saves++;throw Error('write failed');}})});
+  await assert.rejects(service.intake(fromJSON({url:'https://example.invalid/fail'})),/write failed/);
+  assert.equal(saves,1);
+  assert.deepEqual(JSON.parse(serialize(document)).jobs,{});
+});
+
+test('invalid input is rejected with the generic intake error before persistence', async () => {
+  let saves=0;
+  const service=new TaskIntakeService({upsertTransaction:operation=>operation({document:empty(),save:async()=>{saves++;}})});
+  for(const input of [null,[],{url:'PRIVATE-invalid-url'},{url:'https://example.invalid/x',status:'PRIVATE-invalid-status'}]) {
+    await assert.rejects(service.intake(fromJSON(input)),{message:'task intake invalid'});
+  }
+  assert.equal(saves,0);
+  await assert.rejects(service.intake(fromJSON({url:'https://example.invalid/x'}),'migration'),/origin must be human or agent/);
+});

--- a/tools/contracts/task-intake/reference.py
+++ b/tools/contracts/task-intake/reference.py
@@ -1,0 +1,23 @@
+"""Python task-intake oracle, used only with independent synthetic Store copies."""
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path('scripts').resolve()))
+spec = importlib.util.spec_from_file_location('intake_reference', 'scripts/job-apply-store.py')
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+module.utc_now = lambda: '2026-09-10T14:00:00Z'
+store = module.Store(Path(sys.argv[1]))
+store.initialize()
+results = []
+for operation in json.loads(sys.argv[2]):
+    try:
+        payload = json.loads(operation['payloadJson']) if 'payloadJson' in operation else operation['payload']
+        result = {'result': store.intake_task_job(payload, operation.get('origin', 'agent'))}
+    except module.StoreError as error:
+        result = {'error': str(error)}
+    result['document'] = store.jobs_path.read_text()
+    results.append(result)
+print(json.dumps(results))


### PR DESCRIPTION
Adds `task-intake` to the opt-in native fixture CLI. One incoming job is atomically created, updated or resolved as a no-op under the existing upsert transaction. Invalid or conflicting input returns generic intake errors without exposing planner details.

Intake and task snapshots share one field allowlist, keeping URLs, notes, descriptions, provenance and credentials out of task results. Agent origin is the default; human ownership, claim behavior and no-op persistence follow Python. This leaves the full compatibility task CLI and live writer activation unchanged.

Validation: 15 focused model/native/Python differential checks passed, covering claimed jobs, concurrent duplicate convergence, save failures and large stdin. The real Companion/CLI walkthrough passed with Python absent from PATH, including human edits, no-op convergence, snapshot agreement and reload. Five independent review roles completed without findings. Normal commit, deep validation and fresh native push checks passed. The first deep run exposed an existing legacy browser Refresh race; the test now waits for the acknowledged CLI revision before opening the card, preserving all value assertions. The fix passed scoped review and the full gate rerun. CI pending.

Standalone codex review could not run because the installed CLI is too old for its configured model. All fixtures used synthetic data.

CI passed on cba2e992ee10eb1942a430e3fb49e360df29f032: Validate run 34604060105 and Release run 34604064287, including Windows, Linux browser and macOS checks.
