### PR TITLE
Add native Trash listing and reversible job lifecycle

### DIFF
--- a/config/migration/cli-native-job-trash-surfaces.json
+++ b/config/migration/cli-native-job-trash-surfaces.json
@@ -1,0 +1,80 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:trash-list",
+      "kind": "cli",
+      "command": "trash-list",
+      "node": "JOB",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-trash.ts",
+        "src/workspace-core/trash.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:job-trash",
+      "kind": "cli",
+      "command": "job-trash",
+      "node": "JOB",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-trash.ts",
+        "src/workspace-core/trash.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:job-restore",
+      "kind": "cli",
+      "command": "job-restore",
+      "node": "JOB",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-trash.ts",
+        "src/workspace-core/trash.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/http-read-surfaces.json
+++ b/config/migration/http-read-surfaces.json
@@ -349,7 +349,11 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/trash-http.ts",
+        "src/workspace-core/trash.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-write-jobs-surfaces.json
+++ b/config/migration/http-write-jobs-surfaces.json
@@ -192,7 +192,11 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/trash-http.ts",
+        "src/workspace-core/trash.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -220,7 +224,11 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/trash-http.ts",
+        "src/workspace-core/trash.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -110,6 +110,10 @@
       "sha256": "3310d133626397a57545af50e70591523b906036cdf4a0d04884e4a1630f1c3b"
     },
     {
+      "path": "cli-native-job-trash-surfaces.json",
+      "sha256": "ddb9940f442a16dcb478d08d8a1c018a10c761e933af4972c5bc0bbe7ebb1137"
+    },
+    {
       "path": "cli-native-job-upsert-surfaces.json",
       "sha256": "6d98fac8d272d2552aebabab3d7468998b53adfe6f5777329785c28edd853197"
     },
@@ -179,7 +183,7 @@
     },
     {
       "path": "http-read-surfaces.json",
-      "sha256": "aa97ebab7f77fed0ad74a9a9b7c56fd315f2d6068e350b39fbc4df661f8b8c9c"
+      "sha256": "361d916abc603b515fb3d6fd9a9283afc9d7e977e8e09200bc51fabb94573e8a"
     },
     {
       "path": "http-write-accounts-surfaces.json",
@@ -195,7 +199,7 @@
     },
     {
       "path": "http-write-jobs-surfaces.json",
-      "sha256": "86b63f3fbe0dc1ae2a75a3897b6debb14392d04a063dd6201916c01281c5ed77"
+      "sha256": "c10344d5a03033f4550f9f2312d7fa686510d6eb005021d72a384b51a26d9be7"
     },
     {
       "path": "http-write-profile-surfaces.json",
@@ -334,12 +338,16 @@
       "sha256": "d3586b035af22d3f4b4fa3ba3aa7d9e1bc781632317005aff9d158ac78625772"
     },
     {
+      "path": "source-catalog-native-job-trash.json",
+      "sha256": "6dd681f77adccd610b69a2bc08f77491885afcf7f69ae9d50411bbb96756a05e"
+    },
+    {
       "path": "source-catalog-native-job-upsert.json",
       "sha256": "31e6b6cc554c6c19e54f262b1e83834483a11a18577e954d696e7dacb0633f31"
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "07f02a2c29bb09d32f4a87861adc3915c6965af74efb0124375aeafdbe5b949f"
+      "sha256": "77bd7b44df18a471adcd1060e529fdeabb7cd413080ce897875d954a265c3d4c"
     },
     {
       "path": "source-catalog-native-legacy-jobs.json",

--- a/config/migration/source-catalog-native-job-trash.json
+++ b/config/migration/source-catalog-native-job-trash.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "runtime/cli/native-trash.js",
+      "sha256": "438617ba3c91932782c38fa253e5f99f55eee0ff9dc2f57b0227cf1daddc3141",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/trash-http.js",
+      "sha256": "34b2c8cfe900ceaaa481328e42b6f0481c71c84f2ae867f868ba6d5b0aec80a2",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/trash.js",
+      "sha256": "634a63a4313500817a7372db5cacb6fa2ff8f43ad80662f53bc766cf84a7486c",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-trash.ts",
+      "sha256": "66e9edb7f6dd7f2ebfa54face31cb0b6ebf98640b3573fa420d375970cb5326c",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/trash-http.ts",
+      "sha256": "c8b9dd2f3fb0703b0573774ab065df3823fa0aa711b3dca111ebb02d1967f1d4",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/trash.ts",
+      "sha256": "715a6f634b403402173a29861a4f85785d4f52224360281f299a9c110bafb46a",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "abd1b56822d3cb736e6691301542a42668e03d4ca0515436cc5d54142785f526",
+      "sha256": "907e09b26392ae08b2f2f787a6a6510f4be16b8dc1374c87289e8eea06a01a1a",
       "classification": "unreviewed"
     },
     {
@@ -43,7 +43,7 @@
     },
     {
       "path": "runtime/workspace-core/jobs-http.js",
-      "sha256": "92cc141f2e6f02dfd465c175a42e7c1a455f98c71c46fdf78506f5a05d5488ad",
+      "sha256": "5c828e5e059369c09d0398b673a4d8beb009900907a1017254ee553638f2c535",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "767a2e5b792d4aff28ecefc73eef3217dd350eff8d442a03b9016d2b7d86237b",
+      "sha256": "b0cfeace8e42aa8212686cd971ce8794b4ef83f7109b4653fdb7821548ae1380",
       "classification": "unreviewed"
     },
     {
@@ -93,7 +93,7 @@
     },
     {
       "path": "src/workspace-core/jobs-http.ts",
-      "sha256": "eb9b07e63b780c53ddd3aec8321dcfff670e11707bc1b132f46c7ea3429ffcd2",
+      "sha256": "f47704f58e3a304b67cbb433d63b5bde90ac099bd97008d0e3b0b21eb3c5a606",
       "classification": "unreviewed"
     },
     {

--- a/docs/native-job-trash-fixture.md
+++ b/docs/native-job-trash-fixture.md
@@ -1,0 +1,62 @@
+# Native Trash and job recovery fixture
+
+The opt-in version 9 native fixture supports a unified Trash listing and reversible
+job trash/restore through its CLI and authenticated HTTP API. A trashed job is
+hidden from ordinary Jobs results. Restoring it makes it visible in Companion
+Jobs after Refresh or reload, retaining its saved fields and local status.
+
+This tranche adds API and CLI operations only. The native Companion has no Trash
+section or browser trash/restore buttons yet. Full Trash UI, permanent deletion,
+and resume/answer trash and restore operations remain later work.
+
+## Use a synthetic fixture
+
+Follow [Native Jobs fixture](native-jobs-fixture.md) to initialize a new disposable
+Store and build the native lock addon. Keep real applicant data and Python
+writers away from this fixture. With a synthetic job ID and its current revision:
+
+```sh
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node trash-list
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node job-trash --id SYNTHETIC_JOB_ID --expected-revision 1
+node runtime/cli/native-jobs.js --root /private/tmp/new-native-jobs --native-lock /absolute/flock.node job-restore --id SYNTHETIC_JOB_ID --expected-revision 2
+```
+
+Use the revision returned by the preceding operation, rather than assuming the
+example numbers. The fixture CLI returns the updated job directly. Trash sets
+`deletedAt`; restore clears it. A state change increments revision and updates
+timestamps. Repeating the operation at the current revision when already in the
+requested state returns the current job without rewriting it.
+
+Both operations reject stale revisions and existing coordinator claims, including
+expired leases. Restore also rejects
+an unavailable associated resume or an active job with the same normalized URL.
+These failures leave the job unchanged. The commands do not submit an application,
+change its local status, or permanently remove stored content.
+
+## Listing and HTTP contract
+
+`trash-list` and authenticated `GET /api/trash` return `{items, counts, total}`.
+The listing includes trashed jobs, resumes and answers already present in the
+fixture, with deterministic ordering, revisions, labels, deletion timestamps and
+reference blocker counts. Job rows include local status and company; answer rows
+include state and review status. It excludes job URLs and notes, resume paths,
+answer values and claim credentials. Blocker counts describe references; they
+are not a promise that every restore or deletion request would be accepted.
+
+Authenticated `POST /api/jobs/:id/trash` and `POST /api/jobs/:id/restore` accept
+`{"expectedRevision": CURRENT_REVISION}` and return the updated job. The normal
+loopback authorization and origin checks still apply. Unlike the redacted Trash
+listing, these job mutation responses retain the ordinary full job contract.
+
+The existing fixture marker, lock, validation and recovery boundaries remain in
+force. This does not activate native writes for existing owner Stores, change the
+installed launcher default or authorize simultaneous Python and native writers.
+
+## Browser proof
+
+The production browser walkthrough uses an isolated fixture with Python absent
+from the native CLI's PATH. It checks that external trash preserves an open
+editor draft, Refresh hides the trashed card, native CLI and authenticated HTTP
+Trash listings agree and omit private fields, stale restoration leaves Jobs
+unchanged, and restoration survives reload with the saved content intact. It
+exercises both CLI trash with HTTP restore and HTTP trash with CLI restore.

--- a/docs/native-jobs-fixture.md
+++ b/docs/native-jobs-fixture.md
@@ -16,7 +16,8 @@ Facts/profile operations, [active claims](native-claims-fixture.md),
 [CLI legacy job import](native-legacy-jobs-fixture.md) and
 [CLI single-job task intake](native-task-intake-fixture.md), and
 [CLI grouped answer approvals](native-grouped-approvals-fixture.md), and the
-[compatibility task CLI](native-task-cli-fixture.md) are also available. Other
+[compatibility task CLI](native-task-cli-fixture.md), and
+[Trash listing and job recovery](native-job-trash-fixture.md) are also available. Other
 workflows return `unsupported_native_workflow`; they never fall back to Python.
 
 ## Run against a new synthetic root

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,3 +1,4 @@
+import { trashCommands, runTrashCommand } from './native-trash.js';
 import { groupedApprovalCommands, runGroupedApprovalCommand } from './native-grouped-approvals.js';
 import { taskIntakeCommands, runTaskIntakeCommand } from './native-task-intake.js';
 import { legacyJobCommands, runLegacyJobCommand } from './native-legacy-jobs.js';
@@ -46,6 +47,7 @@ export async function runJobsCli(args, input) {
         }
     }
     const fields = {
+        ...trashCommands,
         ...groupedApprovalCommands,
         ...taskIntakeCommands,
         ...legacyJobCommands,
@@ -92,6 +94,8 @@ export async function runJobsCli(args, input) {
             : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command) ? 2 * 1024 * 1024 : 65536;
         return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
     };
