### PR TITLE
Add native answer lifecycle with protected references

### DIFF
--- a/config/migration/cli-native-answer-lifecycle-surfaces.json
+++ b/config/migration/cli-native-answer-lifecycle-surfaces.json
@@ -1,0 +1,80 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:answer-trash",
+      "kind": "cli",
+      "command": "answer-trash",
+      "node": "ANS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-answer-lifecycle.ts",
+        "src/workspace-core/answer-lifecycle.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:answer-restore",
+      "kind": "cli",
+      "command": "answer-restore",
+      "node": "ANS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-answer-lifecycle.ts",
+        "src/workspace-core/answer-lifecycle.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:answer-delete",
+      "kind": "cli",
+      "command": "answer-delete",
+      "node": "ANS",
+      "sources": [
+        "src/cli/native-jobs.ts",
+        "src/cli/native-answer-lifecycle.ts",
+        "src/workspace-core/answer-lifecycle.ts",
+        "src/store/native-jobs.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/http-write-answers-02-surfaces.json
+++ b/config/migration/http-write-answers-02-surfaces.json
@@ -13,7 +13,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answer-lifecycle-http.ts",
+        "src/workspace-core/answer-lifecycle.ts",
+        "src/contracts/workspace/answer-key.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -41,7 +46,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answer-lifecycle-http.ts",
+        "src/workspace-core/answer-lifecycle.ts",
+        "src/contracts/workspace/answer-key.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -204,7 +214,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answer-lifecycle-http.ts",
+        "src/workspace-core/answer-lifecycle.ts",
+        "src/contracts/workspace/answer-key.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -232,7 +247,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answer-lifecycle-http.ts",
+        "src/workspace-core/answer-lifecycle.ts",
+        "src/contracts/workspace/answer-key.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -260,7 +280,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answer-lifecycle-http.ts",
+        "src/workspace-core/answer-lifecycle.ts",
+        "src/contracts/workspace/answer-key.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-write-answers-surfaces.json
+++ b/config/migration/http-write-answers-surfaces.json
@@ -314,7 +314,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/answer-lifecycle-http.ts",
+        "src/workspace-core/answer-lifecycle.ts",
+        "src/contracts/workspace/answer-key.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -86,6 +86,10 @@
       "sha256": "adcbc8737ec21bf25b4e0ea251fb2c7b34e577486f778e79aee43810fa946c07"
     },
     {
+      "path": "cli-native-answer-lifecycle-surfaces.json",
+      "sha256": "687fc1341cc0071e64d0c623843fff3c84d90754319d4c24f1efa70515b97316"
+    },
+    {
       "path": "cli-native-answers-surfaces.json",
       "sha256": "bbb71b096d75f3cb7f33cf946859f0163b66d431c2b5c5c3597ddd69a9df88c9"
     },
@@ -191,11 +195,11 @@
     },
     {
       "path": "http-write-answers-02-surfaces.json",
-      "sha256": "9bebb4810d86e3efa0ecac1efb4b82ccdad560a45adfc27b4642f98228989cea"
+      "sha256": "798539653a4536e458db3d1cdd08ab96710d2544cdfbf2340f3428dcc68e2c10"
     },
     {
       "path": "http-write-answers-surfaces.json",
-      "sha256": "382bc35282fc868af312be49f14e5052585dc18bb564c5dda188f28af1ef47c4"
+      "sha256": "0858bb1bbbeb79411924f6b1fc1b71c67f5529a3738e38ff8c9c55479b9c8dac"
     },
     {
       "path": "http-write-jobs-surfaces.json",
@@ -306,6 +310,10 @@
       "sha256": "c819b8b9447817aa908b5a5626aa9d239b2cfecd46f4caf1cfebb931415129ee"
     },
     {
+      "path": "source-catalog-native-answer-lifecycle.json",
+      "sha256": "a000faf03cf2059ed616e4c6d421d55e9bb795dc988c1be97de1de87a02c2c8a"
+    },
+    {
       "path": "source-catalog-native-answer-merge.json",
       "sha256": "eca9033c0488be05dee9fab734a98782f460adae605ff3f3929879b3a258b660"
     },
