### PR TITLE
Add native fixture grouped answer approvals

### DIFF
--- a/config/migration/cli-native-grouped-approvals-surfaces.json
+++ b/config/migration/cli-native-grouped-approvals-surfaces.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:approval-preview",
+      "kind": "cli",
+      "command": "approval-preview",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-grouped-approvals.ts",
+        "src/workspace-core/grouped-approvals.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:approval-approve",
+      "kind": "cli",
+      "command": "approval-approve",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-grouped-approvals.ts",
+        "src/workspace-core/grouped-approvals.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -102,6 +102,10 @@
       "sha256": "b9710c5943613cea49bf1742e5aea7570220f3ef2db45e956ea4576adcbae223"
     },
     {
+      "path": "cli-native-grouped-approvals-surfaces.json",
+      "sha256": "ad1ffe807f91bf1cfe626471171ac95bbefe39fcf8ea55aaced85d7b3697be40"
+    },
+    {
       "path": "cli-native-job-transitions-surfaces.json",
       "sha256": "3310d133626397a57545af50e70591523b906036cdf4a0d04884e4a1630f1c3b"
     },
@@ -318,6 +322,10 @@
       "sha256": "8a41ab419b7b46311658f0ec43e970c7cda36f6322aa8dba415c41ae9e6e6424"
     },
     {
+      "path": "source-catalog-native-grouped-approvals.json",
+      "sha256": "76fe903c2110f79b75928fbae23d22e521c91f4d4c8e297edd6d03ffe0f20dfe"
+    },
+    {
       "path": "source-catalog-native-job-transitions.json",
       "sha256": "d3586b035af22d3f4b4fa3ba3aa7d9e1bc781632317005aff9d158ac78625772"
     },
@@ -327,7 +335,7 @@
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "c324551966506da7d3105d6bef9a27ad82083f2b1abaf9255cf824f55b59f76b"
+      "sha256": "07f02a2c29bb09d32f4a87861adc3915c6965af74efb0124375aeafdbe5b949f"
     },
     {
       "path": "source-catalog-native-legacy-jobs.json",

--- a/config/migration/source-catalog-native-grouped-approvals.json
+++ b/config/migration/source-catalog-native-grouped-approvals.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "runtime/cli/native-grouped-approvals.js",
+      "sha256": "d31ae59d331df66d04ef0116cab45fa8777037138499a3c066adb8c663539bd3",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/grouped-approvals.js",
+      "sha256": "10e9a315e2586a0f91f852e1ed54df12f102e1011c48ade91730a1e522cb43ef",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-grouped-approvals.ts",
+      "sha256": "d2d1db7e7a18f92a747d18e8fb734f0a00ae07bd05d8aefd3c87c220d4bf1e76",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/grouped-approvals.ts",
+      "sha256": "cf3bd287ece017083161c68266d0616a7c05b90e0508a65827a4ca9a3c1d2999",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "40d1c71beffced194a6484d69e2c5cacc64f678b274607fac72ee9b88ad5bef7",
+      "sha256": "abd1b56822d3cb736e6691301542a42668e03d4ca0515436cc5d54142785f526",
       "classification": "unreviewed"
     },
     {
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "b7ddccad762802242cf56d1bf3bfcd6d30d6b0351fb1708f1c33e54e41535fb1",
+      "sha256": "03c9260afb05df584e722ef45accc92590ac93cb73885645a10ce5895a00da68",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "dfa51598fcf41132fa296391e81a33079873a1d8236d560d95f837a7f5d668ef",
+      "sha256": "767a2e5b792d4aff28ecefc73eef3217dd350eff8d442a03b9016d2b7d86237b",
       "classification": "unreviewed"
     },
     {
@@ -83,7 +83,7 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "ab7223c28daa31565260ec9c9321a21db8df77de3644bb2e6e07ace8967710eb",
+      "sha256": "4beac6cb5f0030e0bd8cf200b24ed9a6700f087ea8091b9d5c71e9b84f272902",
       "classification": "unreviewed"
     },
     {

--- a/docs/native-grouped-approvals-fixture.md
+++ b/docs/native-grouped-approvals-fixture.md
@@ -1,0 +1,77 @@
+# Native grouped approval fixture
+
+New version 9 synthetic Stores support grouped answer approval preview and
+commit through the native CLI. Initialize a fixture and build the native addon
+as described in [Native Jobs](native-jobs-fixture.md). Existing fixtures and
+live applicant Stores are not adopted or upgraded. Keep Python writers away
+from the native fixture.
+
+## Preview and confirm
+
+Use a pending field produced by [claim progress or handoff](native-claims-fixture.md).
+Read the job and session revisions through `job-activity --id ID`. The decision
+reference comes from that session's pending information; the answer must still
+match the pending field's recorded answer revision. Create a JSON input file:
+
+```json
+{"decisions":[{"reference":"pending_0123456789abcdef0123456789abcdef","answerKey":"synthetic-answer","currentUse":true,"remember":false,"policyMode":"strict","useAuthority":"accepted_record","allowedSensitiveFieldClasses":[]}]}
+```
+
+The sample reference is illustrative: replace it with the actual fixture field
+reference and select the policy and authority appropriate to the decision.
+Preview with the current revisions:
+
+```sh
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node approval-preview --id synthetic-job --expected-job-revision 4 --expected-session-revision 123 --input /absolute/decisions.json
+```
+
+Preview returns `jobRevision`, `sessionRevision`, sorted `approvals`, a
+`previewToken` and `mutated: false`. Each approval contains identity, decision,
+policy, eligibility, confidence, reason codes and answer revision, without the
+saved answer value. Preview does not modify the fixture. Review its decisions
+and policy outcome, then explicitly confirm with the returned token and the
+same revisions and input:
+
+```sh
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node approval-approve --id synthetic-job --expected-job-revision 4 --expected-session-revision 123 --input /absolute/decisions.json --preview-token grouped-approval-v1.REPLACE_WITH_RETURNED_HASH --owner-confirmed
+```
+
+Both commands accept `--input -` for stdin. Commit returns `approved: true`,
+the new `sessionRevision` and the stored `approvals`. These are direct fixture
+service results; they do not introduce the compatibility task CLI envelope.
+
+## Revision and consent boundaries
+
+Commit requires explicit owner confirmation and a matching preview token.
+Job, session, pending reference, answer identity and answer revision are checked
+again before the write. A stale preview or unavailable answer requires a fresh
+preview against current state. Semantic confidence, scope and sensitive-field
+policy determine eligibility; recording a decision does not make an ineligible
+answer eligible. Denied current use must carry `useAuthority: "none"`.
+
+A commit updates only the selected session's approvals and timestamp. It retains
+other current approvals and removes stale ones. It does not update the answer
+Store, change job status, resolve pending fields or append application history.
+The `remember` decision is recorded in the approval; this operation does not
+persist a new answer value. Existing claim ownership does not block grouped
+approval. No new journal or HTTP mutation endpoint is introduced.
+
+In Companion, open the job's Activity section and select **Refresh activity**.
+The existing view shows the number of current session approvals and identifies
+pending items with a recorded approval. Changing the saved answer revision makes
+the old approval disappear from that current projection. Approval counts describe
+recorded decisions; they are not a guarantee of reuse eligibility. Final review
+and submission remain human actions.
+
+## Validation and remaining scope
+
+Differential tests use separate synthetic native and Python roots to compare
+policy results, preview tokens, failures and persisted sessions. The production
+browser walkthrough runs the CLI with Python absent from PATH, verifies preview
+is read-only and commit changes only the session, then refreshes Companion to
+check approval visibility and later answer-revision invalidation. The activity
+projection and UI are checked for absence of the synthetic answer value.
+
+The version 9 fixture marker and inventory validation remain unchanged. General
+native Store activation, writer handoff and installable Python-free packaging
+remain separate work.

--- a/docs/native-jobs-fixture.md
+++ b/docs/native-jobs-fixture.md
@@ -14,7 +14,8 @@ Facts/profile operations, [active claims](native-claims-fixture.md),
 [job status transitions](native-job-transitions-fixture.md),
 [CLI job upsert preview/commit](native-job-upsert-fixture.md), and
 [CLI legacy job import](native-legacy-jobs-fixture.md) and
-[CLI single-job task intake](native-task-intake-fixture.md) are also available. Other
+[CLI single-job task intake](native-task-intake-fixture.md), and
+[CLI grouped answer approvals](native-grouped-approvals-fixture.md) are also available. Other
 workflows return `unsupported_native_workflow`; they never fall back to Python.
 
 ## Run against a new synthetic root

--- a/runtime/cli/native-grouped-approvals.js
+++ b/runtime/cli/native-grouped-approvals.js
@@ -1,0 +1,30 @@
+import { GroupedApprovalsService } from '../workspace-core/grouped-approvals.js';
+import { get, keys, object, JobsError } from '../contracts/workspace/values.js';
+const shared = ['--id', '--expected-job-revision', '--expected-session-revision', '--input'];
+export const groupedApprovalCommands = {
+    'approval-preview': shared,
+    'approval-approve': [...shared, '--preview-token', '--owner-confirmed'],
+};
+export async function runGroupedApprovalCommand(command, repository, options, payload) {
+    const required = (key) => {
+        const value = options.get(key);
+        if (!value)
+            throw new JobsError(`required option: ${key}`);
+        return value;
+    };
+    const revision = (key) => {
+        const value = required(key);
+        if (!/^[0-9]+$/.test(value) || BigInt(value) < 1n)
+            throw new JobsError('grouped approval revision is invalid');
+        return BigInt(value);
+    };
+    const incoming = object(await payload(), 'grouped approval input');
+    if (keys(incoming).length !== 1 || !Array.isArray(get(incoming, 'decisions'))) {
+        throw new JobsError('grouped approval input is invalid');
+    }
+    const service = new GroupedApprovalsService(repository);
+    const id = required('--id'), jobRevision = revision('--expected-job-revision');
+    const sessionRevision = revision('--expected-session-revision'), decisions = get(incoming, 'decisions');
+    return command === 'approval-preview' ? service.preview(id, jobRevision, sessionRevision, decisions)
+        : service.approve(id, jobRevision, sessionRevision, decisions, required('--preview-token'), options.has('--owner-confirmed'));
+}

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,3 +1,4 @@
+import { groupedApprovalCommands, runGroupedApprovalCommand } from './native-grouped-approvals.js';
 import { taskIntakeCommands, runTaskIntakeCommand } from './native-task-intake.js';
 import { legacyJobCommands, runLegacyJobCommand } from './native-legacy-jobs.js';
 import { jobUpsertCommands, runJobUpsertCommand } from './native-job-upsert.js';
@@ -45,6 +46,7 @@ export async function runJobsCli(args, input) {
         }
     }
     const fields = {
+        ...groupedApprovalCommands,
         ...taskIntakeCommands,
         ...legacyJobCommands,
         ...jobUpsertCommands,
@@ -90,6 +92,8 @@ export async function runJobsCli(args, input) {
             : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command) ? 2 * 1024 * 1024 : 65536;
         return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
     };
