### PR TITLE
Add React Trash with guarded restore and permanent deletion

### DIFF
--- a/apps/companion/components/Companion.tsx
+++ b/apps/companion/components/Companion.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback,useEffect,useState } from 'react';
+import { useCallback,useEffect,useMemo,useState } from 'react';
 import { createClient,sessionToken,type Client } from './client';
 import type { Boot } from './contracts';
 import { Overview } from './Overview';
@@ -10,7 +10,11 @@ import { Answers } from './Answers';
 import { Extractions } from './Extractions';
 import { NeedsAttention } from './NeedsAttention';
 import './companion.css';
-type WorkspaceTab = 'overview'|'jobs'|'facts'|'resumes'|'answers'|'extractions'|'attention';
+import './trash.css';
+import { Trash } from './Trash';
+import { createTrashClient } from './trash-client';
+import { compatibilityTrashCapabilities, nativeTrashCapabilities } from './trash-model';
+type WorkspaceTab = 'overview'|'jobs'|'facts'|'resumes'|'answers'|'extractions'|'attention'|'trash';
 export default function Companion() {
     const [client,setClient]=useState<Client|null>(null);
     const [boot,setBoot]=useState<Boot|null>(null);
@@ -71,6 +75,8 @@ export default function Companion() {
         token
     }).toString()}`;
     const nativeFixture=boot?.status==='ready'&&boot.mode==='native-jobs-fixture';
+    const trashCapabilities=nativeFixture?nativeTrashCapabilities:compatibilityTrashCapabilities;
+    const trashClient=useMemo(() => createTrashClient(token,trashCapabilities),[token,trashCapabilities]);
     return <main className="companion">
         <div className="topbar">
             <div>
@@ -98,6 +104,7 @@ export default function Companion() {
                     event.preventDefault();
             }}>Open full workspace
             </a>}
+            <button aria-current={tab==='trash'?'page':undefined} onClick={() => navigate('trash')}>Trash</button>
         </nav>
         <p className="trust">Your canonical data stays local. You direct changes and submissions; agents assist from the same record.
         </p>
@@ -113,7 +120,7 @@ export default function Companion() {
             <p>
                 {boot.guidance}
             </p>
-        </section>:boot?.status==='ready'&&client? (tab==='overview'? <Overview
+        </section>:boot?.status==='ready'&&client? (tab==='trash'?<Trash client={trashClient} capabilities={trashCapabilities} dirtyChanged={dirtyChanged}/>:tab==='overview'? <Overview
             client={client}
             openJobs={() => navigate('jobs')}
             openWorkspace={nativeFixture ? navigate : undefined}

--- a/apps/companion/components/Trash.tsx
+++ b/apps/companion/components/Trash.tsx
@@ -1,0 +1,133 @@
+'use client';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { TrashClient } from './trash-client';
+import { referenceText, trashErrorText, type TrashAction, type TrashCapabilities, type TrashItem, type TrashSnapshot, type TrashType } from './trash-model';
+import { TrashConfirmation } from './TrashConfirmation';
+export interface TrashProps {
+    client: TrashClient;
+    capabilities: TrashCapabilities;
+    dirtyChanged(value: boolean): void;
+    onMutation?(): void | Promise<void>;
+}
+export function Trash({ client, capabilities, dirtyChanged, onMutation }: TrashProps) {
+    const [snapshot, setSnapshot] = useState<TrashSnapshot | null>(null);
+    const [filter, setFilter] = useState<TrashType | ''>('');
+    const [selection, setSelection] = useState<{ item: TrashItem; action: TrashAction } | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [stale, setStale] = useState(true);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState('');
+    const [notice, setNotice] = useState('');
+    const generation = useRef(0);
+    const controller = useRef<AbortController | null>(null);
+    const mutation = useRef(false);
+    const mounted = useRef(false);
+    const wasBusy = useRef(false);
+    const opener = useRef<HTMLElement | null>(null);
+    useEffect(() => {
+        if (wasBusy.current && !busy) document.getElementById('trash-refresh')?.focus();
+        wasBusy.current = busy;
+    }, [busy]);
+    const refresh = useCallback(async (): Promise<boolean> => {
+        controller.current?.abort();
+        const abort = new AbortController();
+        controller.current = abort;
+        const request = ++generation.current;
+        setLoading(true);
+        setStale(true);
+        try {
+            const value = await client.list(abort.signal);
+            if (!mounted.current || request !== generation.current) return false;
+            setSnapshot(value);
+            setStale(false);
+            setError('');
+            return true;
+        } catch {
+            if (mounted.current && request === generation.current)
+                setError('Trash could not be refreshed. Displayed records may be outdated; actions are disabled until refresh succeeds.');
+            return false;
+        } finally {
+            if (mounted.current && request === generation.current) setLoading(false);
+        }
+    }, [client]);
+    useEffect(() => {
+        mounted.current = true;
+        setSnapshot(null);
+        setSelection(null);
+        setNotice('');
+        void refresh();
+        return () => { mounted.current = false; ++generation.current; controller.current?.abort(); };
+    }, [refresh]);
+    useEffect(() => {
+        dirtyChanged(selection !== null || busy);
+        return () => dirtyChanged(false);
+    }, [selection, busy, dirtyChanged]);
+    async function submit() {
+        if (!selection || mutation.current || stale || !capabilities[selection.item.type][selection.action]) return;
+        mutation.current = true;
+        setBusy(true);
+        setError('');
+        setNotice('');
+        const current = selection;
+        const request = generation.current;
+        controller.current?.abort();
+        const abort = new AbortController();
+        controller.current = abort;
+        try {
+            await client.mutate(current.item, current.action, abort.signal);
+            if (!mounted.current || request !== generation.current) return;
+            setSelection(null);
+            setStale(true);
+            setNotice(`${current.item.type} ${current.action === 'restore' ? 'restored' : 'permanently deleted'}. The change was saved; do not repeat it if refresh fails.`);
+            await refresh();
+            if (mounted.current) {
+                try { await onMutation?.(); }
+                catch { if (mounted.current) setError('The change was saved, but another workspace view could not refresh. Refresh that view before continuing.'); }
+            }
+        } catch (failure) {
+            if (!mounted.current || request !== generation.current) return;
+            setSelection(null);
+            setStale(true);
+            setError(trashErrorText(failure));
+        } finally {
+            mutation.current = false;
+            if (mounted.current) setBusy(false);
+        }
+    }
+    const items = snapshot?.items.filter(item => !filter || item.type === filter) ?? [];
+    const limited = (['job', 'resume', 'answer'] as const).some(type => !capabilities[type].restore || !capabilities[type].delete);
+    return <section className="trash-workspace" aria-labelledby="trash-title" aria-busy={loading || busy}>
+        <div className="trash-heading">
+            <h1 id="trash-title">Trash</h1>
+            <button id="trash-refresh" disabled={loading || busy || selection !== null} onClick={() => { void refresh(); }}>Refresh Trash</button>
+        </div>
+        <p>Restore individual records or review them for permanent deletion.</p>
+        {limited && <p>Some lifecycle actions are not available in this workspace. Only supported actions are enabled.</p>}
+        <label>Record type <select value={filter} disabled={busy || selection !== null} onChange={event => setFilter(event.target.value as TrashType | '')}>
+            <option value="">All types</option><option value="job">Jobs</option><option value="resume">Resumes</option><option value="answer">Answers</option>
+        </select></label>
+        {notice && <p role="status">{notice}</p>}
+        {error && <p role="alert" className="error">{error}</p>}
+        {loading && <p role="status">Loading Trash…</p>}
+        {snapshot && <>
+            <p>{snapshot.counts.job} jobs · {snapshot.counts.resume} resumes · {snapshot.counts.answer} answers{stale ? ' (outdated)' : ''}</p>
+            {!stale && <p role="status">{items.length ? `${items.length} trashed records in this view.` : filter ? 'No trashed records of this type.' : 'Trash is empty.'}</p>}
+            <ul className="trash-list" aria-label="Trashed records">
+                {items.map(item => <li key={JSON.stringify([item.type, item.id])}>
+                    <article className="trash-card">
+                        <div><p className="eyebrow">{item.type}</p><h2>{item.label}</h2>
+                            <p>{referenceText(item.blockerCounts)}. Checked again when you act.</p></div>
+                        <div className="trash-actions">
+                            {(['restore', 'delete'] as const).map(action => <button key={action}
+                                disabled={stale || loading || busy || selection !== null || !capabilities[item.type][action]}
+                                onClick={event => { opener.current = event.currentTarget; setSelection({ item, action }); }}>
+                                {action === 'restore' ? 'Restore' : 'Delete permanently…'}{!capabilities[item.type][action] ? ' (unavailable)' : ''}
+                            </button>)}
+                        </div>
+                    </article>
+                </li>)}
+            </ul>
+        </>}
+        {selection && <TrashConfirmation opener={opener.current} item={selection.item} action={selection.action} busy={busy} confirm={() => { void submit(); }} cancel={() => { if (!mutation.current) setSelection(null); }} />}
+    </section>;
+}

--- a/apps/companion/components/TrashConfirmation.tsx
+++ b/apps/companion/components/TrashConfirmation.tsx
@@ -1,0 +1,45 @@
+'use client';
+import { useEffect, useId, useRef, useState } from 'react';
+import { deletePhrase, referenceText, type TrashAction, type TrashItem } from './trash-model';
+export function TrashConfirmation({ item, action, busy, confirm, cancel, opener }: {
+    opener: HTMLElement | null; item: TrashItem; action: TrashAction; busy: boolean; confirm(): void; cancel(): void;
+}) {
+    const dialog = useRef<HTMLDialogElement>(null);
+    const input = useRef<HTMLInputElement>(null);
+    const cancelButton = useRef<HTMLButtonElement>(null);
+    const [phrase, setPhrase] = useState('');
+    const title = useId();
+    const description = useId();
+    useEffect(() => {
+        const node = dialog.current;
+        node?.showModal();
+        (action === 'delete' ? input.current : cancelButton.current)?.focus();
+        return () => {
+            node?.close();
+            if (opener?.isConnected) opener.focus();
+            else document.getElementById('trash-refresh')?.focus();
+        };
+    }, [action, opener]);
+    return <dialog ref={dialog} className="trash-confirmation" aria-labelledby={title} aria-describedby={description}
+        onCancel={event => { event.preventDefault(); if (!busy) cancel(); }}>
+        <form onSubmit={event => { event.preventDefault(); if (!busy && (action === 'restore' || phrase === deletePhrase(item.type))) confirm(); }}>
+            <h2 id={title}>{action === 'delete' ? 'Confirm permanent deletion' : 'Restore record?'}</h2>
+            <p>{item.type}: {item.label}</p>
+            <div id={description}>
+                {action === 'delete' ? <p>This permanently deletes the selected canonical record{item.type === 'resume' ? ' and its managed resume file' : ''}.
+                    It does not cascade or erase application history, sessions, or audit evidence.</p> :
+                    <p>This returns the selected record to its library. The server will check its current revision and restore constraints.</p>}
+                <p>{referenceText(item.blockerCounts)}. Reference counts are advisory; the server decides whether this action is allowed.</p>
+            </div>
+            {action === 'delete' && <label>Type <strong>{deletePhrase(item.type)}</strong> to continue
+                <input ref={input} value={phrase} onChange={event => setPhrase(event.target.value)} autoComplete="off" spellCheck={false} disabled={busy} />
+            </label>}
+            <div className="trash-actions">
+                <button ref={cancelButton} type="button" onClick={cancel} disabled={busy}>Cancel</button>
+                <button type="submit" disabled={busy || (action === 'delete' && phrase !== deletePhrase(item.type))}>
+                    {busy ? 'Saving…' : action === 'delete' ? 'Delete permanently' : 'Restore'}
+                </button>
+            </div>
+        </form>
+    </dialog>;
+}

--- a/apps/companion/components/trash-client.ts
+++ b/apps/companion/components/trash-client.ts
@@ -1,0 +1,40 @@
+import { answerPath } from './answer-model';
+import { trashSnapshot, type TrashAction, type TrashCapabilities, type TrashItem, type TrashSnapshot, safeCounts } from './trash-model';
+export interface TrashClient {
+    list(signal: AbortSignal): Promise<TrashSnapshot>;
+    mutate(item: TrashItem, action: TrashAction, signal: AbortSignal): Promise<void>;
+}
+export class TrashApiError extends Error {
+    constructor(public status: number, public code: string, public counts: Record<string, number> = {}) {
+        super('Trash request failed');
+    }
+}
+export function createTrashClient(token: string, capabilities: TrashCapabilities, fetcher: typeof fetch = fetch): TrashClient {
+    async function request(path: string, signal: AbortSignal, expectedRevision?: bigint): Promise<string> {
+        const response = await fetcher(path, {
+            method: expectedRevision === undefined ? 'GET' : 'POST', cache: 'no-store',
+            signal: AbortSignal.any([signal, AbortSignal.timeout(30_000)]),
+            headers: { Authorization: `Bearer ${token}`, ...(expectedRevision === undefined ? {} : { 'Content-Type': 'application/json' }) },
+            body: expectedRevision === undefined ? undefined : `{"expectedRevision":${expectedRevision}}`
+        });
+        const raw = await response.text();
+        if (!response.ok) {
+            let payload: unknown = null;
+            try { payload = JSON.parse(raw); } catch { /* Status remains authoritative. */ }
+            const envelope = payload as { error?: { code?: unknown; counts?: unknown } } | null;
+            throw new TrashApiError(response.status, typeof envelope?.error?.code === 'string' ? envelope.error.code : 'request_error', safeCounts(envelope?.error?.counts));
+        }
+        return raw;
+    }
+    return {
+        list: async signal => trashSnapshot(await request('/api/trash', signal)),
+        mutate: async (item, action, signal) => {
+            if (!capabilities[item.type]?.[action]) throw new TrashApiError(405, 'unsupported_operation');
+            if (typeof item.revision !== 'bigint' || item.revision <= 0n) throw new TrashApiError(400, 'invalid_revision');
+            const collection = { job: 'jobs', resume: 'resumes', answer: 'answers' }[item.type];
+            const path = item.type === 'answer' ? answerPath(item.id) : `/api/${collection}/${encodeURIComponent(item.id)}`;
+            await request(`${path}/${action}`, signal, item.revision);
+            // Successful deletion need not return a record. The UI reloads the canonical list.
+        }
+    };
+}

--- a/apps/companion/components/trash-model.ts
+++ b/apps/companion/components/trash-model.ts
@@ -1,0 +1,104 @@
+import { get, int, object as document, parse, string as stringValue } from '../../../src/contracts/workspace/values';
+export type TrashType = 'job' | 'resume' | 'answer';
+export type TrashAction = 'restore' | 'delete';
+export type TrashCapabilities = Readonly<Record<TrashType, Readonly<Record<TrashAction, boolean>>>>;
+export const compatibilityTrashCapabilities: TrashCapabilities = {
+    job: { restore: true, delete: true }, resume: { restore: true, delete: true }, answer: { restore: true, delete: true }
+};
+export const nativeTrashCapabilities: TrashCapabilities = {
+    job: { restore: true, delete: true }, resume: { restore: false, delete: false }, answer: { restore: true, delete: true }
+};
+export interface TrashItem {
+    type: TrashType;
+    id: string;
+    revision: bigint;
+    deletedAt: string;
+    label: string;
+    blockerCounts: Record<string, number>;
+}
+export interface TrashSnapshot {
+    items: TrashItem[];
+    counts: Record<TrashType, number>;
+    total: number;
+}
+function object(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+function count(value: unknown): value is number {
+    return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+export function isTrashType(value: unknown): value is TrashType {
+    return value === 'job' || value === 'resume' || value === 'answer';
+}
+export function safeCounts(value: unknown): Record<string, number> {
+    if (!object(value)) return {};
+    return Object.fromEntries(Object.entries(value).filter((entry): entry is [string, number] => count(entry[1])));
+}
+export function trashSnapshot(raw: string): TrashSnapshot {
+    const value = document(parse(raw), 'Trash response');
+    const records = get(value, 'items');
+    const countsRecord = document(get(value, 'counts'), 'Trash counts');
+    const total = int(get(value, 'total'));
+    if (!Array.isArray(records) || total === null || total < 0n) throw Error('Invalid Trash response');
+    const items = records.map((entry): TrashItem => {
+        const item = document(entry, 'Trash item');
+        const type = stringValue(get(item, 'type'));
+        const id = stringValue(get(item, 'id'));
+        const label = stringValue(get(item, 'label'));
+        const deletedAt = stringValue(get(item, 'deletedAt'));
+        const revision = int(get(item, 'revision'));
+        if (!isTrashType(type) || !id || label === null || deletedAt === null || revision === null || revision < 1n)
+            throw Error('Invalid Trash record');
+        const blockers = document(get(item, 'blockerCounts'), 'Trash references');
+        const blockerCounts: Record<string, number> = {};
+        for (const [key, value] of blockers.entries()) {
+            const number = int(value);
+            if (number === null || number < 0n || number > BigInt(Number.MAX_SAFE_INTEGER)) throw Error('Invalid reference count');
+            Object.defineProperty(blockerCounts, stringValue(key)!, { value: Number(number), enumerable: true });
+        }
+        return { type, id, label, deletedAt, revision, blockerCounts };
+    });
+    const counts = { job: 0, resume: 0, answer: 0 };
+    for (const type of ['job', 'resume', 'answer'] as const) {
+        const number = int(get(countsRecord, type));
+        if (number !== BigInt(items.filter(item => item.type === type).length)) throw Error('Inconsistent Trash counts');
+        counts[type] = Number(number);
+    }
+    if (total !== BigInt(items.length) || new Set(items.map(item => JSON.stringify([item.type, item.id]))).size !== items.length)
+        throw Error('Inconsistent Trash response');
+    return { items, counts, total: items.length };
+}
+export function deletePhrase(type: TrashType): string { return `DELETE ${type.toUpperCase()}`; }
+export function referenceText(counts: Record<string, number>): string {
+    const total = Object.values(counts).reduce((sum, value) => sum + value, 0);
+    return total ? `${total} protected reference${total === 1 ? '' : 's'}` : 'No known references';
+}
+export function trashErrorText(error: unknown): string {
+    const detail = object(error) ? error : {};
+    if (detail.code === 'revision_conflict')
+        return 'This record changed elsewhere. Refresh Trash and review the latest revision. Nothing was retried.';
+    const guidance: Record<string, string> = {
+        not_found: 'This record no longer exists. Refresh Trash.',
+        claim_blocked: 'Release or complete the coordinator claim before changing this job.',
+        session_reference_blocked: 'Application session references protect this record from permanent deletion. Review the linked application records.',
+        history_reference_blocked: 'Protected application history prevents permanent deletion.',
+        job_reference_blocked: 'A job still references this resume. Review and reassign those jobs first.',
+        default_reference_blocked: 'Active jobs use this default resume. Assign another default first.',
+        duplicate_active_blocked: 'An active record with the same canonical identity already exists. Review it before restoring.',
+        assigned_resume_blocked: 'The assigned resume is unavailable. Restore or reassign that resume first.',
+        redirect_target_blocked: 'This answer is a canonical redirect target and cannot be moved or deleted.',
+        store_rejected: 'The canonical store rejected this lifecycle operation. Refresh and review the record.'
+    };
+    if (typeof detail.code === 'string' && Object.hasOwn(guidance, detail.code)) {
+        const counts = safeCounts(detail.counts);
+        const suffix = Object.values(counts).some(value => value > 0) ? ` (${referenceText(counts)}.)` : '';
+        return `${guidance[detail.code]}${suffix}`;
+    }
+    const total = Object.values(safeCounts(detail.counts)).reduce((sum, value) => sum + value, 0);
+    if (total) return `The operation was rejected with ${total} protected reference${total === 1 ? '' : 's'}. Refresh and review the record.`;
+    if (typeof detail.code === 'string' && /recovery/.test(detail.code))
+        return 'Store recovery is required. Resolve recovery in the workspace before trying again.';
+    if (detail.code === 'unsupported_operation') return 'This action is not available in this workspace.';
+    // Do not render raw transport/storage messages: they may contain private values or paths.
+    return 'The operation could not be confirmed. Refresh Trash to check canonical state before trying again.';
+}

--- a/apps/companion/components/trash.css
+++ b/apps/companion/components/trash.css
@@ -1,0 +1,18 @@
+.trash-workspace { min-width: 0; }
+.trash-heading, .trash-actions { display: flex; align-items: center; flex-wrap: wrap; gap: .75rem; }
+.trash-heading { justify-content: space-between; }
+.trash-list { list-style: none; margin: 1rem 0; padding: 0; display: grid; gap: 1rem; }
+.trash-card { display: flex; justify-content: space-between; gap: 1rem; padding: 1rem; border: 1px solid #87948e; border-radius: .75rem; }
+.trash-card > div { min-width: 0; }
+.trash-card h2, .trash-confirmation p { overflow-wrap: anywhere; }
+.trash-card h2 { font-size: 1.1rem; }
+.trash-workspace button, .trash-confirmation button { min-height: 44px; white-space: normal; }
+.trash-confirmation { width: min(34rem, calc(100vw - 2rem)); max-height: calc(100dvh - 2rem); overflow-y: auto; padding: 1.25rem; border: 1px solid #87948e; border-radius: .75rem; box-sizing: border-box; }
+.trash-confirmation::backdrop { background: rgb(0 0 0 / 50%); }
+.trash-confirmation label { display: grid; gap: .5rem; }
+.trash-confirmation input { min-width: 0; width: 100%; box-sizing: border-box; }
+.trash-confirmation .trash-actions { margin-top: 1rem; justify-content: flex-end; }
+@media (max-width: 600px) {
+    .trash-card { flex-direction: column; }
+    .trash-actions > button { flex: 1 1 8rem; }
+}

--- a/config/migration/browser-react-trash-surfaces.json
+++ b/config/migration/browser-react-trash-surfaces.json
@@ -1,0 +1,269 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "browser:apps/companion/components/Trash.tsx:Trash",
+      "kind": "browser",
+      "export": "Trash",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/Trash.tsx"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/TrashConfirmation.tsx:TrashConfirmation",
+      "kind": "browser",
+      "export": "TrashConfirmation",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/TrashConfirmation.tsx"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/trash-client.ts:TrashApiError",
+      "kind": "browser",
+      "export": "TrashApiError",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/trash-client.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/trash-client.ts:createTrashClient",
+      "kind": "browser",
+      "export": "createTrashClient",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/trash-client.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/trash-model.ts:compatibilityTrashCapabilities",
+      "kind": "browser",
+      "export": "compatibilityTrashCapabilities",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/trash-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/trash-model.ts:nativeTrashCapabilities",
+      "kind": "browser",
+      "export": "nativeTrashCapabilities",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/trash-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/trash-model.ts:isTrashType",
+      "kind": "browser",
+      "export": "isTrashType",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/trash-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/trash-model.ts:safeCounts",
+      "kind": "browser",
+      "export": "safeCounts",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/trash-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/trash-model.ts:trashSnapshot",
+      "kind": "browser",
+      "export": "trashSnapshot",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/trash-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/trash-model.ts:deletePhrase",
+      "kind": "browser",
+      "export": "deletePhrase",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/trash-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/trash-model.ts:referenceText",
+      "kind": "browser",
+      "export": "referenceText",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/trash-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    },
+    {
+      "id": "browser:apps/companion/components/trash-model.ts:trashErrorText",
+      "kind": "browser",
+      "export": "trashErrorText",
+      "node": "UIF",
+      "sources": [
+        "apps/companion/components/trash-model.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
+    }
+  ]
+}

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -54,6 +54,10 @@
       "sha256": "8d0522433ddaa7e6efaad2d80a50b994b20e767ee5ae75b94f3d59353c4eb820"
     },
     {
+      "path": "browser-react-trash-surfaces.json",
+      "sha256": "f88a8932187bf02516c9db98aba7f3c38c792c4092e77d9890f7cde2f9b9f28e"
+    },
+    {
       "path": "cli-01-surfaces.json",
       "sha256": "b05ac334f9949992f3497f79885033b970692cb798e831d4866d62050ce56841"
     },
@@ -295,7 +299,7 @@
     },
     {
       "path": "source-catalog-g02-next.json",
-      "sha256": "3fa963521183a55ab54bbd404e5b7ae794fe7c386a5ca63aeb585a2ad109b208"
+      "sha256": "a36604e5da0ba2ac5d7f26818faf7867a003089bba804dee0e959692be765ff0"
     },
     {
       "path": "source-catalog-m01.json",
@@ -380,6 +384,10 @@
     {
       "path": "source-catalog-native-task-intake.json",
       "sha256": "ecc9ad11a7d4d3cf6258e0b93ddbac8224a1fd7207af36542a1a4d533b164973"
+    },
+    {
+      "path": "source-catalog-react-trash.json",
+      "sha256": "759aaa85f8de2674eed82fc65726ddf3aa1c8a78ac7a946071de57b7abf2fa69"
     },
     {
       "path": "source-catalog-s01.json",

--- a/config/migration/source-catalog-g02-next.json
+++ b/config/migration/source-catalog-g02-next.json
@@ -13,7 +13,7 @@
     },
     {
       "path": "apps/companion/components/Companion.tsx",
-      "sha256": "c7094e4f71fa89adbd11baade44b8175dc052d4f7e9dc21cef98a874e8e5d6ba",
+      "sha256": "b2c2261aec4c5c3083a35f324c87d14769f80360322bf14e42a80e0f98895d45",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-react-trash.json
+++ b/config/migration/source-catalog-react-trash.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "apps/companion/components/Trash.tsx",
+      "sha256": "38b9e7561f173503d3eb893dd8edcbdbeaae74e45d2855df32c3e8e074a6b956",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/TrashConfirmation.tsx",
+      "sha256": "a58cd6ee74e9240773268369978c8b0eb8e705a643bf5099feaa7aa5325f4f66",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/trash-client.ts",
+      "sha256": "7a3b4c112683cc890d2fd526f317731c59b21730ceb4c415c4885a98faf43e28",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/trash-model.ts",
+      "sha256": "7c81eb7b5fc7073cd2e5e70289813611d59644a81f9deb01a2a132b85ad35cbb",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "apps/companion/components/trash.css",
+      "sha256": "d5a5a1f7fd209defa3c7772c699c8ebc3c4a11154320f901285eb4a006718fd3",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/docs/react-trash-fixture.md
+++ b/docs/react-trash-fixture.md
@@ -1,0 +1,61 @@
+# React Trash fixture
+
+The standalone `Trash` component accepts a stable `TrashClient`, explicit
+per-type restore/delete capabilities, a `dirtyChanged(boolean)` callback, and
+an optional `onMutation()` callback for other mounted canonical views. The
+component reports pending confirmation and mutation as dirty. The parent must
+retain its existing navigation/unload guard and memoize the adapter.
+
+`createTrashClient(token, capabilities)` uses the same session token provided by
+Companion, authenticated same-origin requests, no-store caching, cancellation
+and a 30-second deadline. It does not read or create global auth state. Revisions
+are parsed through the existing Python-compatible integer parser and retained
+as bigint. Mutation requests contain only the exact `expectedRevision` integer;
+recordless successful delete responses are supported.
+
+Companion integrates the Trash tab, memoized adapter, capability selection
+and styles with its existing navigation guard. `onMutation` is optional because other tabs unmount and reload on entry.
+
+## Capabilities and recovery
+
+Compatibility mode supports restore and permanent deletion for jobs, resumes
+and answers. `nativeTrashCapabilities` enables job and answer restore/permanent deletion.
+Resume lifecycle actions remain unavailable in native fixture mode.
+Unsupported actions are disabled in the UI and independently rejected by the
+adapter before transport.
+
+Restore uses a confirmation dialog. Permanent deletion requires the exact legacy
+phrase `DELETE JOB`, `DELETE RESUME`, or `DELETE ANSWER`. A resume deletion
+explicitly discloses managed-file deletion. Counts are advisory; the canonical
+server is authoritative. The UI displays only labels, types and count summaries,
+never incidental record values, paths, URLs, or raw server errors.
+
+Every mutation error discards the confirmation and invalidates list authority.
+Actions stay disabled until an explicit refresh succeeds. This includes unknown
+outcomes where storage may have changed before the error. Conflicts never retry.
+A successful mutation followed by a failed refresh remains explicitly saved;
+it must not be replayed. Failed initial load never renders an empty-state claim.
+Aborted or superseded reads cannot replace the current snapshot.
+
+## Focused verification
+
+Run `node --test tests_js/workspace_react_trash.test.mjs` and
+`npm run companion:typecheck`. The focused tests cover exact large revisions,
+malformed projections, redaction, fixed routes/bodies, recordless deletion,
+capability enforcement, safe error guidance and no automatic transport retry.
+
+`reactTrashBrowser(page, { origin, headers })` from
+`tests_js/workspace_react_trash_browser_support.mjs` requires an authenticated
+production Companion page backed by a **disposable Python Store** and the shared
+wiring applied. It creates synthetic jobs, a managed resume and an answer using
+the API; restores and permanently deletes all three through the UI; verifies
+stale-revision rejection, typed confirmation, keyboard focus, advisory reference
+errors, saved-mutation/failed-refresh recovery, redaction and 390px/desktop
+layout. It also verifies native capability limits, failed-load versus empty state,
+and an error returned after a real restore commits. Reference and refresh-error envelopes are injected in the isolated page;
+ordinary lifecycle and revision-conflict requests use the real Python backend.
+The caller owns browser/service/Store cleanup. Do not run against live data.
+
+Production build/browser evidence is worker readiness, not native migration or
+release acceptance. The coordinator owns shared-suite integration, catalog
+ownership, final review and staging integration.

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -1,3 +1,4 @@
+import { nativeReactTrashBrowser } from './workspace_react_trash_native_browser_support.mjs';
 import { jobTrashBrowser } from './workspace_native_job_trash_browser_support.mjs';
 import { taskCliBrowser } from './workspace_native_task_cli_browser_support.mjs';
 import { nativeGroupedApprovalsBrowser } from './workspace_native_grouped_approvals_browser_support.mjs';
@@ -205,10 +206,11 @@ export async function nativeJobsBrowser(buildRoot) {
     const groupedApprovals = await nativeGroupedApprovalsBrowser(page, root, fixture, buildRoot);
     const taskCli = await taskCliBrowser(page, root, fixture, buildRoot);
     const jobTrash = await jobTrashBrowser(page, root, fixture, buildRoot);
+    const reactTrash = await nativeReactTrashBrowser(page, root, fixture, buildRoot);
     const unsupported = await fetch(startup.origin + '/api/resumes/fixture/delete', { method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Origin: startup.origin }, body: JSON.stringify({expectedRevision:1}) });
     assert.equal(unsupported.status, 501);
     assert.deepEqual(pageErrors, []);
-    return { jobTrash, taskCli, groupedApprovals, taskIntake, legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
+    return { reactTrash, jobTrash, taskCli, groupedApprovals, taskIntake, legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {
     releaseInitialClaim?.();
     if (browser) await browser.close();

--- a/tests_js/workspace_next_browser_support.mjs
+++ b/tests_js/workspace_next_browser_support.mjs
@@ -1,3 +1,4 @@
+import { reactTrashBrowser } from './workspace_react_trash_browser_support.mjs';
 import assert from 'node:assert/strict';
 import { chromium } from 'playwright';
 import { spawn, execFile } from 'node:child_process';
@@ -123,6 +124,8 @@ async function productionBrowser(root) {
     await page.getByRole('button', { name: 'Cancel', exact: true }).click();
     await nextDraftAndRecovery(page, origin, headers);
     await nextLateRead(page);
+    const trash = await reactTrashBrowser(page, { origin, headers });
+    await page.reload({ waitUntil: 'networkidle' });
     await page.getByRole('link', { name: 'Open full workspace', exact: true }).first().click();
     await page.getByText('Canonical store connected', { exact: true }).waitFor();
     await page.locator('#nav-jobs').click();
@@ -146,7 +149,7 @@ async function productionBrowser(root) {
     assert.equal(await stopped, 1);
     for (const pid of owned) assert.throws(() => process.kill(pid, 0), { code: 'ESRCH' });
     await assert.rejects(fetch(origin + '/api/boot', { signal: AbortSignal.timeout(1000) }));
-    return { productionStandalone: true, browser: browser.version(), editing: true,
+    return { trash, productionStandalone: true, browser: browser.version(), editing: true,
       draftRefresh: true, revisionConflict: true, reapply: true, reload: true, legacy: true,
       serviceFailureCleanup: true, httpParity: true, cleanDependencyInstall: true, setupDestinations: true, loadingAndDraftRecovery: true, narrowLayout: true, dialogFocus: true, cancelledStaleRead: true, cspViolations: violations };
   } finally {

--- a/tests_js/workspace_next_security_support.mjs
+++ b/tests_js/workspace_next_security_support.mjs
@@ -19,7 +19,8 @@ export async function nextSecurity() {
                 await readFile(join(componentDirectory, name), 'utf8'));
         }
         const catalogs = ['browser-g02-next-surfaces.json', 'browser-native-answers-surfaces.json',
-            'browser-native-extractions-surfaces.json', 'browser-native-projections-surfaces.json', 'browser-native-job-transitions-surfaces.json'];
+            'browser-native-extractions-surfaces.json', 'browser-native-projections-surfaces.json',
+            'browser-native-job-transitions-surfaces.json', 'browser-react-trash-surfaces.json'];
         const surfaces = (await Promise.all(catalogs.map(async name =>
             JSON.parse(await readFile(join(root, 'config/migration', name), 'utf8')).surfaces))).flat();
         assert.deepEqual(checkBrowserBindings(discoverNextBrowserExports(components), surfaces), []);

--- a/tests_js/workspace_react_trash.test.mjs
+++ b/tests_js/workspace_react_trash.test.mjs
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import ts from 'typescript';
+async function compile(file, replacements = {}) {
+    const source = await readFile(new URL(`../apps/companion/components/${file}`, import.meta.url), 'utf8');
+    let output = ts.transpileModule(source, { compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022 } }).outputText;
+    for (const [from, to] of Object.entries(replacements)) output = output.replaceAll(from, to);
+    return `data:text/javascript;base64,${Buffer.from(output).toString('base64')}`;
+}
+const modelUrl = await compile('trash-model.ts', {
+    '../../../src/contracts/workspace/values': new URL('../runtime/contracts/workspace/values.js', import.meta.url).href
+});
+const model = await import(modelUrl);
+const answerModelUrl = await compile('answer-model.ts', {
+    '../../../src/contracts/workspace/values': new URL('../runtime/contracts/workspace/values.js', import.meta.url).href,
+    '../../../src/contracts/python-object': new URL('../runtime/contracts/python-object.js', import.meta.url).href
+});
+const { createTrashClient } = await import(await compile('trash-client.ts', { './trash-model': modelUrl, './answer-model': answerModelUrl }));
+const item = { type: 'job', id: 'synthetic/job #1', label: 'Synthetic job', revision: 1, deletedAt: '2026-09-11', blockerCounts: { claims: 0 } };
+const listing = (items = [item]) => JSON.stringify({ items, total: items.length,
+    counts: Object.fromEntries(['job', 'resume', 'answer'].map(type => [type, items.filter(item => item.type === type).length])) });
+
+test('Trash projection preserves exact integer revisions and omits incidental private fields', () => {
+    const [projected] = model.trashSnapshot(listing([{ ...item, value: 'PRIVATE', path: '/private/file', url: 'https://private.invalid' }])
+        .replace('"revision":1', '"revision":9007199254740993')).items;
+    assert.equal(projected.revision, 9007199254740993n);
+    assert.equal('value' in projected, false);
+    assert.equal('path' in projected, false);
+    assert.equal('url' in projected, false);
+    for (const revision of ['0', '-1', 'true', '1.0', 'null'])
+        assert.throws(() => model.trashSnapshot(listing().replace('"revision":1', `"revision":${revision}`)));
+    assert.throws(() => model.trashSnapshot(listing([item, item])));
+    assert.throws(() => model.trashSnapshot(listing().replace('"total":1', '"total":0')));
+    assert.throws(() => model.trashSnapshot(listing([{ ...item, type: 'secret' }])));
+    assert.throws(() => model.trashSnapshot(listing([{ ...item, blockerCounts: { claims: -1 } }])));
+    assert.equal(model.trashSnapshot(listing([])).total, 0);
+});
+
+test('adapter uses fixed encoded routes, exact revision only, and accepts recordless deletion', async () => {
+    const requests = [];
+    const client = createTrashClient('synthetic-token', model.compatibilityTrashCapabilities, async (path, options) => {
+        requests.push({ path, options });
+        return new Response(options.method === 'GET' ? listing() : '{"deleted":true}', { status: 200 });
+    });
+    const signal = new AbortController().signal;
+    assert.equal((await client.list(signal)).total, 1);
+    for (const type of ['job', 'resume', 'answer']) {
+        await client.mutate({ ...item, type, revision: 9007199254740993n }, 'delete', signal);
+        const call = requests.at(-1);
+        assert.equal(call.path, type === 'answer' ? `/api/answers/by-key/${Buffer.from(item.id).toString('base64url')}/delete` : `/api/${{ job: 'jobs', resume: 'resumes' }[type]}/synthetic%2Fjob%20%231/delete`);
+        assert.equal(call.options.body, '{"expectedRevision":9007199254740993}');
+        assert.equal(call.options.headers.Authorization, 'Bearer synthetic-token');
+    }
+});
+
+test('answer dot-segment keys preserve identity through browser URL normalization', async () => {
+    const seen = [];
+    const client = createTrashClient('synthetic', model.nativeTrashCapabilities, async path => {
+        seen.push(new Request(new URL(path, 'http://localhost:1234')).url);
+        return new Response('{}');
+    });
+    for (const id of ['.', '..']) for (const action of ['restore', 'delete']) {
+        await client.mutate({ ...item, type:'answer', id, revision:1n }, action, new AbortController().signal);
+        assert.equal(new URL(seen.at(-1)).pathname, `/api/answers/by-key/${Buffer.from(id).toString('base64url')}/${action}`);
+    }
+});
+
+test('native adapter refuses unsupported actions before transport', async () => {
+    let calls = 0;
+    const client = createTrashClient('synthetic', model.nativeTrashCapabilities, async () => { ++calls; return new Response('{}'); });
+    const signal = new AbortController().signal;
+    for (const type of ['job', 'resume', 'answer']) for (const action of ['restore', 'delete']) {
+        if (type !== 'resume') continue;
+        await assert.rejects(client.mutate({ ...item, type, revision: 1n }, action, signal), { code: 'unsupported_operation' });
+    }
+    assert.equal(calls, 0);
+    await client.mutate({ ...item, revision: 1n }, 'restore', signal);
+    assert.equal(calls, 1);
+});
+
+test('errors preserve count guidance while suppressing private server messages and never retry', async () => {
+    for (const [code, counts, expected] of [
+        ['revision_conflict', {}, /changed elsewhere/], ['record_referenced', { history: 2 }, /2 protected references/],
+        ['recovery_required', {}, /recovery is required/], ['request_error', {}, /could not be confirmed/]
+    ]) {
+        let calls = 0;
+        const client = createTrashClient('synthetic', model.compatibilityTrashCapabilities, async () => {
+            ++calls;
+            return new Response(JSON.stringify({ error: { code, counts, message: '/private/value secret-token' } }), { status: 409 });
+        });
+        await assert.rejects(client.mutate({ ...item, revision: 1n }, 'delete', new AbortController().signal), error => {
+            assert.match(model.trashErrorText(error), expected);
+            assert.doesNotMatch(model.trashErrorText(error), /private|secret-token/);
+            return true;
+        });
+        assert.equal(calls, 1);
+    }
+    assert.equal(model.deletePhrase('answer'), 'DELETE ANSWER');
+    assert.doesNotMatch(model.trashErrorText({code:'session_reference_blocked',counts:{sessions:1}}), /Complete or abandon/);
+});

--- a/tests_js/workspace_react_trash_browser_support.mjs
+++ b/tests_js/workspace_react_trash_browser_support.mjs
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+
+// Caller provides a production Companion page connected only to a disposable Python Store.
+export async function reactTrashBrowser(page, { origin, headers }) {
+    async function api(path, body) {
+        const response = await page.request.fetch(origin + path, {
+            method: body === undefined ? 'GET' : 'POST', headers, data: body
+        });
+        assert.equal(response.status(), 200, await response.text());
+        return response.json();
+    }
+    const job = await api('/api/jobs', { job: { role: 'React Trash synthetic job', url: 'https://example.invalid/react-trash-private', notes: 'PRIVATE-TRASH-NOTES' } });
+    // Keep an active default for jobs created by the surrounding production walkthrough.
+    await api('/api/resumes/import', { metadata: { label: 'Retained synthetic default' }, filename: 'default.txt', content: Buffer.from('Retained default resume bytes').toString('base64') });
+    const resume = await api('/api/resumes/import', { metadata: { label: 'React Trash synthetic resume' }, filename: 'private-fixture.txt', content: Buffer.from('Synthetic resume bytes').toString('base64') });
+    const answer = await api('/api/answers', { answer: { question: 'React Trash synthetic answer?', state: 'confirmed', value: 'PRIVATE-TRASH-ANSWER' } });
+    const fixtures = [
+        { type: 'job', collection: 'jobs', id: job.id, record: job, label: job.role },
+        { type: 'resume', collection: 'resumes', id: resume.id, record: resume, label: resume.label },
+        { type: 'answer', collection: 'answers', id: answer.key, record: answer, label: answer.question }
+    ];
+    const path = (fixture, action) => `/api/${fixture.collection}/${encodeURIComponent(fixture.id)}/${action}`;
+    for (const fixture of fixtures) await api(path(fixture, 'trash'), { expectedRevision: fixture.record.revision });
+    const navigation = page.getByRole('navigation', { name: 'Workspace sections' });
+    await navigation.getByRole('button', { name: 'Trash', exact: true }).click();
+    const workspace = page.locator('.trash-workspace');
+    const refresh = page.getByRole('button', { name: 'Refresh Trash', exact: true });
+    await workspace.getByText('1 jobs · 1 resumes · 1 answers', { exact: true }).waitFor();
+    assert.doesNotMatch(await workspace.innerText(), /PRIVATE-TRASH|react-trash-private|private-fixture/);
+    for (const width of [390, 1280]) {
+        await page.setViewportSize({ width, height: 844 });
+        assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1), true);
+    }
+    const filter = workspace.getByLabel('Record type');
+    const card = fixture => workspace.locator('.trash-card').filter({ has: page.getByRole('heading', { name: fixture.label, exact: true }) });
+    const modal = page.getByRole('dialog');
+    async function reload() {
+        const response = page.waitForResponse(response => new URL(response.url()).pathname === '/api/trash');
+        await refresh.click();
+        await response;
+        await page.waitForFunction(() => !document.getElementById('trash-refresh').disabled);
+    }
+    for (const fixture of fixtures) {
+        await filter.selectOption(fixture.type);
+        assert.equal(await workspace.locator('.trash-card').count(), 1);
+        await card(fixture).getByRole('button', { name: 'Restore', exact: true }).click();
+        await modal.getByRole('button', { name: 'Cancel', exact: true }).focus();
+        await page.keyboard.press('Escape');
+        await modal.waitFor({ state: 'hidden' });
+        assert.equal(await card(fixture).getByRole('button', { name: 'Restore', exact: true }).evaluate(el => el === document.activeElement), true);
+        await card(fixture).getByRole('button', { name: 'Restore', exact: true }).click();
+        await modal.getByRole('button', { name: 'Restore', exact: true }).click();
+        await card(fixture).waitFor({ state: 'hidden' });
+        const restored = await api(`/api/${fixture.collection}/${encodeURIComponent(fixture.id)}`);
+        assert.equal(restored.deletedAt, null);
+        await api(path(fixture, 'trash'), { expectedRevision: restored.revision });
+        await reload();
+    }
+    const target = fixtures[0];
+    await filter.selectOption('job');
+    // A storage error can follow a committed change. Require reconciliation, never replay.
+    let uncertainWrites = 0;
+    await page.route(`**${path(target, 'restore')}`, async route => {
+        ++uncertainWrites;
+        const response = await route.fetch();
+        assert.equal(response.status(), 200);
+        await route.fulfill({ status: 500, contentType: 'application/json', body: '{"error":{"code":"storage_error"}}' });
+    });
+    await card(target).getByRole('button', { name: 'Restore', exact: true }).click();
+    await modal.getByRole('button', { name: 'Restore', exact: true }).click();
+    await workspace.getByRole('alert').filter({ hasText: 'could not be confirmed' }).waitFor();
+    assert.equal(uncertainWrites, 1);
+    assert.equal(await card(target).getByRole('button', { name: 'Restore', exact: true }).isDisabled(), true);
+    await page.unroute(`**${path(target, 'restore')}`);
+    await reload();
+    await card(target).waitFor({ state: 'hidden' });
+    const uncertainRestored = await api(`/api/jobs/${encodeURIComponent(target.id)}`);
+    assert.equal(uncertainRestored.deletedAt, null);
+    await api(path(target, 'trash'), { expectedRevision: uncertainRestored.revision });
+    await reload();
+    await card(target).getByRole('button', { name: 'Delete permanently…', exact: true }).click();
+    const confirm = modal.getByRole('button', { name: 'Delete permanently', exact: true });
+    await page.setViewportSize({ width: 390, height: 844 });
+    assert.equal(await modal.evaluate(element => element.getBoundingClientRect().right <= innerWidth), true);
+    await page.keyboard.press('Tab');
+    assert.equal(await modal.evaluate(element => element.contains(document.activeElement)), true);
+    assert.equal(await confirm.isDisabled(), true);
+    await modal.getByLabel(/Type DELETE JOB/).fill('delete job');
+    assert.equal(await confirm.isDisabled(), true);
+    await modal.getByRole('button', { name: 'Cancel', exact: true }).click();
+    // Another writer changes the exact revision after the list was read.
+    const current = (await api('/api/trash')).items.find(item => item.id === target.id);
+    const restored = await api(path(target, 'restore'), { expectedRevision: current.revision });
+    await api(path(target, 'trash'), { expectedRevision: restored.revision });
+    let writes = 0;
+    const countWrites = request => { if (request.method() === 'POST' && new URL(request.url()).pathname === path(target, 'delete')) ++writes; };
+    page.on('request', countWrites);
+    await card(target).getByRole('button', { name: 'Delete permanently…', exact: true }).click();
+    await modal.getByLabel(/Type DELETE JOB/).fill('DELETE JOB');
+    await confirm.click();
+    await workspace.getByRole('alert').filter({ hasText: 'changed elsewhere' }).waitFor();
+    assert.equal(writes, 1);
+    assert.equal(await card(target).getByRole('button', { name: 'Restore', exact: true }).isDisabled(), true);
+    await reload();
+    // Synthetic redacted reference envelope: no replay, no incidental message exposure.
+    await page.route(`**${path(target, 'delete')}`, route => route.fulfill({ status: 409, contentType: 'application/json', body: JSON.stringify({ error: { code: 'history_reference_blocked', counts: { history: 1 }, message: 'PRIVATE-SERVER-PATH' } }) }));
+    await card(target).getByRole('button', { name: 'Delete permanently…', exact: true }).click();
+    await modal.getByLabel(/Type DELETE JOB/).fill('DELETE JOB');
+    await confirm.click();
+    await workspace.getByRole('alert').filter({ hasText: '1 protected reference' }).waitFor();
+    assert.doesNotMatch(await workspace.innerText(), /PRIVATE-SERVER-PATH/);
+    await page.unroute(`**${path(target, 'delete')}`);
+    await reload();
+    // Real deletion succeeds, then an injected refresh failure cannot invite replay.
+    await card(target).getByRole('button', { name: 'Delete permanently…', exact: true }).click();
+    await modal.getByLabel(/Type DELETE JOB/).fill('DELETE JOB');
+    await page.route('**/api/trash', route => route.fulfill({ status: 503, body: '{}' }));
+    await confirm.click();
+    await workspace.getByRole('alert').filter({ hasText: 'could not be refreshed' }).waitFor();
+    await workspace.getByRole('status').filter({ hasText: 'The change was saved' }).waitFor();
+    assert.equal(await card(target).getByRole('button', { name: 'Delete permanently…', exact: true }).isDisabled(), true);
+    await page.unroute('**/api/trash');
+    await reload();
+    assert.equal((await api('/api/trash')).items.some(item => item.id === target.id), false);
+    page.off('request', countWrites);
+    for (const fixture of fixtures.slice(1)) {
+        await filter.selectOption(fixture.type);
+        await card(fixture).getByRole('button', { name: 'Delete permanently…', exact: true }).click();
+        if (fixture.type === 'resume') assert.match(await modal.innerText(), /managed resume file/);
+        await modal.getByLabel(new RegExp(`Type DELETE ${fixture.type.toUpperCase()}`)).fill(`DELETE ${fixture.type.toUpperCase()}`);
+        await confirm.click();
+        await card(fixture).waitFor({ state: 'hidden' });
+    }
+    await filter.selectOption('');
+    await workspace.getByText('Trash is empty.', { exact: true }).waitFor();
+    for (const width of [390, 1280]) {
+        await page.setViewportSize({ width, height: 844 });
+        assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1), true);
+    }
+    // Capability and failed-first-load UI checks use only intercepted synthetic projections.
+    await page.route('**/api/boot', route => route.fulfill({ status: 200, contentType: 'application/json', body: '{"status":"ready","mode":"native-jobs-fixture"}' }));
+    let firstLoad = true;
+    await page.route('**/api/trash', route => {
+        if (firstLoad) { firstLoad = false; return route.fulfill({ status: 503, body: '{}' }); }
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({
+            items: fixtures.map(fixture => ({ type: fixture.type, id: fixture.id, label: fixture.label,
+                revision: 2, deletedAt: '2026-09-11T00:00:00Z', blockerCounts: {} })),
+            total: 3, counts: { job: 1, resume: 1, answer: 1 }
+        }) });
+    });
+    await page.reload({ waitUntil: 'networkidle' });
+    await navigation.getByRole('button', { name: 'Trash', exact: true }).click();
+    await workspace.getByRole('alert').waitFor();
+    assert.equal(await workspace.getByText('Trash is empty.', { exact: true }).count(), 0);
+    await reload();
+    for (const fixture of fixtures) {
+        const actions = card(fixture).getByRole('button');
+        assert.equal(await actions.nth(0).isDisabled(), fixture.type === 'resume');
+        assert.equal(await actions.nth(1).isDisabled(), fixture.type === 'resume');
+    }
+    await page.setViewportSize({ width: 390, height: 844 });
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1), true);
+    await page.unroute('**/api/boot');
+    await page.unroute('**/api/trash');
+    return { compatibilityRestoreAndDeleteAllTypes: true, exactTypedConfirmation: true, conflictNoRetry: true,
+        referencePrivacy: true, savedButRefreshFailed: true, keyboardFocus: true, nativeUnsupportedActionsDisabled: true, failedLoadNotEmpty: true, errorAfterCommitReconciled: true, layouts: [390, 1280] };
+}

--- a/tests_js/workspace_react_trash_native_browser_support.mjs
+++ b/tests_js/workspace_react_trash_native_browser_support.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readFile, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// Requires the integrated native job/answer lifecycle backend and React Trash wiring.
+// The caller owns the disposable fixture, production browser and service cleanup.
+export async function nativeReactTrashBrowser(page, root, fixture, buildRoot) {
+    const execute = promisify(execFile);
+    const suffix = randomUUID();
+    const input = join(fixture.root, `react-trash-native-${suffix}.json`);
+    async function cli(command, args = [], payload) {
+        if (payload !== undefined) {
+            await writeFile(input, JSON.stringify(payload), { mode: 0o600 });
+            args = [...args, '--input', input];
+        }
+        const result = await execute(process.execPath, [join(buildRoot, 'runtime/cli/native-jobs.js'),
+            '--root', root, '--native-lock', fixture.receipt.artifact, command, ...args], { env: { PATH: '' } });
+        assert.equal(result.stderr, '');
+        return JSON.parse(result.stdout);
+    }
+    const workspace = page.locator('.trash-workspace');
+    const navigation = page.getByRole('navigation', { name: 'Workspace sections' });
+    const refresh = page.getByRole('button', { name: 'Refresh Trash', exact: true });
+    const filter = workspace.getByLabel('Record type');
+    const modal = page.getByRole('dialog');
+    const card = record => workspace.locator('.trash-card').filter({
+        has: page.getByRole('heading', { name: record.label, exact: true })
+    });
+    const idle = () => page.waitForFunction(() => {
+        const refresh = document.getElementById('trash-refresh');
+        return refresh && !refresh.disabled;
+    });
+    async function reload() {
+        const response = page.waitForResponse(response => new URL(response.url()).pathname === '/api/trash' && response.ok());
+        await refresh.click();
+        await response;
+        await idle();
+    }
+    const revisions = record => ['--' + (record.type === 'answer' ? 'key' : 'id'), record.id,
+        '--expected-revision', String(record.revision)];
+    async function get(record) {
+        return cli(`${record.type}-get`, ['--' + (record.type === 'answer' ? 'key' : 'id'), record.id, '--include-trashed']);
+    }
+    const observedWrites = [];
+    const observe = request => {
+        if (request.method() === 'POST' && /\/(restore|delete)$/.test(new URL(request.url()).pathname)) {
+            observedWrites.push({ pathname: new URL(request.url()).pathname, body: request.postData() });
+        }
+    };
+    page.on('request', observe);
+    try {
+        const before = await cli('trash-list');
+        const job = await cli('job-create', [], {
+            role: `Native React Trash job ${suffix}`, company: 'Synthetic Trash company',
+            url: `https://example.invalid/react-trash-${suffix}?private=PRIVATE-NATIVE-TRASH-URL`,
+            notes: 'PRIVATE-NATIVE-TRASH-NOTES'
+        });
+        const key = `react-trash-回答-🧭-${suffix}`;
+        const answer = await cli('answer-put', [], {
+            key, question: `Native React Trash answer ${suffix}?`, state: 'confirmed',
+            value: 'PRIVATE-NATIVE-TRASH-ANSWER'
+        });
+        assert.equal(answer.key, key);
+        const records = [
+            { type: 'job', id: job.id, label: job.role, revision: job.revision },
+            { type: 'answer', id: key, label: answer.question, revision: answer.revision }
+        ];
+        for (const dotKey of ['.', '..']) {
+            const dot = await cli('answer-put', [], { key: dotKey,
+                question: `Native ${dotKey === '.' ? 'single' : 'double'} dot key ${suffix}?`, state: 'confirmed', value: 'PRIVATE-NATIVE-TRASH-ANSWER' });
+            records.push({ type:'answer', id:dot.key, label:dot.question, revision:dot.revision });
+        }
+        for (const record of records) {
+            const trashed = await cli(`${record.type}-trash`, revisions(record));
+            assert.equal(trashed.revision, record.revision + 1);
+            record.revision = trashed.revision;
+        }
+        await navigation.getByRole('button', { name: 'Trash', exact: true }).click();
+        await idle();
+        await reload();
+        await workspace.getByText('Some lifecycle actions are not available in this workspace. Only supported actions are enabled.', { exact: true }).waitFor();
+        assert.doesNotMatch(await workspace.innerText(), /PRIVATE-NATIVE-TRASH/);
+        const listing = await cli('trash-list');
+        assert.equal(listing.items.find(item => item.type === 'answer' && item.id === key)?.label, answer.question);
+        assert.doesNotMatch(JSON.stringify(listing), /PRIVATE-NATIVE-TRASH/);
+
+        // No unsupported resume mutation or direct fixture file edits are needed.
+        await filter.selectOption('resume');
+        const resumeCards = workspace.locator('.trash-card');
+        const existingResumeCount = await resumeCards.count();
+        for (let index = 0; index < existingResumeCount; index += 1) {
+            const buttons = resumeCards.nth(index).getByRole('button');
+            assert.equal(await buttons.nth(0).isDisabled(), true);
+            assert.equal(await buttons.nth(1).isDisabled(), true);
+        }
+        for (const record of records) {
+            await filter.selectOption(record.type);
+            await card(record).getByRole('button', { name: 'Restore', exact: true }).click();
+            const writeCount = observedWrites.length;
+            await modal.getByRole('button', { name: 'Restore', exact: true }).click();
+            await card(record).waitFor({ state: 'hidden' });
+            await idle();
+            assert.equal(observedWrites.length, writeCount + 1);
+            assert.equal(observedWrites.at(-1).body, `{"expectedRevision":${record.revision}}`);
+            if (record.type === 'answer') {
+                const rawPath = `/api/answers/${encodeURIComponent(record.id)}/restore`;
+                const byKeyPath = `/api/answers/by-key/${Buffer.from(record.id, 'utf8').toString('base64url')}/restore`;
+                assert.ok([rawPath, byKeyPath].includes(observedWrites.at(-1).pathname), 'restore must address the exact Unicode answer key');
+                const canonical = JSON.parse(await readFile(join(root, 'answers.json'), 'utf8')).answers;
+                assert.equal(canonical[record.id].value, 'PRIVATE-NATIVE-TRASH-ANSWER');
+                assert.equal(canonical[record.id].deletedAt, null);
+            }
+            const restored = await get(record);
+            assert.equal(restored.deletedAt, null);
+            assert.equal(restored.revision, record.revision + 1);
+            record.revision = restored.revision;
+            const trashed = await cli(`${record.type}-trash`, revisions(record));
+            record.revision = trashed.revision;
+            await reload();
+
+            // An external lifecycle change invalidates the displayed exact revision.
+            const concurrentRestore = await cli(`${record.type}-restore`, revisions(record));
+            const concurrentTrash = await cli(`${record.type}-trash`, revisions({ ...record, revision: concurrentRestore.revision }));
+            await card(record).getByRole('button', { name: 'Delete permanently…', exact: true }).click();
+            const confirm = modal.getByRole('button', { name: 'Delete permanently', exact: true });
+            assert.equal(await confirm.isDisabled(), true);
+            const phrase = `DELETE ${record.type.toUpperCase()}`;
+            await modal.getByLabel(new RegExp(`Type ${phrase}`)).fill(phrase.toLowerCase());
+            assert.equal(await confirm.isDisabled(), true);
+            await modal.getByLabel(new RegExp(`Type ${phrase}`)).fill(phrase);
+            const failedCount = observedWrites.length;
+            await confirm.click();
+            await workspace.getByRole('alert').filter({ hasText: 'changed elsewhere' }).waitFor();
+            await idle();
+            assert.equal(observedWrites.length, failedCount + 1);
+            assert.equal(observedWrites.at(-1).body, `{"expectedRevision":${record.revision}}`);
+            assert.doesNotMatch(await workspace.innerText(), /PRIVATE-NATIVE-TRASH/);
+            assert.equal(await card(record).getByRole('button', { name: 'Restore', exact: true }).isDisabled(), true);
+            assert.equal((await get(record)).revision, concurrentTrash.revision);
+            record.revision = concurrentTrash.revision;
+            await reload();
+            await card(record).getByRole('button', { name: 'Delete permanently…', exact: true }).click();
+            await modal.getByLabel(new RegExp(`Type ${phrase}`)).fill(phrase);
+            const deletedCount = observedWrites.length;
+            await confirm.click();
+            await card(record).waitFor({ state: 'hidden' });
+            await idle();
+            assert.equal(observedWrites.length, deletedCount + 1);
+            assert.equal(observedWrites.at(-1).body, `{"expectedRevision":${record.revision}}`);
+            assert.equal(await get(record), null);
+        }
+        assert.deepEqual(await cli('trash-list'), before);
+        return { nativeJobRestoreDelete: true, nativeAnswerRestoreDelete: true,
+            exactUnicodeAnswerIdentity: true, dotSegmentAnswerIdentity: true, typedDeletionBothTypes: true,
+            staleRevisionRejectedWithoutRetry: true, canonicalRecordsDeleted: true,
+            errorAndListPrivacy: true, unrelatedTrashPreserved: true,
+            resumeLimitationCopy: true, existingResumeCardsChecked: existingResumeCount,
+            pythonAbsentFromCliPath: true };
+    } finally {
+        page.off('request', observe);
+        await rm(input, { force: true });
+    }
+}