@@ -315,7 +323,7 @@
     },
     {
       "path": "source-catalog-native-answers.json",
-      "sha256": "d53992f00a314edaf8745531ec9f4c3bda984be79663009f46c39e16be3dda42"
+      "sha256": "e0a72c236f94a774feb2f1a9c14d423342beee9668a28f2bb295cd86a6ef06a6"
     },
     {
       "path": "source-catalog-native-claims.json",
@@ -347,7 +355,7 @@
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "77bd7b44df18a471adcd1060e529fdeabb7cd413080ce897875d954a265c3d4c"
+      "sha256": "0c1b711663c8a24298e9fd05bb3e1a403885dd2da7a2adbf022eb735a8854521"
     },
     {
       "path": "source-catalog-native-legacy-jobs.json",

--- a/config/migration/source-catalog-native-answer-lifecycle.json
+++ b/config/migration/source-catalog-native-answer-lifecycle.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "runtime/cli/native-answer-lifecycle.js",
+      "sha256": "df454f449d1b730fc45a10075e0bd507f0367e861bf8f8b6fc0fa2e76ae8b035",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/answer-key.js",
+      "sha256": "3344d2b86c7e84a89ad68be5b9b424078c6d2654cf4b0141033741af6923f74e",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/answer-lifecycle-http.js",
+      "sha256": "864b3857ff2c0d0bcbb03d59b9a8c45ca93f9c620d93ca1fde4892e80e20fb51",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/answer-lifecycle.js",
+      "sha256": "dddb2b53407b3712f22c0fc55d182612c90696a97fdf8534a2e4b783ffb623b5",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-answer-lifecycle.ts",
+      "sha256": "523c59b79f33313ba82ac0956ba82aa4aa108716b71454c7c75c4dc95dbdbd8a",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/answer-key.ts",
+      "sha256": "9baf547441f935ec1093a538a300a8548880f8e5ae7a3a13a8f90b48680ab8e6",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/answer-lifecycle-http.ts",
+      "sha256": "2ffd8a253182fc26e3e2b7f469a86d95a6dcfccc07c40f28ee5f887b29bb4d65",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/answer-lifecycle.ts",
+      "sha256": "9e360d00e674bee5f0c8fc5fed932c9c416583e3377a5d71b3c1141d70ac765f",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/config/migration/source-catalog-native-answers.json
+++ b/config/migration/source-catalog-native-answers.json
@@ -13,7 +13,7 @@
     },
     {
       "path": "src/workspace-core/answers-http.ts",
-      "sha256": "e070a64d473980806231e2f0c5abceac833f688af3bc6402228113163dfcfb3f",
+      "sha256": "30d649ad758884a0eb8b15f6b3a1db1a34c8a5f32a22a84ddf2fff6e9389024f",
       "classification": "unreviewed"
     },
     {
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/workspace-core/answers-http.js",
-      "sha256": "8766ccf644801574819fd3b3ba2368d0e223f8ae59eedb842063813a63543708",
+      "sha256": "e641bd36bcec5e86417efd32c3ad93ebfdf72c97a9b9faec05dce7e89c1b0a80",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "907e09b26392ae08b2f2f787a6a6510f4be16b8dc1374c87289e8eea06a01a1a",
+      "sha256": "0ff828a867e2245a94215c79c31f640a227185e9cd0632b82409cae0fbbeb63a",
       "classification": "unreviewed"
     },
     {
@@ -43,7 +43,7 @@
     },
     {
       "path": "runtime/workspace-core/jobs-http.js",
-      "sha256": "5c828e5e059369c09d0398b673a4d8beb009900907a1017254ee553638f2c535",
+      "sha256": "9e76710e263f639acdb7e04b6fbf272d100f0d80dc1afc7a25ae74eee76fee37",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "b0cfeace8e42aa8212686cd971ce8794b4ef83f7109b4653fdb7821548ae1380",
+      "sha256": "0516cb3fc88f09e1fa98b8787d739608ed918e95db03e822c0602bfc32887731",
       "classification": "unreviewed"
     },
     {
@@ -93,7 +93,7 @@
     },
     {
       "path": "src/workspace-core/jobs-http.ts",
-      "sha256": "f47704f58e3a304b67cbb433d63b5bde90ac099bd97008d0e3b0b21eb3c5a606",
+      "sha256": "f31621e8c14b599722d5137f1d9e83dc804dbe914318ee3c82d87860806647a1",
       "classification": "unreviewed"
     },
     {

--- a/docs/native-answer-lifecycle-fixture.md
+++ b/docs/native-answer-lifecycle-fixture.md
@@ -1,0 +1,71 @@
+# Native answer lifecycle fixture
+
+The native fixture CLI and HTTP API support answer trash, restore and permanent
+deletion for synthetic version 9 Stores.
+This does not activate native writes on owner Stores or change Python launchers.
+
+## Operations and integration
+
+The `AnswerLifecycleService` exports `trash(key, revision)`,
+`restore(key, revision)` and `delete(key, revision)`. It uses the existing
+`AnswerRepository.answerTransaction` to read and write under the fixture lock.
+No new journal or Store interface is introduced.
+
+Shared dispatch composes `answerLifecycleHttp` before `answerHttp` and exposes
+`answerLifecycleCommands` through the native CLI.
+The CLI commands are `answer-trash`, `answer-restore` and `answer-delete`, each
+requiring `--key` and `--expected-revision`. Both adapters use the same locked lifecycle service.
+
+Authenticated `POST /api/answers/:urlEncodedKey/{trash,restore,delete}` and
+`POST /api/answers/by-key/:base64urlKey/{trash,restore,delete}` accept
+exactly `{"expectedRevision": CURRENT_REVISION}`. Revisions are positive integers;
+booleans, JSON floats and additional confirmation fields are rejected. Explicit
+permanent-delete confirmation belongs in the UI. Refresh canonical state after
+acknowledgment or error; never blindly retry a destructive request.
+
+Trash and restore return the existing answer mutation projection, with reference
+counts and nonsensitive values. Sensitive values remain omitted. Delete returns
+`{deleted: true, key}` or `{deleted: false, key}` for an absent identity. An absent
+delete does not check the requested revision. Redirect sources remain immutable
+and reject deletion even when there is no answer record at that source identity.
+
+## Python parity and protected references
+
+The authority is `scripts/job_apply_store/domains/answers/mutations.py`,
+`read.py`, and `scripts/job_apply_workspace/domains/answers.py` plus `auth.py`.
+
+Legacy answers without a revision use revision 1. Existing records check the
+revision before no-op detection. No-op trash/restore preserves bytes and does not
+sample timestamps. A changed trash samples deletion and update timestamps
+separately; restore samples the update timestamp once. Trash rejects canonical
+redirect targets. Restore of an already active target remains a no-op.
+
+Permanent deletion checks redirect source identity, record presence, revision,
+prior trash, incoming redirects, sessions, then history. Every session is
+protected, including completed and abandoned sessions. Both `answerKeys` and
+pending-field `answerKey` references block deletion. Application history remains
+protected. The operation never erases references to make deletion succeed.
+
+Reference errors use locked snapshot counts for sessions and history and fixed
+redacted messages. Counts do not include question text, answer values, paths,
+URLs or credentials. Immutable source deletion maps to `store_rejected`, matching
+Python; immutable target trash maps to `redirect_target_blocked`. Missing records
+map to 404, reference/revision conflicts to 409, and generic Store rejection to
+400. OS failures return a fixed 500 `storage_error` without private exception text.
+
+## Durability and verification
+
+Only answers.json is written; jobs, resumes, sessions and history stay intact.
+Tests inject write, file-sync and replace failures before canonical replacement,
+verify original bytes, and retry through a fresh repository. An error after
+canonical replacement may be ambiguous: do not assume the old answer still
+exists or retry using the old revision. Refresh canonical state first.
+
+`tests_js/workspace_native_lifecycle_answers.test.mjs` runs the actual native
+repository with an isolated lock addon and independent copied Python Stores.
+It compares returned results, errors and persisted answers for legacy records,
+Unicode keys, sensitive values, redirects, all session states, pending fields,
+and history. It also checks no-op bytes/clocks, strict HTTP payloads, CLI leaves,
+redacted OS failures, and repository restart after pre-replacement failures.
+Python and native never write the same Store. These fixture tests do not replace
+shared dispatch, production browser, normal hook or installed-package acceptance.

--- a/runtime/cli/native-answer-lifecycle.js
+++ b/runtime/cli/native-answer-lifecycle.js
@@ -1,0 +1,22 @@
+import { JobsError } from '../contracts/workspace/values.js';
+import { AnswerLifecycleService } from '../workspace-core/answer-lifecycle.js';
+export const answerLifecycleCommands = {
+    'answer-trash': ['--key', '--expected-revision'],
+    'answer-restore': ['--key', '--expected-revision'],
+    'answer-delete': ['--key', '--expected-revision'],
+};
+export function runAnswerLifecycleCommand(command, repository, options) {
+    const key = options.get('--key'), revision = options.get('--expected-revision');
+    if (!key)
+        throw new JobsError('required option: --key');
+    if (!revision || !/^[0-9]+$/.test(revision) || BigInt(revision) < 1n)
+        throw new JobsError('expected revision must be a positive integer');
+    const service = new AnswerLifecycleService(repository);
+    if (command === 'answer-trash')
+        return service.trash(key, BigInt(revision));
+    if (command === 'answer-restore')
+        return service.restore(key, BigInt(revision));
+    if (command === 'answer-delete')
+        return service.delete(key, BigInt(revision));
+    throw new JobsError('unsupported native answer lifecycle command');
+}

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,3 +1,4 @@
+import { answerLifecycleCommands, runAnswerLifecycleCommand } from './native-answer-lifecycle.js';
 import { trashCommands, runTrashCommand } from './native-trash.js';
 import { groupedApprovalCommands, runGroupedApprovalCommand } from './native-grouped-approvals.js';
 import { taskIntakeCommands, runTaskIntakeCommand } from './native-task-intake.js';
@@ -47,6 +48,7 @@ export async function runJobsCli(args, input) {
         }
     }
     const fields = {
+        ...answerLifecycleCommands,
         ...trashCommands,
         ...groupedApprovalCommands,
         ...taskIntakeCommands,
@@ -94,6 +96,8 @@ export async function runJobsCli(args, input) {
             : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command) ? 2 * 1024 * 1024 : 65536;
         return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
     };
+    if (Object.hasOwn(answerLifecycleCommands, command))
+        return serialize(await runAnswerLifecycleCommand(command, repository, options));
     if (Object.hasOwn(trashCommands, command))
         return serialize(await runTrashCommand(command, repository, options));
     if (Object.hasOwn(groupedApprovalCommands, command))

--- a/runtime/contracts/workspace/answer-key.js
+++ b/runtime/contracts/workspace/answer-key.js
@@ -1,0 +1,14 @@
+import { JobsError } from './values.js';
+export function decodeAnswerKey(value) {
+    if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1)
+        throw new JobsError('encoded answer key is invalid');
+    try {
+        const result = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(Buffer.from(value, 'base64url'));
+        if (!result)
+            throw new Error();
+        return result;
+    }
+    catch {
+        throw new JobsError('encoded answer key is invalid');
+    }
+}

