### PR TITLE
Add native fixture task compatibility CLI

### DIFF
--- a/config/migration/cli-native-task-surfaces.json
+++ b/config/migration/cli-native-task-surfaces.json
@@ -1,0 +1,255 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-task.ts:snapshot",
+      "kind": "cli",
+      "command": "snapshot",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-task.ts",
+        "src/cli/task-runner.ts",
+        "src/cli/task-command.ts",
+        "src/cli/task-protocol.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-task.ts:activity",
+      "kind": "cli",
+      "command": "activity",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-task.ts",
+        "src/cli/task-runner.ts",
+        "src/cli/task-command.ts",
+        "src/cli/task-protocol.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-task.ts:intake",
+      "kind": "cli",
+      "command": "intake",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-task.ts",
+        "src/cli/task-runner.ts",
+        "src/cli/task-command.ts",
+        "src/cli/task-protocol.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-task.ts:select",
+      "kind": "cli",
+      "command": "select",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-task.ts",
+        "src/cli/task-runner.ts",
+        "src/cli/task-command.ts",
+        "src/cli/task-protocol.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-task.ts:resolve-pending-answer",
+      "kind": "cli",
+      "command": "resolve-pending-answer",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-task.ts",
+        "src/cli/task-runner.ts",
+        "src/cli/task-command.ts",
+        "src/cli/task-protocol.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-task.ts:semantic-lookup",
+      "kind": "cli",
+      "command": "semantic-lookup",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-task.ts",
+        "src/cli/task-runner.ts",
+        "src/cli/task-command.ts",
+        "src/cli/task-protocol.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-task.ts:cleanup-preview",
+      "kind": "cli",
+      "command": "cleanup-preview",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-task.ts",
+        "src/cli/task-runner.ts",
+        "src/cli/task-command.ts",
+        "src/cli/task-protocol.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-task.ts:cleanup-approve",
+      "kind": "cli",
+      "command": "cleanup-approve",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-task.ts",
+        "src/cli/task-runner.ts",
+        "src/cli/task-command.ts",
+        "src/cli/task-protocol.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-task.ts:approval-preview",
+      "kind": "cli",
+      "command": "approval-preview",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-task.ts",
+        "src/cli/task-runner.ts",
+        "src/cli/task-command.ts",
+        "src/cli/task-protocol.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-task.ts:approval-approve",
+      "kind": "cli",
+      "command": "approval-approve",
+      "node": "SESS",
+      "sources": [
+        "src/cli/native-task.ts",
+        "src/cli/task-runner.ts",
+        "src/cli/task-command.ts",
+        "src/cli/task-protocol.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -134,6 +134,10 @@
       "sha256": "f02dfdea3805c56058502e394c9c8fbcb320bb7001e925c5639d664f0e7b28df"
     },
     {
+      "path": "cli-native-task-surfaces.json",
+      "sha256": "5d76f753b1686977495469a8676895f2059663ee243415453b7a5ed255c301a5"
+    },
+    {
       "path": "cli-root-01-surfaces.json",
       "sha256": "12f7e2a79b07b0f67b299487ac7d0a06d967a0d373e3da336a91b06fc040695a"
     },