+    if (Object.hasOwn(groupedApprovalCommands, command))
+        return serialize(await runGroupedApprovalCommand(command, repository, options, payload));
     if (Object.hasOwn(taskIntakeCommands, command))
         return serialize(await runTaskIntakeCommand(repository, options, payload));
     if (Object.hasOwn(legacyJobCommands, command))

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -349,6 +349,16 @@ export class NativeJobsRepository {
                 commit: operation => this.claimJournal().commit(operation, jobs) });
         });
     }
+    async groupedApprovalTransaction(operation) {
+        return this.transaction(async () => operation({
+            jobs: validateJobsDocument(await this.document('jobs')),
+            sessions: await this.answerSessions(), answers: validateAnswers(await this.document('answers')),
+            saveSession: async (document) => {
+                validateAnswerSession(document);
+                await this.write(join(this.root, `sessions/${safeId(string(get(document, 'applicationId')))}.json`), document, options);
+            },
+        }));
+    }
     async answerMergeTransaction(operation) {
         return this.transaction(async () => {
             const document = validateAnswers(await this.document('answers'));

--- a/runtime/workspace-core/grouped-approvals.js
+++ b/runtime/workspace-core/grouped-approvals.js
@@ -1,0 +1,161 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { answerRevision, fallback } from '../contracts/workspace/answers.js';
+import { sessionRevision } from '../contracts/workspace/answer-resolution.js';
+import { matches, pendingReference } from '../contracts/workspace/answer-session-fields.js';
+import { validateAnswerSession } from '../contracts/workspace/answer-session-validation.js';
+import { evaluateReuse } from '../contracts/workspace/answer-match-reuse.js';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { canonicalClaimAnswer, claimSessionObject, currentClaimApprovals } from '../contracts/workspace/claim-session-pending.js';
+import { emptyObject, safeId } from '../contracts/workspace/jobs.js';
+import { get, integer, keys, object, parse, same, serialize, set, string, text, truth, JobsError } from '../contracts/workspace/values.js';
+import { semanticCandidate } from './answer-match.js';
+const decisionFields = ['reference', 'answerKey', 'currentUse', 'remember', 'policyMode', 'useAuthority', 'allowedSensitiveFieldClasses'];
+const clone = (value) => parse(serialize(value));
+const fingerprint = (value) => createHash('sha256').update(canonicalJson(value)).digest('hex');
+function equalToken(left, right) {
+    const a = Buffer.from(left), b = Buffer.from(right);
+    return a.length === b.length && timingSafeEqual(a, b);
+}
+function answerRecord(answers, key) {
+    const value = get(object(get(answers, 'answers'), 'answers'), canonicalClaimAnswer(answers, key));
+    if (value === null)
+        return null;
+    const answer = object(value, 'answer');
+    return get(answer, 'deletedAt') === null ? answer : null;
+}
+function pendingFields(session) {
+    return new Map(fallback(session, 'pendingFields', []).map(field => [string(get(field, 'reference')), field]));
+}
+function projectDecision(raw, pending, answers, seen) {
+    const decision = claimSessionObject(raw, 'grouped approval decision');
+    if (decision.size !== decisionFields.length || keys(decision).some(key => !decisionFields.includes(key))) {
+        throw new JobsError('grouped approval decision contains unsupported fields');
+    }
+    const answerKey = string(get(decision, 'answerKey'));
+    if (!answerKey)
+        throw new JobsError('grouped approval answer key is invalid');
+    const reference = string(get(decision, 'reference'));
+    if (reference === null || !matches(get(decision, 'reference'), pendingReference) || seen.has(reference) || !pending.has(reference)) {
+        throw new JobsError('grouped approval reference is invalid');
+    }
+    seen.add(reference);
+    const currentUse = get(decision, 'currentUse'), remember = get(decision, 'remember');
+    if (typeof currentUse !== 'boolean' || typeof remember !== 'boolean')
+        throw new JobsError('grouped approval decisions must be booleans');
+    if (!currentUse && string(get(decision, 'useAuthority')) !== 'none')
+        throw new JobsError('denied current use cannot carry reuse authority');
+    const answer = answerRecord(answers, answerKey);
+    if (answer === null)
+        throw new JobsError('grouped approval answer is unavailable');
+    const field = pending.get(reference), boundKey = string(get(field, 'answerKey'));
+    if (boundKey === null || canonicalClaimAnswer(answers, boundKey) !== string(get(answer, 'key'))) {
+        throw new JobsError('grouped approval answer does not match pending field');
+    }
+    const answerSensitivity = fallback(answer, 'sensitivity', text('none'));
+    const sensitivity = string(answerSensitivity) !== 'none' ? answerSensitivity
+        : text(get(field, 'sensitive') === true || string(get(field, 'state')) === 'sensitive' ? 'high' : 'none');
+    if (!same(get(field, 'matchAnswerRevision'), integer(answerRevision(answer))))
+        throw new JobsError('pending field semantic match is stale');
+    const candidate = semanticCandidate(answer), match = emptyObject();
+    set(match, 'answerKey', get(answer, 'key'));
+    set(match, 'confidenceBand', fallback(field, 'matchConfidence', text('none')));
+    set(match, 'reasonCodes', truth(get(field, 'matchReasonCodes')) ? get(field, 'matchReasonCodes') : [text('no_semantic_match')]);
+    let policy;
+    try {
+        policy = evaluateReuse({ match, candidate, scope: fallback(answer, 'scope', emptyObject()),
+            fieldClass: fallback(field, 'fieldClass', text('general')), sensitivity,
+            mode: get(decision, 'policyMode'), useAuthority: get(decision, 'useAuthority'),
+            allowedSensitiveFieldClasses: get(decision, 'allowedSensitiveFieldClasses') });
+    }
+    catch {
+        throw new JobsError('grouped approval policy is invalid');
+    }
+    let reasons = get(policy, 'reasonCodes');
+    if (!equalToken(fingerprint(fallback(answer, 'scope', emptyObject())), string(fallback(field, 'scopeFingerprint', text(fingerprint(emptyObject())))))) {
+        reasons = reasons.filter(code => !['reuse_eligible', 'scope_match'].includes(string(code)));
+        if (!reasons.some(code => string(code) === 'scope_mismatch'))
+            reasons.push(text('scope_mismatch'));
+    }
+    const result = emptyObject();
+    for (const name of ['reference', 'currentUse', 'remember', 'policyMode', 'useAuthority'])
+        set(result, name, get(decision, name));
+    set(result, 'answerKey', get(answer, 'key'));
+    set(result, 'eligible', currentUse && reasons.some(code => string(code) === 'reuse_eligible'));
+    set(result, 'confidenceBand', get(policy, 'confidenceBand'));
+    set(result, 'reasonCodes', reasons);
+    return set(result, 'answerRevision', integer(answerRevision(answer)));
+}
+/** Field-scoped reuse decisions expose metadata only and write only the bound session. */
+export class GroupedApprovalsService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    preview(jobId, jobRevision, expectedSessionRevision, decisions) {
+        safeId(jobId);
+        if (!Array.isArray(decisions) || !decisions.length)
+            throw new JobsError('grouped approval requires at least one field decision');
+        return this.repository.groupedApprovalTransaction(async (transaction) => {
+            const rawJob = get(object(get(transaction.jobs, 'jobs'), 'jobs'), jobId);
+            if (rawJob === null || get(object(rawJob, 'job'), 'deletedAt') !== null)
+                throw new JobsError('grouped approval job does not exist');
+            if (answerRevision(object(rawJob, 'job')) !== jobRevision)
+                throw new JobsError('job revision conflict');
+            const session = transaction.sessions.find(item => string(get(item, 'applicationId')) === jobId);
+            if (!session)
+                throw new JobsError('grouped approval session does not exist');
+            if (sessionRevision(session) !== expectedSessionRevision)
+                throw new JobsError('session revision conflict');
+            const pending = pendingFields(session), seen = new Set();
+            const approvals = decisions.map(raw => projectDecision(raw, pending, transaction.answers, seen));
+            approvals.sort((a, b) => string(get(a, 'reference')) < string(get(b, 'reference')) ? -1 : 1);
+            const result = set(emptyObject(), 'jobRevision', integer(jobRevision));
+            set(result, 'sessionRevision', integer(expectedSessionRevision));
+            set(result, 'approvals', approvals);
+            set(result, 'previewToken', text(`grouped-approval-v1.${fingerprint(result)}`));
+            return set(result, 'mutated', false);
+        });
+    }
+    async approve(jobId, jobRevision, expectedSessionRevision, decisions, previewToken, ownerConfirmed = false) {
+        if (ownerConfirmed !== true)
+            throw new JobsError('grouped approval requires explicit owner confirmation');
+        const preview = await this.preview(jobId, jobRevision, expectedSessionRevision, decisions);
+        if (typeof previewToken !== 'string' || !equalToken(previewToken, string(get(preview, 'previewToken'))))
+            throw new JobsError('grouped approval preview is stale');
+        // Reacquire the lock and recheck every bound identity before applying the preview.
+        return this.repository.groupedApprovalTransaction(async (transaction) => {
+            const rawJob = get(object(get(transaction.jobs, 'jobs'), 'jobs'), jobId);
+            const session = transaction.sessions.find(item => string(get(item, 'applicationId')) === jobId);
+            if (rawJob === null || answerRevision(object(rawJob, 'job')) !== jobRevision || !session)
+                throw new JobsError('grouped approval state changed');
+            if (sessionRevision(session) !== expectedSessionRevision)
+                throw new JobsError('session revision conflict');
+            const pending = pendingFields(session), projected = get(preview, 'approvals');
+            const byReference = new Map(projected.map(approval => [string(get(approval, 'reference')), approval]));
+            for (const decision of decisions) {
+                const reference = string(get(decision, 'reference')), field = pending.get(reference);
+                const answer = answerRecord(transaction.answers, string(get(decision, 'answerKey')));
+                if (!field || !answer)
+                    throw new JobsError('grouped approval state changed');
+                const boundKey = string(get(field, 'answerKey'));
+                if (boundKey === null || canonicalClaimAnswer(transaction.answers, boundKey) !== string(get(answer, 'key'))
+                    || !same(integer(answerRevision(answer)), get(byReference.get(reference), 'answerRevision')))
+                    throw new JobsError('grouped approval state changed');
+            }
+            const updated = object(clone(session), 'session');
+            const approvals = new Map(currentClaimApprovals(session, [...pending.values()], transaction.answers, get(session, 'attemptRevision'))
+                .map(value => [string(get(object(value, 'approval'), 'reference')), value]));
+            for (const approval of projected)
+                approvals.set(string(get(approval, 'reference')), clone(approval));
+            set(updated, 'approvals', [...approvals.keys()].sort().map(reference => approvals.get(reference)));
+            set(updated, 'updatedAt', text(this.now()));
+            validateAnswerSession(updated);
+            await transaction.saveSession(updated);
+            const result = set(emptyObject(), 'approved', true);
+            set(result, 'sessionRevision', integer(sessionRevision(updated)));
+            return set(result, 'approvals', clone(get(updated, 'approvals')));
+        });
+    }
+}

--- a/src/cli/native-grouped-approvals.ts
+++ b/src/cli/native-grouped-approvals.ts
@@ -1,0 +1,32 @@
+import { GroupedApprovalsService } from '../workspace-core/grouped-approvals.js';
+import type { GroupedApprovalRepository } from '../workspace-core/grouped-approvals.js';
+import { get, keys, object, JobsError } from '../contracts/workspace/values.js';
+import type { Value } from '../contracts/workspace/values.js';
+
+const shared = ['--id', '--expected-job-revision', '--expected-session-revision', '--input'];
+export const groupedApprovalCommands: Record<string, string[]> = {
+  'approval-preview': shared,
+  'approval-approve': [...shared, '--preview-token', '--owner-confirmed'],
+};
+export async function runGroupedApprovalCommand(command: string, repository: GroupedApprovalRepository,
+  options: Map<string, string>, payload: () => Promise<Value>): Promise<Value> {
+  const required = (key: string): string => {
+    const value = options.get(key);
+    if (!value) throw new JobsError(`required option: ${key}`);
+    return value;
+  };
+  const revision = (key: string): bigint => {
+    const value = required(key);
+    if (!/^[0-9]+$/.test(value) || BigInt(value) < 1n) throw new JobsError('grouped approval revision is invalid');
+    return BigInt(value);
+  };
+  const incoming = object(await payload(), 'grouped approval input');
+  if (keys(incoming).length !== 1 || !Array.isArray(get(incoming, 'decisions'))) {
+    throw new JobsError('grouped approval input is invalid');
+  }
+  const service = new GroupedApprovalsService(repository);
+  const id = required('--id'), jobRevision = revision('--expected-job-revision');
+  const sessionRevision = revision('--expected-session-revision'), decisions = get(incoming, 'decisions');
+  return command === 'approval-preview' ? service.preview(id, jobRevision, sessionRevision, decisions)
+    : service.approve(id, jobRevision, sessionRevision, decisions, required('--preview-token'), options.has('--owner-confirmed'));
+}

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,3 +1,4 @@
+import { groupedApprovalCommands, runGroupedApprovalCommand } from './native-grouped-approvals.js';
 import { taskIntakeCommands, runTaskIntakeCommand } from './native-task-intake.js';
 import { legacyJobCommands, runLegacyJobCommand } from './native-legacy-jobs.js';
 import { jobUpsertCommands, runJobUpsertCommand } from './native-job-upsert.js';
@@ -40,6 +41,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     }
   }
   const fields: Record<string, string[]> = {
+    ...groupedApprovalCommands,
     ...taskIntakeCommands,
     ...legacyJobCommands,
     ...jobUpsertCommands,
@@ -81,6 +83,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
       : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command!) ? 2 * 1024 * 1024 : 65536;
     return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
   };