--- a/runtime/workspace-core/answer-lifecycle-http.js
+++ b/runtime/workspace-core/answer-lifecycle-http.js
@@ -1,0 +1,67 @@
+import { decodeAnswerKey } from '../contracts/workspace/answer-key.js';
+import { PythonObject } from '../contracts/python-object.js';
+import { fromJSON, get, int, integer, keys, object, parse, serialize, set, JobsError } from '../contracts/workspace/values.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { AnswerLifecycleError, AnswerLifecycleService } from './answer-lifecycle.js';
+const failure = (status, code, message) => ({
+    status, body: serialize(fromJSON({ error: { code, message } })),
+});
+function lifecycleFailure(error, operation) {
+    const rules = [
+        ['revision conflict', 'revision_conflict', 'This record changed elsewhere. Refresh and review the latest revision.'],
+        ['does not exist', 'not_found', 'This record no longer exists.'],
+        ['referenced by an active session', 'session_reference_blocked', 'This answer is referenced by an active session and cannot be permanently deleted.'],
+        ['referenced by application history', 'history_reference_blocked', 'This answer is referenced by protected application history and cannot be permanently deleted.'],
+        ['answer is the target of an immutable redirect', 'redirect_target_blocked', 'This answer is a canonical redirect target and cannot be moved or deleted.'],
+    ];
+    const [, code, message] = rules.find(([fragment]) => error.message.includes(fragment))
+        ?? ['', 'store_rejected', 'The canonical store rejected this lifecycle operation.'];
+    const counts = emptyObject();
+    if (error instanceof AnswerLifecycleError) {
+        set(counts, 'sessions', integer(error.counts.sessions));
+        set(counts, 'history', integer(error.counts.history));
+    }
+    const detail = object(fromJSON({ code, message, recordType: 'answer', operation }), 'lifecycle error');
+    set(detail, 'counts', counts);
+    return { status: code === 'not_found' ? 404 : code === 'store_rejected' ? 400 : 409,
+        body: serialize(set(emptyObject(), 'error', detail)) };
+}
+export async function answerLifecycleHttp(repository, method, path, body) {
+    const match = /^\/api\/answers\/(?:by-key\/([^/]+)|([^/]+))\/(trash|restore|delete)$/.exec(path);
+    if (method !== 'POST' || !match)
+        return null;
+    const operation = match[3];
+    let payload;
+    try {
+        payload = parse(body);
+    }
+    catch {
+        return failure(400, 'request_error', 'request body must be valid JSON');
+    }
+    if (!(payload instanceof PythonObject))
+        return failure(400, 'request_error', 'request body must be a JSON object');
+    let key;
+    try {
+        key = match[1] ? decodeAnswerKey(match[1]) : decodeURIComponent(match[2]);
+    }
+    catch {
+        return failure(400, 'request_error', 'encoded answer key is invalid');
+    }
+    if (keys(payload).length !== 1 || keys(payload)[0] !== 'expectedRevision')
+        return failure(400, 'request_error', `${operation} body requires expectedRevision`);
+    const revision = int(get(payload, 'expectedRevision'));
+    if (revision === null || revision < 1n)
+        return failure(400, 'request_error', 'expectedRevision must be a positive integer');
+    try {
+        const result = await new AnswerLifecycleService(repository)[operation](key, revision);
+        return { status: 200, body: serialize(result) };
+    }
+    catch (error) {
+        if (error instanceof JobsError)
+            return lifecycleFailure(error, operation);
+        if (error instanceof Error && 'code' in error && typeof error.code === 'string' && /^E[A-Z]+$/.test(error.code)) {
+            return failure(500, 'storage_error', 'storage operation failed');
+        }
+        throw error;
+    }
+}

--- a/runtime/workspace-core/answer-lifecycle.js
+++ b/runtime/workspace-core/answer-lifecycle.js
@@ -1,0 +1,91 @@
+import { answerRevision, fallback, validateAnswer, validateAnswers } from '../contracts/workspace/answers.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { copy, get, has, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { answerProjection } from './answers.js';
+export class AnswerLifecycleError extends JobsError {
+    counts;
+    constructor(message, counts) {
+        super(message);
+        this.counts = counts;
+    }
+}
+function requireKey(key) {
+    if (typeof key !== 'string' || !key)
+        throw new JobsError('answer key must be a non-empty string');
+}
+function redirects(document) {
+    return object(fallback(document, 'redirects', emptyObject()), 'answer redirects');
+}
+function requireNotTarget(document, key) {
+    if (redirects(document).entries().some(([, value]) => string(get(object(value, 'redirect'), 'targetKey')) === key)) {
+        throw new JobsError('answer is the target of an immutable redirect');
+    }
+}
+export class AnswerLifecycleService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    trash(key, expectedRevision) {
+        return this.setDeleted(key, expectedRevision, false);
+    }
+    restore(key, expectedRevision) {
+        return this.setDeleted(key, expectedRevision, true);
+    }
+    setDeleted(key, expectedRevision, restore) {
+        requireKey(key);
+        return this.repository.answerTransaction(async (raw, save, references) => {
+            const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+            const value = get(answers, key);
+            if (value === null)
+                throw new JobsError('answer does not exist');
+            const current = object(value, 'answer'), revision = answerRevision(current);
+            if (revision !== expectedRevision)
+                throw new JobsError('answer revision conflict');
+            const trashed = get(current, 'deletedAt') !== null;
+            if (restore === !trashed)
+                return answerProjection(current, references, true);
+            if (!restore)
+                requireNotTarget(document, key);
+            const updated = copy(current);
+            set(updated, 'deletedAt', restore ? null : text(this.now()));
+            set(updated, 'revision', integer(revision + 1n));
+            set(updated, 'updatedAt', text(this.now()));
+            validateAnswer(key, updated);
+            set(answers, key, updated);
+            set(object(get(document, 'metadata'), 'answers.metadata'), 'updatedAt', get(updated, 'updatedAt'));
+            await save(document);
+            return answerProjection(updated, references, true);
+        });
+    }
+    delete(key, expectedRevision) {
+        requireKey(key);
+        return this.repository.answerTransaction(async (raw, save, references) => {
+            const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+            if (has(redirects(document), key))
+                throw new JobsError('merged answer redirects are immutable');
+            const result = set(emptyObject(), 'key', text(key)), value = get(answers, key);
+            if (value === null)
+                return set(result, 'deleted', false);
+            const current = object(value, 'answer');
+            if (answerRevision(current) !== expectedRevision)
+                throw new JobsError('answer revision conflict');
+            if (get(current, 'deletedAt') === null)
+                throw new JobsError('answer must be trashed before permanent deletion');
+            requireNotTarget(document, key);
+            const counts = references.get(key) ?? { sessions: 0n, history: 0n };
+            // The repository counts every session, including completed and abandoned ones.
+            // Incoming redirects are already excluded, so resolved counts match direct references.
+            if (counts.sessions)
+                throw new AnswerLifecycleError('answer is referenced by an active session', counts);
+            if (counts.history)
+                throw new AnswerLifecycleError('answer is referenced by application history', counts);
+            answers.delete(text(key));
+            set(object(get(document, 'metadata'), 'answers.metadata'), 'updatedAt', text(this.now()));
+            await save(document);
+            return set(result, 'deleted', true);
+        });
+    }
+}

--- a/runtime/workspace-core/answers-http.js
+++ b/runtime/workspace-core/answers-http.js
@@ -1,3 +1,4 @@
+import { decodeAnswerKey as decodeKey } from '../contracts/workspace/answer-key.js';
 import { AnswerMergeService } from './answer-merges.js';
 import { AnswersService } from './answers.js';
 import { emptyObject } from '../contracts/workspace/jobs.js';