+    if (Object.hasOwn(trashCommands, command))
+        return serialize(await runTrashCommand(command, repository, options));
     if (Object.hasOwn(groupedApprovalCommands, command))
         return serialize(await runGroupedApprovalCommand(command, repository, options, payload));
     if (Object.hasOwn(taskIntakeCommands, command))

--- a/runtime/cli/native-trash.js
+++ b/runtime/cli/native-trash.js
@@ -1,0 +1,16 @@
+import { TrashService } from '../workspace-core/trash.js';
+import { JobsError } from '../contracts/workspace/values.js';
+export const trashCommands = {
+    'trash-list': [], 'job-trash': ['--id', '--expected-revision'], 'job-restore': ['--id', '--expected-revision'],
+};
+export function runTrashCommand(command, repository, options) {
+    const service = new TrashService(repository);
+    if (command === 'trash-list')
+        return service.list();
+    const id = options.get('--id'), revision = options.get('--expected-revision');
+    if (!id)
+        throw new JobsError('required option: --id');
+    if (!revision || !/^[0-9]+$/.test(revision) || BigInt(revision) < 1n)
+        throw new JobsError('expected revision must be a positive integer');
+    return command === 'job-trash' ? service.trashJob(id, BigInt(revision)) : service.restoreJob(id, BigInt(revision));
+}

--- a/runtime/workspace-core/jobs-http.js
+++ b/runtime/workspace-core/jobs-http.js
@@ -1,3 +1,4 @@
+import { trashHttp } from './trash-http.js';
 import { claimsHttp } from './claims-http.js';
 import { jobTransitionsHttp } from './job-transitions-http.js';
 import { workspaceProjectionsHttp } from './workspace-projections-http.js';
