### PR TITLE
Add native automation settings and employer account registry

### DIFF
--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -330,6 +330,10 @@
       "sha256": "e0a72c236f94a774feb2f1a9c14d423342beee9668a28f2bb295cd86a6ef06a6"
     },
     {
+      "path": "source-catalog-native-automation.json",
+      "sha256": "5aa53af7ed281784e01b17133d13099330543af6e04b3784c96a2726b80c108e"
+    },
+    {
       "path": "source-catalog-native-claims.json",
       "sha256": "4e6cf635ff0237706cdfa8b0a8cc01210382ca8df322e77b817c6619cc38e2af"
     },
@@ -359,7 +363,7 @@
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "0c1b711663c8a24298e9fd05bb3e1a403885dd2da7a2adbf022eb735a8854521"
+      "sha256": "544d544a43e69ff918009ce0ba1a1a1675d604606517e6b1e0ec9241a6c6f95e"
     },
     {
       "path": "source-catalog-native-legacy-jobs.json",

--- a/config/migration/source-catalog-native-automation.json
+++ b/config/migration/source-catalog-native-automation.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "runtime/contracts/workspace/account-realm.js",
+      "sha256": "d59c1087479878c8962ff0b592d5d158003efe89f88d54659e307f66d2a3ddfb",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/accounts.js",
+      "sha256": "a70974ecc52a434c61d2849239057b452285c81befb5e878e37c72e2d8c2dea9",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/automation.js",
+      "sha256": "53f11bceb4e8ec57d2074e477a0b66ac14d63f5e10d1334f5875ec31ba5f6174",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/store/native-automation.js",
+      "sha256": "f538ee8ab5f4d9d1478d8a66086cc805cdba979f5feca98ddbc628306c107f1f",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/accounts.js",
+      "sha256": "d4990182aa9360cb9af8b83051bc36db31009b71e57073ffda9465ca191ef198",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/automation-http.js",
+      "sha256": "dcc1e8d3dffe6b66e2f8f25c5985bfbca716cec6ab7d28acdc868f35caaf7778",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/automation.js",
+      "sha256": "566c7ca083e382ee15796f08e8d4df2b0f55ea673f653c5cd82f531bef88bc82",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/account-realm.ts",
+      "sha256": "a0aab845050ac2b2acb33cd82066ca8109890bfe1023b9b0a60a3d4a32f581b5",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/accounts.ts",
+      "sha256": "958d1c2b206b1d2fc8b22fd876988cb68c45d4e85915f4d1cee3c2093cda24b6",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/automation.ts",
+      "sha256": "62da4e021fa22afdd82c46418d10f8e55fcfe6e38c4ff6c22af80ff84a79ed34",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/store/native-automation.ts",
+      "sha256": "fdc37088cd5af2340a0333054501dd19bbb453c190fe5feea9a9d2b00382cb04",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/accounts.ts",
+      "sha256": "1cb1d368c9ead3665b10278c63b72432f225f37c7a69c78cd0e9ad9cfee35ff0",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/automation-http.ts",
+      "sha256": "869897aa8465f6fe12754ce0f7b4dd32a87bd6551357743dbba2e79db78d994d",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/automation.ts",
+      "sha256": "9fe2298661c1ce0e1797fdd12cd567256c59e1be543d53db796706f541ce3ca0",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "03c9260afb05df584e722ef45accc92590ac93cb73885645a10ce5895a00da68",
+      "sha256": "3713c1b93bbf2557da1c10e0bbf6d89d7f0ba199f79eeb359b4a8a66b18910f1",
       "classification": "unreviewed"
     },
     {
@@ -43,7 +43,7 @@
     },
     {
       "path": "runtime/workspace-core/jobs-http.js",
-      "sha256": "9e76710e263f639acdb7e04b6fbf272d100f0d80dc1afc7a25ae74eee76fee37",
+      "sha256": "7c0f309c154eaf86f714e14c608714fff763ae3a2bd38b1a54dbad2eb71517f1",
       "classification": "unreviewed"
     },
     {
@@ -83,7 +83,7 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "4beac6cb5f0030e0bd8cf200b24ed9a6700f087ea8091b9d5c71e9b84f272902",
+      "sha256": "f638c44b92259a1513601d8ba3b705a5101e30212d55efd20a97a7889b35dc14",
       "classification": "unreviewed"
     },
     {
@@ -93,7 +93,7 @@
     },
     {
       "path": "src/workspace-core/jobs-http.ts",
-      "sha256": "f31621e8c14b599722d5137f1d9e83dc804dbe914318ee3c82d87860806647a1",
+      "sha256": "58514a47de8affe6441e52f56474f93d5a7b5a7f8d4a189662672e306f71b091",
       "classification": "unreviewed"
     },
     {

--- a/docs/native-automation-fixture.md
+++ b/docs/native-automation-fixture.md
@@ -1,0 +1,108 @@
+# Native automation and employer-account control plane
+
+This tranche supplies native settings, realm resolution, and employer-account
+registry services for explicit synthetic fixtures. It does not activate a Store
+writer, initialize an existing Store, inspect a browser, call credentials, or
+run an account executor. New fixtures use version 10 and require both account
+documents. Existing version 9 roots are rejected rather than upgraded or adopted;
+earlier fixture documents describe their historical version. Missing documents
+and unsupported account-operation or trusted-fill journals remain rejected.
+
+## Composition and persistence
+
+`src/store/native-automation.ts` exports `initialAutomationDocuments(now)` and
+`createAutomationRepository(locked)`. The former returns Python-shaped initial
+`automation-settings` and `employer-accounts` documents. Call it only while
+creating a new fixture, before the readiness marker is written.
+
+The repository factory accepts a callback that supplies `read(name)` and
+`write(name, document)` inside the existing validated root and exclusive Store
+lock. `NativeJobsRepository.automationTransaction` supplies private owned regular-file
+checks, no links, point-JSON parsing, schema checking, atomic persistence, and
+fixture readiness under the existing lock and recovery boundary.
+Domain reads are lazy. Settings methods request only settings; account methods
+request only accounts. The shared fixture transaction still validates and may
+recover existing resume/session state before invoking the domain callback; this
+is the synthetic fixture policy, not general Python Store adoption parity. Profile email copy loads the canonical profile first, checks its
+revision, then checks settings revision and email. No read initializes or repairs
+missing documents. Save callbacks validate and write only their named document.
+
+`AutomationService` implements get, update, and profile email copy. Settings
+patches use exactly the Python fields and increment the revision even for an
+unchanged value. Profile copy always conceals the copied identity, including its
+internal `{copied, revision}` response. `AccountsService` implements resolve,
+list, get, create, and email-override update. Account records preserve the legacy
+shape and provider/lifecycle constraints. Registry creation does not provision a
+credential. Public projections omit email, descriptor, provider ID and credential
+reference, retaining the Python revision and configured/assigned flags.
+
+The realm resolver retains Python URL identity rather than WHATWG rewriting:
+Workday tenant host and cell, Oracle tenant host and career site. Unsupported
+hosts, ambiguous gateways, userinfo, fragments and credential query parameters
+remain unresolved with fixed reason codes. It performs no external lookup.
+
+## HTTP boundary
+
+`automationHttp(repository, method, path, body)` supports these Python routes:
+
+- POST `/api/automation/realm-resolve`
+- PATCH `/api/automation/settings`
+- POST `/api/automation/settings/copy-profile-email`
+- POST `/api/employer-accounts`
+- GET/PATCH `/api/employer-accounts/{realmRef}`
+
+It returns a response or null for an unowned route. The composing HTTP boundary
+retains the existing safe request/storage error envelope and revision-conflict
+status mapping through `jobsHttp`. All mutation/detail responses use public projections. The Python
+GET `/api/automation` aggregate also includes provider capability discovery;
+that endpoint is deferred until its truthful native capability contract is
+integrated. There are no invented settings-list or account-list GET endpoints.
+
+## Follow-on dependency map
+
+Python authorities remain read-only:
+`scripts/job_apply_store/domains/accounts/{settings,registry,trusted_fill,synthetic,operations}.py`,
+`scripts/job_apply_store/validation/accounts.py`, `scripts/job_apply_accounts.py`
+and `scripts/job_apply_trusted_fill.py`.
+
+Trusted-fill approval needs a live claimed in-progress job, proven realm,
+managed-resume identity/content revision and preflight observation, canonical
+profile revision, accepted answer bindings, settings/account revisions, policy
+revision, and time/expiry. Approval/revocation persists `trusted-fill.json` with
+approval revisions. Evaluation may perform an attention handoff through the
+coordinator journal, session and application history. It is not a read-only
+boolean permission check. These dependencies need a shared transaction boundary
+before approve/evaluate/revoke routes can be implemented.
+
+Synthetic execution binds job/claim/settings/account revisions and target URL
+fingerprint. The password-backed Python path writes `prepared` before invoking
+the executor; credential provisioning and portal observation can occur before
+the later journal stages are persisted. Each account-stage helper writes the
+account document before its corresponding journal update. The email-only path
+records `signup_in_progress` before its provider call. Follow-on crash-point
+tests must cover these distinct windows. Work must use injected synthetic executors only, with
+separate credentials/account-flow providers; never a real account helper.
+
+Account-operation recovery marks a stranded account ambiguous, increments its
+revision when needed, requires an available job and live same-job claim for an
+in-progress job, performs an attention handoff or accepts an already needs-info
+job, then clears the matching journal. It never infers signup success and returns
+`retryAllowed: false`. The current tranche rejects those journals at the root
+boundary and exposes none of these unsupported routes.
+
+## Focused evidence and remaining integration gates
+
+`tests_js/workspace_native_automation.test.mjs` compares an independent disposable
+Python Store with native atomic document persistence, including revision conflicts,
+email replacement, registry creation/update/list/get, failed-write stability and
+public redaction. Additional tests cover lazy reads and exact HTTP payloads.
+`tests_js/workspace_native_accounts.test.mjs` compares realm edge cases and account
+validation/public projections with the Python authorities. No credentials or
+live data are used. The integrated fixture suite exercises the real native
+repository and HTTP dispatcher, concurrent Python-free writers, private files,
+old-root/missing-document/journal rejection, and unrelated-document preservation.
+
+Typecheck and owned runtime emission are required. The integration owner also
+owns source/runtime catalogs, test matrix, HTTP wiring, fixture marker/allowlist,
+normal commit/push hooks and broader acceptance. Worker readiness is not final
+native activation or migration acceptance.

--- a/runtime/contracts/workspace/account-realm.js
+++ b/runtime/contracts/workspace/account-realm.js
@@ -1,0 +1,64 @@
+import { createHash } from 'node:crypto';
+import { isIP } from 'node:net';
+import { strip } from './job-url.js';
+export const passwordFlow = 'password_candidate_account';
+export const emailFlow = 'email_only_candidate_profile';
+const unresolved = (reasonCode) => ({ status: 'unresolved', reasonCode });
+const credentialKey = /(?:^|[_-])(?:access[_-]?token|auth|authorization|cookie|credential|passcode|password|recovery|secret|session|token)(?:$|[_-])/i;
+const oracleHost = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.fa\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.oraclecloud\.com$/;
+const oraclePath = /^\/hcmUI\/CandidateExperience\/[a-z]{2}(?:-[A-Z]{2})?\/sites\/([a-z0-9](?:[a-z0-9_-]{0,62}[a-z0-9])?)\/job\/[1-9][0-9]*(?:\/apply\/email)?\/?$/;
+function resolved(adapterId, descriptor, authorityKind) {
+    return { status: 'resolved', adapterId, descriptorVersion: 1, descriptor,
+        realmRef: createHash('sha256').update(descriptor).digest('hex'), authorityKind,
+        flowKind: adapterId === 'workday' ? passwordFlow : emailFlow, credentialRequired: adapterId === 'workday' };
+}
+/** Keep Python urlsplit identity: no WHATWG dot-path, percent or IDNA rewriting. */
+export function resolveAccountRealm(input) {
+    if (typeof input !== 'string' || !strip(input))
+        return unresolved('portal_url_required');
+    const value = strip(input).replace(/^[\x00-\x20]+/, '').replace(/[\t\r\n]/g, '');
+    const parsed = /^(?:([a-z][a-z0-9+.-]*):)?\/\/([^/?#]*)([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/is.exec(value);
+    if (!parsed)
+        return unresolved('portal_not_proven');
+    const authority = parsed[2], hostPort = authority.slice(authority.lastIndexOf('@') + 1);
+    if (/[/?#@:]/.test(authority.replace(/[@:#?]/g, '').normalize('NFKC')))
+        return unresolved('portal_url_invalid');
+    let host, port;
+    if (hostPort.includes('[') || hostPort.includes(']')) {
+        const bracket = /^\[([^\]]+)\](?::(.*))?$/.exec(hostPort);
+        if (!bracket || !(isIP(bracket[1]) === 6 || /^v[\da-f]+\..+$/i.test(bracket[1])))
+            return unresolved('portal_url_invalid');
+        host = bracket[1];
+        port = bracket[2];
+    }
+    else {
+        const colon = hostPort.indexOf(':');
+        host = colon < 0 ? hostPort : hostPort.slice(0, colon);
+        port = colon < 0 ? undefined : hostPort.slice(colon + 1);
+    }
+    if (host.endsWith('.'))
+        return unresolved('portal_not_proven');
+    if (port && (!/^[0-9]+$/.test(port) || BigInt(port) > 65535n))
+        return unresolved('portal_url_invalid');
+    if ((parsed[1] ?? '').toLowerCase() !== 'https' || !host || port && BigInt(port) !== 443n)
+        return unresolved('portal_not_proven');
+    if (authority.includes('@'))
+        return unresolved('portal_url_userinfo_rejected');
+    if (parsed[5])
+        return unresolved('portal_url_fragment_rejected');
+    if ([...new URLSearchParams(parsed[4] ?? '').keys()].some(key => credentialKey.test(key.replace(/[İı]/g, 'i').replace(/ſ/g, 's').replace(/K/g, 'k'))))
+        return unresolved('portal_url_credential_parameter_rejected');
+    host = host.toLowerCase();
+    const workday = /^([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)\.(wd[1-9][0-9]*)\.myworkdayjobs\.com$/.exec(host);
+    if (workday)
+        return resolved('workday', `workday:v1:${workday[2]}:${workday[1]}`, 'tenant-host');
+    if (/^wd[1-9][0-9]*\.myworkday\.com$/.test(host))
+        return unresolved('ambiguous_auth_gateway');
+    if (oracleHost.test(host)) {
+        const path = parsed[3], match = oraclePath.exec(path);
+        if (parsed[4] || path.includes('%') || path.includes('//') || !match)
+            return unresolved('oracle_recruiting_path_unproven');
+        return resolved('oracle-recruiting', `oracle-recruiting:v1:${host}:${match[1]}`, 'tenant-site');
+    }
+    return unresolved('adapter_unresolved');
+}

--- a/runtime/contracts/workspace/accounts.js
+++ b/runtime/contracts/workspace/accounts.js
@@ -1,0 +1,61 @@
+import { createHash } from 'node:crypto';
+import { fromJSON, get, has, int, object, set, string, same, JobsError } from './values.js';
+import { exact, optionalEmail, revisionAndTime } from './automation.js';
+import { emailFlow, passwordFlow } from './account-realm.js';
+const legacy = ['realmRef', 'adapterId', 'descriptorVersion', 'descriptor', 'signupEmailOverride', 'providerId', 'credentialRef', 'credentialVersion', 'lifecycleState', 'revision', 'createdAt', 'updatedAt'];
+const lifecycles = ['discovered', 'credential_provisioned', 'signup_in_progress', 'active', 'verification_required', 'reset_required', 'failed_definitive', 'ambiguous'];
+export function validateAccount(key, value) {
+    const record = object(value, 'employer account');
+    exact(record, record.size === legacy.length ? legacy : [...legacy, 'flowKind', 'credentialRequired'], 'employer account record is invalid');
+    if (string(get(record, 'realmRef')) !== key)
+        throw new JobsError('employer account record is invalid');
+    if (!/^[0-9a-f]{64}$/.test(key))
+        throw new JobsError('employer account realm reference is invalid');
+    const adapter = string(get(record, 'adapterId')), descriptor = string(get(record, 'descriptor'));
+    const flow = has(record, 'flowKind') ? string(get(record, 'flowKind')) : passwordFlow;
+    const required = has(record, 'credentialRequired') ? get(record, 'credentialRequired') : true;
+    if (!['workday', 'oracle-recruiting'].includes(adapter ?? '') || flow !== (adapter === 'workday' ? passwordFlow : emailFlow)
+        || required !== (adapter === 'workday') || !same(get(record, 'descriptorVersion'), fromJSON(1))
+        || !descriptor?.startsWith(`${adapter}:v1:`) || createHash('sha256').update(descriptor).digest('hex') !== key)
+        throw new JobsError('employer account realm descriptor is invalid');
+    optionalEmail(get(record, 'signupEmailOverride'), 'signup email override');
+    const provider = get(record, 'providerId'), reference = get(record, 'credentialRef'), version = get(record, 'credentialVersion');
+    const lifecycle = string(get(record, 'lifecycleState')) ?? '';
+    if (!lifecycles.includes(lifecycle))
+        throw new JobsError('account lifecycle state is invalid');
+    if (provider === null) {
+        const allowed = flow === emailFlow ? ['discovered', 'signup_in_progress', 'active', 'verification_required', 'failed_definitive', 'ambiguous'] : ['discovered', 'signup_in_progress', 'ambiguous'];
+        if (reference !== null || version !== null || !allowed.includes(lifecycle))
+            throw new JobsError('credential metadata requires the protected provider');
+    }
+    else if (flow === emailFlow)
+        throw new JobsError('email-only account cannot have protected credential metadata');
+    else if (!/^[a-z][a-z0-9-]{2,63}$/.test(string(provider) ?? '') || !/^credential_[0-9a-f]{64}$/.test(string(reference) ?? '') || (int(version) ?? 0n) < 1n || lifecycle === 'discovered')
+        throw new JobsError('protected credential metadata is invalid');
+    revisionAndTime(record, 'employer account');
+    return record;
+}
+export function validateAccountsDocument(value) {
+    const document = object(value, 'employer accounts');
+    if (int(get(document, 'schemaVersion')) !== 1n)
+        throw new JobsError('employer accounts schema version is unsupported');
+    exact(document, ['schemaVersion', 'accounts', 'metadata'], 'employer accounts document contains unsupported fields');
+    const accounts = object(get(document, 'accounts'), 'employer accounts');
+    const metadata = object(get(document, 'metadata'), 'employer account metadata');
+    exact(metadata, ['createdAt', 'updatedAt'], 'employer account metadata is invalid');
+    for (const field of ['createdAt', 'updatedAt'])
+        if (!string(get(metadata, field)))
+            throw new JobsError('employer account metadata timestamp is invalid');
+    for (const [key, record] of accounts.entries())
+        validateAccount(string(key), record);
+    return document;
+}
+export function publicAccount(record) {
+    const result = object(fromJSON({}), 'account projection');
+    for (const field of ['realmRef', 'adapterId', 'descriptorVersion', 'lifecycleState', 'credentialVersion', 'revision', 'createdAt', 'updatedAt'])
+        set(result, field, get(record, field));
+    set(result, 'flowKind', has(record, 'flowKind') ? get(record, 'flowKind') : fromJSON(passwordFlow));
+    set(result, 'credentialRequired', has(record, 'credentialRequired') ? get(record, 'credentialRequired') : true);
+    set(result, 'signupEmailOverrideConfigured', get(record, 'signupEmailOverride') !== null);
+    return set(result, 'providerAssigned', get(record, 'providerId') !== null);
+}

--- a/runtime/contracts/workspace/automation.js
+++ b/runtime/contracts/workspace/automation.js
@@ -1,0 +1,56 @@
+import { copy, fromJSON, get, has, int, keys, object, set, string, text, JobsError } from './values.js';
+import { strip } from './job-url.js';
+export function exact(record, fields, message) {
+    if (record.size !== fields.length || fields.some(field => !has(record, field)))
+        throw new JobsError(message);
+}
+export function optionalEmail(value, label) {
+    if (value === null)
+        return null;
+    const raw = string(value);
+    if (raw === null)
+        throw new JobsError(`${label} must be an email address or null`);
+    const normalized = strip(raw);
+    const whitespace = /[\u0009-\u000d\u001c-\u0020\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]/u;
+    if ([...normalized].length > 254 || whitespace.test(normalized) || !/^[^@]+@[^@]+\.[^@]+$/u.test(normalized)) {
+        throw new JobsError(`${label} must be a valid email address`);
+    }
+    return fromJSON(normalized);
+}
+export function revisionAndTime(record, label) {
+    if ((int(get(record, 'revision')) ?? 0n) < 1n)
+        throw new JobsError(`${label} revision must be a positive integer`);
+    for (const field of ['createdAt', 'updatedAt'])
+        if (!string(get(record, field)))
+            throw new JobsError(`${label} timestamp is invalid`);
+}
+export function validateSettings(value) {
+    const record = object(value, 'automation settings');
+    exact(record, ['enabled', 'automaticAccountCreation', 'signupEmail', 'passwordStrategy', 'revision', 'createdAt', 'updatedAt'], 'automation settings contain unsupported fields');
+    if (typeof get(record, 'enabled') !== 'boolean' || typeof get(record, 'automaticAccountCreation') !== 'boolean')
+        throw new JobsError('automation settings switches must be booleans');
+    optionalEmail(get(record, 'signupEmail'), 'signup email');
+    if (!['unique_per_realm', 'shared', 'custom', 'ask_each_time'].includes(string(get(record, 'passwordStrategy')) ?? ''))
+        throw new JobsError('password strategy is unsupported');
+    revisionAndTime(record, 'automation settings');
+    return record;
+}
+export function validateSettingsDocument(value) {
+    const document = object(value, 'automation settings');
+    if (int(get(document, 'schemaVersion')) !== 1n)
+        throw new JobsError('automation settings schema version is unsupported');
+    exact(document, ['schemaVersion', 'settings'], 'automation settings document contains unsupported fields');
+    validateSettings(get(document, 'settings'));
+    return document;
+}
+export function publicSettings(record) {
+    const result = copy(record);
+    result.delete(text('signupEmail'));
+    return set(result, 'signupEmailConfigured', get(record, 'signupEmail') !== null);
+}
+export function settingsPatch(value) {
+    const patch = object(value, 'automation settings patch');
+    if (!patch.size || keys(patch).some(key => !['enabled', 'automaticAccountCreation', 'signupEmail', 'passwordStrategy'].includes(key)))
+        throw new JobsError('automation settings patch contains unsupported fields');
+    return patch;
+}

--- a/runtime/store/native-automation.js
+++ b/runtime/store/native-automation.js
@@ -1,0 +1,25 @@
+import { fromJSON, object } from '../contracts/workspace/values.js';
+import { validateSettingsDocument } from '../contracts/workspace/automation.js';
+import { validateAccountsDocument } from '../contracts/workspace/accounts.js';
+export function initialAutomationDocuments(now) {
+    return {
+        'automation-settings': object(fromJSON({ schemaVersion: 1, settings: { enabled: false,
+                automaticAccountCreation: false, signupEmail: null, passwordStrategy: 'unique_per_realm',
+                revision: 1, createdAt: now, updatedAt: now } }), 'automation settings'),
+        'employer-accounts': object(fromJSON({ schemaVersion: 1, accounts: {}, metadata: { createdAt: now, updatedAt: now } }), 'employer accounts'),
+    };
+}
+/** No root adoption, implicit initialization, credentials, or recovery execution. */
+export async function automationTransaction(access, operation) {
+    return operation({
+        loadSettings: () => access.read('automation-settings'),
+        loadAccounts: () => access.read('employer-accounts'),
+        loadProfile: () => access.read('profile'),
+        saveSettings: document => access.write('automation-settings', validateSettingsDocument(document)),
+        saveAccounts: document => access.write('employer-accounts', validateAccountsDocument(document)),
+    });
+}
+/** Factory lets the owner supply the existing root/lock boundary unchanged. */
+export function createAutomationRepository(locked) {
+    return { automationTransaction: operation => locked(access => automationTransaction(access, operation)) };
+}

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -1,3 +1,4 @@
+import { initialAutomationDocuments, automationTransaction as runAutomationTransaction } from './native-automation.js';
 import { NativeClaimJournal, claimOperationKinds, validateClaimJournal } from './native-claim-journal.js';
 import { NativeClaimHistory } from './native-claim-history.js';
 import { validateCoordinator, requireJobUnclaimed } from '../contracts/workspace/claims.js';
@@ -22,8 +23,8 @@ import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
 import { validateAnswers } from "../contracts/workspace/answers.js";
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 };
-const marker = '{"mode":"native-jobs-fixture","version":9}\n';
-const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
+const marker = '{"mode":"native-jobs-fixture","version":10}\n';
+const allowed = new Set(["automation-settings.json", "employer-accounts.json", ".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 };
 /** Creates a NEW synthetic root only. Never adopts or initializes an existing Store. */
@@ -55,6 +56,9 @@ export async function initializeJobsFixture(root) {
     await history.close();
     const lock = await open(join(root, ".store.lock"), "wx", 0o600);
     await lock.close();
+    for (const [name, document] of Object.entries(initialAutomationDocuments(now))) {
+        await atomicWritePointJson(join(root, `${name}.json`), document, options);
+    }
     // The readiness marker is written last; partial initialization is never adopted.
     const handle = await open(join(root, ".native-jobs-fixture"), "wx", 0o600);
     try {
@@ -386,6 +390,12 @@ export class NativeJobsRepository {
                     return this.resolutionJournal().commit(value, jobs, sessions);
                 } });
         });
+    }
+    async automationTransaction(operation) {
+        return this.transaction(async () => runAutomationTransaction({
+            read: name => name === 'automation-settings' ? this.journal(name) : this.document(name),
+            write: (name, document) => this.write(join(this.root, `${name}.json`), document, options),
+        }, operation));
     }
     async resumeSummaries() {
         // Reuse the lock and all root checks for projections too.

--- a/runtime/workspace-core/accounts.js
+++ b/runtime/workspace-core/accounts.js
@@ -1,0 +1,71 @@
+import { copy, fromJSON, get, int, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { exact, optionalEmail } from '../contracts/workspace/automation.js';
+import { publicAccount, validateAccount, validateAccountsDocument } from '../contracts/workspace/accounts.js';
+import { resolveAccountRealm } from '../contracts/workspace/account-realm.js';
+import { cloneDocument } from './automation.js';
+export class AccountsService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    resolve(url) { return fromJSON(resolveAccountRealm(url)); }
+    list(publicView = false) {
+        return this.repository.automationTransaction(async (tx) => {
+            const accounts = object(get(validateAccountsDocument(await tx.loadAccounts()), 'accounts'), 'employer accounts');
+            return [...accounts.entries()].sort(([a], [b]) => string(a) < string(b) ? -1 : 1)
+                .map(([, value]) => this.project(object(value, 'employer account'), publicView));
+        });
+    }
+    get(realmRef, publicView = false) {
+        return this.repository.automationTransaction(async (tx) => {
+            const value = get(object(get(validateAccountsDocument(await tx.loadAccounts()), 'accounts'), 'employer accounts'), realmRef);
+            return value === null ? null : this.project(object(value, 'employer account'), publicView);
+        });
+    }
+    create(url, email = null, publicView = false) {
+        const realm = resolveAccountRealm(url);
+        if (realm.status !== 'resolved')
+            throw new JobsError('employer account realm is unresolved');
+        const override = optionalEmail(email, 'signup email override');
+        return this.repository.automationTransaction(async (tx) => {
+            const document = validateAccountsDocument(await tx.loadAccounts()), accounts = object(get(document, 'accounts'), 'employer accounts');
+            if (get(accounts, realm.realmRef) !== null)
+                throw new JobsError('employer account already exists');
+            const now = this.now();
+            const record = object(fromJSON({ realmRef: realm.realmRef, adapterId: realm.adapterId, descriptorVersion: realm.descriptorVersion,
+                descriptor: realm.descriptor, flowKind: realm.flowKind, credentialRequired: realm.credentialRequired,
+                signupEmailOverride: null, providerId: null, credentialRef: null, credentialVersion: null,
+                lifecycleState: 'discovered', revision: 1, createdAt: now, updatedAt: now }), 'employer account');
+            set(record, 'signupEmailOverride', override);
+            await this.save(tx, document, realm.realmRef, record);
+            return this.project(record, publicView);
+        });
+    }
+    update(realmRef, value, revision, publicView = false) {
+        const patch = object(value, 'employer account patch');
+        exact(patch, ['signupEmailOverride'], 'employer account patch may only change signup email override');
+        const override = optionalEmail(get(patch, 'signupEmailOverride'), 'signup email override');
+        return this.repository.automationTransaction(async (tx) => {
+            const document = validateAccountsDocument(await tx.loadAccounts()), value = get(object(get(document, 'accounts'), 'employer accounts'), realmRef);
+            if (value === null)
+                throw new JobsError('employer account does not exist');
+            const current = object(value, 'employer account');
+            if (int(get(current, 'revision')) !== revision)
+                throw new JobsError('employer account revision conflict');
+            const updated = set(copy(current), 'signupEmailOverride', override);
+            set(updated, 'revision', integer(revision + 1n));
+            set(updated, 'updatedAt', text(this.now()));
+            await this.save(tx, document, realmRef, updated);
+            return this.project(updated, publicView);
+        });
+    }
+    project(record, publicView) { return cloneDocument(publicView ? publicAccount(record) : record); }
+    async save(tx, document, realm, record) {
+        validateAccount(realm, record);
+        const accounts = set(copy(object(get(document, 'accounts'), 'employer accounts')), realm, record);
+        const metadata = set(copy(object(get(document, 'metadata'), 'employer account metadata')), 'updatedAt', get(record, 'updatedAt'));
+        await tx.saveAccounts(set(set(copy(document), 'accounts', accounts), 'metadata', metadata));
+    }
+}

--- a/runtime/workspace-core/automation-http.js
+++ b/runtime/workspace-core/automation-http.js
@@ -1,0 +1,53 @@
+import { PythonObject } from '../contracts/python-object.js';
+import { exact } from '../contracts/workspace/automation.js';
+import { get, has, int, keys, object, parse, serialize, string, JobsError } from '../contracts/workspace/values.js';
+import { AutomationService } from './automation.js';
+import { AccountsService } from './accounts.js';
+const response = (value) => ({ status: 200, body: serialize(value) });
+function revision(value, label = 'expectedRevision') {
+    const result = int(value);
+    if (result === null || result < 1n)
+        throw new JobsError(`${label} must be a positive integer`);
+    return result;
+}
+/** Owner handles generic safe request/storage errors using existing HTTP boundary. */
+export async function automationHttp(repository, method, path, body) {
+    const settings = new AutomationService(repository), accounts = new AccountsService(repository);
+    const updateAccount = /^\/api\/employer-accounts\/([^/]+)$/.exec(path);
+    if (method === 'GET' && updateAccount) {
+        const account = await accounts.get(decodeURIComponent(updateAccount[1]), true);
+        if (account === null)
+            throw new JobsError('employer account does not exist');
+        return response(account);
+    }
+    const recognized = method === 'POST' && ['/api/automation/realm-resolve', '/api/automation/settings/copy-profile-email', '/api/employer-accounts'].includes(path)
+        || method === 'PATCH' && (path === '/api/automation/settings' || updateAccount !== null);
+    if (!recognized)
+        return null;
+    const payload = object(parse(body), 'body');
+    if (path === '/api/automation/realm-resolve') {
+        exact(payload, ['url'], 'body must contain only a portal URL');
+        if (string(get(payload, 'url')) === null)
+            throw new JobsError('body must contain only a portal URL');
+        return response(accounts.resolve(string(get(payload, 'url'))));
+    }
+    if (path === '/api/automation/settings/copy-profile-email') {
+        exact(payload, ['expectedProfileRevision', 'expectedSettingsRevision'], 'body must contain exact profile and settings revisions');
+        const values = ['expectedProfileRevision', 'expectedSettingsRevision'].map(key => int(get(payload, key)));
+        if (values.some(value => value === null || value < 1n))
+            throw new JobsError('profile and settings revisions must be positive integers');
+        return response(await settings.copyProfileEmail(values[0], values[1], true));
+    }
+    if (method === 'POST' && path === '/api/employer-accounts') {
+        if (keys(payload).some(key => !['url', 'signupEmailOverride'].includes(key)) || !has(payload, 'url') || string(get(payload, 'url')) === null)
+            throw new JobsError('body must contain a portal URL and optional signup email override');
+        return response(await accounts.create(string(get(payload, 'url')), get(payload, 'signupEmailOverride'), true));
+    }
+    const label = path === '/api/automation/settings' ? 'settings' : 'account';
+    exact(payload, ['patch', 'expectedRevision'], `body must contain a ${label} patch and expectedRevision`);
+    if (!(get(payload, 'patch') instanceof PythonObject))
+        throw new JobsError(`body must contain a ${label} patch and expectedRevision`);
+    const expected = revision(get(payload, 'expectedRevision'));
+    return response(path === '/api/automation/settings' ? await settings.update(get(payload, 'patch'), expected, true)
+        : await accounts.update(decodeURIComponent(updateAccount[1]), get(payload, 'patch'), expected, true));
+}

--- a/runtime/workspace-core/automation.js
+++ b/runtime/workspace-core/automation.js
@@ -1,0 +1,53 @@
+import { validateProfile } from '../contracts/workspace/profile.js';
+import { copy, fromJSON, get, has, int, integer, object, parse, serialize, set, text, JobsError } from '../contracts/workspace/values.js';
+import { optionalEmail, publicSettings, settingsPatch, validateSettings, validateSettingsDocument } from '../contracts/workspace/automation.js';
+export const cloneDocument = (document) => object(parse(serialize(document)), 'document');
+export class AutomationService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    get(publicView = false) {
+        return this.repository.automationTransaction(async (tx) => {
+            const record = object(get(validateSettingsDocument(await tx.loadSettings()), 'settings'), 'automation settings');
+            return cloneDocument(publicView ? publicSettings(record) : record);
+        });
+    }
+    update(value, expectedRevision, publicView = false) {
+        const patch = settingsPatch(value);
+        return this.repository.automationTransaction(async (tx) => this.save(tx, patch, expectedRevision, publicView));
+    }
+    copyProfileEmail(profileRevision, settingsRevision, publicView = true) {
+        return this.repository.automationTransaction(async (tx) => {
+            const profile = validateProfile(await tx.loadProfile());
+            const metadata = object(get(profile, 'metadata'), 'profile metadata');
+            if ((has(metadata, 'revision') ? int(get(metadata, 'revision')) : 1n) !== profileRevision)
+                throw new JobsError('profile revision conflict');
+            const current = object(get(validateSettingsDocument(await tx.loadSettings()), 'settings'), 'automation settings');
+            if (int(get(current, 'revision')) !== settingsRevision)
+                throw new JobsError('automation settings revision conflict');
+            const email = optionalEmail(get(object(get(profile, 'profile'), 'profile'), 'email'), 'profile email');
+            if (email === null)
+                throw new JobsError('canonical profile email is unavailable');
+            const updated = await this.save(tx, set(object(fromJSON({}), 'patch'), 'signupEmail', email), settingsRevision, true);
+            return publicView ? updated : set(object(fromJSON({ copied: true }), 'copy result'), 'revision', get(updated, 'revision'));
+        });
+    }
+    async save(tx, patch, revision, publicView) {
+        const document = validateSettingsDocument(await tx.loadSettings()), current = object(get(document, 'settings'), 'automation settings');
+        if (int(get(current, 'revision')) !== revision)
+            throw new JobsError('automation settings revision conflict');
+        const updated = copy(current);
+        for (const [key, value] of patch.entries())
+            updated.set(key, value);
+        if (has(patch, 'signupEmail'))
+            set(updated, 'signupEmail', optionalEmail(get(patch, 'signupEmail'), 'signup email'));
+        set(updated, 'revision', integer(revision + 1n));
+        set(updated, 'updatedAt', text(this.now()));
+        validateSettings(updated);
+        await tx.saveSettings(set(copy(document), 'settings', updated));
+        return cloneDocument(publicView ? publicSettings(updated) : updated);
+    }
+}

--- a/runtime/workspace-core/jobs-http.js
+++ b/runtime/workspace-core/jobs-http.js
@@ -1,3 +1,4 @@
+import { automationHttp } from './automation-http.js';
 import { answerLifecycleHttp } from './answer-lifecycle-http.js';
 import { trashHttp } from './trash-http.js';
 import { claimsHttp } from './claims-http.js';
@@ -19,6 +20,9 @@ const envelope = (key, value) => set(emptyObject(), key, value);
 /** Transport-independent dispatch. Host/token/Origin/body bounds belong to the adapter. */
 export async function jobsHttp(service, repository, method, path, body = "") {
     try {
+        const automation = await automationHttp(repository, method, path, body);
+        if (automation)
+            return automation;
         const answerLifecycle = await answerLifecycleHttp(repository, method, path, body);
         if (answerLifecycle)
             return answerLifecycle;

--- a/src/contracts/workspace/account-realm.ts
+++ b/src/contracts/workspace/account-realm.ts
@@ -1,0 +1,54 @@
+import { createHash } from 'node:crypto';
+import { isIP } from 'node:net';
+import { strip } from './job-url.js';
+
+export const passwordFlow = 'password_candidate_account';
+export const emailFlow = 'email_only_candidate_profile';
+export type Realm = { status: 'unresolved'; reasonCode: string } | {
+  status: 'resolved'; adapterId: string; descriptorVersion: number; descriptor: string;
+  realmRef: string; authorityKind: string; flowKind: string; credentialRequired: boolean;
+};
+const unresolved = (reasonCode: string): Realm => ({ status: 'unresolved', reasonCode });
+const credentialKey = /(?:^|[_-])(?:access[_-]?token|auth|authorization|cookie|credential|passcode|password|recovery|secret|session|token)(?:$|[_-])/i;
+const oracleHost = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.fa\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.oraclecloud\.com$/;
+const oraclePath = /^\/hcmUI\/CandidateExperience\/[a-z]{2}(?:-[A-Z]{2})?\/sites\/([a-z0-9](?:[a-z0-9_-]{0,62}[a-z0-9])?)\/job\/[1-9][0-9]*(?:\/apply\/email)?\/?$/;
+function resolved(adapterId: string, descriptor: string, authorityKind: string): Realm {
+  return { status: 'resolved', adapterId, descriptorVersion: 1, descriptor,
+    realmRef: createHash('sha256').update(descriptor).digest('hex'), authorityKind,
+    flowKind: adapterId === 'workday' ? passwordFlow : emailFlow, credentialRequired: adapterId === 'workday' };
+}
+/** Keep Python urlsplit identity: no WHATWG dot-path, percent or IDNA rewriting. */
+export function resolveAccountRealm(input: unknown): Realm {
+  if (typeof input !== 'string' || !strip(input)) return unresolved('portal_url_required');
+  const value = strip(input).replace(/^[\x00-\x20]+/, '').replace(/[\t\r\n]/g, '');
+  const parsed = /^(?:([a-z][a-z0-9+.-]*):)?\/\/([^/?#]*)([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/is.exec(value);
+  if (!parsed) return unresolved('portal_not_proven');
+  const authority = parsed[2]!, hostPort = authority.slice(authority.lastIndexOf('@') + 1);
+  if (/[/?#@:]/.test(authority.replace(/[@:#?]/g, '').normalize('NFKC'))) return unresolved('portal_url_invalid');
+  let host: string, port: string | undefined;
+  if (hostPort.includes('[') || hostPort.includes(']')) {
+    const bracket = /^\[([^\]]+)\](?::(.*))?$/.exec(hostPort);
+    if (!bracket || !(isIP(bracket[1]!) === 6 || /^v[\da-f]+\..+$/i.test(bracket[1]!))) return unresolved('portal_url_invalid');
+    host = bracket[1]!; port = bracket[2];
+  } else {
+    const colon = hostPort.indexOf(':');
+    host = colon < 0 ? hostPort : hostPort.slice(0, colon);
+    port = colon < 0 ? undefined : hostPort.slice(colon + 1);
+  }
+  if (host.endsWith('.')) return unresolved('portal_not_proven');
+  if (port && (!/^[0-9]+$/.test(port) || BigInt(port) > 65535n)) return unresolved('portal_url_invalid');
+  if ((parsed[1] ?? '').toLowerCase() !== 'https' || !host || port && BigInt(port) !== 443n) return unresolved('portal_not_proven');
+  if (authority.includes('@')) return unresolved('portal_url_userinfo_rejected');
+  if (parsed[5]) return unresolved('portal_url_fragment_rejected');
+  if ([...new URLSearchParams(parsed[4] ?? '').keys()].some(key => credentialKey.test(key.replace(/[İı]/g, 'i').replace(/ſ/g, 's').replace(/K/g, 'k')))) return unresolved('portal_url_credential_parameter_rejected');
+  host = host.toLowerCase();
+  const workday = /^([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)\.(wd[1-9][0-9]*)\.myworkdayjobs\.com$/.exec(host);
+  if (workday) return resolved('workday', `workday:v1:${workday[2]}:${workday[1]}`, 'tenant-host');
+  if (/^wd[1-9][0-9]*\.myworkday\.com$/.test(host)) return unresolved('ambiguous_auth_gateway');
+  if (oracleHost.test(host)) {
+    const path = parsed[3]!, match = oraclePath.exec(path);
+    if (parsed[4] || path.includes('%') || path.includes('//') || !match) return unresolved('oracle_recruiting_path_unproven');
+    return resolved('oracle-recruiting', `oracle-recruiting:v1:${host}:${match[1]}`, 'tenant-site');
+  }
+  return unresolved('adapter_unresolved');
+}

--- a/src/contracts/workspace/accounts.ts
+++ b/src/contracts/workspace/accounts.ts
@@ -1,0 +1,50 @@
+import { createHash } from 'node:crypto';
+import { fromJSON, get, has, int, object, set, string, same, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+import { exact, optionalEmail, revisionAndTime } from './automation.js';
+import { emailFlow, passwordFlow } from './account-realm.js';
+
+const legacy = ['realmRef', 'adapterId', 'descriptorVersion', 'descriptor', 'signupEmailOverride', 'providerId', 'credentialRef', 'credentialVersion', 'lifecycleState', 'revision', 'createdAt', 'updatedAt'];
+const lifecycles = ['discovered', 'credential_provisioned', 'signup_in_progress', 'active', 'verification_required', 'reset_required', 'failed_definitive', 'ambiguous'];
+export function validateAccount(key: string, value: Value): Document {
+  const record = object(value, 'employer account');
+  exact(record, record.size === legacy.length ? legacy : [...legacy, 'flowKind', 'credentialRequired'], 'employer account record is invalid');
+  if (string(get(record, 'realmRef')) !== key) throw new JobsError('employer account record is invalid');
+  if (!/^[0-9a-f]{64}$/.test(key)) throw new JobsError('employer account realm reference is invalid');
+  const adapter = string(get(record, 'adapterId')), descriptor = string(get(record, 'descriptor'));
+  const flow = has(record, 'flowKind') ? string(get(record, 'flowKind')) : passwordFlow;
+  const required = has(record, 'credentialRequired') ? get(record, 'credentialRequired') : true;
+  if (!['workday', 'oracle-recruiting'].includes(adapter ?? '') || flow !== (adapter === 'workday' ? passwordFlow : emailFlow)
+    || required !== (adapter === 'workday') || !same(get(record, 'descriptorVersion'), fromJSON(1))
+    || !descriptor?.startsWith(`${adapter}:v1:`) || createHash('sha256').update(descriptor).digest('hex') !== key) throw new JobsError('employer account realm descriptor is invalid');
+  optionalEmail(get(record, 'signupEmailOverride'), 'signup email override');
+  const provider = get(record, 'providerId'), reference = get(record, 'credentialRef'), version = get(record, 'credentialVersion');
+  const lifecycle = string(get(record, 'lifecycleState')) ?? '';
+  if (!lifecycles.includes(lifecycle)) throw new JobsError('account lifecycle state is invalid');
+  if (provider === null) {
+    const allowed = flow === emailFlow ? ['discovered', 'signup_in_progress', 'active', 'verification_required', 'failed_definitive', 'ambiguous'] : ['discovered', 'signup_in_progress', 'ambiguous'];
+    if (reference !== null || version !== null || !allowed.includes(lifecycle)) throw new JobsError('credential metadata requires the protected provider');
+  } else if (flow === emailFlow) throw new JobsError('email-only account cannot have protected credential metadata');
+  else if (!/^[a-z][a-z0-9-]{2,63}$/.test(string(provider) ?? '') || !/^credential_[0-9a-f]{64}$/.test(string(reference) ?? '') || (int(version) ?? 0n) < 1n || lifecycle === 'discovered') throw new JobsError('protected credential metadata is invalid');
+  revisionAndTime(record, 'employer account');
+  return record;
+}
+export function validateAccountsDocument(value: Value): Document {
+  const document = object(value, 'employer accounts');
+  if (int(get(document, 'schemaVersion')) !== 1n) throw new JobsError('employer accounts schema version is unsupported');
+  exact(document, ['schemaVersion', 'accounts', 'metadata'], 'employer accounts document contains unsupported fields');
+  const accounts = object(get(document, 'accounts'), 'employer accounts');
+  const metadata = object(get(document, 'metadata'), 'employer account metadata');
+  exact(metadata, ['createdAt', 'updatedAt'], 'employer account metadata is invalid');
+  for (const field of ['createdAt', 'updatedAt']) if (!string(get(metadata, field))) throw new JobsError('employer account metadata timestamp is invalid');
+  for (const [key, record] of accounts.entries()) validateAccount(string(key)!, record);
+  return document;
+}
+export function publicAccount(record: Document): Document {
+  const result = object(fromJSON({}), 'account projection');
+  for (const field of ['realmRef', 'adapterId', 'descriptorVersion', 'lifecycleState', 'credentialVersion', 'revision', 'createdAt', 'updatedAt']) set(result, field, get(record, field));
+  set(result, 'flowKind', has(record, 'flowKind') ? get(record, 'flowKind') : fromJSON(passwordFlow));
+  set(result, 'credentialRequired', has(record, 'credentialRequired') ? get(record, 'credentialRequired') : true);
+  set(result, 'signupEmailOverrideConfigured', get(record, 'signupEmailOverride') !== null);
+  return set(result, 'providerAssigned', get(record, 'providerId') !== null);
+}

--- a/src/contracts/workspace/automation.ts
+++ b/src/contracts/workspace/automation.ts
@@ -1,0 +1,48 @@
+import { copy, fromJSON, get, has, int, keys, object, set, string, text, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+import { strip } from './job-url.js';
+
+export function exact(record: Document, fields: string[], message: string): void {
+  if (record.size !== fields.length || fields.some(field => !has(record, field))) throw new JobsError(message);
+}
+export function optionalEmail(value: Value, label: string): Value {
+  if (value === null) return null;
+  const raw = string(value);
+  if (raw === null) throw new JobsError(`${label} must be an email address or null`);
+  const normalized = strip(raw);
+  const whitespace = /[\u0009-\u000d\u001c-\u0020\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]/u;
+  if ([...normalized].length > 254 || whitespace.test(normalized) || !/^[^@]+@[^@]+\.[^@]+$/u.test(normalized)) {
+    throw new JobsError(`${label} must be a valid email address`);
+  }
+  return fromJSON(normalized);
+}
+export function revisionAndTime(record: Document, label: string): void {
+  if ((int(get(record, 'revision')) ?? 0n) < 1n) throw new JobsError(`${label} revision must be a positive integer`);
+  for (const field of ['createdAt', 'updatedAt']) if (!string(get(record, field))) throw new JobsError(`${label} timestamp is invalid`);
+}
+export function validateSettings(value: Value): Document {
+  const record = object(value, 'automation settings');
+  exact(record, ['enabled', 'automaticAccountCreation', 'signupEmail', 'passwordStrategy', 'revision', 'createdAt', 'updatedAt'], 'automation settings contain unsupported fields');
+  if (typeof get(record, 'enabled') !== 'boolean' || typeof get(record, 'automaticAccountCreation') !== 'boolean') throw new JobsError('automation settings switches must be booleans');
+  optionalEmail(get(record, 'signupEmail'), 'signup email');
+  if (!['unique_per_realm', 'shared', 'custom', 'ask_each_time'].includes(string(get(record, 'passwordStrategy')) ?? '')) throw new JobsError('password strategy is unsupported');
+  revisionAndTime(record, 'automation settings');
+  return record;
+}
+export function validateSettingsDocument(value: Value): Document {
+  const document = object(value, 'automation settings');
+  if (int(get(document, 'schemaVersion')) !== 1n) throw new JobsError('automation settings schema version is unsupported');
+  exact(document, ['schemaVersion', 'settings'], 'automation settings document contains unsupported fields');
+  validateSettings(get(document, 'settings'));
+  return document;
+}
+export function publicSettings(record: Document): Document {
+  const result = copy(record);
+  result.delete(text('signupEmail'));
+  return set(result, 'signupEmailConfigured', get(record, 'signupEmail') !== null);
+}
+export function settingsPatch(value: Value): Document {
+  const patch = object(value, 'automation settings patch');
+  if (!patch.size || keys(patch).some(key => !['enabled', 'automaticAccountCreation', 'signupEmail', 'passwordStrategy'].includes(key))) throw new JobsError('automation settings patch contains unsupported fields');
+  return patch;
+}

--- a/src/store/native-automation.ts
+++ b/src/store/native-automation.ts
@@ -1,0 +1,37 @@
+import type { Document } from '../contracts/workspace/values.js';
+import { fromJSON, object } from '../contracts/workspace/values.js';
+import { validateSettingsDocument } from '../contracts/workspace/automation.js';
+import { validateAccountsDocument } from '../contracts/workspace/accounts.js';
+import type { AutomationRepository, AutomationTransaction } from '../workspace-core/automation.js';
+
+export type AutomationDocumentName = 'automation-settings' | 'employer-accounts';
+/** All callbacks run inside the composing repository's validated fixture lock. */
+export interface AutomationDocumentAccess {
+  read(name: AutomationDocumentName | 'profile'): Promise<Document>;
+  write(name: AutomationDocumentName, document: Document): Promise<void>;
+}
+export function initialAutomationDocuments(now: string): Record<AutomationDocumentName, Document> {
+  return {
+    'automation-settings': object(fromJSON({ schemaVersion: 1, settings: { enabled: false,
+      automaticAccountCreation: false, signupEmail: null, passwordStrategy: 'unique_per_realm',
+      revision: 1, createdAt: now, updatedAt: now } }), 'automation settings'),
+    'employer-accounts': object(fromJSON({ schemaVersion: 1, accounts: {}, metadata: { createdAt: now, updatedAt: now } }), 'employer accounts'),
+  };
+}
+/** No root adoption, implicit initialization, credentials, or recovery execution. */
+export async function automationTransaction<T>(access: AutomationDocumentAccess,
+  operation: (transaction: AutomationTransaction) => Promise<T>): Promise<T> {
+  return operation({
+    loadSettings: () => access.read('automation-settings'),
+    loadAccounts: () => access.read('employer-accounts'),
+    loadProfile: () => access.read('profile'),
+    saveSettings: document => access.write('automation-settings', validateSettingsDocument(document)),
+    saveAccounts: document => access.write('employer-accounts', validateAccountsDocument(document)),
+  });
+}
+/** Factory lets the owner supply the existing root/lock boundary unchanged. */
+export function createAutomationRepository(
+  locked: <T>(operation: (access: AutomationDocumentAccess) => Promise<T>) => Promise<T>,
+): AutomationRepository {
+  return { automationTransaction: operation => locked(access => automationTransaction(access, operation)) };
+}

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -1,3 +1,5 @@
+import { initialAutomationDocuments, automationTransaction as runAutomationTransaction } from './native-automation.js';
+import type { AutomationTransaction } from '../workspace-core/automation.js';
 import type { GroupedApprovalTransaction } from '../workspace-core/grouped-approvals.js';
 import { NativeClaimJournal, claimOperationKinds, validateClaimJournal } from './native-claim-journal.js';
 import { NativeClaimHistory } from './native-claim-history.js';
@@ -33,8 +35,8 @@ import { validateAnswers } from "../contracts/workspace/answers.js";
 import type { AnswerReferenceCounts } from "../workspace-core/answers.js";
 
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
-const marker = '{"mode":"native-jobs-fixture","version":9}\n';
-const allowed = new Set([".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
+const marker = '{"mode":"native-jobs-fixture","version":10}\n';
+const allowed = new Set(["automation-settings.json", "employer-accounts.json", ".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
 
@@ -73,6 +75,9 @@ export async function initializeJobsFixture(root: string): Promise<void> {
   await history.close();
   const lock = await open(join(root, ".store.lock"), "wx", 0o600);
   await lock.close();
+  for (const [name, document] of Object.entries(initialAutomationDocuments(now))) {
+    await atomicWritePointJson(join(root, `${name}.json`), document, options);
+  }
   // The readiness marker is written last; partial initialization is never adopted.
   const handle = await open(join(root, ".native-jobs-fixture"), "wx", 0o600);
   try { await handle.writeFile(marker); await handle.sync(); } finally { await handle.close(); }
@@ -394,6 +399,13 @@ export class NativeJobsRepository implements JobsRepository {
           return this.resolutionJournal().commit(value,jobs,sessions);
         } });
     });
+  }
+
+  async automationTransaction<T>(operation: (tx: AutomationTransaction) => Promise<T>): Promise<T> {
+    return this.transaction(async () => runAutomationTransaction({
+      read: name => name === 'automation-settings' ? this.journal(name) : this.document(name),
+      write: (name, document) => this.write(join(this.root, `${name}.json`), document, options),
+    }, operation));
   }
 
   async resumeSummaries(): Promise<Value[]> {

--- a/src/workspace-core/accounts.ts
+++ b/src/workspace-core/accounts.ts
@@ -1,0 +1,65 @@
+import { copy, fromJSON, get, int, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import { exact, optionalEmail } from '../contracts/workspace/automation.js';
+import { publicAccount, validateAccount, validateAccountsDocument } from '../contracts/workspace/accounts.js';
+import { resolveAccountRealm } from '../contracts/workspace/account-realm.js';
+import { cloneDocument } from './automation.js';
+import type { AutomationRepository, AutomationTransaction } from './automation.js';
+
+export class AccountsService {
+  constructor(readonly repository: AutomationRepository, private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+  resolve(url: unknown): Value { return fromJSON(resolveAccountRealm(url)); }
+  list(publicView = false): Promise<Document[]> {
+    return this.repository.automationTransaction(async tx => {
+      const accounts = object(get(validateAccountsDocument(await tx.loadAccounts()), 'accounts'), 'employer accounts');
+      return [...accounts.entries()].sort(([a], [b]) => string(a)! < string(b)! ? -1 : 1)
+        .map(([, value]) => this.project(object(value, 'employer account'), publicView));
+    });
+  }
+  get(realmRef: string, publicView = false): Promise<Document | null> {
+    return this.repository.automationTransaction(async tx => {
+      const value = get(object(get(validateAccountsDocument(await tx.loadAccounts()), 'accounts'), 'employer accounts'), realmRef);
+      return value === null ? null : this.project(object(value, 'employer account'), publicView);
+    });
+  }
+  create(url: unknown, email: Value = null, publicView = false): Promise<Document> {
+    const realm = resolveAccountRealm(url);
+    if (realm.status !== 'resolved') throw new JobsError('employer account realm is unresolved');
+    const override = optionalEmail(email, 'signup email override');
+    return this.repository.automationTransaction(async tx => {
+      const document = validateAccountsDocument(await tx.loadAccounts()), accounts = object(get(document, 'accounts'), 'employer accounts');
+      if (get(accounts, realm.realmRef) !== null) throw new JobsError('employer account already exists');
+      const now = this.now();
+      const record = object(fromJSON({ realmRef: realm.realmRef, adapterId: realm.adapterId, descriptorVersion: realm.descriptorVersion,
+        descriptor: realm.descriptor, flowKind: realm.flowKind, credentialRequired: realm.credentialRequired,
+        signupEmailOverride: null, providerId: null, credentialRef: null, credentialVersion: null,
+        lifecycleState: 'discovered', revision: 1, createdAt: now, updatedAt: now }), 'employer account');
+      set(record, 'signupEmailOverride', override);
+      await this.save(tx, document, realm.realmRef, record);
+      return this.project(record, publicView);
+    });
+  }
+  update(realmRef: string, value: Value, revision: bigint, publicView = false): Promise<Document> {
+    const patch = object(value, 'employer account patch');
+    exact(patch, ['signupEmailOverride'], 'employer account patch may only change signup email override');
+    const override = optionalEmail(get(patch, 'signupEmailOverride'), 'signup email override');
+    return this.repository.automationTransaction(async tx => {
+      const document = validateAccountsDocument(await tx.loadAccounts()), value = get(object(get(document, 'accounts'), 'employer accounts'), realmRef);
+      if (value === null) throw new JobsError('employer account does not exist');
+      const current = object(value, 'employer account');
+      if (int(get(current, 'revision')) !== revision) throw new JobsError('employer account revision conflict');
+      const updated = set(copy(current), 'signupEmailOverride', override);
+      set(updated, 'revision', integer(revision + 1n));
+      set(updated, 'updatedAt', text(this.now()));
+      await this.save(tx, document, realmRef, updated);
+      return this.project(updated, publicView);
+    });
+  }
+  private project(record: Document, publicView: boolean): Document { return cloneDocument(publicView ? publicAccount(record) : record); }
+  private async save(tx: AutomationTransaction, document: Document, realm: string, record: Document): Promise<void> {
+    validateAccount(realm, record);
+    const accounts = set(copy(object(get(document, 'accounts'), 'employer accounts')), realm, record);
+    const metadata = set(copy(object(get(document, 'metadata'), 'employer account metadata')), 'updatedAt', get(record, 'updatedAt'));
+    await tx.saveAccounts(set(set(copy(document), 'accounts', accounts), 'metadata', metadata));
+  }
+}

--- a/src/workspace-core/automation-http.ts
+++ b/src/workspace-core/automation-http.ts
@@ -1,0 +1,49 @@
+import { PythonObject } from '../contracts/python-object.js';
+import { exact } from '../contracts/workspace/automation.js';
+import { get, has, int, keys, object, parse, serialize, string, JobsError } from '../contracts/workspace/values.js';
+import type { Value } from '../contracts/workspace/values.js';
+import { AutomationService } from './automation.js';
+import type { AutomationRepository } from './automation.js';
+import { AccountsService } from './accounts.js';
+
+const response = (value: Value) => ({ status: 200, body: serialize(value) });
+function revision(value: Value, label = 'expectedRevision'): bigint {
+  const result = int(value);
+  if (result === null || result < 1n) throw new JobsError(`${label} must be a positive integer`);
+  return result;
+}
+/** Owner handles generic safe request/storage errors using existing HTTP boundary. */
+export async function automationHttp(repository: AutomationRepository, method: string, path: string, body: string): Promise<{status: number; body: string} | null> {
+  const settings = new AutomationService(repository), accounts = new AccountsService(repository);
+  const updateAccount = /^\/api\/employer-accounts\/([^/]+)$/.exec(path);
+  if (method === 'GET' && updateAccount) {
+    const account = await accounts.get(decodeURIComponent(updateAccount[1]!), true);
+    if (account === null) throw new JobsError('employer account does not exist');
+    return response(account);
+  }
+  const recognized = method === 'POST' && ['/api/automation/realm-resolve', '/api/automation/settings/copy-profile-email', '/api/employer-accounts'].includes(path)
+    || method === 'PATCH' && (path === '/api/automation/settings' || updateAccount !== null);
+  if (!recognized) return null;
+  const payload = object(parse(body), 'body');
+  if (path === '/api/automation/realm-resolve') {
+    exact(payload, ['url'], 'body must contain only a portal URL');
+    if (string(get(payload, 'url')) === null) throw new JobsError('body must contain only a portal URL');
+    return response(accounts.resolve(string(get(payload, 'url'))));
+  }
+  if (path === '/api/automation/settings/copy-profile-email') {
+    exact(payload, ['expectedProfileRevision', 'expectedSettingsRevision'], 'body must contain exact profile and settings revisions');
+    const values = ['expectedProfileRevision', 'expectedSettingsRevision'].map(key => int(get(payload, key)));
+    if (values.some(value => value === null || value < 1n)) throw new JobsError('profile and settings revisions must be positive integers');
+    return response(await settings.copyProfileEmail(values[0]!, values[1]!, true));
+  }
+  if (method === 'POST' && path === '/api/employer-accounts') {
+    if (keys(payload).some(key => !['url', 'signupEmailOverride'].includes(key)) || !has(payload, 'url') || string(get(payload, 'url')) === null) throw new JobsError('body must contain a portal URL and optional signup email override');
+    return response(await accounts.create(string(get(payload, 'url')), get(payload, 'signupEmailOverride'), true));
+  }
+  const label = path === '/api/automation/settings' ? 'settings' : 'account';
+  exact(payload, ['patch', 'expectedRevision'], `body must contain a ${label} patch and expectedRevision`);
+  if (!(get(payload, 'patch') instanceof PythonObject)) throw new JobsError(`body must contain a ${label} patch and expectedRevision`);
+  const expected = revision(get(payload, 'expectedRevision'));
+  return response(path === '/api/automation/settings' ? await settings.update(get(payload, 'patch'), expected, true)
+    : await accounts.update(decodeURIComponent(updateAccount![1]!), get(payload, 'patch'), expected, true));
+}

--- a/src/workspace-core/automation.ts
+++ b/src/workspace-core/automation.ts
@@ -1,0 +1,54 @@
+import { validateProfile } from '../contracts/workspace/profile.js';
+import { copy, fromJSON, get, has, int, integer, object, parse, serialize, set, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import { optionalEmail, publicSettings, settingsPatch, validateSettings, validateSettingsDocument } from '../contracts/workspace/automation.js';
+
+export interface AutomationTransaction {
+  loadSettings(): Promise<Document>;
+  loadAccounts(): Promise<Document>;
+  loadProfile(): Promise<Document>;
+  saveSettings(document: Document): Promise<void>;
+  saveAccounts(document: Document): Promise<void>;
+}
+export interface AutomationRepository {
+  automationTransaction<T>(operation: (transaction: AutomationTransaction) => Promise<T>): Promise<T>;
+}
+export const cloneDocument = (document: Document): Document => object(parse(serialize(document)), 'document');
+export class AutomationService {
+  constructor(readonly repository: AutomationRepository, private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+  get(publicView = false): Promise<Document> {
+    return this.repository.automationTransaction(async tx => {
+      const record = object(get(validateSettingsDocument(await tx.loadSettings()), 'settings'), 'automation settings');
+      return cloneDocument(publicView ? publicSettings(record) : record);
+    });
+  }
+  update(value: Value, expectedRevision: bigint, publicView = false): Promise<Document> {
+    const patch = settingsPatch(value);
+    return this.repository.automationTransaction(async tx => this.save(tx, patch, expectedRevision, publicView));
+  }
+  copyProfileEmail(profileRevision: bigint, settingsRevision: bigint, publicView = true): Promise<Document> {
+    return this.repository.automationTransaction(async tx => {
+      const profile = validateProfile(await tx.loadProfile());
+      const metadata = object(get(profile, 'metadata'), 'profile metadata');
+      if ((has(metadata, 'revision') ? int(get(metadata, 'revision')) : 1n) !== profileRevision) throw new JobsError('profile revision conflict');
+      const current = object(get(validateSettingsDocument(await tx.loadSettings()), 'settings'), 'automation settings');
+      if (int(get(current, 'revision')) !== settingsRevision) throw new JobsError('automation settings revision conflict');
+      const email = optionalEmail(get(object(get(profile, 'profile'), 'profile'), 'email'), 'profile email');
+      if (email === null) throw new JobsError('canonical profile email is unavailable');
+      const updated = await this.save(tx, set(object(fromJSON({}), 'patch'), 'signupEmail', email), settingsRevision, true);
+      return publicView ? updated : set(object(fromJSON({ copied: true }), 'copy result'), 'revision', get(updated, 'revision'));
+    });
+  }
+  private async save(tx: AutomationTransaction, patch: Document, revision: bigint, publicView: boolean): Promise<Document> {
+    const document = validateSettingsDocument(await tx.loadSettings()), current = object(get(document, 'settings'), 'automation settings');
+    if (int(get(current, 'revision')) !== revision) throw new JobsError('automation settings revision conflict');
+    const updated = copy(current);
+    for (const [key, value] of patch.entries()) updated.set(key, value);
+    if (has(patch, 'signupEmail')) set(updated, 'signupEmail', optionalEmail(get(patch, 'signupEmail'), 'signup email'));
+    set(updated, 'revision', integer(revision + 1n));
+    set(updated, 'updatedAt', text(this.now()));
+    validateSettings(updated);
+    await tx.saveSettings(set(copy(document), 'settings', updated));
+    return cloneDocument(publicView ? publicSettings(updated) : updated);
+  }
+}

--- a/src/workspace-core/jobs-http.ts
+++ b/src/workspace-core/jobs-http.ts
@@ -1,3 +1,4 @@
+import { automationHttp } from './automation-http.js';
 import { answerLifecycleHttp } from './answer-lifecycle-http.js';
 import { trashHttp } from './trash-http.js';
 import { claimsHttp } from './claims-http.js';
@@ -27,6 +28,8 @@ const envelope = (key: string, value: Value): Value => set(emptyObject(), key, v
 export async function jobsHttp(service: JobsService, repository: NativeJobsRepository,
   method: string, path: string, body = ""): Promise<ApiResult> {
   try {
+    const automation = await automationHttp(repository, method, path, body);
+    if (automation) return automation;
     const answerLifecycle = await answerLifecycleHttp(repository, method, path, body);
     if (answerLifecycle) return answerLifecycle;
     const trash = await trashHttp(repository, method, path, body);

--- a/tests_js/workspace_native_accounts.test.mjs
+++ b/tests_js/workspace_native_accounts.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { resolveAccountRealm } from '../runtime/contracts/workspace/account-realm.js';
+import { validateAccount, publicAccount } from '../runtime/contracts/workspace/accounts.js';
+import { fromJSON, serialize } from '../runtime/contracts/workspace/values.js';
+const plain = value => JSON.parse(serialize(value));
+
+test('realm identity and rejection reasons match Python without URL canonicalization', () => {
+  const oracle = 'https://example.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en-US/sites/careers/job/123';
+  const base = 'https://example.wd1.myworkdayjobs.com';
+  const urls = [null,0,'',' ',base,base+'/en/job/1',base+':443/a',base+':0443/a',base+':/a',base+':444/a',
+    base+':999999/a',base+':abc/a',base+'.',base+'/a#',base+'/a#x',base+'/a?token=x',base+'/a?access_token=x',
+    base+'/a?x_token_x=',base+'/a?%74oken=x',base+'/a?job=42',base+'/a?ſession=x',base+'/a?credentıal=x',base+'/a?COOKIE=x',base+'/a/../b',base+'/a\\b',
+    'https://user@'+base.slice(8), 'https://@'+base.slice(8),base.replace('https:','http:'),
+    '\u001c'+base+'\u0085','https://example.\nwd1.myworkdayjobs.com/x','https://wd1.myworkday.com',
+    'https://unknown.invalid/path','https://[broken/path','https://[::1]/','//[broken','//example.invalid:bad','//example.invalid','https://example\uff1awd1.myworkdayjobs.com',
+    oracle,oracle+'/apply/email',oracle+'/',oracle+'?x=y',oracle+'#x',oracle.replace('/sites/','//sites/'),
+    oracle.replace('/job/','/%6aob/'),oracle.replace('/123','/01'),oracle.replace('en-US','en-us'),
+    oracle.replace('.com/','.com./'),oracle.replace('careers','careers_two'),oracle.replace('careers','CAREERS'),
+  ];
+  const script = `import sys,json
+sys.path.insert(0,'scripts')
+import job_apply_accounts as a
+print(json.dumps([a.normalize_realm(url) for url in json.loads(sys.argv[1])]))`;
+  const expected = JSON.parse(execFileSync('python3',['-c',script,JSON.stringify(urls)],{encoding:'utf8'}));
+  urls.forEach((url,index)=>assert.deepEqual(resolveAccountRealm(url),expected[index],JSON.stringify(url)));
+});
+
+test('account validation including legacy/provider combinations matches Python and redacts private fields', () => {
+  const realm = resolveAccountRealm('https://example.wd1.myworkdayjobs.com');
+  const base = {realmRef:realm.realmRef,adapterId:realm.adapterId,descriptorVersion:1,descriptor:realm.descriptor,
+    flowKind:realm.flowKind,credentialRequired:true,signupEmailOverride:'synthetic@example.invalid',providerId:null,
+    credentialRef:null,credentialVersion:null,lifecycleState:'discovered',revision:1,createdAt:'fixed',updatedAt:'fixed'};
+  const records = [base,{...base,revision:true},{...base,revision:0},{...base,revision:1.5},{...base,descriptor:'bad'},
+    {...base,unknown:'secret'},{...base,lifecycleState:'active'},
+    {...base,providerId:'synthetic-provider',credentialRef:'credential_'+'0'.repeat(64),credentialVersion:1,lifecycleState:'active'},
+    {...base,providerId:'x',credentialRef:'credential_'+'0'.repeat(64),credentialVersion:1,lifecycleState:'active'},
+    {...base,signupEmailOverride:'bad'},{...base,signupEmailOverride:'\ufeffa@example.invalid'},
+    {...base,signupEmailOverride:'a\u0085b@example.invalid'},
+    Object.fromEntries(Object.entries(base).filter(([key])=>!['flowKind','credentialRequired'].includes(key)))];
+  const script = `import sys,json
+sys.path.insert(0,'scripts')
+from job_apply_store.accounts_runtime import validate_employer_account
+import job_apply_accounts as a
+out=[]
+for r in json.loads(sys.argv[1]):
+ try: validate_employer_account(r['realmRef'],r);out.append({'value':a.public_account(r)})
+ except Exception as e: out.append({'error':str(e)})
+print(json.dumps(out))`;
+  const expected = JSON.parse(execFileSync('python3',['-c',script,JSON.stringify(records)],{encoding:'utf8'}));
+  const actual = records.map(record=>{try{return {value:plain(publicAccount(validateAccount(record.realmRef,fromJSON(record))))};}catch(error){return {error:error.message};}});
+  assert.deepEqual(actual,expected);
+  assert.doesNotMatch(JSON.stringify(actual),/synthetic@example|credential_0|workday:v1|synthetic-provider/);
+});

--- a/tests_js/workspace_native_automation.test.mjs
+++ b/tests_js/workspace_native_automation.test.mjs
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initialAutomationDocuments, createAutomationRepository } from '../runtime/store/native-automation.js';
+import { AutomationService } from '../runtime/workspace-core/automation.js';
+import { automationHttp } from '../runtime/workspace-core/automation-http.js';
+import { resolveAccountRealm } from '../runtime/contracts/workspace/account-realm.js';
+import { AccountsService } from '../runtime/workspace-core/accounts.js';
+import { fromJSON, parse, serialize } from '../runtime/contracts/workspace/values.js';
+import { atomicWritePointJson } from '../runtime/store/point-persistence.js';
+const fixed = '2026-09-11T12:00:00Z';
+const plain = value => JSON.parse(serialize(value));
+const profile = {schemaVersion:1,profile:{email:'profile@example.invalid'},metadata:{revision:1,createdAt:fixed,updatedAt:fixed}};
+
+export async function fixture(t) {
+  const root = await mkdtemp(join(tmpdir(), 'native-automation-'));
+  t.after(() => rm(root, {recursive:true,force:true}));
+  const documents = {...initialAutomationDocuments(fixed), profile:fromJSON(profile)};
+  const writes = [], reads = [];
+  for (const [name, document] of Object.entries(documents)) await atomicWritePointJson(join(root, `${name}.json`), document, {pathProfile:'3.12',intMaxStrDigits:4300});
+  const repository = createAutomationRepository(async operation => operation({
+    read:async name => { reads.push(name); return parse(await readFile(join(root, `${name}.json`), 'utf8')); },
+    write:async (name, document) => { writes.push(name); await atomicWritePointJson(join(root, `${name}.json`), document, {pathProfile:'3.12',intMaxStrDigits:4300}); },
+  }));
+  return {root,writes,reads,repository,settings:new AutomationService(repository,()=>fixed),accounts:new AccountsService(repository,()=>fixed)};
+}
+
+test('settings and account writes match independent Python Store sequence and persisted documents', async t => {
+  const f = await fixture(t);
+  const url = 'https://example.wd1.myworkdayjobs.com/en-US/careers/job/42';
+  const realm = resolveAccountRealm(url).realmRef;
+  const ops = [
+    ['get_automation_settings', []],
+    ['update_automation_settings', [{enabled:true,signupEmail:'  synthetic@example.invalid  '},1]],
+    ['update_automation_settings', [{enabled:true},2]],
+    ['update_automation_settings', [{enabled:false},1]],
+    ['update_automation_settings', [{signupEmail:''},3]],
+    ['update_automation_settings', [{unknown:true},3]],
+    ['update_automation_settings', [{automaticAccountCreation:1},3]],
+    ['copy_profile_email_to_automation_settings', [1,3]],
+    ['copy_profile_email_to_automation_settings', [2,4]],
+    ['create_employer_account', [url,'  override@example.invalid  ']],
+    ['create_employer_account', [url]],
+    ['list_employer_accounts', []],
+    ['get_employer_account', [realm]],
+    ['update_employer_account', [realm,{signupEmailOverride:null},1]],
+    ['update_employer_account', [realm,{signupEmailOverride:'new@example.invalid'},1]],
+    ['update_employer_account', [realm,{signupEmailOverride:'new@example.invalid'},2]],
+    ['update_employer_account', [realm,{providerId:'secret'},3]],
+    ['get_employer_account', ['missing']],
+    ['create_employer_account', ['https://example.fa.us1.oraclecloud.com/hcmUI/CandidateExperience/en-US/sites/careers/job/123']],
+    ['list_employer_accounts', []],
+  ];
+  const script = `import sys,json,importlib.util
+from pathlib import Path
+sys.path.insert(0,str(Path('scripts').resolve()))
+spec=importlib.util.spec_from_file_location('automation_reference','scripts/job-apply-store.py')
+m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m)
+m.utc_now=lambda:'${fixed}'
+s=m.Store(Path(sys.argv[1]));s._now=lambda:'${fixed}';s.initialize();s.profile_path.write_text(sys.argv[3])
+out=[]
+for name,args in json.loads(sys.argv[2]):
+ try: out.append({'value':getattr(s,name)(*args,public=True)})
+ except m.StoreError as e: out.append({'error':str(e)})
+print(json.dumps({'results':out,'settings':json.loads(s.automation_settings_path.read_text()),'accounts':json.loads(s.employer_accounts_path.read_text())}))`;
+  const expected = JSON.parse(execFileSync('python3',['-c',script,join(f.root,'python'),JSON.stringify(ops),JSON.stringify(profile)],{encoding:'utf8'}));
+  const actual = [];
+  for (const [name,args] of ops) {
+    try {
+      let value;
+      if (name === 'get_automation_settings') value = await f.settings.get(true);
+      else if (name === 'update_automation_settings') value = await f.settings.update(fromJSON(args[0]),BigInt(args[1]),true);
+      else if (name === 'copy_profile_email_to_automation_settings') value = await f.settings.copyProfileEmail(BigInt(args[0]),BigInt(args[1]),true);
+      else if (name === 'create_employer_account') value = await f.accounts.create(args[0],fromJSON(args[1] ?? null),true);
+      else if (name === 'get_employer_account') value = await f.accounts.get(args[0],true);
+      else if (name === 'update_employer_account') value = await f.accounts.update(args[0],fromJSON(args[1]),BigInt(args[2]),true);
+      else value = await f.accounts.list(true);
+      actual.push({value:plain(value)});
+    } catch (error) { actual.push({error:error.message}); }
+  }
+  assert.deepEqual(actual,expected.results);
+  assert.deepEqual(JSON.parse(await readFile(join(f.root,'automation-settings.json'),'utf8')),expected.settings);
+  assert.deepEqual(JSON.parse(await readFile(join(f.root,'employer-accounts.json'),'utf8')),expected.accounts);
+  assert.deepEqual(f.writes,['automation-settings','automation-settings','automation-settings','employer-accounts','employer-accounts','employer-accounts','employer-accounts']);
+  assert.equal(f.reads.filter(name=>name==='profile').length,2);
+  assert.doesNotMatch(JSON.stringify(actual), /profile@example|synthetic@example|override@example|workday:v1/);
+});
+
+test('copy email never returns identity even in internal mode, failures do not persist', async t => {
+  const f = await fixture(t);
+  assert.deepEqual(plain(await f.settings.copyProfileEmail(1n,1n,false)),{copied:true,revision:2});
+  const before = await readFile(join(f.root,'automation-settings.json'),'utf8');
+  await assert.rejects(f.settings.update(fromJSON({passwordStrategy:'invalid'}),2n),/password strategy is unsupported/);
+  assert.equal(await readFile(join(f.root,'automation-settings.json'),'utf8'),before);
+  assert.equal(f.writes.length,1);
+});
+
+
+test('lazy document reads preserve unrelated operations and error ordering', async t => {
+  const f = await fixture(t);
+  await rm(join(f.root,'profile.json'));
+  await f.settings.get(true);
+  await f.accounts.list(true);
+  assert.ok(!f.reads.includes('profile'));
+  await rm(join(f.root,'employer-accounts.json'));
+  await f.settings.update(fromJSON({enabled:true}),1n,true);
+  await assert.rejects(f.settings.copyProfileEmail(1n,2n), /ENOENT/);
+  assert.deepEqual(f.writes,['automation-settings']);
+});
+
+test('HTTP accepts only Python routes and exact revision payloads; public mutations redact identity', async t => {
+  const f = await fixture(t);
+  const call = (method,path,payload) => automationHttp(f.repository,method,path,JSON.stringify(payload));
+  const response = await call('PATCH','/api/automation/settings',{patch:{signupEmail:'secret@example.invalid'},expectedRevision:1});
+  assert.equal(response.status,200);
+  assert.doesNotMatch(response.body,/secret@example/);
+  await assert.rejects(call('PATCH','/api/automation/settings',{patch:{enabled:true},expectedRevision:true}),/positive integer/);
+  await assert.rejects(call('POST','/api/automation/realm-resolve',{url:'https://example.wd1.myworkdayjobs.com',extra:true}),/only a portal URL/);
+  const created = await call('POST','/api/employer-accounts',{url:'https://example.wd1.myworkdayjobs.com',signupEmailOverride:'private@example.invalid'});
+  assert.doesNotMatch(created.body,/private@example|workday:v1/);
+  const realm = JSON.parse(created.body).realmRef;
+  assert.equal((await call('GET',`/api/employer-accounts/${realm}`,{})).body,created.body);
+  await assert.rejects(call('GET','/api/employer-accounts/missing',{}),/does not exist/);
+  for (const path of ['/api/automation/settings','/api/employer-accounts','/api/automation']) assert.equal(await call('GET',path,{}),null);
+  for (const path of ['/api/trusted-fill/approve','/api/account-operation/recover','/api/account-operation/execute-synthetic']) assert.equal(await call('POST',path,{}),null);
+});

--- a/tests_js/workspace_native_automation_integration.test.mjs
+++ b/tests_js/workspace_native_automation_integration.test.mjs
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { chmod, link, readFile, readdir, realpath, rename, rm, stat, symlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { initializeJobsFixture, NativeJobsRepository } from '../runtime/store/native-jobs.js';
+import { loadPosixFlockProvider } from '../runtime/store/posix-flock.js';
+import { AutomationService } from '../runtime/workspace-core/automation.js';
+import { AccountsService } from '../runtime/workspace-core/accounts.js';
+import { JobsService } from '../runtime/workspace-core/jobs.js';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { serialize } from '../runtime/contracts/workspace/values.js';
+
+const execute = promisify(execFile);
+const plain = value => JSON.parse(serialize(value));
+const portal = 'https://example.wd1.myworkdayjobs.com/en-US/careers/job/42';
+const settingsName = 'automation-settings.json';
+const accountsName = 'employer-accounts.json';
+
+async function snapshot(root) {
+  const files = (await readdir(root)).filter(name => name.endsWith('.json') || name.endsWith('.jsonl') || name === '.native-jobs-fixture');
+  return Object.fromEntries(await Promise.all(files.sort().map(async name => [name, await readFile(join(root, name), 'utf8')])));
+}
+function unchangedExcept(before, after, names) {
+  for (const name of names) { delete before[name]; delete after[name]; }
+  assert.deepEqual(after, before);
+}
+
+test('integrated native automation registry uses private fixture storage and serialized HTTP revisions', { timeout: 60000 }, async t => {
+  const fixture = await nativeFixture();
+  t.after(() => fixture.cleanup());
+  const parent = await realpath(fixture.root);
+  const root = join(parent, 'registry');
+  await initializeJobsFixture(root);
+  const provider = loadPosixFlockProvider(fixture.receipt.artifact);
+  const repository = new NativeJobsRepository(root, provider);
+  const jobs = new JobsService(repository);
+  const settings = new AutomationService(repository);
+  const accounts = new AccountsService(repository);
+  const call = (method, path, payload) => jobsHttp(jobs, repository, method, path, JSON.stringify(payload));
+  let realm;
+
+  await t.test('settings and account HTTP routes persist only their own documents and redact identities', async () => {
+    assert.deepEqual(JSON.parse(await readFile(join(root, '.native-jobs-fixture'), 'utf8')), { mode: 'native-jobs-fixture', version: 10 });
+    for (const name of [settingsName, accountsName]) assert.equal((await stat(join(root, name))).mode & 0o777, 0o600);
+    const initial = await snapshot(root);
+    const updated = await call('PATCH', '/api/automation/settings', {
+      patch: { enabled: true, signupEmail: 'private-settings@example.invalid' }, expectedRevision: 1,
+    });
+    assert.equal(updated.status, 200, updated.body);
+    assert.equal(JSON.parse(updated.body).revision, 2);
+    assert.doesNotMatch(updated.body, /private-settings@example/);
+    assert.equal(plain(await settings.get()).signupEmail, 'private-settings@example.invalid');
+    unchangedExcept(initial, await snapshot(root), [settingsName]);
+    const beforeAccount = await snapshot(root);
+    const resolved = await call('POST', '/api/automation/realm-resolve', { url: portal });
+    assert.equal(resolved.status, 200);
+    realm = JSON.parse(resolved.body).realmRef;
+    const created = await call('POST', '/api/employer-accounts', { url: portal, signupEmailOverride: 'private-account@example.invalid' });
+    assert.equal(created.status, 200, created.body);
+    assert.equal(JSON.parse(created.body).realmRef, realm);
+    assert.doesNotMatch(created.body, /private-account@example|workday:v1/);
+    assert.equal(plain(await accounts.get(realm)).signupEmailOverride, 'private-account@example.invalid');
+    assert.equal((await call('GET', `/api/employer-accounts/${realm}`)).body, created.body);
+    unchangedExcept(beforeAccount, await snapshot(root), [accountsName]);
+    const accountUpdate = await call('PATCH', `/api/employer-accounts/${realm}`, { patch: { signupEmailOverride: null }, expectedRevision: 1 });
+    assert.equal(accountUpdate.status, 200, accountUpdate.body);
+    assert.equal(JSON.parse(accountUpdate.body).revision, 2);
+    assert.equal(plain(await accounts.get(realm)).signupEmailOverride, null);
+    const beforeRejected = await snapshot(root);
+    assert.equal((await call('PATCH', '/api/automation/settings', { patch: { enabled: false }, expectedRevision: 1 })).status, 409);
+    assert.equal((await call('PATCH', `/api/employer-accounts/${realm}`, { patch: { signupEmailOverride: null }, expectedRevision: 1 })).status, 409);
+    assert.equal((await call('PATCH', '/api/automation/settings', { patch: {}, expectedRevision: true })).status, 400);
+    assert.equal((await call('GET', '/api/employer-accounts/missing')).status, 404);
+    assert.equal((await call('GET', '/api/automation')).status, 501);
+    for (const path of ['/api/trusted-fill/approve', '/api/account-operation/recover']) assert.equal((await call('POST', path, {})).status, 501);
+    assert.deepEqual(await snapshot(root), beforeRejected);
+  });
+
+  await t.test('profile email copy checks both revisions, preserves profile and exposes no email', async () => {
+    const profilePath = join(root, 'profile.json');
+    const profile = JSON.parse(await readFile(profilePath, 'utf8'));
+    profile.profile.email = 'private-profile@example.invalid';
+    await writeFile(profilePath, JSON.stringify(profile));
+    const before = await snapshot(root);
+    const path = '/api/automation/settings/copy-profile-email';
+    assert.equal((await call('POST', path, { expectedProfileRevision: 2, expectedSettingsRevision: 2 })).status, 409);
+    assert.equal((await call('POST', path, { expectedProfileRevision: 1, expectedSettingsRevision: 1 })).status, 409);
+    assert.deepEqual(await snapshot(root), before);
+    const copied = await call('POST', path, { expectedProfileRevision: 1, expectedSettingsRevision: 2 });
+    assert.equal(copied.status, 200, copied.body);
+    assert.equal(JSON.parse(copied.body).revision, 3);
+    assert.doesNotMatch(copied.body, /private-profile@example/);
+    assert.equal(plain(await settings.get()).signupEmail, 'private-profile@example.invalid');
+    unchangedExcept(before, await snapshot(root), [settingsName]);
+  });
+
+  await t.test('independent Python-free processes allow only one writer per expected revision', async () => {
+    const script = `
+      import { NativeJobsRepository } from ${JSON.stringify(new URL('../runtime/store/native-jobs.js', import.meta.url).href)};
+      import { loadPosixFlockProvider } from ${JSON.stringify(new URL('../runtime/store/posix-flock.js', import.meta.url).href)};
+      import { JobsService } from ${JSON.stringify(new URL('../runtime/workspace-core/jobs.js', import.meta.url).href)};
+      import { jobsHttp } from ${JSON.stringify(new URL('../runtime/workspace-core/jobs-http.js', import.meta.url).href)};
+      const repository = new NativeJobsRepository(process.argv[1], loadPosixFlockProvider(process.argv[2]));
+      console.log(JSON.stringify(await jobsHttp(new JobsService(repository), repository, 'PATCH', process.argv[3], process.argv[4])));
+    `;
+    for (const [path, payload, name] of [
+      ['/api/automation/settings', { patch: { enabled: false }, expectedRevision: 3 }, settingsName],
+      [`/api/employer-accounts/${realm}`, { patch: { signupEmailOverride: 'concurrent@example.invalid' }, expectedRevision: 2 }, accountsName],
+    ]) {
+      const before = await snapshot(root);
+      const results = await Promise.all(Array.from({ length: 4 }, () => execute(process.execPath,
+        ['--input-type=module', '-e', script, root, fixture.receipt.artifact, path, JSON.stringify(payload)], { env: { PATH: '' } })));
+      const responses = results.map(result => JSON.parse(result.stdout));
+      assert.deepEqual(responses.map(response => response.status).sort(), [200, 409, 409, 409]);
+      assert.equal(JSON.parse(responses.find(response => response.status === 200).body).revision, payload.expectedRevision + 1);
+      unchangedExcept(before, await snapshot(root), [name]);
+    }
+    assert.equal(plain(await new AutomationService(new NativeJobsRepository(root, provider)).get()).revision, 4);
+    assert.equal(plain(await new AccountsService(new NativeJobsRepository(root, provider)).get(realm)).revision, 3);
+  });
+
+  await t.test('private file checks reject public modes, symlinks and hard links without replacing data', async () => {
+    for (const [name, read] of [[settingsName, () => settings.get()], [accountsName, () => accounts.list()]]) {
+      const path = join(root, name), bytes = await readFile(path);
+      await chmod(path, 0o644);
+      try { await assert.rejects(read(), /private and owned/); }
+      finally { await chmod(path, 0o600); }
+      const outside = join(parent, `saved-${name}`);
+      await rename(path, outside);
+      try {
+        await symlink(outside, path);
+        await assert.rejects(read());
+        assert.deepEqual(await readFile(outside), bytes);
+        await rm(path);
+        await link(outside, path);
+        await assert.rejects(read(), /private and owned/);
+        assert.deepEqual(await readFile(outside), bytes);
+      } finally { await rm(path, { force: true }); await rename(outside, path); }
+      assert.deepEqual(await readFile(path), bytes);
+    }
+  });
+
+  await t.test('v9, missing new documents and unsupported recovery journals are rejected without adoption', async () => {
+    const markerPath = join(root, '.native-jobs-fixture');
+    const marker = await readFile(markerPath);
+    await writeFile(markerPath, '{"mode":"native-jobs-fixture","version":9}\n');
+    const old = await snapshot(root);
+    await assert.rejects(settings.get(), /explicitly initialized synthetic fixture/);
+    await assert.rejects(initializeJobsFixture(root), /EEXIST/);
+    assert.deepEqual(await snapshot(root), old);
+    await writeFile(markerPath, marker);
+    for (const name of [settingsName, accountsName]) {
+      const path = join(root, name), saved = join(parent, `missing-${name}`);
+      await rename(path, saved);
+      try {
+        const before = await snapshot(root);
+        await assert.rejects(settings.get(), /unsupported state/);
+        assert.deepEqual(await snapshot(root), before);
+      } finally { await rename(saved, path); }
+    }
+    const journal = join(root, 'account-operation.json');
+    await writeFile(journal, '{"schemaVersion":1,"operation":{"kind":"unsupported"}}', { mode: 0o600 });
+    const before = await snapshot(root);
+    await assert.rejects(settings.get(), /unsupported state or recovery journals/);
+    assert.deepEqual(await snapshot(root), before);
+    await rm(journal);
+    assert.equal(plain(await settings.get()).revision, 4);
+  });
+});


### PR DESCRIPTION
Adds native automation settings, realm resolution, and employer-account registry services behind the existing locked repository and HTTP dispatcher. New synthetic version 10 fixtures initialize the two private documents before readiness; older roots, missing files, and unsupported operation journals are rejected.

Mutations preserve Python revision and public-redaction contracts. Profile email copy checks both revisions. Concurrent writers serialize under the existing Store lock, and settings/account mutations write only their respective documents. Registry creation does not provision credentials.

This tranche does not expose the automation capability aggregate, account execution, trusted-fill, or new CLI commands. Python remains the installed default writer; all evidence uses disposable synthetic Stores.

Validation: runtime166 build and typecheck passed; six differential/leaf tests and six integrated tests/subtests passed, including concurrent Python-free writers, privacy/file checks, rejection boundaries and unrelated byte preservation. Five independent review roles completed; one documentation ordering issue was validated and corrected. Normal commit hooks and all 27 deep/push suites passed. Exact-head Validate (34654349727) and Release (34654351976) passed for 2577077071a58a042fc4afc9dfb7835ed6c06ba4. Native codex review failed due to installed CLI/model incompatibility; focused review remains available.