@@ -18,19 +19,6 @@ function revision(payload) {
     if (value === null || value < 1n)
         throw new JobsError('expectedRevision must be a positive integer');
     return value;
-}
-function decodeKey(value) {
-    if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1)
-        throw new JobsError('encoded answer key is invalid');
-    try {
-        const result = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(Buffer.from(value, 'base64url'));
-        if (!result)
-            throw new Error();
-        return result;
-    }
-    catch {
-        throw new JobsError('encoded answer key is invalid');
-    }
 }
 export async function answerHttp(repository, method, path, body) {
     if (!path.startsWith('/api/answers'))

--- a/runtime/workspace-core/jobs-http.js
+++ b/runtime/workspace-core/jobs-http.js
@@ -1,3 +1,4 @@
+import { answerLifecycleHttp } from './answer-lifecycle-http.js';
 import { trashHttp } from './trash-http.js';
 import { claimsHttp } from './claims-http.js';
 import { jobTransitionsHttp } from './job-transitions-http.js';
@@ -18,6 +19,9 @@ const envelope = (key, value) => set(emptyObject(), key, value);
 /** Transport-independent dispatch. Host/token/Origin/body bounds belong to the adapter. */
 export async function jobsHttp(service, repository, method, path, body = "") {
     try {
+        const answerLifecycle = await answerLifecycleHttp(repository, method, path, body);
+        if (answerLifecycle)
+            return answerLifecycle;
         const trash = await trashHttp(repository, method, path, body);
         if (trash)
             return trash;

--- a/src/cli/native-answer-lifecycle.ts
+++ b/src/cli/native-answer-lifecycle.ts
@@ -1,0 +1,19 @@
+import { JobsError } from '../contracts/workspace/values.js';
+import type { AnswerRepository } from '../workspace-core/answers.js';
+import { AnswerLifecycleService } from '../workspace-core/answer-lifecycle.js';
+
+export const answerLifecycleCommands: Record<string, string[]> = {
+  'answer-trash': ['--key', '--expected-revision'],
+  'answer-restore': ['--key', '--expected-revision'],
+  'answer-delete': ['--key', '--expected-revision'],
+};
+export function runAnswerLifecycleCommand(command: string, repository: AnswerRepository, options: Map<string, string>) {
+  const key = options.get('--key'), revision = options.get('--expected-revision');
+  if (!key) throw new JobsError('required option: --key');
+  if (!revision || !/^[0-9]+$/.test(revision) || BigInt(revision) < 1n) throw new JobsError('expected revision must be a positive integer');
+  const service = new AnswerLifecycleService(repository);
+  if (command === 'answer-trash') return service.trash(key, BigInt(revision));
+  if (command === 'answer-restore') return service.restore(key, BigInt(revision));
+  if (command === 'answer-delete') return service.delete(key, BigInt(revision));
+  throw new JobsError('unsupported native answer lifecycle command');
+}

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,3 +1,4 @@
+import { answerLifecycleCommands, runAnswerLifecycleCommand } from './native-answer-lifecycle.js';
 import { trashCommands, runTrashCommand } from './native-trash.js';
 import { groupedApprovalCommands, runGroupedApprovalCommand } from './native-grouped-approvals.js';
 import { taskIntakeCommands, runTaskIntakeCommand } from './native-task-intake.js';
@@ -42,6 +43,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     }
   }
   const fields: Record<string, string[]> = {
+    ...answerLifecycleCommands,
     ...trashCommands,
     ...groupedApprovalCommands,
     ...taskIntakeCommands,
@@ -85,6 +87,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
       : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command!) ? 2 * 1024 * 1024 : 65536;
     return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
   };
+  if (Object.hasOwn(answerLifecycleCommands, command!)) return serialize(await runAnswerLifecycleCommand(command!, repository, options));
   if (Object.hasOwn(trashCommands, command!)) return serialize(await runTrashCommand(command!, repository, options));
   if (Object.hasOwn(groupedApprovalCommands, command!)) return serialize(await runGroupedApprovalCommand(command!, repository, options, payload));
   if (Object.hasOwn(taskIntakeCommands, command!)) return serialize(await runTaskIntakeCommand(repository, options, payload));

--- a/src/contracts/workspace/answer-key.ts
+++ b/src/contracts/workspace/answer-key.ts
@@ -1,0 +1,10 @@
+import { JobsError } from './values.js';
+
+export function decodeAnswerKey(value: string): string {
+  if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1) throw new JobsError('encoded answer key is invalid');
+  try {
+    const result = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(Buffer.from(value, 'base64url'));
+    if (!result) throw new Error();
+    return result;
+  } catch { throw new JobsError('encoded answer key is invalid'); }
+}

--- a/src/workspace-core/answer-lifecycle-http.ts
+++ b/src/workspace-core/answer-lifecycle-http.ts
@@ -1,0 +1,56 @@
+import { decodeAnswerKey } from '../contracts/workspace/answer-key.js';
+import { PythonObject } from '../contracts/python-object.js';
+import { fromJSON, get, int, integer, keys, object, parse, serialize, set, JobsError } from '../contracts/workspace/values.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import type { AnswerRepository } from './answers.js';
+import { AnswerLifecycleError, AnswerLifecycleService } from './answer-lifecycle.js';
+
+type Result = {status: number; body: string};
+const failure = (status: number, code: string, message: string): Result => ({
+  status, body: serialize(fromJSON({error: {code, message}})),
+});
+function lifecycleFailure(error: JobsError, operation: string): Result {
+  const rules: [string, string, string][] = [
+    ['revision conflict', 'revision_conflict', 'This record changed elsewhere. Refresh and review the latest revision.'],
+    ['does not exist', 'not_found', 'This record no longer exists.'],
+    ['referenced by an active session', 'session_reference_blocked', 'This answer is referenced by an active session and cannot be permanently deleted.'],
+    ['referenced by application history', 'history_reference_blocked', 'This answer is referenced by protected application history and cannot be permanently deleted.'],
+    ['answer is the target of an immutable redirect', 'redirect_target_blocked', 'This answer is a canonical redirect target and cannot be moved or deleted.'],
+  ];
+  const [, code, message] = rules.find(([fragment]) => error.message.includes(fragment))
+    ?? ['', 'store_rejected', 'The canonical store rejected this lifecycle operation.'];
+  const counts = emptyObject();
+  if (error instanceof AnswerLifecycleError) {
+    set(counts, 'sessions', integer(error.counts.sessions));
+    set(counts, 'history', integer(error.counts.history));
+  }
+  const detail = object(fromJSON({code, message, recordType:'answer', operation}), 'lifecycle error');
+  set(detail, 'counts', counts);
+  return {status: code === 'not_found' ? 404 : code === 'store_rejected' ? 400 : 409,
+    body: serialize(set(emptyObject(), 'error', detail))};
+}
+export async function answerLifecycleHttp(repository: AnswerRepository, method: string, path: string, body: string): Promise<Result | null> {
+  const match = /^\/api\/answers\/(?:by-key\/([^/]+)|([^/]+))\/(trash|restore|delete)$/.exec(path);
+  if (method !== 'POST' || !match) return null;
+  const operation = match[3] as 'trash' | 'restore' | 'delete';
+  let payload;
+  try { payload = parse(body); }
+  catch { return failure(400, 'request_error', 'request body must be valid JSON'); }
+  if (!(payload instanceof PythonObject)) return failure(400, 'request_error', 'request body must be a JSON object');
+  let key: string;
+  try { key = match[1] ? decodeAnswerKey(match[1]) : decodeURIComponent(match[2]!); }
+  catch { return failure(400, 'request_error', 'encoded answer key is invalid'); }
+  if (keys(payload).length !== 1 || keys(payload)[0] !== 'expectedRevision') return failure(400, 'request_error', `${operation} body requires expectedRevision`);
+  const revision = int(get(payload, 'expectedRevision'));
+  if (revision === null || revision < 1n) return failure(400, 'request_error', 'expectedRevision must be a positive integer');
+  try {
+    const result = await new AnswerLifecycleService(repository)[operation](key, revision);
+    return {status:200, body:serialize(result)};
+  } catch (error) {
+    if (error instanceof JobsError) return lifecycleFailure(error, operation);
+    if (error instanceof Error && 'code' in error && typeof error.code === 'string' && /^E[A-Z]+$/.test(error.code)) {
+      return failure(500, 'storage_error', 'storage operation failed');
+    }
+    throw error;
+  }
+}