@@ -17,6 +18,9 @@ const envelope = (key, value) => set(emptyObject(), key, value);
 /** Transport-independent dispatch. Host/token/Origin/body bounds belong to the adapter. */
 export async function jobsHttp(service, repository, method, path, body = "") {
     try {
+        const trash = await trashHttp(repository, method, path, body);
+        if (trash)
+            return trash;
         const transition = await jobTransitionsHttp(repository, method, path, body);
         if (transition)
             return transition;

--- a/runtime/workspace-core/trash-http.js
+++ b/runtime/workspace-core/trash-http.js
@@ -1,0 +1,62 @@
+import { TrashService } from './trash.js';
+import { PythonObject } from '../contracts/python-object.js';
+import { JobsError, fromJSON, get, int, keys, parse, serialize } from '../contracts/workspace/values.js';
+const failure = (status, code, message, details = {}) => ({
+    status, body: serialize(fromJSON({ error: { code, message, ...details } })),
+});
+function lifecycleFailure(error, operation) {
+    const message = error.message;
+    const rules = [
+        [message.includes('revision conflict'), 'revision_conflict',
+            'This record changed elsewhere. Refresh and review the latest revision.', {}],
+        [message.includes('does not exist') && message !== 'assigned resume does not exist',
+            'not_found', 'This record no longer exists.', {}],
+        [message.includes('claimed job'), 'claim_blocked',
+            'This job has a coordinator claim that must be released or completed first.', { claims: 1 }],
+        [message.includes('active job URL already exists'), 'duplicate_active_blocked',
+            'An active job with the same canonical identity already exists.', { duplicateActiveRecords: 1 }],
+        [message.includes('assigned resume does not exist'), 'assigned_resume_blocked',
+            "This job's assigned resume is unavailable. Restore or reassign that resume first.", { unavailableAssignedResumes: 1 }],
+    ];
+    const [, code, safeMessage, counts] = rules.find(([matches]) => matches)
+        ?? [true, 'store_rejected', 'The canonical store rejected this lifecycle operation.', {}];
+    return failure(code === 'not_found' ? 404 : code === 'store_rejected' ? 400 : 409, code, safeMessage, { recordType: 'job', operation, counts });
+}
+/** Lifecycle failures carry only operation metadata and fixed blocker counts. */
+export async function trashHttp(repository, method, path, body) {
+    const service = new TrashService(repository);
+    if (method === 'GET' && path === '/api/trash')
+        return { status: 200, body: serialize(await service.list()) };
+    const match = /^\/api\/jobs\/([^/]+)\/(trash|restore)$/.exec(path);
+    if (method !== 'POST' || !match)
+        return null;
+    const operation = match[2];
+    let payload;
+    try {
+        payload = parse(body);
+    }
+    catch {
+        return failure(400, 'request_error', 'request body must be valid JSON');
+    }
+    if (!(payload instanceof PythonObject))
+        return failure(400, 'request_error', 'request body must be a JSON object');
+    if (keys(payload).length !== 1 || keys(payload)[0] !== 'expectedRevision') {
+        return failure(400, 'request_error', `${operation} body requires expectedRevision`);
+    }
+    const revision = int(get(payload, 'expectedRevision'));
+    if (revision === null || revision < 1n)
+        return failure(400, 'request_error', 'expectedRevision must be a positive integer');
+    try {
+        const id = decodeURIComponent(match[1]);
+        return { status: 200, body: serialize(await (operation === 'trash'
+                ? service.trashJob(id, revision) : service.restoreJob(id, revision))) };
+    }
+    catch (error) {
+        if (error instanceof JobsError)
+            return lifecycleFailure(error, operation);
+        if (error instanceof Error && 'code' in error && typeof error.code === 'string' && /^E[A-Z]+$/.test(error.code)) {
+            return failure(500, 'storage_error', 'storage operation failed');
+        }
+        throw error;
+    }
+}

--- a/runtime/workspace-core/trash.js
+++ b/runtime/workspace-core/trash.js
@@ -1,0 +1,130 @@
+import { answerReferenceCounts } from '../contracts/workspace/answer-sessions.js';
+import { answerView, fallback } from '../contracts/workspace/answers.js';
+import { casefold } from '../contracts/workspace/casefold.js';
+import { emptyObject, safeId, validateJob } from '../contracts/workspace/jobs.js';
+import { copy, get, int, integer, object, same, set, string, text, truth, JobsError } from '../contracts/workspace/values.js';
+function records(document, field) {
+    return object(get(document, field), field).entries().map(([, value]) => object(value, field));
+}
+function label(record, fields, defaultLabel) {
+    for (const field of fields)
+        if (truth(get(record, field)))
+            return get(record, field);
+    return text(defaultLabel);
+}
+function item(record, type, idField, name) {
+    const result = emptyObject();
+    set(result, 'type', text(type));
+    set(result, 'id', get(record, idField));
+    for (const field of ['revision', 'deletedAt'])
+        set(result, field, get(record, field));
+    return set(result, 'label', name);
+}
+function counts(values) {
+    const result = emptyObject();
+    for (const [key, value] of Object.entries(values))
+        set(result, key, integer(value));
+    return result;
+}
+function projectTrash(tx) {
+    const jobs = records(tx.jobs, 'jobs'), resumes = records(tx.resumes, 'resumes');
+    const sessions = new Map(tx.sessions.map(session => [string(get(session, 'applicationId')), session]));
+    const claim = get(tx.coordinator, 'claim');
+    const references = answerReferenceCounts(tx.answers, tx.sessions, tx.history);
+    const items = [];
+    for (const record of jobs) {
+        if (get(record, 'deletedAt') === null)
+            continue;
+        const id = string(get(record, 'id')), session = sessions.get(id);
+        const result = item(record, 'job', 'id', label(record, ['role', 'company'], 'Untitled job'));
+        set(result, 'secondaryLabel', label(record, ['company'], ''));
+        set(result, 'status', fallback(record, 'status', text('saved')));
+        set(result, 'blockerCounts', counts({
+            claims: BigInt(claim !== null && string(get(object(claim, 'claim'), 'jobId')) === id),
+            nonterminalSessions: BigInt(session !== undefined && !['completed', 'abandoned'].includes(string(get(session, 'status')))),
+        }));
+        items.push(result);
+    }
+    for (const record of resumes) {
+        if (get(record, 'deletedAt') === null)
+            continue;
+        const result = item(record, 'resume', 'id', label(record, ['label'], 'Untitled resume'));
+        set(result, 'blockerCounts', counts({
+            jobReferences: BigInt(jobs.filter(job => same(get(job, 'resumeId'), get(record, 'id'))).length),
+        }));
+        items.push(result);
+    }
+    for (const raw of records(tx.answers, 'answers')) {
+        const record = answerView(raw);
+        if (get(record, 'deletedAt') === null)
+            continue;
+        const key = string(get(record, 'key'));
+        const result = item(record, 'answer', 'key', label(record, ['question'], key));
+        for (const field of ['state', 'reviewStatus'])
+            set(result, field, get(record, field));
+        set(result, 'blockerCounts', counts(references.get(key) ?? { sessions: 0n, history: 0n }));
+        items.push(result);
+    }
+    items.sort((a, b) => {
+        for (const field of ['type', 'label', 'id']) {
+            const left = string(get(a, field)), right = string(get(b, field));
+            const difference = text(field === 'label' ? casefold(left) : left)
+                .compare(text(field === 'label' ? casefold(right) : right));
+            if (difference)
+                return difference;
+        }
+        return 0;
+    });
+    const result = set(emptyObject(), 'items', items);
+    set(result, 'counts', counts(Object.fromEntries(['job', 'resume', 'answer'].map(kind => [kind, BigInt(items.filter(record => string(get(record, 'type')) === kind).length)]))));
+    return set(result, 'total', integer(BigInt(items.length)));
+}
+export class TrashService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    list() {
+        return this.repository.claimTransaction(async (transaction) => projectTrash(transaction));
+    }
+    trashJob(id, expectedRevision) {
+        return this.setJobDeleted(id, expectedRevision, false);
+    }
+    restoreJob(id, expectedRevision) {
+        return this.setJobDeleted(id, expectedRevision, true);
+    }
+    setJobDeleted(id, expectedRevision, restore) {
+        safeId(id);
+        return this.repository.transaction(async (transaction) => {
+            const jobs = object(get(transaction.document, 'jobs'), 'jobs.jobs'), value = get(jobs, id);
+            if (value === null)
+                throw new JobsError('job does not exist');
+            const current = object(value, 'job record');
+            if (int(get(current, 'revision')) !== expectedRevision)
+                throw new JobsError('job revision conflict');
+            transaction.requireUnclaimed?.(id);
+            const trashed = get(current, 'deletedAt') !== null;
+            if (restore === !trashed)
+                return current;
+            if (restore) {
+                await transaction.requireResume(get(current, 'resumeId'));
+                if (jobs.entries().some(([key, value]) => string(key) !== id
+                    && get(object(value, 'job record'), 'deletedAt') === null
+                    && same(get(object(value, 'job record'), 'normalizedUrl'), get(current, 'normalizedUrl')))) {
+                    throw new JobsError('active job URL already exists');
+                }
+            }
+            const updated = copy(current);
+            set(updated, 'deletedAt', restore ? null : text(this.now()));
+            set(updated, 'revision', integer(expectedRevision + 1n));
+            set(updated, 'updatedAt', text(this.now()));
+            validateJob(id, updated);
+            set(jobs, id, updated);
+            set(object(get(transaction.document, 'metadata'), 'jobs.metadata'), 'updatedAt', get(updated, 'updatedAt'));
+            await transaction.save(transaction.document);
+            return updated;
+        });
+    }
+}

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,3 +1,4 @@
+import { trashCommands, runTrashCommand } from './native-trash.js';
 import { groupedApprovalCommands, runGroupedApprovalCommand } from './native-grouped-approvals.js';
 import { taskIntakeCommands, runTaskIntakeCommand } from './native-task-intake.js';
 import { legacyJobCommands, runLegacyJobCommand } from './native-legacy-jobs.js';
@@ -41,6 +42,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     }
   }
   const fields: Record<string, string[]> = {
+    ...trashCommands,
     ...groupedApprovalCommands,
     ...taskIntakeCommands,
     ...legacyJobCommands,
@@ -83,6 +85,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
       : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command!) ? 2 * 1024 * 1024 : 65536;
     return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
   };