### PR DESCRIPTION
Adds a React Trash tab with type filters, guarded restore, and typed permanent-delete confirmation. Successful changes refresh canonical records; conflicts and uncertain failures require an explicit refresh before another mutation. Native mode enables supported job and answer actions and explains the resume limitation.

Answer actions use the existing base64url identity route, including keys `.` and `..`. Trash displays redacted fields and advisory reference counts, preserves navigation guards, and restores dialog focus.

Validation: five independent review roles; accepted answer-key routing defect fixed and covered by unit and native browser regressions. Five focused tests, typecheck, source-size and matrix checks passed. Production compatibility and native browser walkthroughs passed, including narrow layouts, stale revisions, typed deletion, privacy and recovery states. Normal commit checks and all 27 deep/push suites passed. Exact-head Validate (34651121158) and Release (34651123289) both passed for f7a5a755699405c5cf6a91d4f430cf2405677d10.

The first deep run caught a missing Trash catalog in the browser-security test inventory; that integration was corrected and the targeted security check passed. Native `codex review` could not run because the installed CLI does not support its configured model; independent reviews completed. This remains synthetic migration work; Python remains the installed default writer.

A later deep run failed in the existing compatibility browser CRUD check (new job not visible to CLI). That test passed on the unchanged commit in a clean snapshot, and the unchanged full deep retry passed. Cause remains unconfirmed; logs retained.