+  if (Object.hasOwn(groupedApprovalCommands, command!)) return serialize(await runGroupedApprovalCommand(command!, repository, options, payload));
   if (Object.hasOwn(taskIntakeCommands, command!)) return serialize(await runTaskIntakeCommand(repository, options, payload));
   if (Object.hasOwn(legacyJobCommands, command!)) return serialize(await runLegacyJobCommand(command!, repository, options, selected));
   if (Object.hasOwn(jobUpsertCommands, command!)) return serialize(await runJobUpsertCommand(command!, repository, options, payload));

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -1,3 +1,4 @@
+import type { GroupedApprovalTransaction } from '../workspace-core/grouped-approvals.js';
 import { NativeClaimJournal, claimOperationKinds, validateClaimJournal } from './native-claim-journal.js';
 import { NativeClaimHistory } from './native-claim-history.js';
 import { validateCoordinator, requireJobUnclaimed } from '../contracts/workspace/claims.js';
@@ -353,6 +354,17 @@ export class NativeJobsRepository implements JobsRepository {
         saveSession:async document => { validateAnswerSession(document);await this.write(join(this.root,`sessions/${safeId(string(get(document,'applicationId')))}.json`),document,options); },
         commit:operation => this.claimJournal().commit(operation,jobs)});
     });