+  if (Object.hasOwn(trashCommands, command!)) return serialize(await runTrashCommand(command!, repository, options));
   if (Object.hasOwn(groupedApprovalCommands, command!)) return serialize(await runGroupedApprovalCommand(command!, repository, options, payload));
   if (Object.hasOwn(taskIntakeCommands, command!)) return serialize(await runTaskIntakeCommand(repository, options, payload));
   if (Object.hasOwn(legacyJobCommands, command!)) return serialize(await runLegacyJobCommand(command!, repository, options, selected));

--- a/src/cli/native-trash.ts
+++ b/src/cli/native-trash.ts
@@ -1,0 +1,15 @@
+import { TrashService } from '../workspace-core/trash.js';
+import type { TrashRepository } from '../workspace-core/trash.js';
+import { JobsError } from '../contracts/workspace/values.js';
+
+export const trashCommands: Record<string, string[]> = {
+  'trash-list': [], 'job-trash': ['--id', '--expected-revision'], 'job-restore': ['--id', '--expected-revision'],
+};
+export function runTrashCommand(command: string, repository: TrashRepository, options: Map<string, string>) {
+  const service = new TrashService(repository);
+  if (command === 'trash-list') return service.list();
+  const id = options.get('--id'), revision = options.get('--expected-revision');
+  if (!id) throw new JobsError('required option: --id');
+  if (!revision || !/^[0-9]+$/.test(revision) || BigInt(revision) < 1n) throw new JobsError('expected revision must be a positive integer');
+  return command === 'job-trash' ? service.trashJob(id, BigInt(revision)) : service.restoreJob(id, BigInt(revision));
+}

--- a/src/workspace-core/jobs-http.ts
+++ b/src/workspace-core/jobs-http.ts
@@ -1,3 +1,4 @@
+import { trashHttp } from './trash-http.js';
 import { claimsHttp } from './claims-http.js';
 import { jobTransitionsHttp } from './job-transitions-http.js';
 import { workspaceProjectionsHttp } from './workspace-projections-http.js';