--- a/src/workspace-core/answer-lifecycle.ts
+++ b/src/workspace-core/answer-lifecycle.ts
@@ -1,0 +1,76 @@
+import { answerRevision, fallback, validateAnswer, validateAnswers } from '../contracts/workspace/answers.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { copy, get, has, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document } from '../contracts/workspace/values.js';
+import { answerProjection } from './answers.js';
+import type { AnswerReferences, AnswerRepository } from './answers.js';
+
+export class AnswerLifecycleError extends JobsError {
+  constructor(message: string, readonly counts: AnswerReferences) { super(message); }
+}
+function requireKey(key: string): void {
+  if (typeof key !== 'string' || !key) throw new JobsError('answer key must be a non-empty string');
+}
+function redirects(document: Document): Document {
+  return object(fallback(document, 'redirects', emptyObject()), 'answer redirects');
+}
+function requireNotTarget(document: Document, key: string): void {
+  if (redirects(document).entries().some(([, value]) => string(get(object(value, 'redirect'), 'targetKey')) === key)) {
+    throw new JobsError('answer is the target of an immutable redirect');
+  }
+}
+export class AnswerLifecycleService {
+  constructor(readonly repository: AnswerRepository,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+
+  trash(key: string, expectedRevision: bigint): Promise<Document> {
+    return this.setDeleted(key, expectedRevision, false);
+  }
+  restore(key: string, expectedRevision: bigint): Promise<Document> {
+    return this.setDeleted(key, expectedRevision, true);
+  }
+  private setDeleted(key: string, expectedRevision: bigint, restore: boolean): Promise<Document> {
+    requireKey(key);
+    return this.repository.answerTransaction(async (raw, save, references) => {
+      const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+      const value = get(answers, key);
+      if (value === null) throw new JobsError('answer does not exist');
+      const current = object(value, 'answer'), revision = answerRevision(current);
+      if (revision !== expectedRevision) throw new JobsError('answer revision conflict');
+      const trashed = get(current, 'deletedAt') !== null;
+      if (restore === !trashed) return answerProjection(current, references, true);
+      if (!restore) requireNotTarget(document, key);
+      const updated = copy(current);
+      set(updated, 'deletedAt', restore ? null : text(this.now()));
+      set(updated, 'revision', integer(revision + 1n));
+      set(updated, 'updatedAt', text(this.now()));
+      validateAnswer(key, updated);
+      set(answers, key, updated);
+      set(object(get(document, 'metadata'), 'answers.metadata'), 'updatedAt', get(updated, 'updatedAt'));
+      await save(document);
+      return answerProjection(updated, references, true);
+    });
+  }
+  delete(key: string, expectedRevision: bigint): Promise<Document> {
+    requireKey(key);
+    return this.repository.answerTransaction(async (raw, save, references) => {
+      const document = validateAnswers(raw), answers = object(get(document, 'answers'), 'answers');
+      if (has(redirects(document), key)) throw new JobsError('merged answer redirects are immutable');
+      const result = set(emptyObject(), 'key', text(key)), value = get(answers, key);
+      if (value === null) return set(result, 'deleted', false);
+      const current = object(value, 'answer');
+      if (answerRevision(current) !== expectedRevision) throw new JobsError('answer revision conflict');
+      if (get(current, 'deletedAt') === null) throw new JobsError('answer must be trashed before permanent deletion');
+      requireNotTarget(document, key);
+      const counts = references.get(key) ?? {sessions: 0n, history: 0n};
+      // The repository counts every session, including completed and abandoned ones.
+      // Incoming redirects are already excluded, so resolved counts match direct references.
+      if (counts.sessions) throw new AnswerLifecycleError('answer is referenced by an active session', counts);
+      if (counts.history) throw new AnswerLifecycleError('answer is referenced by application history', counts);
+      answers.delete(text(key));
+      set(object(get(document, 'metadata'), 'answers.metadata'), 'updatedAt', text(this.now()));
+      await save(document);
+      return set(result, 'deleted', true);
+    });
+  }
+}

--- a/src/workspace-core/answers-http.ts
+++ b/src/workspace-core/answers-http.ts
@@ -1,3 +1,4 @@
+import { decodeAnswerKey as decodeKey } from '../contracts/workspace/answer-key.js';
 import { AnswerMergeService } from './answer-merges.js';
 import { AnswersService } from './answers.js';
 import type { AnswerQuery, AnswerRepository } from './answers.js';
@@ -18,14 +19,6 @@ function revision(payload: Document): bigint {
   const value = int(get(payload, 'expectedRevision'));
   if (value === null || value < 1n) throw new JobsError('expectedRevision must be a positive integer');
   return value;
-}
-function decodeKey(value: string): string {
-  if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1) throw new JobsError('encoded answer key is invalid');
-  try {
-    const result = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(Buffer.from(value, 'base64url'));
-    if (!result) throw new Error();
-    return result;
-  } catch { throw new JobsError('encoded answer key is invalid'); }
 }
 export async function answerHttp(repository: AnswerRepository, method: string, path: string, body: string): Promise<{ status: number; body: string } | null> {
   if (!path.startsWith('/api/answers')) return null;

--- a/src/workspace-core/jobs-http.ts
+++ b/src/workspace-core/jobs-http.ts
@@ -1,3 +1,4 @@
+import { answerLifecycleHttp } from './answer-lifecycle-http.js';
 import { trashHttp } from './trash-http.js';
 import { claimsHttp } from './claims-http.js';
 import { jobTransitionsHttp } from './job-transitions-http.js';
@@ -26,6 +27,8 @@ const envelope = (key: string, value: Value): Value => set(emptyObject(), key, v
 export async function jobsHttp(service: JobsService, repository: NativeJobsRepository,
   method: string, path: string, body = ""): Promise<ApiResult> {
   try {
+    const answerLifecycle = await answerLifecycleHttp(repository, method, path, body);
+    if (answerLifecycle) return answerLifecycle;
     const trash = await trashHttp(repository, method, path, body);
     if (trash) return trash;
     const transition = await jobTransitionsHttp(repository, method, path, body);

--- a/tests_js/workspace_native_answers_browser_support.mjs
+++ b/tests_js/workspace_native_answers_browser_support.mjs
@@ -1,3 +1,4 @@
+import { nativeAnswerLifecycleBrowser } from './workspace_native_lifecycle_answers_browser_support.mjs';
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -72,5 +73,6 @@ export async function nativeAnswersBrowser(page, root, fixture, buildRoot) {
     const creation = await nativeAnswerCreationBrowser(page, root);
     const cleanup = await nativeAnswerCleanupBrowser(page, root, cli);
     const pendingQuestions = await nativePendingAnswersBrowser(page, root, cli);
-    return { pendingQuestions, cleanup, creation, persistedEdits: true, cliConflictReapply: true, losslessScope: true, explicitSensitiveConsent: true, review: true, reload: true, narrow: true };
+    const lifecycle = await nativeAnswerLifecycleBrowser(page, root, fixture, buildRoot);
+    return { lifecycle, pendingQuestions, cleanup, creation, persistedEdits: true, cliConflictReapply: true, losslessScope: true, explicitSensitiveConsent: true, review: true, reload: true, narrow: true };
 }

--- a/tests_js/workspace_native_lifecycle_answers.test.mjs
+++ b/tests_js/workspace_native_lifecycle_answers.test.mjs
@@ -1,0 +1,173 @@
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { JobsService } from '../runtime/workspace-core/jobs.js';
+import { runJobsCli } from '../runtime/cli/native-jobs.js';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { join } from 'node:path';
+import { writeFile } from 'node:fs/promises';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { setup, plain, read, write, snapshot, at, differential } from './workspace_native_lifecycle_answers_support.mjs';
+import { AnswerLifecycleService } from '../runtime/workspace-core/answer-lifecycle.js';
+import { answerLifecycleHttp } from '../runtime/workspace-core/answer-lifecycle-http.js';
+import { runAnswerLifecycleCommand } from '../runtime/cli/native-answer-lifecycle.js';
+import { NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { atomicWritePointJson, createNativePointAtomicWriteIO } from '../runtime/store/point-persistence.js';
+
+const session = (status, answerKeys = [], pendingFields = []) => ({
+  schemaVersion:1, applicationId:'job', status, ats:'greenhouse', answerKeys, pendingFields,
+});
+test('answer lifecycle matches independent Python with legacy, redirect and protected-reference semantics', {timeout:60000}, async t => {
+  const fixture = await nativeFixture();
+  let serial = 0;
+  const isolated = extra => setup(fixture, `answers-${++serial}`, extra);
+  try {
+    await t.test('legacy defaults, stale revisions, idempotence, missing and Unicode identities', async () => {
+      const state = await isolated();
+      await differential(state, join(fixture.root,'python-basic'), [
+        {kind:'restore',revision:1}, {kind:'delete',revision:9}, {kind:'delete',revision:1},
+        {kind:'trash',revision:1}, {kind:'trash',revision:2}, {kind:'trash',revision:1},
+        {kind:'restore',revision:2}, {kind:'restore',revision:3}, {kind:'trash',revision:3},
+        {kind:'delete',revision:4}, {kind:'delete',revision:999},
+        {kind:'trash',key:'missing',revision:1}, {kind:'restore',key:'',revision:1},
+      ]);
+      const document = await read(state.root,'answers.json');
+      const key = 'réponse/😀';
+      document.answers[key] = {key,question:'Unicode?',state:'missing',value:null,updatedAt:at};
+      await write(state.root,'answers.json',document);
+      await differential(state,join(fixture.root,'python-unicode'),[
+        {kind:'trash',key,revision:1}, {kind:'restore',key,revision:2},
+      ]);
+      const result = await answerLifecycleHttp(state.repository,'POST',`/api/answers/${encodeURIComponent(key)}/trash`,'{"expectedRevision":3}');
+      assert.equal(result.status,200); assert.equal(JSON.parse(result.body).key,key);
+    });
+    await t.test('sensitive lifecycle mutation projections never expose the stored value', async () => {
+      const state = await isolated({answers:{answer:{key:'answer',question:'Private?',state:'sensitive',
+        value:'PRIVATE-MARKER',rememberedWithConsentAt:at,updatedAt:at}}});
+      await differential(state,join(fixture.root,'python-sensitive'),[
+        {kind:'trash',revision:1},{kind:'trash',revision:2},{kind:'restore',revision:2},
+      ]);
+      const response = await answerLifecycleHttp(state.repository,'POST','/api/answers/answer/trash','{"expectedRevision":3}');
+      assert.equal(response.status,200); assert.doesNotMatch(response.body,/PRIVATE-MARKER/);
+      assert.equal(JSON.parse(response.body).valueRedacted,true);
+    });
+    await t.test('redirect sources and targets preserve guard order and restore no-op', async () => {
+      const state = await isolated({redirects:{retired:{targetKey:'answer',mergedAt:at}}});
+      await differential(state,join(fixture.root,'python-redirect'),[
+        {kind:'delete',key:'retired',revision:99},{kind:'trash',key:'retired',revision:1},
+        {kind:'restore',key:'retired',revision:1},{kind:'trash',revision:9},
+        {kind:'trash',revision:1},{kind:'restore',revision:1},{kind:'delete',revision:1},
+      ]);
+      const response = await answerLifecycleHttp(state.repository,'POST','/api/answers/answer/trash','{"expectedRevision":1}');
+      assert.equal(response.status,409); assert.equal(JSON.parse(response.body).error.code,'redirect_target_blocked');
+      const retired = await answerLifecycleHttp(state.repository,'POST','/api/answers/retired/delete','{"expectedRevision":1}');
+      assert.equal(retired.status,400); assert.equal(JSON.parse(retired.body).error.code,'store_rejected');
+    });
+    await t.test('all session states and pending fields block deletion; history survives untouched', async () => {
+      for (const status of ['active','review','completed','abandoned']) {
+        for (const pending of [false,true]) {
+          const state = await isolated();
+          await write(state.root,'sessions/job.json',session(status,pending ? [] : ['answer','answer'],pending ? [
+            {answerKey:'answer',question:'Private question?',reference:`pending_${'a'.repeat(32)}`},
+          ] : []));
+          await writeFile(join(state.root,'applications.jsonl'),JSON.stringify({schemaVersion:1,eventId:'history',
+            applicationId:'job',event:'saved',answerKeys:['answer','answer'],at})+'\n');
+          await differential(state,join(fixture.root,`python-${status}-${pending}`),[
+            {kind:'trash',revision:1},{kind:'delete',revision:2},{kind:'restore',revision:2},{kind:'trash',revision:3},
+          ]);
+          const before = await snapshot(state.root);
+          const response = await answerLifecycleHttp(state.repository,'POST','/api/answers/answer/delete','{"expectedRevision":4}');
+          assert.equal(response.status,409);
+          assert.deepEqual(JSON.parse(response.body).error, {code:'session_reference_blocked',
+            message:'This answer is referenced by an active session and cannot be permanently deleted.',
+            recordType:'answer',operation:'delete',counts:{sessions:1,history:1}});
+          assert.deepEqual(await snapshot(state.root),before);
+        }
+      }
+      const state = await isolated();
+      await writeFile(join(state.root,'applications.jsonl'),JSON.stringify({schemaVersion:1,eventId:'history',
+        applicationId:'job',event:'saved',answerKeys:['answer'],at})+'\n');
+      await differential(state,join(fixture.root,'python-history'),[{kind:'trash',revision:1},{kind:'delete',revision:2}]);
+      const response = await answerLifecycleHttp(state.repository,'POST','/api/answers/answer/delete','{"expectedRevision":2}');
+      assert.equal(JSON.parse(response.body).error.code,'history_reference_blocked');
+      assert.deepEqual(JSON.parse(response.body).error.counts,{sessions:0,history:1});
+    });
+    await t.test('noops do not sample clocks or rewrite bytes; timestamps follow Python call order', async () => {
+      const state = await isolated(), times=['2026-09-11T01:00:01Z','2026-09-11T01:00:02Z','2026-09-11T01:00:03Z'];
+      let calls=0;
+      const service=new AnswerLifecycleService(state.repository,()=>times[calls++]);
+      const before=await snapshot(state.root);
+      await service.restore('answer',1n); assert.deepEqual(await snapshot(state.root),before); assert.equal(calls,0);
+      const trashed=plain(await service.trash('answer',1n));
+      assert.equal(trashed.deletedAt,times[0]); assert.equal(trashed.updatedAt,times[1]);
+      const deleted=await snapshot(state.root);
+      await service.trash('answer',2n); assert.deepEqual(await snapshot(state.root),deleted); assert.equal(calls,2);
+      assert.equal(plain(await service.restore('answer',2n)).updatedAt,times[2]);
+    });
+    await t.test('HTTP rejects open bodies; CLI leaves preserve exact revisions and delete response', async () => {
+      const state=await isolated();
+      for(const body of ['{','[]','{}','{"expectedRevision":true}','{"expectedRevision":1.0}',
+        '{"expectedRevision":0}','{"expectedRevision":1,"confirmation":true}']) {
+        const before=await snapshot(state.root);
+        const response=await answerLifecycleHttp(state.repository,'POST','/api/answers/answer/delete',body);
+        assert.equal(response.status,400); assert.equal(JSON.parse(response.body).error.code,'request_error');
+        assert.deepEqual(await snapshot(state.root),before);
+      }
+      const run=(kind,revision)=>runAnswerLifecycleCommand(`answer-${kind}`,state.repository,new Map([
+        ['--key','answer'],['--expected-revision',revision],
+      ]));
+      assert.equal(plain(await run('trash','1')).revision,2);
+      assert.throws(()=>run('delete','1.0'),/positive integer/);
+      assert.deepEqual(plain(await run('delete','2')),{deleted:true,key:'answer'});
+      assert.deepEqual(plain(await run('delete','999')),{deleted:false,key:'answer'});
+      const missing=await answerLifecycleHttp(state.repository,'POST','/api/answers/answer/restore','{"expectedRevision":1}');
+      assert.equal(missing.status,404); assert.equal(JSON.parse(missing.body).error.operation,'restore');
+    });
+    await t.test('shared CLI and HTTP support Unicode by-key lifecycle routes', async () => {
+      const state = await isolated(), key = 'réponse/😀';
+      const document = await read(state.root, 'answers.json');
+      document.answers[key] = {key, question:'Unicode?', state:'missing', value:null, updatedAt:at};
+      await write(state.root, 'answers.json', document);
+      const cli = async (command, revision) => JSON.parse(await runJobsCli([
+        '--root',state.root,'--native-lock',fixture.receipt.artifact,command,
+        '--key',key,'--expected-revision',String(revision),
+      ], async () => {throw Error('unexpected input');}));
+      assert.equal((await cli('answer-trash',1)).revision,2);
+      const base = `/api/answers/by-key/${Buffer.from(key).toString('base64url')}`;
+      const request = (path, revision) => jobsHttp(new JobsService(state.repository),state.repository,
+        'POST',path,`{"expectedRevision":${revision}}`);
+      const restored = await request(`${base}/restore`,2);
+      assert.equal(restored.status,200); assert.equal(JSON.parse(restored.body).revision,3);
+      const before = await snapshot(state.root);
+      for (const encoded of ['a','_w','%%%']) {
+        const invalid = await request(`/api/answers/by-key/${encoded}/trash`,3);
+        assert.equal(invalid.status,400);
+      }
+      assert.deepEqual(await snapshot(state.root),before);
+      assert.equal((await request(`${base}/trash`,3)).status,200);
+      assert.deepEqual(await cli('answer-delete',4),{deleted:true,key});
+      assert.deepEqual(JSON.parse((await request(`${base}/delete`,4)).body),{deleted:false,key});
+    });
+    await t.test('atomic failures retain answer and release lock for restart; OS errors are redacted', async () => {
+      const state=await isolated();
+      await state.service.trash('answer',1n);
+      for(const stage of ['write','sync','replace']) {
+        const repository=new NativeJobsRepository(state.root,state.provider,async(path,value,options)=>{
+          const io=createNativePointAtomicWriteIO(options.pathProfile);
+          const fail=async()=>{throw Object.assign(Error('PRIVATE PATH'),{code:'EIO'});};
+          if(stage==='replace') io.replace=fail;
+          else {
+            const original=io.createTemporary;
+            io.createTemporary=async(...args)=>{const handle=await original(...args);handle[stage]=fail;return handle;};
+          }
+          await atomicWritePointJson(path,value,options,io);
+        });
+        const before=await snapshot(state.root);
+        const response=await answerLifecycleHttp(repository,'POST','/api/answers/answer/delete','{"expectedRevision":2}');
+        assert.equal(response.status,500); assert.deepEqual(JSON.parse(response.body),{error:{code:'storage_error',message:'storage operation failed'}});
+        assert.deepEqual(await snapshot(state.root),before);
+      }
+      const restarted=new AnswerLifecycleService(new NativeJobsRepository(state.root,state.provider),()=>at);
+      assert.deepEqual(plain(await restarted.delete('answer',2n)),{deleted:true,key:'answer'});
+    });
+  } finally {await fixture.cleanup();}
+});

--- a/tests_js/workspace_native_lifecycle_answers_browser_support.mjs
+++ b/tests_js/workspace_native_lifecycle_answers_browser_support.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// Runs only in the caller's disposable native fixture; Python is absent from CLI PATH.
+export async function nativeAnswerLifecycleBrowser(page, root, fixture, buildRoot) {
+  const execute = promisify(execFile), suffix = randomUUID();
+  const key = `browser-lifecycle/é😀-${suffix}`, question = `Lifecycle browser answer ${suffix}?`;
+  const sensitiveKey = `browser-lifecycle-sensitive-${suffix}`;
+  const privateValue = `PRIVATE-LIFECYCLE-${suffix}`, savedValue = `SAVED-LIFECYCLE-${suffix}`;
+  async function cli(command, args = [], payload) {
+    if (payload !== undefined) {
+      const input = join(fixture.root, `answer-lifecycle-${suffix}.json`);
+      await writeFile(input, JSON.stringify(payload), {mode:0o600});
+      args = [...args, '--input', input];
+    }
+    const result = await execute(process.execPath, [join(buildRoot, 'runtime/cli/native-jobs.js'),
+      '--root', root, '--native-lock', fixture.receipt.artifact, command, ...args],
+    {env:{PATH:''}, timeout:15000});
+    assert.equal(result.stderr, '');
+    return JSON.parse(result.stdout);
+  }
+  const args = (id, revision) => ['--key', id, '--expected-revision', String(revision)];
+  const route = (id, operation) => `/api/answers/${encodeURIComponent(id)}/${operation}`;
+  async function api(path, body) {
+    const authorization = await page.evaluate(() => `Bearer ${sessionStorage.getItem('jobApplyWorkspaceToken')}`);
+    const response = await page.request.fetch(new URL(path, page.url()).href, {
+      method:body === undefined ? 'GET' : 'POST',
+      headers:{Authorization:authorization, Origin:new URL(page.url()).origin}, data:body,
+    });
+    assert.equal(response.status(), 200, await response.text());
+    return response.json();
+  }
+  const answer = await cli('answer-put', [], {key, question, state:'confirmed', value:savedValue});
+  await page.reload();
+  await page.getByRole('button', {name:'Answers', exact:true}).click();
+  const search = page.getByLabel('Find answers', {exact:true});
+  const searchButton = page.getByRole('button', {name:'Search answers', exact:true});
+  const card = page.getByRole('button', {name:question, exact:true});
+  const value = page.getByLabel('Answer value', {exact:true});
+  await search.fill(question);
+  await searchButton.click();
+  await card.click();
+  assert.equal(await value.inputValue(), savedValue);
+  await value.fill('Unsaved lifecycle answer draft');
+  const trashed = await cli('answer-trash', args(key, answer.revision));
+  assert.equal(trashed.revision, answer.revision + 1);
+  assert.equal(typeof trashed.deletedAt, 'string');
+  assert.equal(await value.inputValue(), 'Unsaved lifecycle answer draft');
+  await searchButton.click();
+  await card.waitFor({state:'hidden'});
+  assert.equal(await value.inputValue(), 'Unsaved lifecycle answer draft');
+  const beforeList = await readFile(join(root, 'answers.json'), 'utf8');
+  const listed = await cli('trash-list');
+  assert.deepEqual(await api('/api/trash'), listed);
+  assert.equal(await readFile(join(root, 'answers.json'), 'utf8'), beforeList);
+  assert.deepEqual(listed.items.find(item => item.type === 'answer' && item.id === key), {
+    type:'answer', id:key, revision:trashed.revision, deletedAt:trashed.deletedAt,
+    label:question, state:'confirmed', reviewStatus:'accepted', blockerCounts:{sessions:0, history:0},
+  });
+  assert.equal(JSON.stringify(listed).includes(savedValue), false);
+  const encodedRestore = `/api/answers/by-key/${Buffer.from(key, 'utf8').toString('base64url')}/restore`;
+  const restored = await api(encodedRestore, {expectedRevision:trashed.revision});
+  assert.equal(restored.revision, trashed.revision + 1);
+  assert.equal(restored.deletedAt, null);
+  assert.equal(restored.value, savedValue);
+  assert.equal(await value.inputValue(), 'Unsaved lifecycle answer draft');
+  // Return the draft to its original value before leaving the editor.
+  await value.fill(savedValue);
+  await page.reload();
+  await page.getByRole('button', {name:'Answers', exact:true}).click();
+  await search.fill(question);
+  await searchButton.click();
+  await card.click();
+  assert.equal(await value.inputValue(), savedValue);
+  const again = await api(route(key, 'trash'), {expectedRevision:restored.revision});
+  const cliRestored = await cli('answer-restore', args(key, again.revision));
+  assert.equal(cliRestored.revision, again.revision + 1);
+  assert.equal(cliRestored.deletedAt, null);
+  assert.equal(cliRestored.value, savedValue);
+  const finalTrash = await api(route(key, 'trash'), {expectedRevision:cliRestored.revision});
+  assert.deepEqual(await api(route(key, 'delete'), {expectedRevision:finalTrash.revision}), {deleted:true, key});
+  const afterDelete = await readFile(join(root, 'answers.json'), 'utf8');
+  assert.deepEqual(await cli('answer-delete', args(key, finalTrash.revision)), {deleted:false, key});
+  assert.equal(await readFile(join(root, 'answers.json'), 'utf8'), afterDelete);
+  assert.equal(Object.hasOwn(JSON.parse(afterDelete).answers, key), false);
+  assert.equal((await api('/api/trash')).items.some(item => item.type === 'answer' && item.id === key), false);
+  await page.reload();
+  await page.getByRole('button', {name:'Answers', exact:true}).click();
+  await search.fill(question);
+  await searchButton.click();
+  await page.getByText('No matching answers.', {exact:true}).waitFor();
+  assert.equal(await card.count(), 0);
+
+  const sensitive = await cli('answer-put', ['--remember-sensitive'], {key:sensitiveKey,
+    question:`Sensitive lifecycle browser answer ${suffix}?`, state:'sensitive', value:privateValue});
+  const hiddenTrash = await api(route(sensitiveKey, 'trash'), {expectedRevision:sensitive.revision});
+  const hiddenRestore = await cli('answer-restore', args(sensitiveKey, hiddenTrash.revision));
+  for (const projection of [sensitive, hiddenTrash, hiddenRestore]) {
+    assert.equal(projection.valueRedacted, true);
+    assert.equal(Object.hasOwn(projection, 'value'), false);
+    assert.equal(JSON.stringify(projection).includes(privateValue), false);
+  }
+  const sensitiveTrash = await cli('answer-trash', args(sensitiveKey, hiddenRestore.revision));
+  const sensitiveList = await api('/api/trash');
+  assert.equal(sensitiveList.items.some(item => item.type === 'answer' && item.id === sensitiveKey), true);
+  assert.equal(JSON.stringify(sensitiveList).includes(privateValue), false);
+  assert.deepEqual(await api(route(sensitiveKey, 'delete'), {expectedRevision:sensitiveTrash.revision}),
+    {deleted:true, key:sensitiveKey});
+  assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1));
+  return {cliTrashApiRestore:true, unicodeByKeyRestore:true, apiTrashCliRestore:true, externalDraftPreserved:true,
+    redactedListingAgreement:true, listingReadOnly:true, sensitiveProjection:true,
+    apiDeleteCliMissingNoop:true, canonicalReloadAbsence:true, pythonAbsentFromPath:true};
+}

--- a/tests_js/workspace_native_lifecycle_answers_support.mjs
+++ b/tests_js/workspace_native_lifecycle_answers_support.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { cp } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { setup as baseSetup, plain, read, write, snapshot } from './workspace_native_claims_support.mjs';
+import { AnswerLifecycleService } from '../runtime/workspace-core/answer-lifecycle.js';
+export { plain, read, write, snapshot };
+export const at = '2026-09-10T15:00:00Z';
+export async function setup(fixture, name, extra = {}) {
+  const state = await baseSetup(fixture, name);
+  await write(state.root, 'answers.json', {schemaVersion:1, redirects:{}, metadata:{updatedAt:at},
+    answers:{answer:{key:'answer', question:'Preferred editor?', state:'confirmed', value:'synthetic answer', updatedAt:at}}, ...extra});
+  return {...state, service:new AnswerLifecycleService(state.repository, () => at)};
+}
+const python = `import importlib.util,json,sys
+from pathlib import Path
+sys.path.insert(0,str(Path('scripts').resolve()))
+spec=importlib.util.spec_from_file_location('lifecycle_reference','scripts/job-apply-store.py')
+module=importlib.util.module_from_spec(spec); spec.loader.exec_module(module)
+module.utc_now=lambda:'2026-09-10T15:00:00Z'
+store=module.Store(Path(sys.argv[1])); store.initialize()
+results=[]
+for op in json.loads(sys.argv[2]):
+ try: result={'value':getattr(store,op['kind']+'_answer')(op.get('key','answer'),op['revision'])}
+ except module.StoreError as error: result={'error':str(error)}
+ result['answers']=json.loads(store.answers_path.read_text())
+ results.append(result)
+print(json.dumps(results))`;
+export async function differential(state, target, operations) {
+  await cp(state.root, target, {recursive:true});
+  const reference = JSON.parse((await promisify(execFile)('python3', ['-c',python,target,JSON.stringify(operations)], {maxBuffer:8*1024*1024})).stdout);
+  for (const [index, op] of operations.entries()) {
+    const before = await snapshot(state.root);
+    let actual;
+    try { actual = {value:plain(await state.service[op.kind](op.key ?? 'answer', BigInt(op.revision)))}; }
+    catch (error) { actual = {error:error.message}; }
+    const {answers, ...expected} = reference[index];
+    assert.deepEqual(actual, expected, `operation ${index}: ${JSON.stringify(op)}`);
+    assert.deepEqual(await read(state.root, 'answers.json'), answers);
+    const after = await snapshot(state.root);
+    if (actual.error) assert.deepEqual(after, before);
+    delete before['answers.json']; delete after['answers.json'];
+    assert.deepEqual(after, before, 'only answers.json may change');
+  }
+}


### PR DESCRIPTION
Adds answer trash, restore and permanent deletion to the native fixture CLI and authenticated HTTP API. Shared dispatch supports both legacy URL-encoded keys and base64url by-key routes, reusing the existing strict decoder. Mutations preserve Python revisions, no-op behavior, redirects, sensitive projections and all session/history references, and write only Answers.

Reference failures report counts from the locked snapshot. Documentation requires canonical refresh after ambiguous post-replacement errors. This remains synthetic fixture functionality; no live Store adoption, native activation or new Trash UI is included.

Validation:
- Nine focused tests passed, including independent Python/native comparisons, exact revisions, legacy records, sensitive values, redirects, terminal sessions, history, atomic faults and shared Unicode CLI/HTTP dispatch.
- Integrated production browser passed both CLI/API lifecycle directions, by-key restore, draft preservation, redacted listing, sensitive projection, deletion/no-op and canonical reload with Python absent from native PATH.
- Source-size, matrix and TypeScript checks passed; five independent review roles found no actionable issues; all 10 normal commit-hook suites passed. Built-in Codex review remains unavailable due to installed CLI/model incompatibility.
- All 27 deep-validation suites and normal push gates passed on the unchanged retry. Validate Plugin 34642747803 and Release Validation 34642749964 passed on the exact reviewed head. Initial full gate hit a five-second timeout in an unchanged Python atomic-write reference subprocess. All 180 reference tests passed in an unchanged isolated checkout; the full unchanged rerun retains the original failure evidence and changes no assertions/time limits.