+  }
+
+  async groupedApprovalTransaction<T>(operation: (transaction: GroupedApprovalTransaction) => Promise<T>): Promise<T> {
+    return this.transaction(async () => operation({
+      jobs: validateJobsDocument(await this.document('jobs')),
+      sessions: await this.answerSessions(), answers: validateAnswers(await this.document('answers')),
+      saveSession: async document => {
+        validateAnswerSession(document);
+        await this.write(join(this.root, `sessions/${safeId(string(get(document, 'applicationId')))}.json`), document, options);
+      },
+    }));
   }
 
   async answerMergeTransaction<T>(operation: (transaction: AnswerMergeTransaction) => Promise<T>): Promise<T> {

--- a/src/workspace-core/grouped-approvals.ts
+++ b/src/workspace-core/grouped-approvals.ts
@@ -1,0 +1,145 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { answerRevision, fallback } from '../contracts/workspace/answers.js';
+import { sessionRevision } from '../contracts/workspace/answer-resolution.js';
+import { matches, pendingReference } from '../contracts/workspace/answer-session-fields.js';
+import { validateAnswerSession } from '../contracts/workspace/answer-session-validation.js';
+import { evaluateReuse } from '../contracts/workspace/answer-match-reuse.js';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { canonicalClaimAnswer, claimSessionObject, currentClaimApprovals } from '../contracts/workspace/claim-session-pending.js';
+import { emptyObject, safeId } from '../contracts/workspace/jobs.js';
+import { get, integer, keys, object, parse, same, serialize, set, string, text, truth, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import { semanticCandidate } from './answer-match.js';
+
+export interface GroupedApprovalTransaction {
+  jobs: Document;
+  sessions: Document[];
+  answers: Document;
+  saveSession(document: Document): Promise<void>;
+}
+export interface GroupedApprovalRepository {
+  groupedApprovalTransaction<T>(operation: (transaction: GroupedApprovalTransaction) => Promise<T>): Promise<T>;
+}
+const decisionFields = ['reference','answerKey','currentUse','remember','policyMode','useAuthority','allowedSensitiveFieldClasses'];
+const clone = (value: Value): Value => parse(serialize(value));
+const fingerprint = (value: Value): string => createHash('sha256').update(canonicalJson(value)).digest('hex');
+function equalToken(left: string, right: string): boolean {
+  const a = Buffer.from(left), b = Buffer.from(right);
+  return a.length === b.length && timingSafeEqual(a,b);
+}
+function answerRecord(answers: Document, key: string): Document | null {
+  const value = get(object(get(answers,'answers'),'answers'),canonicalClaimAnswer(answers,key));
+  if (value === null) return null;
+  const answer = object(value,'answer');
+  return get(answer,'deletedAt') === null ? answer : null;
+}
+function pendingFields(session: Document): Map<string,Document> {
+  return new Map((fallback(session,'pendingFields',[]) as Document[]).map(field => [string(get(field,'reference'))!,field]));
+}
+function projectDecision(raw: Value, pending: Map<string,Document>, answers: Document, seen: Set<string>): Document {
+  const decision = claimSessionObject(raw,'grouped approval decision');
+  if (decision.size !== decisionFields.length || keys(decision).some(key => !decisionFields.includes(key))) {
+    throw new JobsError('grouped approval decision contains unsupported fields');
+  }
+  const answerKey = string(get(decision,'answerKey'));
+  if (!answerKey) throw new JobsError('grouped approval answer key is invalid');
+  const reference = string(get(decision,'reference'));
+  if (reference === null || !matches(get(decision,'reference'),pendingReference) || seen.has(reference) || !pending.has(reference)) {
+    throw new JobsError('grouped approval reference is invalid');
+  }
+  seen.add(reference);
+  const currentUse = get(decision,'currentUse'), remember = get(decision,'remember');
+  if (typeof currentUse !== 'boolean' || typeof remember !== 'boolean') throw new JobsError('grouped approval decisions must be booleans');
+  if (!currentUse && string(get(decision,'useAuthority')) !== 'none') throw new JobsError('denied current use cannot carry reuse authority');
+  const answer = answerRecord(answers,answerKey);
+  if (answer === null) throw new JobsError('grouped approval answer is unavailable');
+  const field = pending.get(reference)!, boundKey = string(get(field,'answerKey'));
+  if (boundKey === null || canonicalClaimAnswer(answers,boundKey) !== string(get(answer,'key'))) {
+    throw new JobsError('grouped approval answer does not match pending field');
+  }
+  const answerSensitivity = fallback(answer,'sensitivity',text('none'));
+  const sensitivity = string(answerSensitivity) !== 'none' ? answerSensitivity
+    : text(get(field,'sensitive') === true || string(get(field,'state')) === 'sensitive' ? 'high':'none');
+  if (!same(get(field,'matchAnswerRevision'),integer(answerRevision(answer)))) throw new JobsError('pending field semantic match is stale');
+  const candidate = semanticCandidate(answer), match = emptyObject();
+  set(match,'answerKey',get(answer,'key'));
+  set(match,'confidenceBand',fallback(field,'matchConfidence',text('none')));
+  set(match,'reasonCodes',truth(get(field,'matchReasonCodes')) ? get(field,'matchReasonCodes') : [text('no_semantic_match')]);
+  let policy: Document;
+  try {
+    policy = evaluateReuse({match,candidate,scope:fallback(answer,'scope',emptyObject()),
+      fieldClass:fallback(field,'fieldClass',text('general')),sensitivity,
+      mode:get(decision,'policyMode'),useAuthority:get(decision,'useAuthority'),
+      allowedSensitiveFieldClasses:get(decision,'allowedSensitiveFieldClasses')});
+  } catch { throw new JobsError('grouped approval policy is invalid'); }
+  let reasons = get(policy,'reasonCodes') as Value[];
+  if (!equalToken(fingerprint(fallback(answer,'scope',emptyObject())),string(fallback(field,'scopeFingerprint',text(fingerprint(emptyObject()))))!)) {
+    reasons = reasons.filter(code => !['reuse_eligible','scope_match'].includes(string(code)!));
+    if (!reasons.some(code => string(code) === 'scope_mismatch')) reasons.push(text('scope_mismatch'));
+  }
+  const result = emptyObject();
+  for (const name of ['reference','currentUse','remember','policyMode','useAuthority']) set(result,name,get(decision,name));
+  set(result,'answerKey',get(answer,'key'));
+  set(result,'eligible',currentUse && reasons.some(code => string(code) === 'reuse_eligible'));
+  set(result,'confidenceBand',get(policy,'confidenceBand'));
+  set(result,'reasonCodes',reasons);
+  return set(result,'answerRevision',integer(answerRevision(answer)));
+}
+
+/** Field-scoped reuse decisions expose metadata only and write only the bound session. */
+export class GroupedApprovalsService {
+  constructor(private readonly repository: GroupedApprovalRepository, private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+  preview(jobId: string, jobRevision: bigint, expectedSessionRevision: bigint, decisions: Value): Promise<Document> {
+    safeId(jobId);
+    if (!Array.isArray(decisions) || !decisions.length) throw new JobsError('grouped approval requires at least one field decision');
+    return this.repository.groupedApprovalTransaction(async transaction => {
+      const rawJob = get(object(get(transaction.jobs,'jobs'),'jobs'),jobId);
+      if (rawJob === null || get(object(rawJob,'job'),'deletedAt') !== null) throw new JobsError('grouped approval job does not exist');
+      if (answerRevision(object(rawJob,'job')) !== jobRevision) throw new JobsError('job revision conflict');
+      const session = transaction.sessions.find(item => string(get(item,'applicationId')) === jobId);
+      if (!session) throw new JobsError('grouped approval session does not exist');
+      if (sessionRevision(session) !== expectedSessionRevision) throw new JobsError('session revision conflict');
+      const pending = pendingFields(session), seen = new Set<string>();
+      const approvals = decisions.map(raw => projectDecision(raw,pending,transaction.answers,seen));
+      approvals.sort((a,b) => string(get(a,'reference'))! < string(get(b,'reference'))! ? -1 : 1);
+      const result = set(emptyObject(),'jobRevision',integer(jobRevision));
+      set(result,'sessionRevision',integer(expectedSessionRevision));
+      set(result,'approvals',approvals);
+      set(result,'previewToken',text(`grouped-approval-v1.${fingerprint(result)}`));
+      return set(result,'mutated',false);
+    });
+  }
+  async approve(jobId: string, jobRevision: bigint, expectedSessionRevision: bigint, decisions: Value, previewToken: string, ownerConfirmed = false): Promise<Document> {
+    if (ownerConfirmed !== true) throw new JobsError('grouped approval requires explicit owner confirmation');
+    const preview = await this.preview(jobId,jobRevision,expectedSessionRevision,decisions);
+    if (typeof previewToken !== 'string' || !equalToken(previewToken,string(get(preview,'previewToken'))!)) throw new JobsError('grouped approval preview is stale');
+    // Reacquire the lock and recheck every bound identity before applying the preview.
+    return this.repository.groupedApprovalTransaction(async transaction => {
+      const rawJob = get(object(get(transaction.jobs,'jobs'),'jobs'),jobId);
+      const session = transaction.sessions.find(item => string(get(item,'applicationId')) === jobId);
+      if (rawJob === null || answerRevision(object(rawJob,'job')) !== jobRevision || !session) throw new JobsError('grouped approval state changed');
+      if (sessionRevision(session) !== expectedSessionRevision) throw new JobsError('session revision conflict');
+      const pending = pendingFields(session), projected = get(preview,'approvals') as Document[];
+      const byReference = new Map(projected.map(approval => [string(get(approval,'reference')),approval]));
+      for (const decision of decisions as Document[]) {
+        const reference = string(get(decision,'reference'))!, field = pending.get(reference);
+        const answer = answerRecord(transaction.answers,string(get(decision,'answerKey'))!);
+        if (!field || !answer) throw new JobsError('grouped approval state changed');
+        const boundKey = string(get(field,'answerKey'));
+        if (boundKey === null || canonicalClaimAnswer(transaction.answers,boundKey) !== string(get(answer,'key'))
+          || !same(integer(answerRevision(answer)),get(byReference.get(reference)!,'answerRevision'))) throw new JobsError('grouped approval state changed');
+      }
+      const updated = object(clone(session),'session');
+      const approvals = new Map(currentClaimApprovals(session,[...pending.values()],transaction.answers,get(session,'attemptRevision'))
+        .map(value => [string(get(object(value,'approval'),'reference'))!,value]));
+      for (const approval of projected) approvals.set(string(get(approval,'reference'))!,clone(approval));
+      set(updated,'approvals',[...approvals.keys()].sort().map(reference => approvals.get(reference)!));
+      set(updated,'updatedAt',text(this.now()));
+      validateAnswerSession(updated);
+      await transaction.saveSession(updated);
+      const result = set(emptyObject(),'approved',true);
+      set(result,'sessionRevision',integer(sessionRevision(updated)));
+      return set(result,'approvals',clone(get(updated,'approvals')));
+    });
+  }
+}

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,3 +1,4 @@
+import { nativeGroupedApprovalsBrowser } from './workspace_native_grouped_approvals_browser_support.mjs';
 import { legacyJobsBrowser } from './workspace_native_legacy_jobs_browser_support.mjs';
 import { taskIntakeBrowser } from './workspace_native_task_intake_browser_support.mjs';
 import { claimsBrowser } from './workspace_native_claims_browser_support.mjs';
@@ -199,10 +200,11 @@ export async function nativeJobsBrowser(buildRoot) {
         return JSON.parse(result.stdout);
       },
     });
+    const groupedApprovals = await nativeGroupedApprovalsBrowser(page, root, fixture, buildRoot);
     const unsupported = await fetch(startup.origin + '/api/trash', { headers: { Authorization: `Bearer ${token}` } });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { taskIntake, legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { groupedApprovals, taskIntake, legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     releaseInitialClaim?.();
     if (browser) await browser.close();

--- a/tests_js/workspace_native_grouped_approvals.test.mjs
+++ b/tests_js/workspace_native_grouped_approvals.test.mjs
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, revisions, preview, differential, unchanged, plain, read, write, snapshot, at } from './workspace_native_grouped_approvals_support.mjs';
+import { cli } from './workspace_native_claims_support.mjs';
+import { NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { GroupedApprovalsService } from '../runtime/workspace-core/grouped-approvals.js';
+import { fromJSON } from '../runtime/contracts/workspace/values.js';
+
+test('native grouped approvals preserve Python policy, privacy and revision contracts', {timeout:120000}, async t => {
+  const fixture = await nativeFixture();
+  try {
+    await t.test('preview is deterministic and approval stores only field decisions', async () => {
+      const state = await setup(fixture, 'parity');
+      const before = await snapshot(state.root);
+      const initial = await preview(state);
+      assert.equal(initial.mutated, false);
+      assert.ok(initial.approvals.every(item => item.eligible));
+      assert.deepEqual(await preview(state, [...state.decisions].reverse()), initial);
+      assert.deepEqual(await snapshot(state.root), before);
+      await differential(state, join(fixture.root, 'parity-python'), [
+        {decisions:state.decisions},
+        {decisions:[state.decisions[0]], approve:true},
+        {decisions:[state.decisions[1]], approve:true},
+        {decisions:[{...state.decisions[0], currentUse:false, useAuthority:'none', remember:true}], approve:true},
+      ]);
+      const session = await read(state.root, 'sessions/job.json');
+      assert.equal(session.approvals.length, 2);
+      const denied = session.approvals.find(item => item.reference === state.decisions[0].reference);
+      assert.equal(denied.currentUse, false); assert.equal(denied.eligible, false); assert.equal(denied.remember, true);
+      assert.equal((await stat(join(state.root, 'sessions/job.json'))).mode & 0o777, 0o600);
+      assert.doesNotMatch(await readFile(join(state.root, 'sessions/job.json'), 'utf8'), /PRIVATE-/);
+    });
+    await t.test('malformed, stale and owner-unconfirmed decisions are unchanged differential failures', async () => {
+      const state = await setup(fixture, 'errors'), first = state.decisions[0];
+      await differential(state, join(fixture.root, 'errors-python'), [
+        {decisions:[]}, {decisions:[first,first]},
+        {decisions:[{...first, extra:'PRIVATE-INVALID'}]},
+        {decisions:[{...first, answerKey:''}]},
+        {decisions:[{...first, reference:`pending_${'f'.repeat(32)}`}]},
+        {decisions:[{...first, currentUse:1}]},
+        {decisions:[{...first, currentUse:false}]},
+        {decisions:[{...first, answerKey:'absent'}]},
+        {decisions:[{...first, answerKey:'second'}]},
+        {decisions:[{...first, policyMode:'PRIVATE-INVALID'}]},
+        {decisions:[{...first, allowedSensitiveFieldClasses:'invalid'}]},
+        {decisions:[first], jobRevision:1},
+        {decisions:[first], sessionRevision:1},
+        {decisions:[first], approve:true, token:'tampered'},
+        {decisions:[first], approve:true, confirmed:false},
+      ]);
+    });
+    await t.test('scope and sensitive-field restrictions cannot be overridden by current use', async () => {
+      const state = await setup(fixture, 'policy');
+      const session = await read(state.root, 'sessions/job.json');
+      session.pendingFields[0].scopeFingerprint = '0'.repeat(64);
+      session.pendingFields[1].sensitive = true;
+      await write(state.root, 'sessions/job.json', session);
+      await differential(state, join(fixture.root, 'policy-python'), [
+        {decisions:state.decisions}, {decisions:state.decisions, approve:true},
+      ]);
+      const result = await preview(state);
+      assert.equal(result.approvals.find(item => item.reference === state.decisions[0].reference).eligible, false);
+      assert.ok(result.approvals.find(item => item.reference === state.decisions[0].reference).reasonCodes.includes('scope_mismatch'));
+      assert.equal(result.approvals.find(item => item.reference === state.decisions[1].reference).eligible, false);
+    });
+    await t.test('partial approval prunes obsolete answer revisions and retains current decisions', async () => {
+      const state = await setup(fixture, 'retention');
+      const initial = await preview(state);
+      await state.service.approve('job', ...await revisions(state), fromJSON(state.decisions), initial.previewToken, true);
+      const answers = await read(state.root, 'answers.json');
+      answers.answers.first.revision += 1;
+      await write(state.root, 'answers.json', answers);
+      await differential(state, join(fixture.root, 'retention-python'), [
+        {decisions:[state.decisions[0]]},
+        {decisions:[state.decisions[1]], approve:true},
+      ]);
+      const session = await read(state.root, 'sessions/job.json');
+      assert.deepEqual(session.approvals.map(item => item.answerKey).sort(), ['second','third']);
+    });
+    await t.test('retired answer identities resolve to the current canonical answer', async () => {
+      const state = await setup(fixture, 'redirect');
+      const answers = await read(state.root, 'answers.json');
+      answers.redirects = {...answers.redirects, retired:{targetKey:'first', mergedAt:at}};
+      await write(state.root, 'answers.json', answers);
+      const session = await read(state.root, 'sessions/job.json');
+      session.pendingFields[0].answerKey = 'retired';
+      await write(state.root, 'sessions/job.json', session);
+      const decision = {...state.decisions[0], answerKey:'retired'};
+      await differential(state, join(fixture.root, 'redirect-python'), [{decisions:[decision]}, {decisions:[decision], approve:true}]);
+      assert.equal((await read(state.root, 'sessions/job.json')).approvals[0].answerKey, 'first');
+    });
+    await t.test('answer changes between preview and commit are rejected under the second lock', async () => {
+      const state = await setup(fixture, 'answer-race'), current = await preview(state), revs = await revisions(state);
+      const before = await readFile(join(state.root, 'sessions/job.json'), 'utf8');
+      const service = new GroupedApprovalsService(state.repository, () => at);
+      const original = service.preview.bind(service);
+      service.preview = async (...args) => {
+        const result = await original(...args);
+        await state.answers.update('first', fromJSON({aliases:['First authorization field']}), 1n);
+        return result;
+      };
+      await assert.rejects(() => service.approve('job', ...revs, fromJSON(state.decisions), current.previewToken, true), /grouped approval state changed/);
+      assert.equal(await readFile(join(state.root, 'sessions/job.json'), 'utf8'), before);
+    });
+    await t.test('an active coordinator claim remains intact during owner approval', async () => {
+      const state = await setup(fixture, 'claimed', {claimed:true});
+      const before = await readFile(join(state.root, 'coordinator.json'), 'utf8');
+      await differential(state, join(fixture.root, 'claimed-python'), [{decisions:state.decisions, approve:true}]);
+      assert.equal(await readFile(join(state.root, 'coordinator.json'), 'utf8'), before);
+    });
+    await t.test('competing approvals accept one session revision and reject the stale writer', async () => {
+      const state = await setup(fixture, 'concurrent'), current = await preview(state), revs = await revisions(state);
+      const reopened = new GroupedApprovalsService(new NativeJobsRepository(state.root, state.provider), () => at);
+      const result = await Promise.allSettled([state.service, reopened].map(service => service.approve(
+        'job', ...revs, fromJSON(state.decisions), current.previewToken, true)));
+      assert.equal(result.filter(item => item.status === 'fulfilled').length, 1);
+      assert.match(result.find(item => item.status === 'rejected').reason.message, /session revision conflict/);
+      assert.equal((await read(state.root, 'sessions/job.json')).approvals.length, 3);
+    });
+    await t.test('write errors propagate without a successful result or partial session change', async () => {
+      const state = await setup(fixture, 'write-failure'), current = await preview(state), revs = await revisions(state);
+      const repository = new NativeJobsRepository(state.root, state.provider, async () => {throw Error('fixture write failed');});
+      const service = new GroupedApprovalsService(repository, () => at);
+      assert.deepEqual(plain(await service.preview('job', ...revs, fromJSON(state.decisions))), current);
+      await unchanged(state.root, () => service.approve('job', ...revs, fromJSON(state.decisions), current.previewToken, true), /fixture write failed/);
+    });
+    await t.test('CLI previews and commits using the native fixture with Python absent', async () => {
+      const state = await setup(fixture, 'cli'), revs = await revisions(state);
+      const flags = ['--id','job','--expected-job-revision',String(revs[0]),'--expected-session-revision',String(revs[1])];
+      const current = await cli(fixture, state.root, 'approval-preview', flags, {decisions:state.decisions});
+      assert.deepEqual(current, await preview(state));
+      const approved = await cli(fixture, state.root, 'approval-approve', [...flags,'--preview-token',current.previewToken,'--owner-confirmed'], {decisions:state.decisions});
+      assert.equal(approved.approved, true);
+      assert.equal(approved.approvals.length, 3);
+      assert.doesNotMatch(JSON.stringify(approved), /PRIVATE-|tokenHash/);
+    });
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_grouped_approvals_browser_support.mjs
+++ b/tests_js/workspace_native_grouped_approvals_browser_support.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { snapshot } from './workspace_native_claims_support.mjs';
+
+// The caller owns this newly initialized, disposable v9 fixture and its browser.
+export async function nativeGroupedApprovalsBrowser(page, root, fixture, buildRoot) {
+  const execute = promisify(execFile), id = 'grouped-browser-job', key = 'grouped-browser-answer';
+  async function cli(command, args = [], payload) {
+    if (payload !== undefined) {
+      const input = join(fixture.root, 'grouped-browser-input.json');
+      await writeFile(input, JSON.stringify(payload), { mode: 0o600 });
+      args = [...args, '--input', input];
+    }
+    const result = await execute(process.execPath, [join(buildRoot, 'runtime/cli/native-jobs.js'),
+      '--root', root, '--native-lock', fixture.receipt.artifact, command, ...args], { env: { PATH: '' } });
+    assert.equal(result.stderr, '');
+    return JSON.parse(result.stdout);
+  }
+  await cli('answer-put', [], { key, question: 'Grouped fixture authorization?', state: 'confirmed',
+    value: 'PRIVATE-GROUPED-BROWSER-VALUE', scope: { ats: 'greenhouse' }, fieldClass: 'authorization' });
+  await cli('job-create', [], { id, url: 'https://example.invalid/grouped-browser', ats: 'greenhouse',
+    role: 'Grouped fixture role', company: 'Grouped fixture company' });
+  await cli('task-select', ['--id', id, '--expected-revision', '1', '--owner-confirmed']);
+  const acquired = await cli('job-acquire', ['--id', id, '--expected-revision', '2', '--owner', 'Fixture browser']);
+  await cli('claim-handoff', ['--id', id, '--token', acquired.token, '--status', 'needs_info', '--expected-revision', '3'],
+    { status: 'active', pendingFields: [{ question: 'Grouped fixture authorization?', state: 'missing',
+      answerKey: key, sensitive: false, fieldClass: 'authorization', scope: { ats: 'greenhouse' } }] });
+  const sessionPath = join(root, 'sessions', `${id}.json`);
+  const session = JSON.parse(await readFile(sessionPath, 'utf8'));
+  const activity = await cli('job-activity', ['--id', id]);
+  const args = ['--id', id, '--expected-job-revision', String(activity.job.revision),
+    '--expected-session-revision', String(activity.session.revision)];
+  const payload = { decisions: [{ reference: session.pendingFields[0].reference, answerKey: key,
+    currentUse: true, remember: false, policyMode: 'strict', useAuthority: 'accepted_record', allowedSensitiveFieldClasses: [] }] };
+  await page.getByRole('button', { name: 'Jobs', exact: true }).click();
+  await page.getByRole('button', { name: 'Refresh', exact: true }).click();
+  await page.getByRole('button', { name: /Grouped fixture role/ }).click();
+  const modal = page.getByRole('dialog', { name: 'Edit job', exact: true });
+  const panel = modal.getByRole('region', { name: 'Job activity', exact: true });
+  await panel.getByText('1 pending items · 0 current session approvals', { exact: true }).waitFor();
+  const before = await snapshot(root);
+  const preview = await cli('approval-preview', args, payload);
+  assert.equal(preview.mutated, false);
+  assert.equal(preview.approvals[0].eligible, true);
+  assert.deepEqual(await snapshot(root), before);
+  const approved = await cli('approval-approve', [...args, '--preview-token', preview.previewToken, '--owner-confirmed'], payload);
+  assert.equal(approved.approved, true);
+  const after = await snapshot(root);
+  assert.notEqual(after[`sessions/${id}.json`], before[`sessions/${id}.json`]);
+  delete before[`sessions/${id}.json`]; delete after[`sessions/${id}.json`];
+  assert.deepEqual(after, before, 'approval writes only the selected session');
+  const refreshed = page.waitForResponse(response => response.url().endsWith(`/api/jobs/${id}/activity`));
+  await panel.getByRole('button', { name: 'Refresh activity', exact: true }).click();
+  const response = await refreshed;
+  assert.equal(response.status(), 200);
+  const projected = await response.json();
+  assert.deepEqual(projected.session.approvals, approved.approvals);
+  assert.equal(projected.session.revision, approved.sessionRevision);
+  await panel.getByText('1 pending items · 1 current session approvals', { exact: true }).waitFor();
+  await panel.getByText(/Current session approval recorded\./).waitFor();
+  assert.doesNotMatch(await panel.innerText(), /PRIVATE-GROUPED-BROWSER-VALUE/);
+  assert.doesNotMatch(JSON.stringify(projected), /PRIVATE-GROUPED-BROWSER-VALUE|tokenHash/);
+  // A later answer revision makes the persisted approval stale in the existing projection.
+  await cli('answer-update', ['--key', key, '--expected-revision', '1'], { source: 'Fixture revision change' });
+  await panel.getByRole('button', { name: 'Refresh activity', exact: true }).click();
+  await panel.getByText('1 pending items · 0 current session approvals', { exact: true }).waitFor();
+  await panel.getByText(/No current session approval\./).waitFor();
+  assert.equal(JSON.parse(await readFile(sessionPath, 'utf8')).approvals.length, 1);
+  assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1));
+  await modal.getByRole('button', { name: 'Close job details', exact: true }).click();
+  return { previewReadOnly: true, sessionOnlyCommit: true, activityRefresh: true,
+    approvalInvalidation: true, valueFree: true, narrow: true, pythonAbsentFromPath: true };
+}

--- a/tests_js/workspace_native_grouped_approvals_support.mjs
+++ b/tests_js/workspace_native_grouped_approvals_support.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { cp } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join } from 'node:path';
+import { setup as claimsSetup, plain, read, write, snapshot } from './workspace_native_claims_support.mjs';
+import { AnswersService } from '../runtime/workspace-core/answers.js';
+import { GroupedApprovalsService } from '../runtime/workspace-core/grouped-approvals.js';
+import { sessionRevision } from '../runtime/contracts/workspace/answer-resolution.js';
+import { fromJSON, text } from '../runtime/contracts/workspace/values.js';
+export { plain, read, write, snapshot };
+export const at = '2026-09-10T14:00:00Z';
+export async function setup(fixture, name, { claimed = false } = {}) {
+  const state = await claimsSetup(fixture, name);
+  const answers = new AnswersService(state.repository, () => at);
+  for (const key of ['first', 'second', 'third']) {
+    await answers.put(fromJSON({key, question:`Stored ${key} field?`, state:'confirmed', value:`PRIVATE-ANSWER-${key}`,
+      scope:{ats:'greenhouse'}, fieldClass:'authorization'}));
+  }
+  await state.claims.select('job', 1n, true);
+  const acquired = plain(await state.claims.acquire('job', text('Fixture owner'), 2n));
+  const packet = {status:'active', pendingFields:['first','second','third'].map(key => ({question:`Stored ${key} field?`,
+    state:'missing', answerKey:key, sensitive:false, fieldClass:'authorization', scope:{ats:'greenhouse'}}))};
+  if (claimed) await state.claims.progress('job', text(acquired.token), fromJSON(packet));
+  else await state.claims.handoff('job', text(acquired.token), 'needs_info', fromJSON(packet), 3n);
+  const session = await read(state.root, 'sessions/job.json');
+  const decisions = session.pendingFields.map(field => ({reference:field.reference, answerKey:field.answerKey,
+    currentUse:true, remember:false, policyMode:'strict', useAuthority:'accepted_record', allowedSensitiveFieldClasses:[]}));
+  return {...state, answers, decisions, service:new GroupedApprovalsService(state.repository, () => at)};
+}
+export async function revisions(state) {
+  return [BigInt((await read(state.root, 'jobs.json')).jobs.job.revision),
+    sessionRevision(fromJSON(await read(state.root, 'sessions/job.json')))];
+}
+export async function preview(state, decisions = state.decisions) {
+  return plain(await state.service.preview('job', ...await revisions(state), fromJSON(decisions)));
+}
+export async function unchanged(root, operation, pattern) {
+  const before = await snapshot(root);
+  await assert.rejects(operation, pattern);
+  assert.deepEqual(await snapshot(root), before);
+}
+const python = `import importlib.util,json,sys
+from pathlib import Path
+from datetime import datetime,timezone
+sys.path.insert(0,str(Path('scripts').resolve()))
+spec=importlib.util.spec_from_file_location('approval_reference','scripts/job-apply-store.py')
+module=importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+module.utc_now=lambda:'2026-09-10T14:00:00Z'
+store=module.Store(Path(sys.argv[1]),clock=lambda:datetime(2026,9,10,14,tzinfo=timezone.utc))
+store.initialize()
+results=[]
+for operation in json.loads(sys.argv[2]):
+    session=store._read_session_projection(store._session_path('job'),'job','greenhouse')
+    job_revision=store._load_jobs_document()['jobs']['job']['revision']
+    session_revision=store._session_revision(session)
+    try:
+        args=('job',operation.get('jobRevision',job_revision),operation.get('sessionRevision',session_revision),operation['decisions'])
+        preview=store.preview_grouped_approval(*args)
+        result=store.approve_grouped_approval(*args,operation.get('token',preview['previewToken']),owner_confirmed=operation.get('confirmed',True)) if operation.get('approve') else preview
+        record={'result':result}
+    except module.StoreError as error:
+        record={'error':str(error)}
+    record['session']=json.loads(store._session_path('job').read_text())
+    results.append(record)
+print(json.dumps(results))`;
+export async function differential(state, target, operations) {
+  await cp(state.root, target, {recursive:true, preserveTimestamps:true});
+  const expected = JSON.parse((await promisify(execFile)('python3', ['-c', python, target, JSON.stringify(operations)],
+    {maxBuffer:8*1024*1024})).stdout);
+  for (const [index, operation] of operations.entries()) {
+    const before = await snapshot(state.root);
+    const revs = await revisions(state);
+    const args = ['job', BigInt(operation.jobRevision ?? revs[0]), BigInt(operation.sessionRevision ?? revs[1]), fromJSON(operation.decisions)];
+    let actual;
+    try {
+      const projected = plain(await state.service.preview(...args));
+      actual = {result:operation.approve ? plain(await state.service.approve(...args, operation.token ?? projected.previewToken, operation.confirmed ?? true)) : projected};
+    } catch (error) { actual = {error:error.message}; }
+    const {session, ...result} = expected[index];
+    assert.deepEqual(actual, result, `operation ${index}`);
+    assert.deepEqual(await read(state.root, 'sessions/job.json'), session, `persisted session ${index}`);
+    const after = await snapshot(state.root);
+    if (actual.error || !operation.approve) assert.deepEqual(after, before);
+    delete before['sessions/job.json']; delete after['sessions/job.json'];
+    assert.deepEqual(after, before, 'grouped approval changes only its session');
+    assert.doesNotMatch(JSON.stringify(actual), /PRIVATE-|tokenHash|resume\.txt/);
+  }
+}


### PR DESCRIPTION
Adds native fixture `approval-preview` and `approval-approve` commands for field-specific answer reuse decisions. Preview evaluates the existing semantic and sensitive-field policy without writing. Approval requires explicit owner confirmation and the preview token, rechecks job/session/answer revisions under the Store lock, and atomically saves only the selected session while retaining other current approvals.

The commands return value-free service results. The version 9 synthetic-fixture boundary remains in force; this does not activate live native Stores or implement the full compatibility task CLI wrapper.

Validation:
- 11 focused tests passed, including Python differential results/tokens/persisted sessions, stale state, redirects, sensitivity, concurrent approvals and write failures.
- Production standalone browser walkthrough passed with Python absent from the native CLI PATH; Activity reflects approvals and invalidates them after answer changes.
- TypeScript build, source-size and test-matrix checks passed.
- Five independent reviews (correctness, contracts, silent failures, tests and documentation) found no actionable issues. Normal commit hooks, all 27 deep-validation suites and normal push hooks passed. [Validate Plugin](https://github.com/neonwatty/job-apply-plugin/actions/runs/34608766466) and [Release Plugin](https://github.com/neonwatty/job-apply-plugin/actions/runs/34608769089) passed on `e18da71b0d33295b0ec51fc807a34f8ff2cb2861`.
- Native `codex review` could not run because the installed CLI does not support the configured model; independent review proceeded against staging.