@@ -25,6 +26,8 @@ const envelope = (key: string, value: Value): Value => set(emptyObject(), key, v
 export async function jobsHttp(service: JobsService, repository: NativeJobsRepository,
   method: string, path: string, body = ""): Promise<ApiResult> {
   try {
+    const trash = await trashHttp(repository, method, path, body);
+    if (trash) return trash;
     const transition = await jobTransitionsHttp(repository, method, path, body);
     if (transition) return transition;
     const projection = await workspaceProjectionsHttp(repository, method, path);

--- a/src/workspace-core/trash-http.ts
+++ b/src/workspace-core/trash-http.ts
@@ -1,0 +1,56 @@
+import { TrashService } from './trash.js';
+import type { TrashRepository } from './trash.js';
+import { PythonObject } from '../contracts/python-object.js';
+import { JobsError, fromJSON, get, int, keys, parse, serialize } from '../contracts/workspace/values.js';
+
+type Result = { status: number; body: string };
+const failure = (status: number, code: string, message: string, details = {}): Result => ({
+  status, body: serialize(fromJSON({ error: { code, message, ...details } })),
+});
+function lifecycleFailure(error: JobsError, operation: string): Result {
+  const message = error.message;
+  const rules: [boolean, string, string, Record<string, number>][] = [
+    [message.includes('revision conflict'), 'revision_conflict',
+      'This record changed elsewhere. Refresh and review the latest revision.', {}],
+    [message.includes('does not exist') && message !== 'assigned resume does not exist',
+      'not_found', 'This record no longer exists.', {}],
+    [message.includes('claimed job'), 'claim_blocked',
+      'This job has a coordinator claim that must be released or completed first.', { claims: 1 }],
+    [message.includes('active job URL already exists'), 'duplicate_active_blocked',
+      'An active job with the same canonical identity already exists.', { duplicateActiveRecords: 1 }],
+    [message.includes('assigned resume does not exist'), 'assigned_resume_blocked',
+      "This job's assigned resume is unavailable. Restore or reassign that resume first.", { unavailableAssignedResumes: 1 }],
+  ];
+  const [, code, safeMessage, counts] = rules.find(([matches]) => matches)
+    ?? [true, 'store_rejected', 'The canonical store rejected this lifecycle operation.', {}];
+  return failure(code === 'not_found' ? 404 : code === 'store_rejected' ? 400 : 409, code, safeMessage,
+    { recordType: 'job', operation, counts });
+}
+/** Lifecycle failures carry only operation metadata and fixed blocker counts. */
+export async function trashHttp(repository: TrashRepository, method: string, path: string, body: string): Promise<Result | null> {
+  const service = new TrashService(repository);
+  if (method === 'GET' && path === '/api/trash') return { status: 200, body: serialize(await service.list()) };
+  const match = /^\/api\/jobs\/([^/]+)\/(trash|restore)$/.exec(path);
+  if (method !== 'POST' || !match) return null;
+  const operation = match[2]!;
+  let payload;
+  try { payload = parse(body); }
+  catch { return failure(400, 'request_error', 'request body must be valid JSON'); }
+  if (!(payload instanceof PythonObject)) return failure(400, 'request_error', 'request body must be a JSON object');
+  if (keys(payload).length !== 1 || keys(payload)[0] !== 'expectedRevision') {
+    return failure(400, 'request_error', `${operation} body requires expectedRevision`);
+  }
+  const revision = int(get(payload, 'expectedRevision'));
+  if (revision === null || revision < 1n) return failure(400, 'request_error', 'expectedRevision must be a positive integer');
+  try {
+    const id = decodeURIComponent(match[1]!);
+    return { status: 200, body: serialize(await (operation === 'trash'
+      ? service.trashJob(id, revision) : service.restoreJob(id, revision))) };
+  } catch (error) {
+    if (error instanceof JobsError) return lifecycleFailure(error, operation);
+    if (error instanceof Error && 'code' in error && typeof error.code === 'string' && /^E[A-Z]+$/.test(error.code)) {
+      return failure(500, 'storage_error', 'storage operation failed');
+    }
+    throw error;
+  }
+}

--- a/src/workspace-core/trash.ts
+++ b/src/workspace-core/trash.ts
@@ -1,0 +1,126 @@
+import { answerReferenceCounts } from '../contracts/workspace/answer-sessions.js';
+import { answerView, fallback } from '../contracts/workspace/answers.js';
+import { casefold } from '../contracts/workspace/casefold.js';
+import { emptyObject, safeId, validateJob } from '../contracts/workspace/jobs.js';
+import { copy, get, int, integer, object, same, set, string, text, truth, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import type { ClaimRepository, ClaimTransaction } from './claims.js';
+import type { JobsRepository } from './jobs.js';
+
+export interface TrashRepository extends JobsRepository, ClaimRepository {}
+
+function records(document: Document, field: string): Document[] {
+  return object(get(document, field), field).entries().map(([, value]) => object(value, field));
+}
+function label(record: Document, fields: string[], defaultLabel: string): Value {
+  for (const field of fields) if (truth(get(record, field))) return get(record, field);
+  return text(defaultLabel);
+}
+function item(record: Document, type: string, idField: string, name: Value): Document {
+  const result = emptyObject();
+  set(result, 'type', text(type));
+  set(result, 'id', get(record, idField));
+  for (const field of ['revision', 'deletedAt']) set(result, field, get(record, field));
+  return set(result, 'label', name);
+}
+function counts(values: Record<string, bigint>): Document {
+  const result = emptyObject();
+  for (const [key, value] of Object.entries(values)) set(result, key, integer(value));
+  return result;
+}
+function projectTrash(tx: ClaimTransaction): Document {
+  const jobs = records(tx.jobs, 'jobs'), resumes = records(tx.resumes, 'resumes');
+  const sessions = new Map(tx.sessions.map(session => [string(get(session, 'applicationId')), session]));
+  const claim = get(tx.coordinator, 'claim');
+  const references = answerReferenceCounts(tx.answers, tx.sessions, tx.history);
+  const items: Document[] = [];
+  for (const record of jobs) {
+    if (get(record, 'deletedAt') === null) continue;
+    const id = string(get(record, 'id'))!, session = sessions.get(id);
+    const result = item(record, 'job', 'id', label(record, ['role', 'company'], 'Untitled job'));
+    set(result, 'secondaryLabel', label(record, ['company'], ''));
+    set(result, 'status', fallback(record, 'status', text('saved')));
+    set(result, 'blockerCounts', counts({
+      claims: BigInt(claim !== null && string(get(object(claim, 'claim'), 'jobId')) === id),
+      nonterminalSessions: BigInt(session !== undefined && !['completed', 'abandoned'].includes(string(get(session, 'status'))!)),
+    }));
+    items.push(result);
+  }
+  for (const record of resumes) {
+    if (get(record, 'deletedAt') === null) continue;
+    const result = item(record, 'resume', 'id', label(record, ['label'], 'Untitled resume'));
+    set(result, 'blockerCounts', counts({
+      jobReferences: BigInt(jobs.filter(job => same(get(job, 'resumeId'), get(record, 'id'))).length),
+    }));
+    items.push(result);
+  }
+  for (const raw of records(tx.answers, 'answers')) {
+    const record = answerView(raw);
+    if (get(record, 'deletedAt') === null) continue;
+    const key = string(get(record, 'key'))!;
+    const result = item(record, 'answer', 'key', label(record, ['question'], key));
+    for (const field of ['state', 'reviewStatus']) set(result, field, get(record, field));
+    set(result, 'blockerCounts', counts(references.get(key) ?? {sessions: 0n, history: 0n}));
+    items.push(result);
+  }
+  items.sort((a, b) => {
+    for (const field of ['type', 'label', 'id']) {
+      const left = string(get(a, field))!, right = string(get(b, field))!;
+      const difference = text(field === 'label' ? casefold(left) : left)
+        .compare(text(field === 'label' ? casefold(right) : right));
+      if (difference) return difference;
+    }
+    return 0;
+  });
+  const result = set(emptyObject(), 'items', items);
+  set(result, 'counts', counts(Object.fromEntries(['job', 'resume', 'answer'].map(kind =>
+    [kind, BigInt(items.filter(record => string(get(record, 'type')) === kind).length)]))));
+  return set(result, 'total', integer(BigInt(items.length)));
+}
+
+export class TrashService {
+  constructor(readonly repository: TrashRepository,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+
+  list(): Promise<Document> {
+    return this.repository.claimTransaction(async transaction => projectTrash(transaction));
+  }
+
+  trashJob(id: string, expectedRevision: bigint): Promise<Document> {
+    return this.setJobDeleted(id, expectedRevision, false);
+  }
+
+  restoreJob(id: string, expectedRevision: bigint): Promise<Document> {
+    return this.setJobDeleted(id, expectedRevision, true);
+  }
+
+  private setJobDeleted(id: string, expectedRevision: bigint, restore: boolean): Promise<Document> {
+    safeId(id);
+    return this.repository.transaction(async transaction => {
+      const jobs = object(get(transaction.document, 'jobs'), 'jobs.jobs'), value = get(jobs, id);
+      if (value === null) throw new JobsError('job does not exist');
+      const current = object(value, 'job record');
+      if (int(get(current, 'revision')) !== expectedRevision) throw new JobsError('job revision conflict');
+      transaction.requireUnclaimed?.(id);
+      const trashed = get(current, 'deletedAt') !== null;
+      if (restore === !trashed) return current;
+      if (restore) {
+        await transaction.requireResume(get(current, 'resumeId'));
+        if (jobs.entries().some(([key, value]) => string(key) !== id
+          && get(object(value, 'job record'), 'deletedAt') === null
+          && same(get(object(value, 'job record'), 'normalizedUrl'), get(current, 'normalizedUrl')))) {
+          throw new JobsError('active job URL already exists');
+        }
+      }
+      const updated = copy(current);
+      set(updated, 'deletedAt', restore ? null : text(this.now()));
+      set(updated, 'revision', integer(expectedRevision + 1n));
+      set(updated, 'updatedAt', text(this.now()));
+      validateJob(id, updated);
+      set(jobs, id, updated);
+      set(object(get(transaction.document, 'metadata'), 'jobs.metadata'), 'updatedAt', get(updated, 'updatedAt'));
+      await transaction.save(transaction.document);
+      return updated;
+    });
+  }
+}

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,3 +1,4 @@
+import { jobTrashBrowser } from './workspace_native_job_trash_browser_support.mjs';
 import { taskCliBrowser } from './workspace_native_task_cli_browser_support.mjs';
 import { nativeGroupedApprovalsBrowser } from './workspace_native_grouped_approvals_browser_support.mjs';
 import { legacyJobsBrowser } from './workspace_native_legacy_jobs_browser_support.mjs';
@@ -203,10 +204,11 @@ export async function nativeJobsBrowser(buildRoot) {
     });
     const groupedApprovals = await nativeGroupedApprovalsBrowser(page, root, fixture, buildRoot);
     const taskCli = await taskCliBrowser(page, root, fixture, buildRoot);
-    const unsupported = await fetch(startup.origin + '/api/trash', { headers: { Authorization: `Bearer ${token}` } });
+    const jobTrash = await jobTrashBrowser(page, root, fixture, buildRoot);
+    const unsupported = await fetch(startup.origin + '/api/jobs/fixture/delete', { method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Origin: startup.origin }, body: JSON.stringify({expectedRevision:1}) });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { taskCli, groupedApprovals, taskIntake, legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { jobTrash, taskCli, groupedApprovals, taskIntake, legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     releaseInitialClaim?.();
     if (browser) await browser.close();

--- a/tests_js/workspace_native_job_trash.test.mjs
+++ b/tests_js/workspace_native_job_trash.test.mjs
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, plain, read, write, snapshot, cli, at, differential, unchanged } from './workspace_native_job_trash_support.mjs';
+import { TrashService } from '../runtime/workspace-core/trash.js';
+import { NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { AnswersService } from '../runtime/workspace-core/answers.js';
+import { fromJSON, text } from '../runtime/contracts/workspace/values.js';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { atomicWritePointJson, createNativePointAtomicWriteIO } from '../runtime/store/point-persistence.js';
+
+test('native Trash listing and job lifecycle preserve Python contracts and persistence',{timeout:60000},async t=>{
+  const fixture=await nativeFixture();
+  let serial=0;
+  const isolated=()=>setup(fixture,`trash-${++serial}`);
+  try {
+    await t.test('trash, restore, noops, stale revisions and missing identities match Python',async()=>{
+      const state=await isolated();
+      await differential(state,join(fixture.root,'python-lifecycle'),[
+        {kind:'list'},{kind:'restore',revision:1},{kind:'trash',revision:1},
+        {kind:'trash',revision:2},{kind:'trash',revision:1},{kind:'list'},
+        {kind:'restore',revision:2},{kind:'restore',revision:3},{kind:'list'},
+        {kind:'trash',id:'missing',revision:1},{kind:'trash',id:'../private',revision:1},
+      ]);
+      assert.equal(plain(await state.jobs.get('job')).revision,3);
+    });
+    await t.test('trash samples deletion and update clocks separately; restore samples once; noops never sample',async()=>{
+      const state=await isolated();
+      const times=['2026-09-10T15:00:01Z','2026-09-10T15:00:02Z','2026-09-10T15:00:03Z'];
+      let calls=0;
+      const service=new TrashService(state.repository,()=>times[calls++]);
+      const trashed=plain(await service.trashJob('job',1n));
+      assert.equal(trashed.deletedAt,times[0]); assert.equal(trashed.updatedAt,times[1]);
+      const before=await snapshot(state.root);
+      await service.trashJob('job',2n);
+      assert.deepEqual(await snapshot(state.root),before); assert.equal(calls,2);
+      const restored=plain(await service.restoreJob('job',2n));
+      assert.equal(restored.deletedAt,null); assert.equal(restored.updatedAt,times[2]);
+      await service.restoreJob('job',3n); assert.equal(calls,3);
+    });
+    await t.test('restore rejects an active duplicate and unavailable assigned resume without changes',async()=>{
+      const state=await isolated();
+      await state.service.trashJob('job',1n);
+      const jobs=await read(state.root,'jobs.json');
+      jobs.jobs.other.url=jobs.jobs.job.url; jobs.jobs.other.normalizedUrl=jobs.jobs.job.normalizedUrl;
+      await write(state.root,'jobs.json',jobs);
+      await differential(state,join(fixture.root,'python-duplicate'),[{kind:'restore',revision:2}]);
+      await unchanged(state,()=>state.service.restoreJob('job',2n),/active job URL already exists/);
+      jobs.jobs.other.deletedAt=at; jobs.jobs.job.resumeId='resume';
+      await write(state.root,'jobs.json',jobs);
+      const resumes=await read(state.root,'resumes.json'); resumes.resumes.resume.deletedAt=at;
+      await write(state.root,'resumes.json',resumes);
+      await differential(state,join(fixture.root,'python-resume'),[{kind:'restore',revision:2}]);
+      await unchanged(state,()=>state.service.restoreJob('job',2n),/assigned resume does not exist/);
+    });
+    await t.test('claims including expired claims block both mutations before noops',async()=>{
+      const state=await isolated();
+      await state.claims.select('job',1n,true);
+      await state.claims.acquire('job',text('Synthetic owner'),2n);
+      await differential(state,join(fixture.root,'python-claimed'),[
+        {kind:'trash',revision:3},{kind:'restore',revision:3},
+      ]);
+      const coordinator=await read(state.root,'coordinator.json');
+      coordinator.claim.expiresAt='2020-01-01T00:00:00Z';
+      await write(state.root,'coordinator.json',coordinator);
+      await differential(state,join(fixture.root,'python-expired'),[
+        {kind:'trash',revision:3},{kind:'restore',revision:3},
+      ]);
+    });
+    await t.test('unified listing redacts private values and counts all references in deterministic Unicode order',async()=>{
+      const state=await isolated();
+      await state.claims.select('job',1n,true);
+      const acquired=plain(await state.claims.acquire('job',text('Synthetic owner'),2n));
+      await state.claims.progress('job',text(acquired.token),fromJSON({status:'active',pendingFields:[]}));
+      const answers=new AnswersService(state.repository,()=>at);
+      await answers.put(fromJSON({key:'answer',question:'ßeta?',state:'confirmed',value:'PRIVATE ANSWER'}));
+      const answerDoc=await read(state.root,'answers.json'); answerDoc.answers.answer.deletedAt=at;
+      await write(state.root,'answers.json',answerDoc);
+      const jobs=await read(state.root,'jobs.json');
+      for(const job of Object.values(jobs.jobs)) {job.deletedAt=at;job.resumeId='resume';job.notes='PRIVATE NOTE';}
+      jobs.jobs.job.role='ßeta'; jobs.jobs.other.role='SSeta';
+      await write(state.root,'jobs.json',jobs);
+      const resumes=await read(state.root,'resumes.json'); resumes.resumes.resume.deletedAt=at;
+      await write(state.root,'resumes.json',resumes);
+      const session=await read(state.root,'sessions/job.json'); session.answerKeys=['answer'];
+      await write(state.root,'sessions/job.json',session);
+      await write(state.root,'sessions/other.json',{...session,applicationId:'other',status:'completed',answerKeys:[]});
+      await writeFile(join(state.root,'applications.jsonl'),JSON.stringify({schemaVersion:1,eventId:'fixture-history',applicationId:'job',event:'saved',at,answerKeys:['answer','answer']})+'\n');
+      const coordinator=await read(state.root,'coordinator.json'); coordinator.claim.expiresAt='2020-01-01T00:00:00Z';
+      await write(state.root,'coordinator.json',coordinator);
+      await differential(state,join(fixture.root,'python-projection'),[{kind:'list'}]);
+      const result=plain(await state.service.list());
+      assert.deepEqual(result.counts,{job:2,resume:1,answer:1}); assert.equal(result.total,4);
+      assert.deepEqual(result.items.find(item=>item.id==='job').blockerCounts,{claims:1,nonterminalSessions:1});
+      assert.equal(result.items.find(item=>item.type==='resume').blockerCounts.jobReferences,2);
+      assert.deepEqual(result.items.find(item=>item.type==='answer').blockerCounts,{sessions:1,history:1});
+      assert.deepEqual(result.items.find(item=>item.id==='other').blockerCounts,{claims:0,nonterminalSessions:0});
+      assert.doesNotMatch(JSON.stringify(result),/PRIVATE|tokenHash|managedFile|originalFilename|digest|https:|resume\.txt/);
+      const response=await jobsHttp(state.jobs,state.repository,'GET','/api/trash');
+      assert.equal(response.status,200); assert.deepEqual(JSON.parse(response.body),result);
+    });
+    await t.test('independent CLI writers serialize revision checks and results survive repository restart',async()=>{
+      const state=await isolated();
+      const outcomes=await Promise.allSettled(Array.from({length:4},()=>cli(fixture,state.root,'job-trash',['--id','job','--expected-revision','1'])));
+      assert.equal(outcomes.filter(item=>item.status==='fulfilled').length,1);
+      for(const outcome of outcomes.filter(item=>item.status==='rejected')) assert.match(outcome.reason.stderr,/revision conflict/);
+      const restarted=new TrashService(new NativeJobsRepository(state.root,state.provider),()=>at);
+      assert.equal(plain(await restarted.list()).total,1);
+      const restored=await cli(fixture,state.root,'job-restore',['--id','job','--expected-revision','2']);
+      assert.equal(restored.revision,3); assert.equal(restored.deletedAt,null);
+      assert.equal((await cli(fixture,state.root,'trash-list')).total,0);
+    });
+    await t.test('atomic write, sync and replace failures retain bytes and release the lock',async()=>{
+      const state=await isolated();
+      for(const stage of ['write','sync','replace']) {
+        const repository=new NativeJobsRepository(state.root,state.provider,async(path,value,options)=>{
+          const io=createNativePointAtomicWriteIO(options.pathProfile);
+          if(stage==='replace') io.replace=async()=>{throw Error('injected trash fault');};
+          else {
+            const original=io.createTemporary;
+            io.createTemporary=async(...args)=>{const handle=await original(...args);handle[stage]=async()=>{throw Error('injected trash fault');};return handle;};
+          }
+          await atomicWritePointJson(path,value,options,io);
+        });
+        await unchanged(state,()=>new TrashService(repository,()=>at).trashJob('job',1n),/injected trash fault/);
+        assert.equal((await readdir(state.root)).some(name=>name.endsWith('.tmp')),false);
+      }
+      assert.equal(plain(await state.service.trashJob('job',1n)).revision,2);
+    });
+    await t.test('HTTP revision bodies are closed and errors retain established envelopes',async()=>{
+      const state=await isolated();
+      for(const body of ['{}','{"expectedRevision":true}','{"expectedRevision":1.0}','{"expectedRevision":0}','{"expectedRevision":1,"private":"secret"}']) {
+        const before=await snapshot(state.root);
+        const result=await jobsHttp(state.jobs,state.repository,'POST','/api/jobs/job/trash',body);
+        assert.equal(result.status,400); assert.equal(JSON.parse(result.body).error.code,'request_error');
+        assert.deepEqual(await snapshot(state.root),before);
+      }
+      const missing=await jobsHttp(state.jobs,state.repository,'POST','/api/jobs/missing/trash','{"expectedRevision":1}');
+      assert.equal(missing.status,404); assert.equal(JSON.parse(missing.body).error.code,'not_found');
+      const success=await jobsHttp(state.jobs,state.repository,'POST','/api/jobs/job/trash','{"expectedRevision":1}');
+      assert.equal(success.status,200); assert.equal(JSON.parse(success.body).revision,2);
+      const stale=await jobsHttp(state.jobs,state.repository,'POST','/api/jobs/job/restore','{"expectedRevision":1}');
+      assert.equal(stale.status,409); assert.equal(JSON.parse(stale.body).error.code,'revision_conflict');
+      for(const path of ['/api/jobs/job/delete','/api/resumes/resume/trash']) {
+        assert.equal((await jobsHttp(state.jobs,state.repository,'POST',path,'{"expectedRevision":2}')).status,501);
+      }
+    });
+    await t.test('unsupported fixture state fails closed without altering jobs',async()=>{
+      const state=await isolated(), before=await readFile(join(state.root,'jobs.json'));
+      await writeFile(join(state.root,'pending-journal.json'),'{}');
+      await assert.rejects(state.service.list(),/unsupported state/);
+      await assert.rejects(state.service.trashJob('job',1n),/unsupported state/);
+      assert.deepEqual(await readFile(join(state.root,'jobs.json')),before);
+    });
+  } finally {await fixture.cleanup();}
+});

--- a/tests_js/workspace_native_job_trash_browser_support.mjs
+++ b/tests_js/workspace_native_job_trash_browser_support.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// Only the caller's disposable native fixture is mutated; Python is absent from PATH.
+export async function jobTrashBrowser(page, root, fixture, buildRoot) {
+  const execute = promisify(execFile);
+  async function cli(command, args = [], payload) {
+    if (payload !== undefined) {
+      const input = join(fixture.root, 'job-trash-browser-input.json');
+      await writeFile(input, JSON.stringify(payload), { mode: 0o600 });
+      args = [...args, '--input', input];
+    }
+    const result = await execute(process.execPath, [join(buildRoot, 'runtime/cli/native-jobs.js'),
+      '--root', root, '--native-lock', fixture.receipt.artifact, command, ...args], { env: { PATH: '' } });
+    assert.equal(result.stderr, '');
+    return JSON.parse(result.stdout);
+  }
+  const authorization = await page.evaluate(() => `Bearer ${sessionStorage.getItem('jobApplyWorkspaceToken')}`);
+  async function api(path, body) {
+    const response = await page.request.fetch(new URL(path, page.url()).href, {
+      method: body === undefined ? 'GET' : 'POST',
+      headers: { Authorization: authorization, Origin: new URL(page.url()).origin }, data: body,
+    });
+    assert.equal(response.status(), 200, await response.text());
+    return response.json();
+  }
+  const role = 'Recoverable native browser job';
+  const job = await cli('job-create', [], { role, company: 'Trash fixture company',
+    url: 'https://example.invalid/trash-browser?private=trash', notes: 'PRIVATE-TRASH-NOTES' });
+  const args = revision => ['--id', job.id, '--expected-revision', String(revision)];
+  const navigation = page.getByRole('navigation', { name: 'Workspace sections' });
+  const modal = page.getByRole('dialog', { name: 'Edit job', exact: true });
+  const card = page.getByRole('button', { name: new RegExp(role) });
+  await navigation.getByRole('button', { name: 'Jobs', exact: true }).click();
+  await page.getByRole('button', { name: 'Refresh', exact: true }).click();
+  await card.click();
+  const company = modal.locator('[name="company"]');
+  await company.fill('Unsaved trash browser draft');
+  const trashed = await cli('job-trash', args(job.revision));
+  assert.equal(trashed.revision, job.revision + 1);
+  assert.equal(typeof trashed.deletedAt, 'string');
+  assert.equal(await company.inputValue(), 'Unsaved trash browser draft');
+  // External lifecycle changes must not replace the owner's current editor draft.
+  await company.fill(job.company);
+  await modal.getByRole('button', { name: 'Close job details', exact: true }).click();
+  await page.getByRole('button', { name: 'Refresh', exact: true }).click();
+  await card.waitFor({ state: 'hidden' });
+  const beforeList = await readFile(join(root, 'jobs.json'), 'utf8');
+  const listed = await cli('trash-list');
+  assert.deepEqual(await api('/api/trash'), listed);
+  assert.equal(await readFile(join(root, 'jobs.json'), 'utf8'), beforeList);
+  const item = listed.items.find(value => value.type === 'job' && value.id === job.id);
+  assert.deepEqual(item, { type: 'job', id: job.id, revision: trashed.revision,
+    deletedAt: trashed.deletedAt, label: role, secondaryLabel: job.company,
+    status: job.status, blockerCounts: { claims: 0, nonterminalSessions: 0 } });
+  assert.doesNotMatch(JSON.stringify(listed), /PRIVATE-TRASH-NOTES|private=trash/);
+  await assert.rejects(cli('job-restore', args(job.revision)), /revision conflict/);
+  assert.equal(await readFile(join(root, 'jobs.json'), 'utf8'), beforeList);
+  const restored = await api(`/api/jobs/${job.id}/restore`, { expectedRevision: trashed.revision });
+  assert.equal(restored.deletedAt, null);
+  assert.equal(restored.revision, trashed.revision + 1);
+  await page.reload();
+  await navigation.getByRole('button', { name: 'Jobs', exact: true }).click();
+  await card.filter({ hasText: new RegExp(`revision ${restored.revision}$`) }).click();
+  assert.equal(await company.inputValue(), job.company);
+  assert.equal(await modal.locator('[name="notes"]').inputValue(), job.notes);
+  await modal.getByRole('button', { name: 'Close job details', exact: true }).click();
+  const again = await api(`/api/jobs/${job.id}/trash`, { expectedRevision: restored.revision });
+  assert.equal(again.revision, restored.revision + 1);
+  const final = await cli('job-restore', args(again.revision));
+  assert.equal(final.deletedAt, null);
+  assert.equal((await api('/api/trash')).items.some(value => value.type === 'job' && value.id === job.id), false);
+  await page.getByRole('button', { name: 'Refresh', exact: true }).click();
+  await card.filter({ hasText: new RegExp(`revision ${final.revision}$`) }).click();
+  assert.equal(await company.inputValue(), job.company);
+  assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1));
+  await modal.getByRole('button', { name: 'Close job details', exact: true }).click();
+  return { cliTrashHidden: true, apiRestoreReload: true, apiTrashCliRestore: true,
+    redactedListingAgreement: true, listingReadOnly: true, staleRevisionRejected: true,
+    externalDraftPreserved: true, restoredContentPreserved: true, pythonAbsentFromPath: true };
+}

--- a/tests_js/workspace_native_job_trash_support.mjs
+++ b/tests_js/workspace_native_job_trash_support.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { cp } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { setup as claimsSetup, plain, read, write, snapshot, cli } from './workspace_native_claims_support.mjs';
+import { TrashService } from '../runtime/workspace-core/trash.js';
+export { plain, read, write, snapshot, cli };
+export const at = '2026-09-10T15:00:00Z';
+export async function setup(fixture,name) {
+  const state=await claimsSetup(fixture,name);
+  return {...state,service:new TrashService(state.repository,()=>at)};
+}
+const python = `import importlib.util,json,sys
+from pathlib import Path
+sys.path.insert(0,str(Path('scripts').resolve()))
+spec=importlib.util.spec_from_file_location('trash_reference','scripts/job-apply-store.py')
+module=importlib.util.module_from_spec(spec); spec.loader.exec_module(module)
+module.utc_now=lambda:'2026-09-10T15:00:00Z'
+from job_apply_workspace.projections import unified_trash_projection
+store=module.Store(Path(sys.argv[1])); store.initialize()
+results=[]
+for op in json.loads(sys.argv[2]):
+ try:
+  value=unified_trash_projection(store) if op['kind']=='list' else getattr(store,op['kind']+'_job')(op.get('id','job'),op['revision'])
+  result={'value':value}
+ except module.StoreError as error: result={'error':str(error)}
+ result['jobs']=json.loads(store.jobs_path.read_text())
+ results.append(result)
+print(json.dumps(results))`;
+export async function differential(state,target,operations) {
+  await cp(state.root,target,{recursive:true});
+  const reference=JSON.parse((await promisify(execFile)('python3',['-c',python,target,JSON.stringify(operations)],{maxBuffer:8*1024*1024})).stdout);
+  for(const [index,op] of operations.entries()) {
+    const before=await snapshot(state.root);
+    let actual;
+    try {actual={value:plain(await (op.kind==='list'?state.service.list():state.service[`${op.kind}Job`](op.id??'job',BigInt(op.revision))))};}
+    catch(error) {actual={error:error.message};}
+    const {jobs,...expected}=reference[index];
+    assert.deepEqual(actual,expected,`operation ${index}: ${JSON.stringify(op)}`);
+    assert.deepEqual(await read(state.root,'jobs.json'),jobs);
+    const after=await snapshot(state.root);
+    if(op.kind==='list'||actual.error) assert.deepEqual(after,before);
+    delete before['jobs.json']; delete after['jobs.json'];
+    assert.deepEqual(after,before,'only jobs.json may change');
+  }
+}
+export async function unchanged(state,operation,pattern) {
+  const before=await snapshot(state.root);
+  await assert.rejects(operation,pattern);
+  assert.deepEqual(await snapshot(state.root),before);
+}

--- a/tests_js/workspace_native_jobs.test.mjs
+++ b/tests_js/workspace_native_jobs.test.mjs
@@ -116,7 +116,8 @@ print(json.dumps(out))
       assert.equal((await jobsHttp(service, repository, 'PATCH', '/api/jobs/one', '{"patch":{},"expectedRevision":true}')).status, 400);
       assert.equal((await jobsHttp(service, repository, 'GET', '/api/jobs/missing')).status, 404);
       assert.equal((await jobsHttp(service, repository, 'POST', '/api/jobs/one/transition', '{}')).status, 400);
-      assert.equal((await jobsHttp(service, repository, 'GET', '/api/trash')).status, 501);
+      assert.equal((await jobsHttp(service, repository, 'GET', '/api/trash')).status, 200);
+      assert.equal((await jobsHttp(service, repository, 'POST', '/api/jobs/job/delete', '{"expectedRevision":1}')).status, 501);
     });
     await t.test('independent CLI writers serialize revisions without Python', async () => {
       const cli = resolve('runtime/cli/native-jobs.js');


### PR DESCRIPTION
Adds unified Trash listing and reversible job trash/restore to the native fixture API and CLI. The listing exposes redacted job/resume/answer metadata and blocker counts. Job mutations retain Python revision, claim, no-op, assigned-resume and duplicate-identity rules, preserve provenance and update only Jobs through the existing guarded transaction.

HTTP lifecycle failures return operation-aware redacted errors. The fixture remains version9; no live Store adoption, permanent deletion, resume/answer mutations or new Trash UI is enabled.

Validation:
- 10 focused tests passed, including independent Python projection/persistence parity, exact clock behavior, expired claims, restore conflicts, concurrency, atomic write faults and HTTP errors.
- Production standalone browser proof passed both CLI/API lifecycle directions, redacted listing agreement, draft preservation, stale revision rejection and restored content after reload.
- Runtime build, source-size and test-matrix checks passed.
- Five independent review roles found no actionable issues. Normal commit hooks, all 27 deep-validation suites and normal push hooks passed. Validate Plugin (34630119745, attempt 2) and Release Validation (34630122754) passed on the exact reviewed head.
- Built-in Codex review remains unavailable because the installed CLI does not support the configured model; focused independent review proceeds against staging.

CI retry note: the initial compatibility owner-beta account UI test timed out waiting for an email override revision. The unchanged test passed on an isolated clean checkout, then the failed CI jobs passed on the same commit. The initial failure log is preserved; no assertions were weakened and no race fix is claimed.