@@ -352,6 +356,10 @@
     {
       "path": "source-catalog-native-resumes.json",
       "sha256": "29dd7f8508a7d203df336e2dad4c4b643daf4c4441f4cbee96d4ea0f5d15cc17"
+    },
+    {
+      "path": "source-catalog-native-task-cli.json",
+      "sha256": "df55a8733e48d55074f60d5546eb5103d5d3f01bd3711341a8311843c3db6ff2"
     },
     {
       "path": "source-catalog-native-task-intake.json",

--- a/config/migration/source-catalog-native-task-cli.json
+++ b/config/migration/source-catalog-native-task-cli.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "runtime/cli/native-task.js",
+      "sha256": "f227ee026943d25d28b3afad4a957365e4f780be20e920665c7b56001ceb9af7",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/cli/task-command.js",
+      "sha256": "e5640e721a4a32f6343ed8b11d4700a75d5200ab569690eb9d853bde3921c34c",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/cli/task-protocol.js",
+      "sha256": "7c409af49fa649f6dec4deb930b8807e6e73c98e5ea3d16893e4530d0a3811df",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/cli/task-runner.js",
+      "sha256": "fc8b1eb6c4111bf7377ef9c735735441d1da679c53a6dbb7246ca0273f224e79",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-task.ts",
+      "sha256": "4d58ad624fac8b0793de17093b9b51dd5b174c541490a14e058968fcc9d76bbd",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/task-command.ts",
+      "sha256": "12f81837cad2bd95a907a359891c79cc826bf41965e6408af79dfaad91ec3bb7",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/task-protocol.ts",
+      "sha256": "993a6276118ddde24ca96ce811f56647c6485b99f4d7d99c231a49f51e092fb9",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/task-runner.ts",
+      "sha256": "08862128094374203cc3601c8bb6d813413ad6b4c86cd0b4d1eea05be7fc7012",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/docs/native-jobs-fixture.md
+++ b/docs/native-jobs-fixture.md
@@ -15,7 +15,8 @@ Facts/profile operations, [active claims](native-claims-fixture.md),
 [CLI job upsert preview/commit](native-job-upsert-fixture.md), and
 [CLI legacy job import](native-legacy-jobs-fixture.md) and
 [CLI single-job task intake](native-task-intake-fixture.md), and
-[CLI grouped answer approvals](native-grouped-approvals-fixture.md) are also available. Other
+[CLI grouped answer approvals](native-grouped-approvals-fixture.md), and the
+[compatibility task CLI](native-task-cli-fixture.md) are also available. Other
 workflows return `unsupported_native_workflow`; they never fall back to Python.
 
 ## Run against a new synthetic root

--- a/docs/native-task-cli-fixture.md
+++ b/docs/native-task-cli-fixture.md
@@ -1,0 +1,72 @@
+# Native task compatibility CLI fixture
+
+The opt-in version 9 native fixture exposes the ten task commands through
+`runtime/cli/native-task.js`. This entry point wraps the existing native services
+in the Python task CLI's JSON success and error protocol. It does not change the
+installed launcher or authorize migration of an existing applicant Store.
+
+## Connect to a disposable fixture
+
+Build the native runtime and addon and initialize a new synthetic Store as
+explained in [Native Jobs fixture](native-jobs-fixture.md). Supply both native
+connection flags before the command:
+
+```sh
+node runtime/cli/native-task.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node snapshot
+node runtime/cli/native-task.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node intake --input /absolute/synthetic-job.json
+node runtime/cli/native-task.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node activity --id synthetic-job
+```
+
+`--root` and `--native-lock` select an explicitly initialized native fixture and
+its addon. They are native connection requirements, separate from compatibility
+of the task command protocol. The wrapper does not default to the owner's home
+Store or activate Python-to-native writer handoff. Keep Python writers and real
+applicant data away from the native fixture.
+
+All `--input` arguments name UTF-8 JSON files containing an object. Unlike the
+lower-level native Jobs CLI, this wrapper does not interpret `--input -` as stdin;
+it names a file literally called `-`. Intake always uses agent provenance. The
+lower-level `runtime/cli/native-jobs.js` entry point remains available with its
+existing command names and service results.
+
+## Commands and results
+
+| Command | Required command arguments |
+| --- | --- |
+| `snapshot` | None |
+| `activity` | `--id` |
+| `intake` | `--input` |
+| `select` | `--id`, `--expected-revision` |
+| `resolve-pending-answer` | `--id`, `--reference`, `--expected-job-revision`, `--expected-session-revision`, `--expected-answer-revision` |
+| `semantic-lookup` | `--input` |
+| `cleanup-preview` | None |
+| `cleanup-approve` | `--input` |
+| `approval-preview` | `--id`, `--expected-job-revision`, `--expected-session-revision`, `--input` |
+| `approval-approve` | `--id`, `--expected-job-revision`, `--expected-session-revision`, `--preview-token`, `--input` |
+
+`select`, `resolve-pending-answer`, `cleanup-approve` and `approval-approve`
+require explicit `--owner-confirmed` to perform their operation. Do not add this
+flag without the owner's confirmation. Existing preflight, exact revision,
+semantic reuse and preview-token checks remain in force. Grouped approval input
+is an object containing only `decisions`; see the
+[grouped approval fixture](native-grouped-approvals-fixture.md) for its fields.
+
+Successful operations exit 0 and emit JSON on stdout with `ok: true` and the
+command name. Snapshot nests its result under `snapshot`; activity returns
+`jobId` and `activity`. Other commands include their service result in the
+success envelope. Intake and snapshot retain their restricted job projections.
+Errors exit 2 and emit `{"ok":false,"error":{"code":"…","message":"…"}}`
+on stdout with generic, redacted messages and empty stderr. `--help` displays
+usage rather than a task result.
+
+## Validation boundary
+
+The production Companion browser proof runs the wrapper with Python absent from
+PATH against a disposable fixture. It captures a job, checks its visibility in
+Jobs, verifies activity and snapshot envelopes, rejects selection without owner
+confirmation without changing Jobs, then selects with confirmation and reloads
+the canonical revision in Companion. This adds no HTTP endpoint or browser form.
+
+Compatibility at this fixture boundary does not establish live writer handoff,
+legacy Store adoption, installed launcher activation or complete Python-free
+packaging. Those remain separate migration work.

--- a/runtime/cli/native-task.js
+++ b/runtime/cli/native-task.js
@@ -1,0 +1,16 @@
+import { realpathSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+/** Keep module/addon load failures inside the redacted task protocol boundary. */
+export async function runTaskCli(args) {
+    try {
+        return await (await import('./task-runner.js')).runTask(args);
+    }
+    catch {
+        return { output: '{"error":{"code":"store_unavailable","message":"The canonical store is unavailable."},"ok":false}\n', exitCode: 2 };
+    }
+}
+if (process.argv[1] && pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url) {
+    const result = await runTaskCli(process.argv.slice(2));
+    process.stdout.write(result.output);
+    process.exitCode = result.exitCode;
+}

--- a/runtime/cli/task-command.js
+++ b/runtime/cli/task-command.js
@@ -1,0 +1,59 @@
+import { WorkspaceProjectionsService } from '../workspace-core/workspace-projections.js';
+import { TaskIntakeService } from '../workspace-core/task-intake.js';
+import { ClaimsService } from '../workspace-core/claims.js';
+import { PendingAnswersService } from '../workspace-core/pending-answers.js';
+import { AnswersService } from '../workspace-core/answers.js';
+import { AnswerMergeService } from '../workspace-core/answer-merges.js';
+import { GroupedApprovalsService } from '../workspace-core/grouped-approvals.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { get, keys, object, set, text } from '../contracts/workspace/values.js';
+import { parseTaskRevision, TaskRequestError } from './task-protocol.js';
+/** Adapt task protocol envelopes to the existing locked native services. */
+export async function runTaskCommand(parsed, repository, payload) {
+    const { command, options, ownerConfirmed } = parsed;
+    const option = (name) => options.get(name);
+    const revision = (name) => parseTaskRevision(option(name));
+    const result = set(set(emptyObject(), 'ok', true), 'command', text(command));
+    if (command === 'snapshot')
+        return set(result, 'snapshot', await new WorkspaceProjectionsService(repository).taskSnapshot());
+    if (command === 'activity') {
+        set(result, 'jobId', text(option('--id')));
+        return set(result, 'activity', await new WorkspaceProjectionsService(repository).activity(option('--id')));
+    }
+    let operation;
+    switch (command) {
+        case 'intake':
+            operation = await new TaskIntakeService(repository).intake(await payload(), 'agent');
+            break;
+        case 'select':
+            operation = await new ClaimsService(repository).select(option('--id'), revision('--expected-revision'), ownerConfirmed);
+            break;
+        case 'resolve-pending-answer':
+            operation = await new PendingAnswersService(repository).resolve(option('--id'), option('--reference'), revision('--expected-job-revision'), revision('--expected-session-revision'), revision('--expected-answer-revision'), ownerConfirmed);
+            break;
+        case 'semantic-lookup':
+            operation = await new AnswersService(repository).semanticLookup(await payload());
+            break;
+        case 'cleanup-preview':
+            operation = await new AnswersService(repository).cleanupPreview();
+            break;
+        case 'cleanup-approve':
+            operation = await new AnswerMergeService(repository).approve(await payload(), ownerConfirmed);
+            break;
+        case 'approval-preview':
+        case 'approval-approve': {
+            const incoming = await payload();
+            if (keys(incoming).length !== 1 || !Array.isArray(get(incoming, 'decisions')))
+                throw new TaskRequestError();
+            const service = new GroupedApprovalsService(repository);
+            const args = [option('--id'), revision('--expected-job-revision'), revision('--expected-session-revision'), get(incoming, 'decisions')];
+            operation = command === 'approval-preview' ? await service.preview(...args)
+                : await service.approve(...args, option('--preview-token'), ownerConfirmed);
+            break;
+        }
+        default: throw new TaskRequestError();
+    }
+    for (const [key, value] of object(operation, 'task result').entries())
+        result.set(key, value);
+    return result;
+}

--- a/runtime/cli/task-protocol.js
+++ b/runtime/cli/task-protocol.js
@@ -1,0 +1,146 @@
+import { JobsError, fromJSON, object } from '../contracts/workspace/values.js';
+import { StoreValidationError } from '../store/validation.js';
+export class TaskRequestError extends Error {
+    constructor() { super('invalid task request'); }
+}
+export class TaskHelp extends Error {
+    command;
+    constructor(command) {
+        super('task help requested');
+        this.command = command;
+    }
+}
+const revisionFields = ['--expected-job-revision', '--expected-session-revision'];
+const approvalFields = ['--id', ...revisionFields, '--input'];
+export const taskCommandFields = {
+    snapshot: [], activity: ['--id'], intake: ['--input'],
+    select: ['--id', '--expected-revision', '--owner-confirmed'],
+    'resolve-pending-answer': ['--id', '--reference', ...revisionFields,
+        '--expected-answer-revision', '--owner-confirmed'],
+    'semantic-lookup': ['--input'], 'cleanup-preview': [],
+    'cleanup-approve': ['--input', '--owner-confirmed'],
+    'approval-preview': approvalFields,
+    'approval-approve': [...approvalFields, '--preview-token', '--owner-confirmed'],
+};
+// Unicode 15.0 decimal block starts, matching the pinned CPython 3.12 oracle.
+// Each block contains ten digits; the five mathematical alphabets are separate blocks.
+const digitStarts = [
+    0x30, 0x660, 0x6f0, 0x7c0, 0x966, 0x9e6, 0xa66, 0xae6, 0xb66, 0xbe6,
+    0xc66, 0xce6, 0xd66, 0xde6, 0xe50, 0xed0, 0xf20, 0x1040, 0x1090, 0x17e0,
+    0x1810, 0x1946, 0x19d0, 0x1a80, 0x1a90, 0x1b50, 0x1bb0, 0x1c40, 0x1c50,
+    0xa620, 0xa8d0, 0xa900, 0xa9d0, 0xa9f0, 0xaa50, 0xabf0, 0xff10, 0x104a0,
+    0x10d30, 0x11066, 0x110f0, 0x11136, 0x111d0, 0x112f0, 0x11450, 0x114d0,
+    0x11650, 0x116c0, 0x11730, 0x118e0, 0x11950, 0x11c50, 0x11d50, 0x11da0,
+    0x11f50, 0x16a60, 0x16ac0, 0x16b50, 0x1d7ce, 0x1d7d8, 0x1d7e2, 0x1d7ec,
+    0x1d7f6, 0x1e140, 0x1e2f0, 0x1e4f0, 0x1e950, 0x1fbf0,
+];
+function decimalText(value) {
+    return Array.from(value, character => {
+        const point = character.codePointAt(0);
+        const start = digitStarts.find(start => point >= start && point < start + 10);
+        return start === undefined ? character : String(point - start);
+    }).join('');
+}
+export function parseTaskRevision(value) {
+    // int() accepts Unicode whitespace but rejects ASCII information separators and BOM.
+    const stripped = value.replace(/^[\u0009-\u000d\u0020\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+|[\u0009-\u000d\u0020\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+$/g, '');
+    const normalized = decimalText(stripped);
+    if (!/^[+-]?[0-9](?:_?[0-9])*$/.test(normalized))
+        throw new TaskRequestError();
+    const digits = normalized.replace(/[+_-]/g, '');
+    if (digits.length > 4300)
+        throw new TaskRequestError();
+    return BigInt(normalized.replaceAll('_', ''));
+}
+function optionName(raw, supported) {
+    if (supported.includes(raw))
+        return raw;
+    const matches = raw.startsWith('--') ? supported.filter(name => name.startsWith(raw)) : [];
+    if (matches.length !== 1)
+        throw new TaskRequestError();
+    return matches[0];
+}
+function isValue(value) {
+    return !value.startsWith('-') || value === '-' || value.includes(' ')
+        || /^-(?:[0-9]+|[0-9]*\.[0-9]+)$/.test(decimalText(value));
+}
+export function parseTaskArgs(args) {
+    let command;
+    const options = new Map();
+    for (let index = 0; index < args.length; index++) {
+        const argument = args[index];
+        if (!argument.startsWith('-')) {
+            if (command || !Object.hasOwn(taskCommandFields, argument))
+                throw new TaskRequestError();
+            command = argument;
+            continue;
+        }
+        const supported = command ? taskCommandFields[command] : ['--root', '--native-lock'];
+        const equals = argument.indexOf('=');
+        const raw = equals < 0 ? argument : argument.slice(0, equals);
+        const key = optionName(raw, [...supported, '--help', '-h']);
+        if (key === '--help' || key === '-h') {
+            if (equals >= 0)
+                throw new TaskRequestError();
+            throw new TaskHelp(command);
+        }
+        if (key === '--owner-confirmed') {
+            if (equals >= 0)
+                throw new TaskRequestError();
+            options.set(key, 'true');
+            continue;
+        }
+        let value;
+        if (equals >= 0)
+            value = argument.slice(equals + 1);
+        else {
+            const next = args[++index];
+            if (next === undefined || !isValue(next))
+                throw new TaskRequestError();
+            value = next;
+        }
+        if (key.startsWith('--expected-'))
+            value = parseTaskRevision(value).toString();
+        options.set(key, value);
+    }
+    if (!command || !options.get('--root') || !options.get('--native-lock'))
+        throw new TaskRequestError();
+    for (const key of taskCommandFields[command]) {
+        if (key !== '--owner-confirmed' && !options.has(key))
+            throw new TaskRequestError();
+    }
+    return { command, options, ownerConfirmed: options.has('--owner-confirmed') };
+}
+export function classifyTaskError(error) {
+    let code = 'store_unavailable';
+    let message = 'The canonical store is unavailable.';
+    if (error instanceof TaskRequestError) {
+        code = 'invalid_request';
+        message = 'The task request is invalid.';
+    }
+    else if (error instanceof JobsError || error instanceof StoreValidationError) {
+        const detail = error.message;
+        const rules = [
+            [detail.includes('owner confirmation') || detail.includes('owner approval'),
+                'owner_confirmation_required', 'Explicit owner confirmation is required.'],
+            [detail.includes('revision conflict') || detail.includes('preview is stale'),
+                'stale_revision', 'A selected canonical revision is stale.'],
+            [detail.includes('reference is stale'), 'stale_revision', 'The pending question reference is stale.'],
+            [detail.includes('sensitive pending'), 'sensitive_answer',
+                'Sensitive answers require fresh owner reconfirmation in Answers.'],
+            [detail.includes('not accepted and confirmed') || detail.includes('no referenced answer'),
+                'answer_unavailable', 'The referenced answer is not accepted and confirmed.'],
+            [detail.includes('preflight failed'), 'preflight_failed', 'The selected job is not ready.'],
+            [detail.includes('intake conflict') || detail.includes('one active job'),
+                'job_identity_conflict', 'The URL does not resolve to one active job.'],
+            [detail.includes('unavailable') || detail.includes('does not exist'),
+                'job_unavailable', 'The requested job is unavailable.'],
+            [detail.includes('intake invalid') || detail.includes('input') || detail.includes('URL'),
+                'invalid_request', 'The task request is invalid.'],
+        ];
+        const matched = rules.find(([matches]) => matches);
+        code = matched?.[1] ?? 'store_rejected';
+        message = matched?.[2] ?? 'The canonical store rejected the task request.';
+    }
+    return object(fromJSON({ ok: false, error: { code, message } }), 'task error');
+}

--- a/runtime/cli/task-runner.js
+++ b/runtime/cli/task-runner.js
@@ -1,0 +1,37 @@
+import { readFile } from 'node:fs/promises';
+import { NativeJobsRepository } from '../store/native-jobs.js';
+import { loadPosixFlockProvider } from '../store/posix-flock.js';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { object, parse } from '../contracts/workspace/values.js';
+import { runTaskCommand } from './task-command.js';
+import { classifyTaskError, parseTaskArgs, TaskHelp, TaskRequestError } from './task-protocol.js';
+const commands = 'snapshot, activity, intake, select, resolve-pending-answer, semantic-lookup, cleanup-preview, cleanup-approve, approval-preview, approval-approve';
+function help(command) {
+    return `Native synthetic-fixture task CLI${command ? `: ${command}` : ''}\n`
+        + 'Usage: native-task --root ABSOLUTE_FIXTURE --native-lock ABSOLUTE_ADDON COMMAND [options]\n'
+        + `Commands: ${commands}\n`
+        + 'Use the Python task command options; --input reads a JSON object from a file.\n'
+        + 'Only explicitly initialized native version 9 fixtures are supported.\n';
+}
+export async function runTask(args) {
+    try {
+        const parsed = parseTaskArgs(args);
+        const repository = new NativeJobsRepository(parsed.options.get('--root'), loadPosixFlockProvider(parsed.options.get('--native-lock')));
+        const payload = async () => {
+            try {
+                // Python Path.read_text is strict UTF-8 and treats '-' as an ordinary filename.
+                const bytes = await readFile(parsed.options.get('--input'));
+                return object(parse(new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(bytes)), 'task input');
+            }
+            catch {
+                throw new TaskRequestError();
+            }
+        };
+        return { output: canonicalJson(await runTaskCommand(parsed, repository, payload)) + '\n', exitCode: 0 };
+    }
+    catch (error) {
+        if (error instanceof TaskHelp)
+            return { output: help(error.command), exitCode: 0 };
+        return { output: canonicalJson(classifyTaskError(error)) + '\n', exitCode: 2 };
+    }
+}

--- a/src/cli/native-task.ts
+++ b/src/cli/native-task.ts
@@ -1,0 +1,16 @@
+import { realpathSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+/** Keep module/addon load failures inside the redacted task protocol boundary. */
+export async function runTaskCli(args: string[]): Promise<{ output: string; exitCode: number }> {
+  try {
+    return await (await import('./task-runner.js')).runTask(args);
+  } catch {
+    return { output: '{"error":{"code":"store_unavailable","message":"The canonical store is unavailable."},"ok":false}\n', exitCode: 2 };
+  }
+}
+if (process.argv[1] && pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url) {
+  const result = await runTaskCli(process.argv.slice(2));
+  process.stdout.write(result.output);
+  process.exitCode = result.exitCode;
+}

--- a/src/cli/task-command.ts
+++ b/src/cli/task-command.ts
@@ -1,0 +1,51 @@
+import { WorkspaceProjectionsService } from '../workspace-core/workspace-projections.js';
+import { TaskIntakeService } from '../workspace-core/task-intake.js';
+import { ClaimsService } from '../workspace-core/claims.js';
+import { PendingAnswersService } from '../workspace-core/pending-answers.js';
+import { AnswersService } from '../workspace-core/answers.js';
+import { AnswerMergeService } from '../workspace-core/answer-merges.js';
+import { GroupedApprovalsService } from '../workspace-core/grouped-approvals.js';
+import type { NativeJobsRepository } from '../store/native-jobs.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { get, keys, object, set, text } from '../contracts/workspace/values.js';
+import type { Document } from '../contracts/workspace/values.js';
+import { parseTaskRevision, TaskRequestError } from './task-protocol.js';
+
+/** Adapt task protocol envelopes to the existing locked native services. */
+export async function runTaskCommand(parsed: { command: string; options: Map<string, string>; ownerConfirmed: boolean },
+  repository: NativeJobsRepository, payload: () => Promise<Document>): Promise<Document> {
+  const { command, options, ownerConfirmed } = parsed;
+  const option = (name: string): string => options.get(name)!;
+  const revision = (name: string): bigint => parseTaskRevision(option(name));
+  const result = set(set(emptyObject(), 'ok', true), 'command', text(command));
+  if (command === 'snapshot') return set(result, 'snapshot', await new WorkspaceProjectionsService(repository).taskSnapshot());
+  if (command === 'activity') {
+    set(result, 'jobId', text(option('--id')));
+    return set(result, 'activity', await new WorkspaceProjectionsService(repository).activity(option('--id')));
+  }
+  let operation;
+  switch (command) {
+    case 'intake': operation = await new TaskIntakeService(repository).intake(await payload(), 'agent'); break;
+    case 'select': operation = await new ClaimsService(repository).select(option('--id'), revision('--expected-revision'), ownerConfirmed); break;
+    case 'resolve-pending-answer':
+      operation = await new PendingAnswersService(repository).resolve(option('--id'), option('--reference'),
+        revision('--expected-job-revision'), revision('--expected-session-revision'), revision('--expected-answer-revision'), ownerConfirmed);
+      break;
+    case 'semantic-lookup': operation = await new AnswersService(repository).semanticLookup(await payload()); break;
+    case 'cleanup-preview': operation = await new AnswersService(repository).cleanupPreview(); break;
+    case 'cleanup-approve': operation = await new AnswerMergeService(repository).approve(await payload(), ownerConfirmed); break;
+    case 'approval-preview':
+    case 'approval-approve': {
+      const incoming = await payload();
+      if (keys(incoming).length !== 1 || !Array.isArray(get(incoming, 'decisions'))) throw new TaskRequestError();
+      const service = new GroupedApprovalsService(repository);
+      const args = [option('--id'), revision('--expected-job-revision'), revision('--expected-session-revision'), get(incoming, 'decisions')] as const;
+      operation = command === 'approval-preview' ? await service.preview(...args)
+        : await service.approve(...args, option('--preview-token'), ownerConfirmed);
+      break;
+    }
+    default: throw new TaskRequestError();
+  }
+  for (const [key, value] of object(operation, 'task result').entries()) result.set(key, value);
+  return result;
+}

--- a/src/cli/task-protocol.ts
+++ b/src/cli/task-protocol.ts
@@ -1,0 +1,134 @@
+import { JobsError, fromJSON, object, type Document } from '../contracts/workspace/values.js';
+import { StoreValidationError } from '../store/validation.js';
+
+export class TaskRequestError extends Error {
+  constructor() { super('invalid task request'); }
+}
+export class TaskHelp extends Error {
+  constructor(readonly command?: string) { super('task help requested'); }
+}
+
+const revisionFields = ['--expected-job-revision', '--expected-session-revision'];
+const approvalFields = ['--id', ...revisionFields, '--input'];
+export const taskCommandFields: Record<string, readonly string[]> = {
+  snapshot: [], activity: ['--id'], intake: ['--input'],
+  select: ['--id', '--expected-revision', '--owner-confirmed'],
+  'resolve-pending-answer': ['--id', '--reference', ...revisionFields,
+    '--expected-answer-revision', '--owner-confirmed'],
+  'semantic-lookup': ['--input'], 'cleanup-preview': [],
+  'cleanup-approve': ['--input', '--owner-confirmed'],
+  'approval-preview': approvalFields,
+  'approval-approve': [...approvalFields, '--preview-token', '--owner-confirmed'],
+};
+
+// Unicode 15.0 decimal block starts, matching the pinned CPython 3.12 oracle.
+// Each block contains ten digits; the five mathematical alphabets are separate blocks.
+const digitStarts = [
+  0x30, 0x660, 0x6f0, 0x7c0, 0x966, 0x9e6, 0xa66, 0xae6, 0xb66, 0xbe6,
+  0xc66, 0xce6, 0xd66, 0xde6, 0xe50, 0xed0, 0xf20, 0x1040, 0x1090, 0x17e0,
+  0x1810, 0x1946, 0x19d0, 0x1a80, 0x1a90, 0x1b50, 0x1bb0, 0x1c40, 0x1c50,
+  0xa620, 0xa8d0, 0xa900, 0xa9d0, 0xa9f0, 0xaa50, 0xabf0, 0xff10, 0x104a0,
+  0x10d30, 0x11066, 0x110f0, 0x11136, 0x111d0, 0x112f0, 0x11450, 0x114d0,
+  0x11650, 0x116c0, 0x11730, 0x118e0, 0x11950, 0x11c50, 0x11d50, 0x11da0,
+  0x11f50, 0x16a60, 0x16ac0, 0x16b50, 0x1d7ce, 0x1d7d8, 0x1d7e2, 0x1d7ec,
+  0x1d7f6, 0x1e140, 0x1e2f0, 0x1e4f0, 0x1e950, 0x1fbf0,
+];
+function decimalText(value: string): string {
+  return Array.from(value, character => {
+    const point = character.codePointAt(0)!;
+    const start = digitStarts.find(start => point >= start && point < start + 10);
+    return start === undefined ? character : String(point - start);
+  }).join('');
+}
+export function parseTaskRevision(value: string): bigint {
+  // int() accepts Unicode whitespace but rejects ASCII information separators and BOM.
+  const stripped = value.replace(/^[\u0009-\u000d\u0020\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+|[\u0009-\u000d\u0020\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+$/g, '');
+  const normalized = decimalText(stripped);
+  if (!/^[+-]?[0-9](?:_?[0-9])*$/.test(normalized)) throw new TaskRequestError();
+  const digits = normalized.replace(/[+_-]/g, '');
+  if (digits.length > 4300) throw new TaskRequestError();
+  return BigInt(normalized.replaceAll('_', ''));
+}
+function optionName(raw: string, supported: readonly string[]): string {
+  if (supported.includes(raw)) return raw;
+  const matches = raw.startsWith('--') ? supported.filter(name => name.startsWith(raw)) : [];
+  if (matches.length !== 1) throw new TaskRequestError();
+  return matches[0]!;
+}
+function isValue(value: string): boolean {
+  return !value.startsWith('-') || value === '-' || value.includes(' ')
+    || /^-(?:[0-9]+|[0-9]*\.[0-9]+)$/.test(decimalText(value));
+}
+export function parseTaskArgs(args: string[]): {
+  command: string; options: Map<string, string>; ownerConfirmed: boolean;
+} {
+  let command: string | undefined;
+  const options = new Map<string, string>();
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index]!;
+    if (!argument.startsWith('-')) {
+      if (command || !Object.hasOwn(taskCommandFields, argument)) throw new TaskRequestError();
+      command = argument;
+      continue;
+    }
+    const supported = command ? taskCommandFields[command]! : ['--root', '--native-lock'];
+    const equals = argument.indexOf('=');
+    const raw = equals < 0 ? argument : argument.slice(0, equals);
+    const key = optionName(raw, [...supported, '--help', '-h']);
+    if (key === '--help' || key === '-h') {
+      if (equals >= 0) throw new TaskRequestError();
+      throw new TaskHelp(command);
+    }
+    if (key === '--owner-confirmed') {
+      if (equals >= 0) throw new TaskRequestError();
+      options.set(key, 'true');
+      continue;
+    }
+    let value: string;
+    if (equals >= 0) value = argument.slice(equals + 1);
+    else {
+      const next = args[++index];
+      if (next === undefined || !isValue(next)) throw new TaskRequestError();
+      value = next;
+    }
+    if (key.startsWith('--expected-')) value = parseTaskRevision(value).toString();
+    options.set(key, value);
+  }
+  if (!command || !options.get('--root') || !options.get('--native-lock')) throw new TaskRequestError();
+  for (const key of taskCommandFields[command]!) {
+    if (key !== '--owner-confirmed' && !options.has(key)) throw new TaskRequestError();
+  }
+  return { command, options, ownerConfirmed: options.has('--owner-confirmed') };
+}
+
+export function classifyTaskError(error: unknown): Document {
+  let code = 'store_unavailable';
+  let message = 'The canonical store is unavailable.';
+  if (error instanceof TaskRequestError) {
+    code = 'invalid_request'; message = 'The task request is invalid.';
+  } else if (error instanceof JobsError || error instanceof StoreValidationError) {
+    const detail = error.message;
+    const rules: [boolean, string, string][] = [
+      [detail.includes('owner confirmation') || detail.includes('owner approval'),
+        'owner_confirmation_required', 'Explicit owner confirmation is required.'],
+      [detail.includes('revision conflict') || detail.includes('preview is stale'),
+        'stale_revision', 'A selected canonical revision is stale.'],
+      [detail.includes('reference is stale'), 'stale_revision', 'The pending question reference is stale.'],
+      [detail.includes('sensitive pending'), 'sensitive_answer',
+        'Sensitive answers require fresh owner reconfirmation in Answers.'],
+      [detail.includes('not accepted and confirmed') || detail.includes('no referenced answer'),
+        'answer_unavailable', 'The referenced answer is not accepted and confirmed.'],
+      [detail.includes('preflight failed'), 'preflight_failed', 'The selected job is not ready.'],
+      [detail.includes('intake conflict') || detail.includes('one active job'),
+        'job_identity_conflict', 'The URL does not resolve to one active job.'],
+      [detail.includes('unavailable') || detail.includes('does not exist'),
+        'job_unavailable', 'The requested job is unavailable.'],
+      [detail.includes('intake invalid') || detail.includes('input') || detail.includes('URL'),
+        'invalid_request', 'The task request is invalid.'],
+    ];
+    const matched = rules.find(([matches]) => matches);
+    code = matched?.[1] ?? 'store_rejected';
+    message = matched?.[2] ?? 'The canonical store rejected the task request.';
+  }
+  return object(fromJSON({ ok: false, error: { code, message } }), 'task error');
+}

--- a/src/cli/task-runner.ts
+++ b/src/cli/task-runner.ts
@@ -1,0 +1,33 @@
+import { readFile } from 'node:fs/promises';
+import { NativeJobsRepository } from '../store/native-jobs.js';
+import { loadPosixFlockProvider } from '../store/posix-flock.js';
+import { canonicalJson } from '../contracts/workspace/canonical-json.js';
+import { object, parse } from '../contracts/workspace/values.js';
+import { runTaskCommand } from './task-command.js';
+import { classifyTaskError, parseTaskArgs, TaskHelp, TaskRequestError } from './task-protocol.js';
+
+const commands = 'snapshot, activity, intake, select, resolve-pending-answer, semantic-lookup, cleanup-preview, cleanup-approve, approval-preview, approval-approve';
+function help(command?: string): string {
+  return `Native synthetic-fixture task CLI${command ? `: ${command}` : ''}\n`
+    + 'Usage: native-task --root ABSOLUTE_FIXTURE --native-lock ABSOLUTE_ADDON COMMAND [options]\n'
+    + `Commands: ${commands}\n`
+    + 'Use the Python task command options; --input reads a JSON object from a file.\n'
+    + 'Only explicitly initialized native version 9 fixtures are supported.\n';
+}
+export async function runTask(args: string[]): Promise<{ output: string; exitCode: number }> {
+  try {
+    const parsed = parseTaskArgs(args);
+    const repository = new NativeJobsRepository(parsed.options.get('--root')!, loadPosixFlockProvider(parsed.options.get('--native-lock')!));
+    const payload = async () => {
+      try {
+        // Python Path.read_text is strict UTF-8 and treats '-' as an ordinary filename.
+        const bytes = await readFile(parsed.options.get('--input')!);
+        return object(parse(new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(bytes)), 'task input');
+      } catch { throw new TaskRequestError(); }
+    };
+    return { output: canonicalJson(await runTaskCommand(parsed, repository, payload)) + '\n', exitCode: 0 };
+  } catch (error) {
+    if (error instanceof TaskHelp) return { output: help(error.command), exitCode: 0 };
+    return { output: canonicalJson(classifyTaskError(error)) + '\n', exitCode: 2 };
+  }
+}

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,3 +1,4 @@
+import { taskCliBrowser } from './workspace_native_task_cli_browser_support.mjs';
 import { nativeGroupedApprovalsBrowser } from './workspace_native_grouped_approvals_browser_support.mjs';
 import { legacyJobsBrowser } from './workspace_native_legacy_jobs_browser_support.mjs';
 import { taskIntakeBrowser } from './workspace_native_task_intake_browser_support.mjs';
@@ -201,10 +202,11 @@ export async function nativeJobsBrowser(buildRoot) {
       },
     });
     const groupedApprovals = await nativeGroupedApprovalsBrowser(page, root, fixture, buildRoot);
+    const taskCli = await taskCliBrowser(page, root, fixture, buildRoot);
     const unsupported = await fetch(startup.origin + '/api/trash', { headers: { Authorization: `Bearer ${token}` } });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { groupedApprovals, taskIntake, legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { taskCli, groupedApprovals, taskIntake, legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     releaseInitialClaim?.();
     if (browser) await browser.close();

--- a/tests_js/workspace_native_task_cli.test.mjs
+++ b/tests_js/workspace_native_task_cli.test.mjs
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { copyFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, read, snapshot, invoke, input, parity, failure } from './workspace_native_task_cli_support.mjs';
+import { setup as groupedSetup, revisions } from './workspace_native_grouped_approvals_support.mjs';
+import { AnswersService } from '../runtime/workspace-core/answers.js';
+import { fromJSON } from '../runtime/contracts/workspace/values.js';
+
+// Each oracle runs on a fresh copy: Python and native code never share a writable Store.
+test('native task wrapper preserves all ten Python command envelopes and owner boundaries', { timeout: 120000 }, async t => {
+  const fixture = await nativeFixture();
+  try {
+    await t.test('snapshot, activity, intake and selection', async () => {
+      const state = await setup(fixture, 'task-jobs');
+      const before = await snapshot(state.root);
+      for (const args of [['snapshot'], ['activity', '--id', 'job']]) {
+        const result = await parity(fixture, state.root, args);
+        assert.equal(result.ok, true);
+        assert.equal(result.command, args[0]);
+      }
+      assert.deepEqual(await snapshot(state.root), before);
+      failure(await parity(fixture, state.root, ['activity', '--id', 'missing']), 'job_unavailable');
+      const intake = ['intake', ...await input(fixture, { url: 'https://example.invalid/job', description: 'PRIVATE-description' })];
+      const changed = await parity(fixture, state.root, intake, { mutation: true });
+      assert.equal(changed.action, 'update');
+      assert.equal((await parity(fixture, state.root, intake)).action, 'noop');
+      const args = ['select', '--id', 'job', '--expected-revision', String(changed.job.revision)];
+      failure(await parity(fixture, state.root, args), 'owner_confirmation_required');
+      const selected = await parity(fixture, state.root, [...args, '--owner-confirmed'], { mutation: true });
+      assert.equal(selected.action, 'ready');
+      failure(await parity(fixture, state.root, [...args, '--owner-confirmed']), 'stale_revision');
+      assert.equal((await parity(fixture, state.root, ['select', '--id', 'job', '--expected-revision',
+        String(selected.job.revision), '--owner-confirmed'])).action, 'noop');
+    });
+    await t.test('semantic lookup and approved cleanup', async () => {
+      const state = await setup(fixture, 'task-cleanup');
+      const answers = new AnswersService(state.repository, () => '2026-09-10T12:00:00Z');
+      await answers.put(fromJSON({ question: 'Does the applicant have permission to work in this jurisdiction?',
+        state: 'confirmed', value: 'PRIVATE-ANSWER', scope: {} }));
+      await answers.observe(fromJSON({ question: 'Is employment authorization available in the country?', state: 'missing', scope: {} }));
+      const lookup = await parity(fixture, state.root, ['semantic-lookup', ...await input(fixture, {
+        question: 'Is employment authorization available in the country?', scope: {}, fieldClass: 'general',
+        sensitivity: 'none', mode: 'strict', useAuthority: 'accepted_record', limit: 5,
+      })]);
+      assert.ok(lookup.candidates.length);
+      const preview = await parity(fixture, state.root, ['cleanup-preview']);
+      assert.ok(preview.proposals.length);
+      const proposal = preview.proposals[0];
+      const payload = Object.fromEntries(['winnerKey', 'duplicateKey', 'winnerRevision', 'duplicateRevision'].map(key => [key, proposal[key]]));
+      payload.previewToken = preview.previewToken;
+      const args = ['cleanup-approve', ...await input(fixture, payload)];
+      failure(await parity(fixture, state.root, args), 'owner_confirmation_required');
+      failure(await parity(fixture, state.root, ['cleanup-approve', '--owner-confirmed',
+        ...await input(fixture, { ...payload, previewToken: 'stale' })]), 'stale_revision');
+      const approved = await parity(fixture, state.root, [...args, '--owner-confirmed'], { mutation: true });
+      assert.equal(approved.approved, true);
+    });
+    await t.test('grouped approvals and pending answer resolution', async () => {
+      const state = await groupedSetup(fixture, 'task-approval');
+      const [jobRevision, sessionRevision] = await revisions(state);
+      const options = ['--id', 'job', '--expected-job-revision', String(jobRevision),
+        '--expected-session-revision', String(sessionRevision), ...await input(fixture, { decisions: state.decisions })];
+      const preview = await parity(fixture, state.root, ['approval-preview', ...options]);
+      assert.equal(preview.mutated, false);
+      const args = ['approval-approve', ...options, '--preview-token', preview.previewToken];
+      failure(await parity(fixture, state.root, args), 'owner_confirmation_required');
+      failure(await parity(fixture, state.root, ['approval-approve', ...options, '--preview-token', 'stale', '--owner-confirmed']), 'stale_revision');
+      assert.equal((await parity(fixture, state.root, [...args, '--owner-confirmed'], { mutation: true })).approved, true);
+      const revs = await revisions(state);
+      const resolve = ['resolve-pending-answer', '--id', 'job', '--reference', state.decisions[0].reference,
+        '--expected-job-revision', String(revs[0]), '--expected-session-revision', String(revs[1]), '--expected-answer-revision', '1'];
+      failure(await parity(fixture, state.root, resolve), 'owner_confirmation_required');
+      const result = await parity(fixture, state.root, [...resolve, '--owner-confirmed'], { mutation: true });
+      assert.equal(result.ok, true);
+      assert.equal(result.ready, false);
+    });
+  } finally { await fixture.cleanup(); }
+});
+
+test('native task wrapper redacts malformed requests and keeps input file-only', { timeout: 120000 }, async () => {
+  const fixture = await nativeFixture();
+  try {
+    const state = await setup(fixture, 'task-invalid');
+    const before = await snapshot(state.root);
+    for (const args of [[], ['unknown'], ['snapshot', '--private-unknown'], ['activity'],
+      ['select', '--id', 'job', '--expected-revision', '1.0'],
+      ['select', '--id', 'job', '--expected-revision', 'PRIVATE-number'],
+      ['intake'], ['intake', '--input', join(fixture.root, 'PRIVATE-missing')],
+      ['intake', ...await input(fixture, 'not json PRIVATE-secret')],
+      ['intake', ...await input(fixture, Buffer.from([0xff, 0xfe]))],
+      ['intake', ...await input(fixture, [])],
+      ['intake', ...await input(fixture, '{"url":"https://example.invalid/new","priority":1.0}')],
+      ['approval-preview', '--id', 'job', '--expected-job-revision', '1', '--expected-session-revision', '1',
+        ...await input(fixture, { decisions: [], extra: 'PRIVATE-secret' })],
+    ]) failure(await parity(fixture, state.root, args), 'invalid_request');
+    // '-' is an ordinary filename, including when that file happens to exist.
+    failure(await parity(fixture, state.root, ['intake', '--input', '-'], { cwd: fixture.root }), 'invalid_request');
+    await writeFile(join(fixture.root, '-'), JSON.stringify({ url: 'https://example.invalid/job' }));
+    assert.equal((await parity(fixture, state.root, ['intake', '--input', '-'], { cwd: fixture.root })).action, 'noop');
+    assert.deepEqual(await snapshot(state.root), before);
+    const unavailable = await invoke(fixture, state.root, ['snapshot'], { globals: false });
+    assert.equal(unavailable.code, 2);
+    assert.equal(unavailable.value.ok, false);
+    assert.deepEqual(await snapshot(state.root), before);
+  } finally { await fixture.cleanup(); }
+});
+
+test('native task wrapper preserves arbitrary integer tokens and Python revision argument syntax', { timeout: 60000 }, async () => {
+  const fixture = await nativeFixture();
+  try {
+    const state = await setup(fixture, 'task-numbers');
+    const jobs = await read(state.root, 'jobs.json');
+    const huge = '900719925474099312345';
+    // Keep the raw integer lexeme; JSON.parse would erase the precision this protocol promises.
+    jobs.jobs.job.revision = 'BIG_REVISION';
+    await writeFile(join(state.root, 'jobs.json'), JSON.stringify(jobs).replace('"BIG_REVISION"', huge));
+    const activity = await invoke(fixture, state.root, ['activity', '--id', 'job']);
+    assert.equal(activity.code, 0);
+    assert.match(activity.stdout, new RegExp(`"revision"\\s*:\\s*${huge}`));
+    await parity(fixture, state.root, ['activity', '--id', 'job']);
+    const selected = await parity(fixture, state.root, ['select', '--id', 'job', '--expected-revision', huge, '--owner-confirmed'], { mutation: true });
+    assert.equal(selected.action, 'ready');
+    const after = await invoke(fixture, state.root, ['activity', '--id', 'job']);
+    assert.match(after.stdout, /"revision"\s*:\s*900719925474099312346/);
+    // argparse accepts signs, underscores, whitespace and Unicode decimal digits.
+    for (const revision of ['+1', ' 1 ', '١', '1_0', '-1', '0']) {
+      await parity(fixture, state.root, ['select', '--id', 'other', '--expected-revision', revision, '--owner-confirmed'], { mutation: true });
+    }
+  } finally { await fixture.cleanup(); }
+});
+
+
+test('native task bootstrap and addon load failures stay inside the redacted JSON protocol', { timeout: 60000 }, async () => {
+  const fixture = await nativeFixture();
+  try {
+    const state = await setup(fixture, 'task-bootstrap');
+    const before = await snapshot(state.root);
+    const isolatedEntry = join(fixture.root, 'PRIVATE-isolated-task.mjs');
+    await copyFile(new URL('../runtime/cli/native-task.js', import.meta.url), isolatedEntry);
+    const missingRunner = await invoke(fixture, state.root, ['snapshot'], { entry: isolatedEntry });
+    const missingAddon = await invoke(fixture, state.root, [
+      '--root', state.root, '--native-lock', join(fixture.root, 'PRIVATE-missing-addon.node'), 'snapshot',
+    ], { globals: false });
+    for (const result of [missingRunner, missingAddon]) {
+      assert.equal(result.code, 2);
+      assert.deepEqual(result.value, {
+        ok: false, error: { code: 'store_unavailable', message: 'The canonical store is unavailable.' },
+      });
+      assert.equal(result.stdout.includes(fixture.root), false);
+    }
+    assert.deepEqual(await snapshot(state.root), before);
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_task_cli_browser_support.mjs
+++ b/tests_js/workspace_native_task_cli_browser_support.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// The caller supplies a disposable v9 fixture with synthetic preflight-ready facts/resume.
+export async function taskCliBrowser(page, root, fixture, buildRoot) {
+  const execute = promisify(execFile);
+  async function cli(command, args = [], payload, expectedCode = 0) {
+    if (payload !== undefined) {
+      const input = join(fixture.root, 'task-wrapper-browser-input.json');
+      await writeFile(input, JSON.stringify(payload), { mode: 0o600 });
+      args = [...args, '--input', input];
+    }
+    let result;
+    try {
+      result = await execute(process.execPath, [join(buildRoot, 'runtime/cli/native-task.js'),
+        '--root', root, '--native-lock', fixture.receipt.artifact, command, ...args], { env: { PATH: '' } });
+      assert.equal(expectedCode, 0);
+    } catch (error) {
+      assert.equal(error.code, expectedCode);
+      result = error;
+    }
+    assert.equal(result.stderr, '');
+    const value = JSON.parse(result.stdout);
+    assert.equal(value.ok, expectedCode === 0);
+    if (value.ok) assert.equal(value.command, command);
+    assert.doesNotMatch(result.stdout, /PRIVATE-WRAPPER-BROWSER|private=wrapper|tokenHash/);
+    return value;
+  }
+  const role = 'Task wrapper browser role';
+  const created = await cli('intake', [], { role, company: 'Task wrapper company',
+    url: 'https://example.invalid/task-wrapper?private=wrapper', description: 'PRIVATE-WRAPPER-BROWSER' });
+  assert.equal(created.action, 'create');
+  const id = created.job.id;
+  assert.deepEqual((await cli('snapshot')).snapshot.jobs.find(job => job.id === id), created.job);
+  const navigation = page.getByRole('navigation', { name: 'Workspace sections' });
+  await navigation.getByRole('button', { name: 'Jobs', exact: true }).click();
+  await page.getByRole('button', { name: 'Refresh', exact: true }).click();
+  await page.getByRole('button', { name: new RegExp(role) }).click();
+  const modal = page.getByRole('dialog', { name: 'Edit job', exact: true });
+  assert.equal(await modal.locator('[name="company"]').inputValue(), 'Task wrapper company');
+  const panel = modal.getByRole('region', { name: 'Job activity', exact: true });
+  await panel.getByText(/Status: saved/i).waitFor();
+  const initialActivity = await cli('activity', ['--id', id]);
+  assert.equal(initialActivity.jobId, id);
+  assert.equal(initialActivity.activity.job.status, 'saved');
+  const jobsPath = join(root, 'jobs.json');
+  const before = await readFile(jobsPath, 'utf8');
+  const selectArgs = ['--id', id, '--expected-revision', String(created.job.revision)];
+  const denied = await cli('select', selectArgs, undefined, 2);
+  assert.deepEqual(denied, { ok: false, error: { code: 'owner_confirmation_required',
+    message: 'Explicit owner confirmation is required.' } });
+  assert.equal(await readFile(jobsPath, 'utf8'), before);
+  const selected = await cli('select', [...selectArgs, '--owner-confirmed']);
+  assert.equal(selected.action, 'ready');
+  assert.equal(selected.job.status, 'ready');
+  assert.equal(selected.job.revision, created.job.revision + 1);
+  const activity = await cli('activity', ['--id', id]);
+  assert.equal(activity.activity.job.status, 'ready');
+  assert.equal(activity.activity.job.revision, selected.job.revision);
+  assert.deepEqual((await cli('snapshot')).snapshot.jobs.find(job => job.id === id), selected.job);
+  // Reload closes the old editor and loads the canonical revision before reopening.
+  await page.reload();
+  await navigation.getByRole('button', { name: 'Jobs', exact: true }).click();
+  await page.getByRole('button', { name: new RegExp(role) })
+    .filter({ hasText: new RegExp(`revision ${selected.job.revision}$`) }).click();
+  await panel.getByText(/Status: ready/i).waitFor();
+  assert.equal(await modal.locator('[name="company"]').inputValue(), 'Task wrapper company');
+  assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1));
+  await modal.getByRole('button', { name: 'Close job details', exact: true }).click();
+  return { intakeVisible: true, envelopes: true, ownerConfirmationRequired: true,
+    canonicalReload: true, activitySnapshotAgreement: true, pythonAbsentFromPath: true };
+}

--- a/tests_js/workspace_native_task_cli_support.mjs
+++ b/tests_js/workspace_native_task_cli_support.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { cp, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { join } from 'node:path';
+export { setup, read, write, snapshot, plain } from './workspace_native_claims_support.mjs';
+let serial = 0;
+const execute = promisify(execFile);
+export async function invoke(fixture, root, args, { python = false, cwd, globals = true, entry } = {}) {
+  const command = python ? 'python3' : process.execPath;
+  const script = entry ?? new URL(python ? '../scripts/job-apply-task.py' : '../runtime/cli/native-task.js', import.meta.url).pathname;
+  const globalArgs = globals ? ['--root', root, ...python ? [] : ['--native-lock', fixture.receipt.artifact]] : [];
+  let result;
+  try {
+    result = { ...await execute(command, [script, ...globalArgs, ...args], {
+      cwd: cwd ?? new URL('../', import.meta.url), timeout: 15000,
+      env: python ? process.env : { PATH: '' }, maxBuffer: 4 * 1024 * 1024,
+    }), code: 0 };
+  } catch (error) {
+    if (typeof error.code !== 'number') throw error;
+    result = error;
+  }
+  assert.equal(result.stderr, '', 'task protocol never writes diagnostics to stderr');
+  assert.ok([0, 2].includes(result.code), result.stdout);
+  assert.doesNotMatch(result.stdout, /PRIVATE-|private\.invalid|tokenHash|PRIVATE RESUME/);
+  return { code: result.code, value: JSON.parse(result.stdout), stdout: result.stdout };
+}
+export async function input(fixture, value) {
+  const path = join(fixture.root, `task-input-${++serial}.json`);
+  await writeFile(path, typeof value === 'string' || Buffer.isBuffer(value) ? value : JSON.stringify(value));
+  return ['--input', path];
+}
+function normalize(value, mutation) {
+  if (Array.isArray(value)) return value.map(item => normalize(item, mutation));
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => {
+    if (mutation && /^(createdAt|updatedAt|lastSeenAt|mergedAt)$/.test(key)) return [key, '<timestamp>'];
+    // A session revision is a hash of its timestamp-bearing document. Preserve its safe integer contract.
+    if (mutation && (key === 'sessionRevision' || key === 'revision' && value.pendingInformation)) {
+      assert.ok(Number.isSafeInteger(item) && item > 0);
+      return [key, '<session revision>'];
+    }
+    return [key, normalize(item, mutation)];
+  }));
+}
+export async function parity(fixture, root, args, { mutation = false, ...options } = {}) {
+  const oracleRoot = join(fixture.root, `task-python-${++serial}`);
+  await cp(root, oracleRoot, { recursive: true, preserveTimestamps: true });
+  const expected = await invoke(fixture, oracleRoot, args, { ...options, python: true });
+  const actual = await invoke(fixture, root, args, options);
+  assert.equal(actual.code, expected.code);
+  assert.deepEqual(normalize(actual.value, mutation), normalize(expected.value, mutation), args[0]);
+  return actual.value;
+}
+export function failure(value, code) {
+  assert.equal(value.ok, false);
+  assert.equal(value.error.code, code);
+  assert.deepEqual(Object.keys(value).sort(), ['error', 'ok']);
+  assert.deepEqual(Object.keys(value.error).sort(), ['code', 'message']);
+}


### PR DESCRIPTION
Adds a native fixture task CLI for all ten existing task operations, using the Python task CLI success envelopes, redacted error classification and exit statuses. The wrapper delegates to the existing locked services, preserves exact integer revisions, reads strict UTF-8 JSON files, and requires explicit native fixture root/addon connection flags.

The new entry point does not adopt a live Store or change the installed launcher. Native runtime and addon load failures return the generic task error without printing paths or stack traces.

Validation:
- Python differential checks cover all ten command responses on independent synthetic Store copies, consent/stale failures, malformed input and exact large integer output.
- Production standalone browser proof passed wrapper intake/selection, Activity/snapshot agreement and canonical reload with Python absent from PATH.
- Runtime build, source-size and test-matrix checks passed.
- Five independent review roles found no actionable issues. Normal commit hooks, all 27 deep-validation suites and normal push hooks passed. [Validate Plugin](https://github.com/neonwatty/job-apply-plugin/actions/runs/34614469857) and [Release Plugin](https://github.com/neonwatty/job-apply-plugin/actions/runs/34614472531) passed on `3f8ee09d20dd27bedbed89d2ac71b2939699a43f`.
- Built-in Codex review is unavailable because the installed CLI does not support the configured model; independent focused review proceeds against staging.
