### PR TITLE
Add native permanent job deletion

### DIFF
--- a/config/migration/cli-native-job-trash-surfaces.json
+++ b/config/migration/cli-native-job-trash-surfaces.json
@@ -75,6 +75,31 @@
         "recovery": "unverified",
         "platform": "unverified"
       }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:job-delete",
+      "kind": "cli",
+      "command": "job-delete",
+      "node": "JOB",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-trash.ts",
+        "src/workspace-core/trash.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
     }
   ]
 }

--- a/config/migration/http-write-jobs-surfaces.json
+++ b/config/migration/http-write-jobs-surfaces.json
@@ -256,7 +256,11 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/trash-http.ts",
+        "src/workspace-core/trash.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -111,7 +111,7 @@
     },
     {
       "path": "cli-native-job-trash-surfaces.json",
-      "sha256": "ddb9940f442a16dcb478d08d8a1c018a10c761e933af4972c5bc0bbe7ebb1137"
+      "sha256": "d3609ccbb2d44f685ac5c9dd7ea0a7537ea66dab837ab30494672ee328274eae"
     },
     {
       "path": "cli-native-job-upsert-surfaces.json",
@@ -199,7 +199,7 @@
     },
     {
       "path": "http-write-jobs-surfaces.json",
-      "sha256": "c10344d5a03033f4550f9f2312d7fa686510d6eb005021d72a384b51a26d9be7"
+      "sha256": "cc4e61028f78841558a294c01ee5f71340fcece6bc63e23c97643ab175af4590"
     },
     {
       "path": "http-write-profile-surfaces.json",
@@ -339,7 +339,7 @@
     },
     {
       "path": "source-catalog-native-job-trash.json",
-      "sha256": "6dd681f77adccd610b69a2bc08f77491885afcf7f69ae9d50411bbb96756a05e"
+      "sha256": "2acfa5a69e084fd7ac11adce3e4097e09a128cf35026cbf102ad401777ac9ff3"
     },
     {
       "path": "source-catalog-native-job-upsert.json",

--- a/config/migration/source-catalog-native-job-trash.json
+++ b/config/migration/source-catalog-native-job-trash.json
@@ -3,32 +3,32 @@
   "sources": [
     {
       "path": "runtime/cli/native-trash.js",
-      "sha256": "438617ba3c91932782c38fa253e5f99f55eee0ff9dc2f57b0227cf1daddc3141",
+      "sha256": "07c2552d519d8464109c68dde30728104d4a1419230112972d054fbd1eb62303",
       "classification": "unreviewed"
     },
     {
       "path": "runtime/workspace-core/trash-http.js",
-      "sha256": "34b2c8cfe900ceaaa481328e42b6f0481c71c84f2ae867f868ba6d5b0aec80a2",
+      "sha256": "f0ed04457c7442f933b7c26a54b536d178374119192b3da640fcb90271348ed8",
       "classification": "unreviewed"
     },
     {
       "path": "runtime/workspace-core/trash.js",
-      "sha256": "634a63a4313500817a7372db5cacb6fa2ff8f43ad80662f53bc766cf84a7486c",
+      "sha256": "9f2c42669a109ad95c8bc614485ebef6e29fc27b24c5a7610d6d65474d7d18fa",
       "classification": "unreviewed"
     },
     {
       "path": "src/cli/native-trash.ts",
-      "sha256": "66e9edb7f6dd7f2ebfa54face31cb0b6ebf98640b3573fa420d375970cb5326c",
+      "sha256": "22e77ad516e6d5277650f8c42d41b00c69cab03e268911028e5ad2bd18b344ba",
       "classification": "unreviewed"
     },
     {
       "path": "src/workspace-core/trash-http.ts",
-      "sha256": "c8b9dd2f3fb0703b0573774ab065df3823fa0aa711b3dca111ebb02d1967f1d4",
+      "sha256": "6558edf9bd92d2b3f94969cd115d5856648bde69b15fbc8e6bbf0d72c8d7b68a",
       "classification": "unreviewed"
     },
     {
       "path": "src/workspace-core/trash.ts",
-      "sha256": "715a6f634b403402173a29861a4f85785d4f52224360281f299a9c110bafb46a",
+      "sha256": "73840304f8c65286a1c1e91bd38e5636d08d1530cf782afa04025ebcfc2a75c9",
       "classification": "unreviewed"
     }
   ]

--- a/docs/native-job-trash-fixture.md
+++ b/docs/native-job-trash-fixture.md
@@ -1,13 +1,13 @@
 # Native Trash and job recovery fixture
 
 The opt-in version 9 native fixture supports a unified Trash listing and reversible
-job trash/restore through its CLI and authenticated HTTP API. A trashed job is
+job trash/restore and permanent deletion through its CLI and authenticated HTTP API. A trashed job is
 hidden from ordinary Jobs results. Restoring it makes it visible in Companion
 Jobs after Refresh or reload, retaining its saved fields and local status.
 
 This tranche adds API and CLI operations only. The native Companion has no Trash
-section or browser trash/restore buttons yet. Full Trash UI, permanent deletion,
-and resume/answer trash and restore operations remain later work.
+section or browser trash/restore buttons yet. Full Trash UI and
+resume/answer lifecycle operations remain separate integration work.
 
 ## Use a synthetic fixture
 
@@ -32,6 +32,25 @@ expired leases. Restore also rejects
 an unavailable associated resume or an active job with the same normalized URL.
 These failures leave the job unchanged. The commands do not submit an application,
 change its local status, or permanently remove stored content.
+
+## Permanent job deletion
+
+`job-delete --id SYNTHETIC_JOB_ID --expected-revision CURRENT_REVISION` and
+`POST /api/jobs/:id/delete` permanently remove a trashed job. The POST accepts
+only `{"expectedRevision": CURRENT_REVISION}`. The response is `{deleted, id}`,
+not a job record. Missing jobs return `deleted: false`, even with an old revision.
+Existing jobs require the current revision, no coordinator claim (including an
+expired claim), prior trash, and an absent or completed/abandoned session, in
+that order. Session and application history evidence remains byte-for-byte intact.
+Failures before atomic replacement preserve the record. A later failure can
+report an error after deletion has taken effect. Refresh canonical state after
+any failed deletion before deciding whether another attempt is appropriate.
+
+HTTP failures use redacted lifecycle metadata: `recordType: "job"`,
+`operation: "delete"`, and fixed blocker counts. Nonterminal sessions return
+409 `session_reference_blocked` with `nonterminalSessions: 1`. Confirmation is
+an explicit UI responsibility; it is not an additional HTTP request field.
+A client should refresh after success and must not blindly retry conflicts.
 
 ## Listing and HTTP contract
 

--- a/docs/native-lifecycle-fixture.md
+++ b/docs/native-lifecycle-fixture.md
@@ -1,0 +1,101 @@
+# Native lifecycle migration boundaries
+
+The first lifecycle tranche implements permanent job deletion in the synthetic
+version 9 fixture. See [job Trash fixture](native-job-trash-fixture.md) for the
+runnable CLI and HTTP contract. Resume and answer lifecycle operations below
+are mapped work, not enabled native functionality.
+
+## Python authority and remaining behavior
+
+| Record | Store authority | HTTP authority |
+| --- | --- | --- |
+| Job | `scripts/job_apply_store/domains/jobs/crud.py` | `scripts/job_apply_workspace/domains/jobs.py` |
+| Resume | `scripts/job_apply_store/domains/resumes/lifecycle.py` | `scripts/job_apply_workspace/domains/resumes.py` |
+| Answer | `scripts/job_apply_store/domains/answers/mutations.py` | `scripts/job_apply_workspace/domains/answers.py` |
+
+All lifecycle POST routes accept exactly `{expectedRevision: positive integer}`.
+Python `auth.py` owns operation-aware redacted failures. Job delete returns
+`{deleted, id}`; answer delete returns `{deleted, key}`. Resume HTTP mutations
+run through `public_resume`, including deletion; preserve that projection rather
+than assuming all lifecycle mutations return full records.
+
+Resume trash checks revision before no-op detection. It blocks assignments by
+active jobs and implicit use of the default resume by active unassigned jobs.
+Trash clears the default flag and cancels open extraction requests through the
+extraction journal. Restore checks managed digest identity or legacy path
+identity against active resumes; it sets default only when no other active
+resume exists. Neither operation changes managed content identity.
+
+Resume delete returns an absent-record no-op before checking revision. Existing
+records require revision, prior trash, no open extraction request, and no job
+reference, including trashed jobs. Managed content is quarantined before record
+removal. Python restores quarantine on metadata write failure and tolerates an
+unlink failure after successful metadata deletion. Legacy source files are not
+removed. Crash recovery needs explicit fixture support before route activation.
+
+Answer trash/restore checks revision before no-op detection, using the legacy
+revision default of 1. Trash blocks immutable redirect targets. Mutation results
+use the existing answer projection and reference counts. Permanent deletion
+first rejects redirect source identities, then returns an absent-record no-op.
+Existing records require revision, prior trash, no incoming redirect, no session
+answerKeys or pendingFields reference, and no history answerKeys reference.
+The session check includes terminal sessions. Do not remove protected references
+to make deletion succeed. Job deletion retaining sessions is therefore material
+to subsequent answer deletion behavior.
+
+## Narrow proposed repository interfaces
+
+Job deletion uses the existing `ClaimRepository.claimTransaction` snapshot,
+`requireJobUnclaimed` contract, and `saveJobs`. It needs no new journal because
+only jobs.json changes. Shared recovery remains the repository's responsibility.
+
+Answer lifecycle can use existing `AnswerRepository.answerTransaction` with
+`document`, `save`, and `AnswerReferenceCounts`. Redirect protection precedes
+reference checks, so redirect-resolved reference counts do not weaken deletion
+guards. Reuse `answerProjection` for mutation responses. The coordinator wires
+the new leaf's HTTP/CLI entry points into shared dispatch.
+
+Resume lifecycle needs one lock-consistent repository callback:
+
+```ts
+interface ResumeLifecycleTransaction {
+  resumes: Document;
+  jobs: Document;
+  requests: Document;
+  saveResumes(document: Document): Promise<void>;
+  deleteManaged(record: Document, document: Document): Promise<void>;
+}
+interface ResumeLifecycleRepository {
+  resumeLifecycleTransaction<T>(
+    operation: (tx: ResumeLifecycleTransaction) => Promise<T>
+  ): Promise<T>;
+}
+```
+
+`saveResumes` should reuse extraction request closure and its existing journal.
+`deleteManaged` belongs to a new owned Store leaf, with the coordinator composing
+recovery before ordinary resume recovery. This is a proposal, not a committed
+API. The existing `NativeResumeFiles.validate` accepts canonical files and native
+temporary files only, and its recovery journal accepts install operations only.
+Adding quarantine filenames or a deletion operation requires a reviewed recovery
+contract and shared wiring; do not loosen validation or create unrecognized
+journals in a version 9 Store as a shortcut.
+
+## Required next evidence
+
+Resume acceptance needs independent cloned Python/native Stores covering default
+selection, active and trashed job references, duplicate identities, extraction
+cancellation, open-request delete rejection, and managed/legacy/missing files.
+Inject rename, metadata write, unlink, and directory sync failures and restart
+at every durable boundary. Reject links, traversal, foreign files and malformed
+journals before cleanup. Check that unrelated files and metadata remain intact.
+
+Answer acceptance needs independent Python/native comparisons for legacy
+records, redirect sources/targets, sensitive projection, current/stale/no-op
+revisions, pending fields, terminal sessions and protected history. Preserve raw
+session/history bytes and compare redacted HTTP error counts.
+
+The coordinator owns catalogs, normal hooks, review, browser integration and
+staging publication. A browser may exercise the new job delete route after
+explicit confirmation and must refresh canonical state after acknowledgment.
+It must continue treating native resume/answer lifecycle routes as unsupported.

--- a/runtime/cli/native-trash.js
+++ b/runtime/cli/native-trash.js
@@ -2,6 +2,7 @@ import { TrashService } from '../workspace-core/trash.js';
 import { JobsError } from '../contracts/workspace/values.js';
 export const trashCommands = {
     'trash-list': [], 'job-trash': ['--id', '--expected-revision'], 'job-restore': ['--id', '--expected-revision'],
+    'job-delete': ['--id', '--expected-revision'],
 };
 export function runTrashCommand(command, repository, options) {
     const service = new TrashService(repository);
@@ -12,5 +13,11 @@ export function runTrashCommand(command, repository, options) {
         throw new JobsError('required option: --id');
     if (!revision || !/^[0-9]+$/.test(revision) || BigInt(revision) < 1n)
         throw new JobsError('expected revision must be a positive integer');
-    return command === 'job-trash' ? service.trashJob(id, BigInt(revision)) : service.restoreJob(id, BigInt(revision));
+    if (command === 'job-trash')
+        return service.trashJob(id, BigInt(revision));
+    if (command === 'job-restore')
+        return service.restoreJob(id, BigInt(revision));
+    if (command === 'job-delete')
+        return service.deleteJob(id, BigInt(revision));
+    throw new JobsError('unsupported trash command');
 }

--- a/runtime/workspace-core/trash-http.js
+++ b/runtime/workspace-core/trash-http.js
@@ -13,6 +13,8 @@ function lifecycleFailure(error, operation) {
             'not_found', 'This record no longer exists.', {}],
         [message.includes('claimed job'), 'claim_blocked',
             'This job has a coordinator claim that must be released or completed first.', { claims: 1 }],
+        [message.includes('nonterminal application session'), 'session_reference_blocked',
+            'This job has a nonterminal application session that must be completed or abandoned first.', { nonterminalSessions: 1 }],
         [message.includes('active job URL already exists'), 'duplicate_active_blocked',
             'An active job with the same canonical identity already exists.', { duplicateActiveRecords: 1 }],
         [message.includes('assigned resume does not exist'), 'assigned_resume_blocked',
@@ -27,7 +29,7 @@ export async function trashHttp(repository, method, path, body) {
     const service = new TrashService(repository);
     if (method === 'GET' && path === '/api/trash')
         return { status: 200, body: serialize(await service.list()) };
-    const match = /^\/api\/jobs\/([^/]+)\/(trash|restore)$/.exec(path);
+    const match = /^\/api\/jobs\/([^/]+)\/(trash|restore|delete)$/.exec(path);
     if (method !== 'POST' || !match)
         return null;
     const operation = match[2];
@@ -49,7 +51,8 @@ export async function trashHttp(repository, method, path, body) {
     try {
         const id = decodeURIComponent(match[1]);
         return { status: 200, body: serialize(await (operation === 'trash'
-                ? service.trashJob(id, revision) : service.restoreJob(id, revision))) };
+                ? service.trashJob(id, revision) : operation === 'restore'
+                ? service.restoreJob(id, revision) : service.deleteJob(id, revision))) };
     }
     catch (error) {
         if (error instanceof JobsError)

--- a/runtime/workspace-core/trash.js
+++ b/runtime/workspace-core/trash.js
@@ -1,6 +1,7 @@
 import { answerReferenceCounts } from '../contracts/workspace/answer-sessions.js';
 import { answerView, fallback } from '../contracts/workspace/answers.js';
 import { casefold } from '../contracts/workspace/casefold.js';
+import { requireJobUnclaimed } from '../contracts/workspace/claims.js';
 import { emptyObject, safeId, validateJob } from '../contracts/workspace/jobs.js';
 import { copy, get, int, integer, object, same, set, string, text, truth, JobsError } from '../contracts/workspace/values.js';
 function records(document, field) {
@@ -94,6 +95,31 @@ export class TrashService {
     }
     restoreJob(id, expectedRevision) {
         return this.setJobDeleted(id, expectedRevision, true);
+    }
+    deleteJob(id, expectedRevision) {
+        safeId(id);
+        return this.repository.claimTransaction(async (transaction) => {
+            const jobs = object(get(transaction.jobs, 'jobs'), 'jobs.jobs');
+            const value = get(jobs, id);
+            const result = set(emptyObject(), 'id', text(id));
+            if (value === null)
+                return set(result, 'deleted', false);
+            const current = object(value, 'job record');
+            if (int(get(current, 'revision')) !== expectedRevision)
+                throw new JobsError('job revision conflict');
+            requireJobUnclaimed(transaction.coordinator, id);
+            if (get(current, 'deletedAt') === null)
+                throw new JobsError('job must be trashed before permanent deletion');
+            const session = transaction.sessions.find(item => string(get(item, 'applicationId')) === id);
+            if (session && !['completed', 'abandoned'].includes(string(get(session, 'status')))) {
+                throw new JobsError('job is referenced by a nonterminal application session');
+            }
+            // Retain session and history evidence, including answer references.
+            jobs.delete(text(id));
+            set(object(get(transaction.jobs, 'metadata'), 'jobs.metadata'), 'updatedAt', text(this.now()));
+            await transaction.saveJobs(transaction.jobs);
+            return set(result, 'deleted', true);
+        });
     }
     setJobDeleted(id, expectedRevision, restore) {
         safeId(id);

--- a/src/cli/native-trash.ts
+++ b/src/cli/native-trash.ts
@@ -4,6 +4,7 @@ import { JobsError } from '../contracts/workspace/values.js';
 
 export const trashCommands: Record<string, string[]> = {
   'trash-list': [], 'job-trash': ['--id', '--expected-revision'], 'job-restore': ['--id', '--expected-revision'],
+  'job-delete': ['--id', '--expected-revision'],
 };
 export function runTrashCommand(command: string, repository: TrashRepository, options: Map<string, string>) {
   const service = new TrashService(repository);
@@ -11,5 +12,8 @@ export function runTrashCommand(command: string, repository: TrashRepository, op
   const id = options.get('--id'), revision = options.get('--expected-revision');
   if (!id) throw new JobsError('required option: --id');
   if (!revision || !/^[0-9]+$/.test(revision) || BigInt(revision) < 1n) throw new JobsError('expected revision must be a positive integer');
-  return command === 'job-trash' ? service.trashJob(id, BigInt(revision)) : service.restoreJob(id, BigInt(revision));
+  if (command === 'job-trash') return service.trashJob(id, BigInt(revision));
+  if (command === 'job-restore') return service.restoreJob(id, BigInt(revision));
+  if (command === 'job-delete') return service.deleteJob(id, BigInt(revision));
+  throw new JobsError('unsupported trash command');
 }

--- a/src/workspace-core/trash-http.ts
+++ b/src/workspace-core/trash-http.ts
@@ -16,6 +16,8 @@ function lifecycleFailure(error: JobsError, operation: string): Result {
       'not_found', 'This record no longer exists.', {}],
     [message.includes('claimed job'), 'claim_blocked',
       'This job has a coordinator claim that must be released or completed first.', { claims: 1 }],
+    [message.includes('nonterminal application session'), 'session_reference_blocked',
+      'This job has a nonterminal application session that must be completed or abandoned first.', { nonterminalSessions: 1 }],
     [message.includes('active job URL already exists'), 'duplicate_active_blocked',
       'An active job with the same canonical identity already exists.', { duplicateActiveRecords: 1 }],
     [message.includes('assigned resume does not exist'), 'assigned_resume_blocked',
@@ -30,7 +32,7 @@ function lifecycleFailure(error: JobsError, operation: string): Result {
 export async function trashHttp(repository: TrashRepository, method: string, path: string, body: string): Promise<Result | null> {
   const service = new TrashService(repository);
   if (method === 'GET' && path === '/api/trash') return { status: 200, body: serialize(await service.list()) };
-  const match = /^\/api\/jobs\/([^/]+)\/(trash|restore)$/.exec(path);
+  const match = /^\/api\/jobs\/([^/]+)\/(trash|restore|delete)$/.exec(path);
   if (method !== 'POST' || !match) return null;
   const operation = match[2]!;
   let payload;
@@ -45,7 +47,8 @@ export async function trashHttp(repository: TrashRepository, method: string, pat
   try {
     const id = decodeURIComponent(match[1]!);
     return { status: 200, body: serialize(await (operation === 'trash'
-      ? service.trashJob(id, revision) : service.restoreJob(id, revision))) };
+      ? service.trashJob(id, revision) : operation === 'restore'
+        ? service.restoreJob(id, revision) : service.deleteJob(id, revision))) };
   } catch (error) {
     if (error instanceof JobsError) return lifecycleFailure(error, operation);
     if (error instanceof Error && 'code' in error && typeof error.code === 'string' && /^E[A-Z]+$/.test(error.code)) {

--- a/src/workspace-core/trash.ts
+++ b/src/workspace-core/trash.ts
@@ -1,6 +1,7 @@
 import { answerReferenceCounts } from '../contracts/workspace/answer-sessions.js';
 import { answerView, fallback } from '../contracts/workspace/answers.js';
 import { casefold } from '../contracts/workspace/casefold.js';
+import { requireJobUnclaimed } from '../contracts/workspace/claims.js';
 import { emptyObject, safeId, validateJob } from '../contracts/workspace/jobs.js';
 import { copy, get, int, integer, object, same, set, string, text, truth, JobsError } from '../contracts/workspace/values.js';
 import type { Document, Value } from '../contracts/workspace/values.js';
@@ -92,6 +93,29 @@ export class TrashService {
 
   restoreJob(id: string, expectedRevision: bigint): Promise<Document> {
     return this.setJobDeleted(id, expectedRevision, true);
+  }
+
+  deleteJob(id: string, expectedRevision: bigint): Promise<Document> {
+    safeId(id);
+    return this.repository.claimTransaction(async transaction => {
+      const jobs = object(get(transaction.jobs, 'jobs'), 'jobs.jobs');
+      const value = get(jobs, id);
+      const result = set(emptyObject(), 'id', text(id));
+      if (value === null) return set(result, 'deleted', false);
+      const current = object(value, 'job record');
+      if (int(get(current, 'revision')) !== expectedRevision) throw new JobsError('job revision conflict');
+      requireJobUnclaimed(transaction.coordinator, id);
+      if (get(current, 'deletedAt') === null) throw new JobsError('job must be trashed before permanent deletion');
+      const session = transaction.sessions.find(item => string(get(item, 'applicationId')) === id);
+      if (session && !['completed', 'abandoned'].includes(string(get(session, 'status'))!)) {
+        throw new JobsError('job is referenced by a nonterminal application session');
+      }
+      // Retain session and history evidence, including answer references.
+      jobs.delete(text(id));
+      set(object(get(transaction.jobs, 'metadata'), 'jobs.metadata'), 'updatedAt', text(this.now()));
+      await transaction.saveJobs(transaction.jobs);
+      return set(result, 'deleted', true);
+    });
   }
 
   private setJobDeleted(id: string, expectedRevision: bigint, restore: boolean): Promise<Document> {

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -205,7 +205,7 @@ export async function nativeJobsBrowser(buildRoot) {
     const groupedApprovals = await nativeGroupedApprovalsBrowser(page, root, fixture, buildRoot);
     const taskCli = await taskCliBrowser(page, root, fixture, buildRoot);
     const jobTrash = await jobTrashBrowser(page, root, fixture, buildRoot);
-    const unsupported = await fetch(startup.origin + '/api/jobs/fixture/delete', { method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Origin: startup.origin }, body: JSON.stringify({expectedRevision:1}) });
+    const unsupported = await fetch(startup.origin + '/api/resumes/fixture/delete', { method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Origin: startup.origin }, body: JSON.stringify({expectedRevision:1}) });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
     return { jobTrash, taskCli, groupedApprovals, taskIntake, legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };

--- a/tests_js/workspace_native_job_trash.test.mjs
+++ b/tests_js/workspace_native_job_trash.test.mjs
@@ -143,7 +143,7 @@ test('native Trash listing and job lifecycle preserve Python contracts and persi
       assert.equal(success.status,200); assert.equal(JSON.parse(success.body).revision,2);
       const stale=await jobsHttp(state.jobs,state.repository,'POST','/api/jobs/job/restore','{"expectedRevision":1}');
       assert.equal(stale.status,409); assert.equal(JSON.parse(stale.body).error.code,'revision_conflict');
-      for(const path of ['/api/jobs/job/delete','/api/resumes/resume/trash']) {
+      for(const path of ['/api/resumes/resume/trash']) {
         assert.equal((await jobsHttp(state.jobs,state.repository,'POST',path,'{"expectedRevision":2}')).status,501);
       }
     });

--- a/tests_js/workspace_native_job_trash_browser_support.mjs
+++ b/tests_js/workspace_native_job_trash_browser_support.mjs
@@ -78,7 +78,19 @@ export async function jobTrashBrowser(page, root, fixture, buildRoot) {
   assert.equal(await company.inputValue(), job.company);
   assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1));
   await modal.getByRole('button', { name: 'Close job details', exact: true }).click();
+  const deletion = await cli('job-trash', args(final.revision));
+  const beforeDelete = await readFile(join(root, 'jobs.json'), 'utf8');
+  await assert.rejects(cli('job-delete', args(final.revision)), /revision conflict/);
+  assert.equal(await readFile(join(root, 'jobs.json'), 'utf8'), beforeDelete);
+  assert.deepEqual(await api(`/api/jobs/${job.id}/delete`, { expectedRevision: deletion.revision }),
+    { deleted: true, id: job.id });
+  assert.deepEqual(await cli('job-delete', args(deletion.revision)), { deleted: false, id: job.id });
+  assert.equal((await api('/api/trash')).items.some(value => value.id === job.id), false);
+  await page.reload();
+  await navigation.getByRole('button', { name: 'Jobs', exact: true }).click();
+  await card.waitFor({ state: 'hidden' });
+  assert.equal(JSON.parse(await readFile(join(root, 'jobs.json'), 'utf8')).jobs[job.id], undefined);
   return { cliTrashHidden: true, apiRestoreReload: true, apiTrashCliRestore: true,
-    redactedListingAgreement: true, listingReadOnly: true, staleRevisionRejected: true,
+    apiDeleteCliNoop: true, deletedAbsentAfterReload: true, redactedListingAgreement: true, listingReadOnly: true, staleRevisionRejected: true,
     externalDraftPreserved: true, restoredContentPreserved: true, pythonAbsentFromPath: true };
 }

--- a/tests_js/workspace_native_job_trash_delete.test.mjs
+++ b/tests_js/workspace_native_job_trash_delete.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, plain, read, write, snapshot, cli, at, differential, unchanged } from './workspace_native_job_trash_support.mjs';
+import { TrashService } from '../runtime/workspace-core/trash.js';
+import { NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { fromJSON, text } from '../runtime/contracts/workspace/values.js';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { atomicWritePointJson, createNativePointAtomicWriteIO } from '../runtime/store/point-persistence.js';
+
+test('permanent job deletion matches Python guards, retained evidence and durable failure behavior', {timeout:60000}, async t => {
+  const fixture = await nativeFixture();
+  let serial = 0;
+  const isolated = () => setup(fixture, `delete-${++serial}`);
+  try {
+    await t.test('missing, active, stale, trashed and repeated deletion match independent Python', async () => {
+      const state = await isolated();
+      await differential(state, join(fixture.root, 'python-delete'), [
+        {kind:'delete', id:'missing', revision:99},
+        {kind:'delete', revision:2}, {kind:'delete', revision:1},
+        {kind:'trash', revision:1}, {kind:'delete', revision:1},
+        {kind:'delete', revision:2}, {kind:'delete', revision:2},
+        {kind:'delete', id:'../private', revision:1}, {kind:'list'},
+      ]);
+      assert.equal(await state.jobs.get('job'), null);
+      const before = await snapshot(state.root);
+      const restarted = new TrashService(new NativeJobsRepository(state.root, state.provider), () => {
+        throw Error('missing delete must not sample clock');
+      });
+      assert.deepEqual(plain(await restarted.deleteJob('job', 999n)), {deleted:false, id:'job'});
+      assert.deepEqual(await snapshot(state.root), before);
+    });
+    await t.test('claimed and expired claims win over trash and session guards', async () => {
+      const state = await isolated();
+      await state.claims.select('job', 1n, true);
+      await state.claims.acquire('job', text('Synthetic'), 2n);
+      await differential(state, join(fixture.root, 'python-delete-claim'), [
+        {kind:'delete', revision:2}, {kind:'delete', revision:3},
+      ]);
+      const coordinator = await read(state.root, 'coordinator.json');
+      coordinator.claim.expiresAt = '2020-01-01T00:00:00Z';
+      await write(state.root, 'coordinator.json', coordinator);
+      const jobs = await read(state.root, 'jobs.json');
+      jobs.jobs.job.deletedAt = at;
+      await write(state.root, 'jobs.json', jobs);
+      await differential(state, join(fixture.root, 'python-delete-expired'), [{kind:'delete', revision:3}]);
+    });
+    await t.test('nonterminal sessions block while terminal session and history bytes survive', async () => {
+      for (const status of ['active', 'completed', 'abandoned']) {
+        const state = await isolated();
+        await state.claims.select('job', 1n, true);
+        const acquired = plain(await state.claims.acquire('job', text('Synthetic'), 2n));
+        await state.claims.progress('job', text(acquired.token), fromJSON({status:'active', pendingFields:[]}));
+        const coordinator = await read(state.root, 'coordinator.json');
+        coordinator.claim = null;
+        await write(state.root, 'coordinator.json', coordinator);
+        const session = await read(state.root, 'sessions/job.json');
+        session.status = status;
+        await write(state.root, 'sessions/job.json', session);
+        await state.service.trashJob('job', 3n);
+        await differential(state, join(fixture.root, `python-delete-${status}`), [{kind:'delete', revision:4}]);
+        assert.equal(Boolean((await read(state.root, 'jobs.json')).jobs.job), status === 'active');
+      }
+    });
+    await t.test('write, fsync and replace failures preserve record and allow retry', async () => {
+      const state = await isolated();
+      await state.service.trashJob('job', 1n);
+      for (const stage of ['write', 'sync', 'replace']) {
+        const repository = new NativeJobsRepository(state.root, state.provider, async (path, value, options) => {
+          const io = createNativePointAtomicWriteIO(options.pathProfile);
+          if (stage === 'replace') io.replace = async () => { throw Error('injected delete fault'); };
+          else {
+            const original = io.createTemporary;
+            io.createTemporary = async (...args) => {
+              const handle = await original(...args);
+              handle[stage] = async () => { throw Error('injected delete fault'); };
+              return handle;
+            };
+          }
+          await atomicWritePointJson(path, value, options, io);
+        });
+        await unchanged(state, () => new TrashService(repository, () => at).deleteJob('job', 2n), /injected delete fault/);
+      }
+      assert.deepEqual(plain(await state.service.deleteJob('job', 2n)), {deleted:true, id:'job'});
+    });
+    await t.test('HTTP closed bodies, operation metadata, redaction and CLI idempotence', async () => {
+      const state = await isolated();
+      const request = body => jobsHttp(state.jobs, state.repository, 'POST', '/api/jobs/job/delete', body);
+      for (const body of ['{}', '{"expectedRevision":true}', '{"expectedRevision":1.0}', '{"expectedRevision":0}', '{"expectedRevision":1,"confirm":true}']) {
+        const before = await snapshot(state.root);
+        assert.equal((await request(body)).status, 400);
+        assert.deepEqual(await snapshot(state.root), before);
+      }
+      const active = await request('{"expectedRevision":1}');
+      assert.equal(active.status, 400);
+      assert.deepEqual(JSON.parse(active.body).error, {
+        code:'store_rejected', message:'The canonical store rejected this lifecycle operation.',
+        recordType:'job', operation:'delete', counts:{},
+      });
+      await state.service.trashJob('job', 1n);
+      const stale = await request('{"expectedRevision":1}');
+      assert.equal(stale.status, 409);
+      assert.equal(JSON.parse(stale.body).error.operation, 'delete');
+      assert.deepEqual(await cli(fixture, state.root, 'job-delete', ['--id','job','--expected-revision','2']), {deleted:true,id:'job'});
+      assert.deepEqual(JSON.parse((await request('{"expectedRevision":2}')).body), {deleted:false,id:'job'});
+    });
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_jobs.test.mjs
+++ b/tests_js/workspace_native_jobs.test.mjs
@@ -117,7 +117,7 @@ print(json.dumps(out))
       assert.equal((await jobsHttp(service, repository, 'GET', '/api/jobs/missing')).status, 404);
       assert.equal((await jobsHttp(service, repository, 'POST', '/api/jobs/one/transition', '{}')).status, 400);
       assert.equal((await jobsHttp(service, repository, 'GET', '/api/trash')).status, 200);
-      assert.equal((await jobsHttp(service, repository, 'POST', '/api/jobs/job/delete', '{"expectedRevision":1}')).status, 501);
+      assert.equal((await jobsHttp(service, repository, 'POST', '/api/resumes/resume/delete', '{"expectedRevision":1}')).status, 501);
     });
     await t.test('independent CLI writers serialize revisions without Python', async () => {
       const cli = resolve('runtime/cli/native-jobs.js');


### PR DESCRIPTION
Adds permanent job deletion to the native fixture CLI and HTTP API. Deletion requires the current revision, no coordinator claim, prior trash, and no nonterminal application session. Only Jobs changes; session/history evidence remains intact. Missing records return an idempotent `{deleted: false, id}` result.

Lifecycle failures retain Python-compatible redacted operation metadata. The fixture remains synthetic-only; this change does not add Trash UI, resume/answer lifecycle, or live Store activation. Documentation distinguishes failures before replacement from errors after deletion may already have taken effect.

Validation:
- Existing Trash suite: 10 tests passed; deletion suite: 6 passed, covering independent Python results/persistence, guard ordering, expired claims, terminal sessions, no-ops, CLI/HTTP and atomic faults.
- Integrated production browser passed CLI trash/API delete, repeated CLI deletion, canonical reload, listing privacy and preserved drafts with Python absent from the native launch PATH.
- Source-size, test-matrix and TypeScript checks passed. All 10 normal commit-hook suites passed.
- Five independent review roles completed. One documentation overclaim was independently validated and corrected; no implementation findings remained. Built-in Codex review could not run because the installed CLI does not support the configured model.
- All 27 deep-validation suites and normal push gates passed. Validate Plugin 34636190734 and Release Validation 34636193408 passed on the exact reviewed commit.
