### PR TITLE
Add native resume lifecycle

### DIFF
--- a/apps/companion/components/trash-model.ts
+++ b/apps/companion/components/trash-model.ts
@@ -6,7 +6,7 @@ export const compatibilityTrashCapabilities: TrashCapabilities = {
     job: { restore: true, delete: true }, resume: { restore: true, delete: true }, answer: { restore: true, delete: true }
 };
 export const nativeTrashCapabilities: TrashCapabilities = {
-    job: { restore: true, delete: true }, resume: { restore: false, delete: false }, answer: { restore: true, delete: true }
+    job: { restore: true, delete: true }, resume: { restore: true, delete: true }, answer: { restore: true, delete: true }
 };
 export interface TrashItem {
     type: TrashType;

--- a/config/migration/cli-native-resume-lifecycle-surfaces.json
+++ b/config/migration/cli-native-resume-lifecycle-surfaces.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-trash",
+      "kind": "cli",
+      "command": "resume-trash",
+      "node": "RES",
+      "sources": ["src/cli/native-jobs.ts", "src/cli/native-resume-lifecycle.ts", "src/workspace-core/resume-lifecycle.ts", "src/store/native-jobs.ts"],
+      "effects": "unclassified",
+      "scenarios": {"valid":"unverified","invalid":"unverified","missing":"unverified","noop":"unverified","privacy":"unverified","conflict":"unverified","concurrency":"unverified","interruption":"unverified","recovery":"unverified","platform":"unverified"}
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-restore",
+      "kind": "cli",
+      "command": "resume-restore",
+      "node": "RES",
+      "sources": ["src/cli/native-jobs.ts", "src/cli/native-resume-lifecycle.ts", "src/workspace-core/resume-lifecycle.ts", "src/store/native-jobs.ts"],
+      "effects": "unclassified",
+      "scenarios": {"valid":"unverified","invalid":"unverified","missing":"unverified","noop":"unverified","privacy":"unverified","conflict":"unverified","concurrency":"unverified","interruption":"unverified","recovery":"unverified","platform":"unverified"}
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:resume-delete",
+      "kind": "cli",
+      "command": "resume-delete",
+      "node": "RES",
+      "sources": ["src/cli/native-jobs.ts", "src/cli/native-resume-lifecycle.ts", "src/workspace-core/resume-lifecycle.ts", "src/store/native-jobs.ts", "src/store/native-resume-files.ts"],
+      "effects": "unclassified",
+      "scenarios": {"valid":"unverified","invalid":"unverified","missing":"unverified","noop":"unverified","privacy":"unverified","conflict":"unverified","concurrency":"unverified","interruption":"unverified","recovery":"unverified","platform":"unverified"}
+    }
+  ]
+}

--- a/config/migration/document-native-resumes-surfaces.json
+++ b/config/migration/document-native-resumes-surfaces.json
@@ -47,6 +47,29 @@
         "recovery": "unverified",
         "platform": "unverified"
       }
+    },
+    {
+      "id": "document:resume-files/.<managed>.<nonce>.quarantine",
+      "kind": "document",
+      "path": "resume-files/.<managed>.<nonce>.quarantine",
+      "artifact": "temporary",
+      "node": "RES",
+      "sources": [
+        "src/store/native-resume-files.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
     }
   ]
 }

--- a/config/migration/http-write-resumes-surfaces.json
+++ b/config/migration/http-write-resumes-surfaces.json
@@ -242,7 +242,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/cli/native-jobs-server.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/resume-lifecycle-http.ts",
+        "src/workspace-core/resume-lifecycle.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -270,7 +275,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/cli/native-jobs-server.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/resume-lifecycle-http.ts",
+        "src/workspace-core/resume-lifecycle.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -298,7 +308,13 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/cli/native-jobs-server.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/resume-lifecycle-http.ts",
+        "src/workspace-core/resume-lifecycle.ts",
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/journal-native-resumes-surfaces.json
+++ b/config/migration/journal-native-resumes-surfaces.json
@@ -50,6 +50,31 @@
         "recovery": "unverified",
         "platform": "unverified"
       }
+    },
+    {
+      "id": "journal:resume-operation.json:operation.kind:delete",
+      "kind": "journal",
+      "path": "resume-operation.json",
+      "discriminator": "operation.kind",
+      "value": "delete",
+      "node": "RES",
+      "sources": [
+        "src/store/native-jobs.ts",
+        "src/store/native-resume-files.ts"
+      ],
+      "effects": "unclassified",
+      "scenarios": {
+        "valid": "unverified",
+        "invalid": "unverified",
+        "missing": "unverified",
+        "noop": "unverified",
+        "privacy": "unverified",
+        "conflict": "unverified",
+        "concurrency": "unverified",
+        "interruption": "unverified",
+        "recovery": "unverified",
+        "platform": "unverified"
+      }
     }
   ]
 }

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -138,6 +138,10 @@
       "sha256": "db44fabe54a6f0bfb360f02880cdc06fc2780f4f78c3c0a487492cb485344a06"
     },
     {
+      "path": "cli-native-resume-lifecycle-surfaces.json",
+      "sha256": "305db8a623ab4805570f0deeac2046f9572de5e41f441d2ac3eac91c8d965271"
+    },
+    {
       "path": "cli-native-resumes-surfaces.json",
       "sha256": "23b9fd1e5a29720b5b4143d59a9767dfb9ee98a00e09ef3962f9112c9cda4e5c"
     },
@@ -163,7 +167,7 @@
     },
     {
       "path": "document-native-resumes-surfaces.json",
-      "sha256": "ccdefde93534faa31fc3c45e772b83703914b11323f45d1d858dd86c127de42d"
+      "sha256": "79aff4dc348dfc30bf59d7fc47239e2b4a05c80881dade65185b17f3dcfa7375"
     },
     {
       "path": "http-asset-head-surfaces.json",
@@ -215,7 +219,7 @@
     },
     {
       "path": "http-write-resumes-surfaces.json",
-      "sha256": "62274f8bdaf20fabf79a3988d41d134a3459452d2ba7eea5215d7a8feb7f36a8"
+      "sha256": "30b56cbdd1021963acaab8b3ba512f9c31872f894dbcef9935a638770b31ce1d"
     },
     {
       "path": "http-write-surfaces.json",
@@ -235,7 +239,7 @@
     },
     {
       "path": "journal-native-resumes-surfaces.json",
-      "sha256": "85609a0155cb88c4335662b0ed827ebc4e09745840bce1c16f40897321c15ad4"
+      "sha256": "9afc2c76f4044f124a6664840c3c178b8e496a91bbde5cb1731045d7455830eb"
     },
     {
       "path": "nodes.json",
@@ -363,7 +367,7 @@
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "544d544a43e69ff918009ce0ba1a1a1675d604606517e6b1e0ec9241a6c6f95e"
+      "sha256": "d55bf95dc463784de761295dfa29136a88981bf011675bc6dbefd7328fe2e3d5"
     },
     {
       "path": "source-catalog-native-legacy-jobs.json",
@@ -378,12 +382,16 @@
       "sha256": "a78ee13b41a59fbe409c647d88721f62bf986db60bcdd94bc71e938c88456488"
     },
     {
+      "path": "source-catalog-native-resume-lifecycle.json",
+      "sha256": "37a68abab20716253d945e3aced757a14c44dc20d27d54aa0053447dde9091aa"
+    },
+    {
       "path": "source-catalog-native-resumes.json",
-      "sha256": "29dd7f8508a7d203df336e2dad4c4b643daf4c4441f4cbee96d4ea0f5d15cc17"
+      "sha256": "52ae646a7b15a768e16a7adfe9335574e536d77ce2a8a2ae3ee28ba925f73dd2"
     },
     {
       "path": "source-catalog-native-task-cli.json",
-      "sha256": "df55a8733e48d55074f60d5546eb5103d5d3f01bd3711341a8311843c3db6ff2"
+      "sha256": "b593f1030030c0db4ab5dd1c802fb759157fbcb3e231d39bc781806af50bc117"
     },
     {
       "path": "source-catalog-native-task-intake.json",
@@ -391,7 +399,7 @@
     },
     {
       "path": "source-catalog-react-trash.json",
-      "sha256": "759aaa85f8de2674eed82fc65726ddf3aa1c8a78ac7a946071de57b7abf2fa69"
+      "sha256": "41758fb45d752f7b2e5e44f3f5ddba05146a5fe35a5f627790a9e1a0916cf49e"
     },
     {
       "path": "source-catalog-s01.json",

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "0ff828a867e2245a94215c79c31f640a227185e9cd0632b82409cae0fbbeb63a",
+      "sha256": "8a9a8086f7d8687562f4662fa5270f2b8f76d1a1eae91bfd98107494d80bd8a6",
       "classification": "unreviewed"
     },
     {
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "3713c1b93bbf2557da1c10e0bbf6d89d7f0ba199f79eeb359b4a8a66b18910f1",
+      "sha256": "603a4571d8aee0a872ec95f379673d696167b797e21028b44eae940a04b4c025",
       "classification": "unreviewed"
     },
     {
@@ -43,7 +43,7 @@
     },
     {
       "path": "runtime/workspace-core/jobs-http.js",
-      "sha256": "7c0f309c154eaf86f714e14c608714fff763ae3a2bd38b1a54dbad2eb71517f1",
+      "sha256": "8497751c99a72c7d5a3d3695e995fbf9bd34abac8ed3e6ee57bc35ec89c35fb7",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "0516cb3fc88f09e1fa98b8787d739608ed918e95db03e822c0602bfc32887731",
+      "sha256": "fa111b7c4dfc494d64c3b2ff554e0572e5f4f7bee87c973966aa8872db2a2a76",
       "classification": "unreviewed"
     },
     {
@@ -83,7 +83,7 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "f638c44b92259a1513601d8ba3b705a5101e30212d55efd20a97a7889b35dc14",
+      "sha256": "5faaae36d489a1dabfa390656c60d65ae1f1cc12ff4c184b849f7b1b557191e7",
       "classification": "unreviewed"
     },
     {
@@ -93,7 +93,7 @@
     },
     {
       "path": "src/workspace-core/jobs-http.ts",
-      "sha256": "58514a47de8affe6441e52f56474f93d5a7b5a7f8d4a189662672e306f71b091",
+      "sha256": "a3c7199df9e9a8878afba358e29f340e8a0250c4e41d529e4e2332e450f30307",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-resume-lifecycle.json
+++ b/config/migration/source-catalog-native-resume-lifecycle.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    { "path": "runtime/cli/native-resume-lifecycle.js", "sha256": "2fe7976b3bf1b900faa56596bce004e03e9a8bf36a346098e3619b66cb27e03f", "classification": "unreviewed" },
+    { "path": "runtime/workspace-core/resume-lifecycle-http.js", "sha256": "2df397de9f579d13ca839f10f82530af87a56e49c14b25b3fa8c518665f86b3c", "classification": "unreviewed" },
+    { "path": "runtime/workspace-core/resume-lifecycle.js", "sha256": "9915e9b61126cb45f52c96c40ec5dfe3c19642d4b142da5440645c297d4d751d", "classification": "unreviewed" },
+    { "path": "src/cli/native-resume-lifecycle.ts", "sha256": "331a22c2c794b40042d5da182ad9085114dac92bb8f1b8879abb2465402b9a92", "classification": "unreviewed" },
+    { "path": "src/workspace-core/resume-lifecycle-http.ts", "sha256": "1fd9ec3c62d0fb409ee554f35cfc73a6228bda04fe0dd11e5dc852c6fef229f7", "classification": "unreviewed" },
+    { "path": "src/workspace-core/resume-lifecycle.ts", "sha256": "8e652da3ec3c2d54d84500ab9e03aadf37f754188807829305741da0f8c6ace9", "classification": "unreviewed" }
+  ]
+}

--- a/config/migration/source-catalog-native-resumes.json
+++ b/config/migration/source-catalog-native-resumes.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "sources": [
     { "path": "runtime/contracts/workspace/resume-content.js", "sha256": "6e1aeb9b02c7a3ecfc904e6ececb7cd74ba01b80003cc3e788c8076a4755be18", "classification": "unreviewed" },
-    { "path": "runtime/store/native-resume-files.js", "sha256": "1bb45c99fb1981c921e0dcd1250dca7d8c946308cd46fa59b54f3d9849b3136d", "classification": "unreviewed" },
+    { "path": "runtime/store/native-resume-files.js", "sha256": "4cb365a34fe8b42fb759a39dddd6ff8ff42a95b84c8b54fd1694580ea5e218c5", "classification": "unreviewed" },
     { "path": "runtime/workspace-core/resumes-http.js", "sha256": "bdbb6b958bab5e7ed03818a98d2a7a7c2170c480eccb1aa4dd58b90fc81de287", "classification": "unreviewed" },
     { "path": "runtime/workspace-core/resumes.js", "sha256": "393a21b96618bed15b8317df5442cb403353f489c6d2acdd0360a3cd1724c623", "classification": "unreviewed" },
     { "path": "src/contracts/workspace/resume-content.ts", "sha256": "6578551f4655b6e9fd9db3b7f9aeecc3ddaee67d6f9270742a67e32eb15be2f9", "classification": "unreviewed" },
-    { "path": "src/store/native-resume-files.ts", "sha256": "56c43f6de09e97e20d329d671ab6cd01c5b72b56c6ac979dbc02fb5ac2cf0769", "classification": "unreviewed" },
+    { "path": "src/store/native-resume-files.ts", "sha256": "b2009c9d39e7ca2724a5adecb5d8e9d1e404a369b39dbf567646004485570b21", "classification": "unreviewed" },
     { "path": "src/workspace-core/resumes-http.ts", "sha256": "bf29e88b477f5b0cee81154e4f9ddb7b85c186700ea519c024e843f16d9ae15f", "classification": "unreviewed" },
     { "path": "src/workspace-core/resumes.ts", "sha256": "246072b9292684976f461a0fe4b31297f955b6b2dece93dc2ef63b0988747903", "classification": "unreviewed" }
   ]

--- a/config/migration/source-catalog-native-task-cli.json
+++ b/config/migration/source-catalog-native-task-cli.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "runtime/cli/task-runner.js",
-      "sha256": "fc8b1eb6c4111bf7377ef9c735735441d1da679c53a6dbb7246ca0273f224e79",
+      "sha256": "230048687bf1c09dbc3da324698916e273dbe0cc3d4adf370da44c07f9f0d0fa",
       "classification": "unreviewed"
     },
     {
@@ -38,7 +38,7 @@
     },
     {
       "path": "src/cli/task-runner.ts",
-      "sha256": "08862128094374203cc3601c8bb6d813413ad6b4c86cd0b4d1eea05be7fc7012",
+      "sha256": "52458ff55c7ac0d469a533dd8d0c6f5c59166e99320522a0c4e305e8038ca46d",
       "classification": "unreviewed"
     }
   ]

--- a/config/migration/source-catalog-react-trash.json
+++ b/config/migration/source-catalog-react-trash.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "apps/companion/components/trash-model.ts",
-      "sha256": "7c81eb7b5fc7073cd2e5e70289813611d59644a81f9deb01a2a132b85ad35cbb",
+      "sha256": "ed5b8464a5a430fb08a70af6d919830b0b383dddd472f6cfb16dcaa378248afa",
       "classification": "unreviewed"
     },
     {

--- a/docs/native-job-trash-fixture.md
+++ b/docs/native-job-trash-fixture.md
@@ -1,13 +1,13 @@
 # Native Trash and job recovery fixture
 
-The opt-in version 9 native fixture supports a unified Trash listing and reversible
+The opt-in version 10 native fixture supports a unified Trash listing and reversible
 job trash/restore and permanent deletion through its CLI and authenticated HTTP API. A trashed job is
 hidden from ordinary Jobs results. Restoring it makes it visible in Companion
 Jobs after Refresh or reload, retaining its saved fields and local status.
 
-This tranche adds API and CLI operations only. The native Companion has no Trash
-section or browser trash/restore buttons yet. Full Trash UI and
-resume/answer lifecycle operations remain separate integration work.
+The native Companion Trash section restores and permanently deletes jobs,
+resumes and answers. Each mutation uses the displayed revision and refreshes the
+canonical listing before enabling another action.
 
 ## Use a synthetic fixture
 

--- a/docs/native-lifecycle-fixture.md
+++ b/docs/native-lifecycle-fixture.md
@@ -1,11 +1,10 @@
 # Native lifecycle migration boundaries
 
-The first lifecycle tranche implements permanent job deletion in the synthetic
-version 9 fixture. See [job Trash fixture](native-job-trash-fixture.md) for the
-runnable CLI and HTTP contract. Resume and answer lifecycle operations below
-are mapped work, not enabled native functionality.
+The synthetic version 10 fixture implements trash, restore and permanent delete
+for jobs, resumes and answers. See [job Trash fixture](native-job-trash-fixture.md)
+for the shared listing and browser contract.
 
-## Python authority and remaining behavior
+## Python authority and native behavior
 
 | Record | Store authority | HTTP authority |
 | --- | --- | --- |
@@ -29,9 +28,10 @@ resume exists. Neither operation changes managed content identity.
 Resume delete returns an absent-record no-op before checking revision. Existing
 records require revision, prior trash, no open extraction request, and no job
 reference, including trashed jobs. Managed content is quarantined before record
-removal. Python restores quarantine on metadata write failure and tolerates an
-unlink failure after successful metadata deletion. Legacy source files are not
-removed. Crash recovery needs explicit fixture support before route activation.
+removal. A metadata failure before replacement restores the canonical filename.
+If replacement succeeded before a later failure was reported, the durable intent
+remains and restart completes deletion. Cleanup failure after metadata deletion is
+tolerated. Legacy source files are not removed.
 
 Answer trash/restore checks revision before no-op detection, using the legacy
 revision default of 1. Trash blocks immutable redirect targets. Mutation results
@@ -43,7 +43,7 @@ The session check includes terminal sessions. Do not remove protected references
 to make deletion succeed. Job deletion retaining sessions is therefore material
 to subsequent answer deletion behavior.
 
-## Narrow proposed repository interfaces
+## Repository interfaces
 
 Job deletion uses the existing `ClaimRepository.claimTransaction` snapshot,
 `requireJobUnclaimed` contract, and `saveJobs`. It needs no new journal because
@@ -60,10 +60,10 @@ Resume lifecycle needs one lock-consistent repository callback:
 ```ts
 interface ResumeLifecycleTransaction {
   resumes: Document;
-  jobs: Document;
-  requests: Document;
-  saveResumes(document: Document): Promise<void>;
-  deleteManaged(record: Document, document: Document): Promise<void>;
+  jobs(): Promise<Document>;
+  requests(): Promise<Document>;
+  saveResumes(document: Document, closeRequests: boolean): Promise<void>;
+  deleteManaged(record: Document, previous: Document, document: Document): Promise<void>;
 }
 interface ResumeLifecycleRepository {
   resumeLifecycleTransaction<T>(
@@ -73,29 +73,24 @@ interface ResumeLifecycleRepository {
 ```
 
 `saveResumes` should reuse extraction request closure and its existing journal.
-`deleteManaged` belongs to a new owned Store leaf, with the coordinator composing
-recovery before ordinary resume recovery. This is a proposal, not a committed
-API. The existing `NativeResumeFiles.validate` accepts canonical files and native
-temporary files only, and its recovery journal accepts install operations only.
-Adding quarantine filenames or a deletion operation requires a reviewed recovery
-contract and shared wiring; do not loosen validation or create unrecognized
-journals in a version 9 Store as a shortcut.
+`deleteManaged` uses `NativeResumeFiles`, and recovery runs under the Store lock
+before ordinary resume access. Validation accepts canonical files, native staging
+files and the exact owned quarantine pattern. Install and delete journal payloads
+are closed schemas; foreign names and malformed recovery identities fail closed.
 
-## Required next evidence
+## Verification
 
-Resume acceptance needs independent cloned Python/native Stores covering default
-selection, active and trashed job references, duplicate identities, extraction
-cancellation, open-request delete rejection, and managed/legacy/missing files.
-Inject rename, metadata write, unlink, and directory sync failures and restart
-at every durable boundary. Reject links, traversal, foreign files and malformed
-journals before cleanup. Check that unrelated files and metadata remain intact.
+Focused resume tests cover default selection, active and trashed job references,
+extraction cancellation, managed-file removal, synchronous rollback and restart
+at every durable delete boundary. Quarantine reconciliation restores the unique
+referenced digest, removes owned orphans and rejects foreign names before cleanup.
 
-Answer acceptance needs independent Python/native comparisons for legacy
-records, redirect sources/targets, sensitive projection, current/stale/no-op
-revisions, pending fields, terminal sessions and protected history. Preserve raw
-session/history bytes and compare redacted HTTP error counts.
+Answer tests compare the native implementation with independent Python Stores
+for legacy records, redirect sources and targets, sensitive projections,
+current/stale/no-op revisions, pending fields, terminal sessions and protected
+history. Raw session and history evidence remains intact.
 
-The coordinator owns catalogs, normal hooks, review, browser integration and
-staging publication. A browser may exercise the new job delete route after
-explicit confirmation and must refresh canonical state after acknowledgment.
-It must continue treating native resume/answer lifecycle routes as unsupported.
+The production browser exercises job, resume and answer restore/delete through
+the native HTTP adapter with Python absent from the CLI PATH. It verifies exact
+revision bodies, typed deletion, stale-conflict handling, redaction, managed-file
+removal and canonical refresh after every acknowledged mutation.

--- a/docs/react-trash-fixture.md
+++ b/docs/react-trash-fixture.md
@@ -18,11 +18,10 @@ and styles with its existing navigation guard. `onMutation` is optional because 
 
 ## Capabilities and recovery
 
-Compatibility mode supports restore and permanent deletion for jobs, resumes
-and answers. `nativeTrashCapabilities` enables job and answer restore/permanent deletion.
-Resume lifecycle actions remain unavailable in native fixture mode.
-Unsupported actions are disabled in the UI and independently rejected by the
-adapter before transport.
+Compatibility and native fixture modes support restore and permanent deletion
+for jobs, resumes and answers. `nativeTrashCapabilities` enables all three record
+types. Unsupported actions in any future capability profile remain disabled in
+the UI and are independently rejected by the adapter before transport.
 
 Restore uses a confirmation dialog. Permanent deletion requires the exact legacy
 phrase `DELETE JOB`, `DELETE RESUME`, or `DELETE ANSWER`. A resume deletion
@@ -51,7 +50,7 @@ wiring applied. It creates synthetic jobs, a managed resume and an answer using
 the API; restores and permanently deletes all three through the UI; verifies
 stale-revision rejection, typed confirmation, keyboard focus, advisory reference
 errors, saved-mutation/failed-refresh recovery, redaction and 390px/desktop
-layout. It also verifies native capability limits, failed-load versus empty state,
+layout. It also verifies native capability enablement, failed-load versus empty state,
 and an error returned after a real restore commits. Reference and refresh-error envelopes are injected in the isolated page;
 ordinary lifecycle and revision-conflict requests use the real Python backend.
 The caller owns browser/service/Store cleanup. Do not run against live data.

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,4 +1,5 @@
 import { answerLifecycleCommands, runAnswerLifecycleCommand } from './native-answer-lifecycle.js';
+import { resumeLifecycleCommands, runResumeLifecycleCommand } from './native-resume-lifecycle.js';
 import { trashCommands, runTrashCommand } from './native-trash.js';
 import { groupedApprovalCommands, runGroupedApprovalCommand } from './native-grouped-approvals.js';
 import { taskIntakeCommands, runTaskIntakeCommand } from './native-task-intake.js';
@@ -49,6 +50,7 @@ export async function runJobsCli(args, input) {
     }
     const fields = {
         ...answerLifecycleCommands,
+        ...resumeLifecycleCommands,
         ...trashCommands,
         ...groupedApprovalCommands,
         ...taskIntakeCommands,
@@ -98,6 +100,8 @@ export async function runJobsCli(args, input) {
     };
     if (Object.hasOwn(answerLifecycleCommands, command))
         return serialize(await runAnswerLifecycleCommand(command, repository, options));
+    if (Object.hasOwn(resumeLifecycleCommands, command))
+        return serialize(await runResumeLifecycleCommand(command, repository, options));
     if (Object.hasOwn(trashCommands, command))
         return serialize(await runTrashCommand(command, repository, options));
     if (Object.hasOwn(groupedApprovalCommands, command))

--- a/runtime/cli/native-resume-lifecycle.js
+++ b/runtime/cli/native-resume-lifecycle.js
@@ -1,0 +1,23 @@
+import { JobsError } from '../contracts/workspace/values.js';
+import { ResumeLifecycleService } from '../workspace-core/resume-lifecycle.js';
+export const resumeLifecycleCommands = {
+    'resume-trash': ['--id', '--expected-revision'],
+    'resume-restore': ['--id', '--expected-revision'],
+    'resume-delete': ['--id', '--expected-revision'],
+};
+export function runResumeLifecycleCommand(command, repository, options) {
+    const id = options.get('--id'), revision = options.get('--expected-revision');
+    if (!id)
+        throw new JobsError('required option: --id');
+    if (!revision || !/^[0-9]+$/.test(revision) || BigInt(revision) < 1n) {
+        throw new JobsError('expected revision must be a positive integer');
+    }
+    const service = new ResumeLifecycleService(repository);
+    if (command === 'resume-trash')
+        return service.trash(id, BigInt(revision));
+    if (command === 'resume-restore')
+        return service.restore(id, BigInt(revision));
+    if (command === 'resume-delete')
+        return service.delete(id, BigInt(revision));
+    throw new JobsError('unsupported native resume lifecycle command');
+}

--- a/runtime/cli/task-runner.js
+++ b/runtime/cli/task-runner.js
@@ -11,7 +11,7 @@ function help(command) {
         + 'Usage: native-task --root ABSOLUTE_FIXTURE --native-lock ABSOLUTE_ADDON COMMAND [options]\n'
         + `Commands: ${commands}\n`
         + 'Use the Python task command options; --input reads a JSON object from a file.\n'
-        + 'Only explicitly initialized native version 9 fixtures are supported.\n';
+        + 'Only explicitly initialized native version 10 fixtures are supported.\n';
 }
 export async function runTask(args) {
     try {

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -144,6 +144,10 @@ export class NativeJobsRepository {
     extractionJournal() {
         return new NativeExtractionJournal(() => this.journal(extractionJournalName), (name, document) => this.write(join(this.root, `${name}.json`), document, documentOptions));
     }
+    async saveResumeDocument(document) {
+        validateExtractionResumes(document);
+        await this.write(join(this.root, "resumes.json"), document, documentOptions);
+    }
     async saveResumes(document) {
         validateExtractionResumes(document);
         const requests = validateExtractionRequests(await this.document("resume-extraction-requests"));
@@ -151,7 +155,7 @@ export class NativeJobsRepository {
         if (closed)
             await this.extractionJournal().commit("resume-request-close", { requests: closed, resumes: document });
         else
-            await this.write(join(this.root, "resumes.json"), document, documentOptions);
+            await this.saveResumeDocument(document);
     }
     async recoverResumes() {
         // The extraction journal can contain the resume document intended by the file
@@ -263,6 +267,22 @@ export class NativeJobsRepository {
                     await this.saveResumes(value);
                 },
                 saveJournal: async (value) => this.saveJournal(value),
+            });
+        }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
+    }
+    async resumeLifecycleTransaction(operation) {
+        await this.validateRoot();
+        return withExclusiveFileLock(join(this.root, ".store.lock"), async () => {
+            await this.validateRoot(true);
+            const files = new NativeResumeFiles(this.root, this.checkpoint);
+            const resumes = await this.recoverResumes();
+            validateResumeReferences(object(get(resumes, "resumes"), "resumes.resumes"));
+            const saveResumes = async (document, closeRequests) => closeRequests
+                ? this.saveResumes(document) : this.saveResumeDocument(document);
+            return operation({ resumes, files, saveResumes,
+                jobs: () => this.document("jobs"),
+                requests: () => this.document("resume-extraction-requests"),
+                deleteManaged: (record, previous, document) => files.delete(record, previous, document, value => this.saveJournal(value), value => this.saveResumeDocument(value), () => this.document("resumes")),
             });
         }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
     }

--- a/runtime/store/native-resume-files.js
+++ b/runtime/store/native-resume-files.js
@@ -3,11 +3,14 @@ import { lstat, open, readdir, rename, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import { resumeLimit, validateResumeContent } from '../contracts/workspace/resume-content.js';
-import { get, has, int, integer, keys, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { safeId } from '../contracts/workspace/jobs.js';
+import { copy, get, has, int, integer, keys, object, same, set, string, text, JobsError } from '../contracts/workspace/values.js';
 import { emptyObject } from '../contracts/workspace/jobs.js';
+import { validateExtractionResumes } from './native-extraction-journal.js';
 import { resumeModifiedAt } from './resume-modified-at.js';
 const filePattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\.(pdf|docx|txt)$/;
 const tempPattern = /^\.native-[a-f0-9-]{36}\.tmp$/;
+const quarantinePattern = /^\.([A-Za-z0-9][A-Za-z0-9._-]{0,127}\.(?:pdf|docx|txt))\.([a-f0-9]{32})\.quarantine$/;
 const hash = (bytes) => createHash('sha256').update(bytes).digest('hex');
 const absent = (error) => error instanceof Error && 'code' in error && error.code === 'ENOENT';
 export async function syncDirectory(path) {
@@ -31,8 +34,9 @@ export class NativeResumeFiles {
         if (!metadata.isDirectory() || metadata.isSymbolicLink() || metadata.uid !== process.getuid?.() || metadata.mode & 0o077)
             throw new JobsError('resume directory must be private and owned');
         for (const name of await readdir(this.directory)) {
-            if (!filePattern.test(name) && !tempPattern.test(name))
+            if (!filePattern.test(name) && !tempPattern.test(name) && !quarantinePattern.test(name)) {
                 throw new JobsError('unsupported resume recovery state');
+            }
             const stat = await lstat(join(this.directory, name));
             if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || stat.uid !== process.getuid?.() || stat.mode & 0o077)
                 throw new JobsError('resume file must be private and owned, without links');
@@ -175,54 +179,213 @@ export class NativeResumeFiles {
         await saveJournal(null);
         await this.checkpoint('cleared');
     }
+    /** A durable intent makes every delete crash window recoverable without guessing. */
+    async delete(record, previousDocument, document, saveJournal, save, readCurrent) {
+        if (string(get(record, 'storageKind')) !== 'managed') {
+            await save(document);
+            return;
+        }
+        const source = string(get(record, 'managedFile')), sourcePath = this.path(record);
+        try {
+            await lstat(sourcePath);
+        }
+        catch (error) {
+            if (absent(error)) {
+                await save(document);
+                return;
+            }
+            throw error;
+        }
+        const quarantine = `.${source}.${randomUUID().replaceAll('-', '')}.quarantine`;
+        const journal = emptyObject();
+        set(journal, 'version', integer(1n));
+        set(journal, 'kind', text('delete'));
+        set(journal, 'id', get(record, 'id'));
+        set(journal, 'source', text(source));
+        set(journal, 'quarantine', text(quarantine));
+        set(journal, 'digest', get(record, 'digest'));
+        set(journal, 'previousDocument', previousDocument);
+        set(journal, 'document', document);
+        await saveJournal(journal);
+        await this.checkpoint('delete-journal');
+        await rename(sourcePath, join(this.directory, quarantine));
+        await syncDirectory(this.directory);
+        await this.checkpoint('delete-quarantined');
+        try {
+            await save(document);
+        }
+        catch (error) {
+            // Atomic replacement may report a later chmod/fsync failure after installing
+            // the intended document. Roll back bytes only when disk still proves the old
+            // document; otherwise preserve the journal and quarantine for recovery.
+            let current = null;
+            try {
+                current = await readCurrent();
+            }
+            catch { /* Preserve recoverable intent. */ }
+            if (current && same(current, previousDocument)) {
+                await saveJournal(null);
+                await rename(join(this.directory, quarantine), sourcePath);
+                await syncDirectory(this.directory);
+            }
+            throw error;
+        }
+        await this.checkpoint('delete-metadata');
+        try {
+            await unlink(join(this.directory, quarantine));
+        }
+        catch (error) {
+            if (!absent(error)) { /* Python tolerates cleanup failure. */ }
+        }
+        await syncDirectory(this.directory);
+        await saveJournal(null);
+        await this.checkpoint('delete-cleared');
+    }
     async recover(journal, current, save, clear) {
         await this.validate();
         if (journal) {
-            if (int(get(journal, 'version')) !== 1n || string(get(journal, 'kind')) !== 'install' || journal.size !== 7
-                || keys(journal).some(key => !['version', 'kind', 'temporary', 'destination', 'previous', 'digest', 'document'].includes(key)))
-                throw new JobsError('invalid resume recovery journal');
-            const temporary = string(get(journal, 'temporary')), destination = string(get(journal, 'destination')), previous = string(get(journal, 'previous')), digest = string(get(journal, 'digest'));
-            if (!temporary || !tempPattern.test(temporary) || !destination || !filePattern.test(destination) || !digest || !/^[a-f0-9]{64}$/.test(digest)
-                || get(journal, 'previous') !== null && (!previous || !filePattern.test(previous)))
-                throw new JobsError('invalid resume recovery journal');
-            const document = object(get(journal, 'document'), 'resume recovery document');
-            const records = object(get(document, 'resumes'), 'resumes.resumes');
-            const matches = records.entries().filter(([, value]) => string(get(object(value, 'resume'), 'managedFile')) === destination && string(get(object(value, 'resume'), 'digest')) === digest);
-            if (matches.length !== 1)
-                throw new JobsError('resume recovery identity differs');
-            const oldRecords = object(get(current, 'resumes'), 'resumes.resumes');
-            const targetId = string(matches[0][0]);
-            if (previous && (!has(oldRecords, targetId) || ![previous, destination].includes(string(get(object(get(oldRecords, targetId), 'resume'), 'managedFile')))))
-                throw new JobsError('resume recovery previous identity differs');
-            let installed = false;
-            try {
-                installed = hash(await this.readPath(join(this.directory, destination), true)) === digest;
+            if (string(get(journal, 'kind')) === 'delete') {
+                await this.recoverDelete(journal, current, save, clear);
+                current = validateExtractionResumes(object(get(journal, 'document'), 'resume delete document'));
             }
-            catch { /* Staged bytes must prove the expected digest below. */ }
-            if (!installed) {
-                const bytes = await this.readPath(join(this.directory, temporary), true);
-                if (hash(bytes) !== digest)
-                    throw new JobsError('resume recovery bytes are unavailable');
-                await rename(join(this.directory, temporary), join(this.directory, destination));
+            else {
+                if (int(get(journal, 'version')) !== 1n || string(get(journal, 'kind')) !== 'install' || journal.size !== 7
+                    || keys(journal).some(key => !['version', 'kind', 'temporary', 'destination', 'previous', 'digest', 'document'].includes(key)))
+                    throw new JobsError('invalid resume recovery journal');
+                const temporary = string(get(journal, 'temporary')), destination = string(get(journal, 'destination'));
+                const previous = string(get(journal, 'previous')), digest = string(get(journal, 'digest'));
+                if (!temporary || !tempPattern.test(temporary) || !destination || !filePattern.test(destination) || !digest || !/^[a-f0-9]{64}$/.test(digest)
+                    || get(journal, 'previous') !== null && (!previous || !filePattern.test(previous)))
+                    throw new JobsError('invalid resume recovery journal');
+                const document = object(get(journal, 'document'), 'resume recovery document');
+                const records = object(get(document, 'resumes'), 'resumes.resumes');
+                const matches = records.entries().filter(([, value]) => string(get(object(value, 'resume'), 'managedFile')) === destination
+                    && string(get(object(value, 'resume'), 'digest')) === digest);
+                if (matches.length !== 1)
+                    throw new JobsError('resume recovery identity differs');
+                const oldRecords = object(get(current, 'resumes'), 'resumes.resumes');
+                const targetId = string(matches[0][0]);
+                if (previous && (!has(oldRecords, targetId) || ![previous, destination].includes(string(get(object(get(oldRecords, targetId), 'resume'), 'managedFile')))))
+                    throw new JobsError('resume recovery previous identity differs');
+                let installed = false;
+                try {
+                    installed = hash(await this.readPath(join(this.directory, destination), true)) === digest;
+                }
+                catch { /* Staged bytes must prove the expected digest below. */ }
+                if (!installed) {
+                    const bytes = await this.readPath(join(this.directory, temporary), true);
+                    if (hash(bytes) !== digest)
+                        throw new JobsError('resume recovery bytes are unavailable');
+                    await rename(join(this.directory, temporary), join(this.directory, destination));
+                    await syncDirectory(this.directory);
+                }
+                await save(document);
+                if (previous && previous !== destination) {
+                    try {
+                        await unlink(join(this.directory, previous));
+                    }
+                    catch (error) {
+                        if (!absent(error))
+                            throw error;
+                    }
+                }
+                await syncDirectory(this.directory);
+                await clear();
+            }
+        }
+        // Only owned native staging names are collected under the Store lock.
+        for (const name of await readdir(this.directory))
+            if (tempPattern.test(name))
+                await unlink(join(this.directory, name));
+        await this.reconcileQuarantines(current);
+        await syncDirectory(this.directory);
+    }
+    async recoverDelete(journal, current, save, clear) {
+        const fields = ['version', 'kind', 'id', 'source', 'quarantine', 'digest', 'previousDocument', 'document'];
+        if (int(get(journal, 'version')) !== 1n || journal.size !== fields.length || keys(journal).some(key => !fields.includes(key))) {
+            throw new JobsError('invalid resume recovery journal');
+        }
+        const id = safeId(string(get(journal, 'id'))), source = string(get(journal, 'source'));
+        const quarantine = string(get(journal, 'quarantine')), digest = string(get(journal, 'digest'));
+        if (!source || !filePattern.test(source) || !quarantine || quarantinePattern.exec(quarantine)?.[1] !== source
+            || !digest || !/^[a-f0-9]{64}$/.test(digest))
+            throw new JobsError('invalid resume recovery journal');
+        const previous = validateExtractionResumes(object(get(journal, 'previousDocument'), 'resume delete previous document'));
+        const intended = validateExtractionResumes(object(get(journal, 'document'), 'resume delete document'));
+        const previousRecords = object(get(previous, 'resumes'), 'resumes.resumes');
+        const record = object(get(previousRecords, id), 'deleted resume');
+        if (get(record, 'deletedAt') === null || string(get(record, 'managedFile')) !== source
+            || string(get(record, 'digest')) !== digest || has(object(get(intended, 'resumes'), 'resumes.resumes'), id)) {
+            throw new JobsError('resume recovery identity differs');
+        }
+        const derived = copy(previous), derivedRecords = copy(object(get(derived, 'resumes'), 'resumes.resumes'));
+        const derivedMetadata = copy(object(get(derived, 'metadata'), 'resumes.metadata'));
+        set(derived, 'resumes', derivedRecords);
+        set(derived, 'metadata', derivedMetadata);
+        derivedRecords.delete(text(id));
+        set(derivedMetadata, 'updatedAt', get(object(get(intended, 'metadata'), 'resumes.metadata'), 'updatedAt'));
+        if (!same(derived, intended))
+            throw new JobsError('resume recovery identity differs');
+        const before = same(current, previous), after = same(current, intended);
+        if (!before && !after)
+            throw new JobsError('resume recovery document differs');
+        const sourcePath = join(this.directory, source), quarantinePath = join(this.directory, quarantine);
+        const sourceExists = await lstat(sourcePath).then(() => true, error => absent(error) ? false : Promise.reject(error));
+        const quarantineExists = await lstat(quarantinePath).then(() => true, error => absent(error) ? false : Promise.reject(error));
+        if (before) {
+            if (sourceExists === quarantineExists)
+                throw new JobsError('resume recovery bytes are unavailable');
+            if (sourceExists) {
+                await rename(sourcePath, quarantinePath);
                 await syncDirectory(this.directory);
             }
-            await save(document);
-            if (previous && previous !== destination) {
+            if (hash(await this.readPath(quarantinePath, true)) !== digest)
+                throw new JobsError('resume recovery bytes are unavailable');
+            await save(intended);
+        }
+        else if (sourceExists)
+            throw new JobsError('resume recovery identity differs');
+        if (await lstat(quarantinePath).then(() => true, error => absent(error) ? false : Promise.reject(error))) {
+            await unlink(quarantinePath);
+        }
+        await syncDirectory(this.directory);
+        await clear();
+    }
+    async reconcileQuarantines(current) {
+        const records = object(get(validateExtractionResumes(current), 'resumes'), 'resumes.resumes');
+        const groups = new Map();
+        for (const name of await readdir(this.directory)) {
+            const match = quarantinePattern.exec(name);
+            if (match)
+                groups.set(match[1], [...(groups.get(match[1]) ?? []), name]);
+        }
+        for (const [source, quarantines] of groups) {
+            const record = records.entries().map(([, value]) => object(value, 'resume')).find(value => string(get(value, 'managedFile')) === source);
+            const sourcePath = join(this.directory, source);
+            const sourceExists = await lstat(sourcePath).then(() => true, error => absent(error) ? false : Promise.reject(error));
+            const sourceMatches = record && sourceExists
+                ? hash(await this.readPath(sourcePath, true)) === string(get(record, 'digest')) : false;
+            if (record && !sourceMatches) {
+                const digest = string(get(record, 'digest'));
+                const matches = [];
+                for (const name of quarantines)
+                    if (hash(await this.readPath(join(this.directory, name), true)) === digest)
+                        matches.push(name);
+                if (matches.length !== 1)
+                    throw new JobsError('resume recovery bytes are unavailable');
+                if (sourceExists)
+                    await unlink(sourcePath);
+                await rename(join(this.directory, matches[0]), sourcePath);
+            }
+            for (const name of quarantines) {
                 try {
-                    await unlink(join(this.directory, previous));
+                    await unlink(join(this.directory, name));
                 }
                 catch (error) {
                     if (!absent(error))
                         throw error;
                 }
             }
-            await syncDirectory(this.directory);
-            await clear();
         }
-        // Only owned native staging names are collected under the Store lock.
-        for (const name of await readdir(this.directory))
-            if (tempPattern.test(name))
-                await unlink(join(this.directory, name));
-        await syncDirectory(this.directory);
     }
 }

--- a/runtime/workspace-core/jobs-http.js
+++ b/runtime/workspace-core/jobs-http.js
@@ -1,4 +1,5 @@
 import { automationHttp } from './automation-http.js';
+import { resumeLifecycleHttp } from './resume-lifecycle-http.js';
 import { answerLifecycleHttp } from './answer-lifecycle-http.js';
 import { trashHttp } from './trash-http.js';
 import { claimsHttp } from './claims-http.js';
@@ -23,6 +24,9 @@ export async function jobsHttp(service, repository, method, path, body = "") {
         const automation = await automationHttp(repository, method, path, body);
         if (automation)
             return automation;
+        const resumeLifecycle = await resumeLifecycleHttp(repository, method, path, body);
+        if (resumeLifecycle)
+            return resumeLifecycle;
         const answerLifecycle = await answerLifecycleHttp(repository, method, path, body);
         if (answerLifecycle)
             return answerLifecycle;

--- a/runtime/workspace-core/resume-lifecycle-http.js
+++ b/runtime/workspace-core/resume-lifecycle-http.js
@@ -1,0 +1,64 @@
+import { PythonObject } from '../contracts/python-object.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { fromJSON, get, int, integer, keys, object, parse, serialize, set, JobsError } from '../contracts/workspace/values.js';
+import { publicResume } from './resumes-http.js';
+import { ResumeLifecycleError, ResumeLifecycleService } from './resume-lifecycle.js';
+const failure = (status, code, message) => ({
+    status, body: serialize(fromJSON({ error: { code, message } })),
+});
+function lifecycleFailure(error, operation) {
+    const rules = [
+        ['revision conflict', 'revision_conflict', 'This record changed elsewhere. Refresh and review the latest revision.'],
+        ['does not exist', 'not_found', 'This record no longer exists.'],
+        ['still referenced by a job', 'job_reference_blocked', 'This resume is referenced by one or more jobs. Reassign or delete those jobs first.'],
+        ['assigned to an active job', 'job_reference_blocked', 'This resume is assigned to an active job. Reassign that job first.'],
+        ['default resume is used by an active job', 'default_reference_blocked', 'This default resume is in use by active jobs. Assign another default first.'],
+        ['active resume file already exists', 'duplicate_active_blocked', 'An active resume with the same canonical file identity already exists.'],
+    ];
+    const [, code, message] = rules.find(([fragment]) => error.message.includes(fragment))
+        ?? ['', 'store_rejected', 'The canonical store rejected this lifecycle operation.'];
+    const counts = emptyObject();
+    if (error instanceof ResumeLifecycleError)
+        set(counts, 'jobReferences', integer(error.jobReferences));
+    else if (code === 'duplicate_active_blocked')
+        set(counts, 'duplicateActiveRecords', integer(1n));
+    const detail = object(fromJSON({ code, message, recordType: 'resume', operation }), 'lifecycle error');
+    set(detail, 'counts', counts);
+    return { status: code === 'not_found' ? 404 : code === 'store_rejected' ? 400 : 409,
+        body: serialize(set(emptyObject(), 'error', detail)) };
+}
+export async function resumeLifecycleHttp(repository, method, path, body) {
+    const match = /^\/api\/resumes\/([^/]+)\/(trash|restore|delete)$/.exec(path);
+    if (method !== 'POST' || !match)
+        return null;
+    const operation = match[2];
+    let payload;
+    try {
+        payload = parse(body);
+    }
+    catch {
+        return failure(400, 'request_error', 'request body must be valid JSON');
+    }
+    if (!(payload instanceof PythonObject))
+        return failure(400, 'request_error', 'request body must be a JSON object');
+    if (keys(payload).length !== 1 || keys(payload)[0] !== 'expectedRevision') {
+        return failure(400, 'request_error', `${operation} body requires expectedRevision`);
+    }
+    const revision = int(get(payload, 'expectedRevision'));
+    if (revision === null || revision < 1n)
+        return failure(400, 'request_error', 'expectedRevision must be a positive integer');
+    try {
+        const result = await new ResumeLifecycleService(repository)[operation](decodeURIComponent(match[1]), revision);
+        return { status: 200, body: serialize(publicResume(result)) };
+    }
+    catch (error) {
+        if (error instanceof URIError)
+            return failure(400, 'request_error', 'encoded resume id is invalid');
+        if (error instanceof JobsError)
+            return lifecycleFailure(error, operation);
+        if (error instanceof Error && 'code' in error && typeof error.code === 'string' && /^E[A-Z]+$/.test(error.code)) {
+            return failure(500, 'storage_error', 'storage operation failed');
+        }
+        throw error;
+    }
+}

--- a/runtime/workspace-core/resume-lifecycle.js
+++ b/runtime/workspace-core/resume-lifecycle.js
@@ -1,0 +1,115 @@
+import { emptyObject, safeId } from '../contracts/workspace/jobs.js';
+import { validateResumeReferences } from '../contracts/workspace/resume-reference.js';
+import { copy, get, int, integer, object, same, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { validateExtractionRequests } from '../contracts/workspace/extraction-requests.js';
+import { validateJobsDocument } from '../contracts/workspace/jobs.js';
+import { validateExtractionResumes } from '../store/native-extraction-journal.js';
+export class ResumeLifecycleError extends JobsError {
+    jobReferences;
+    constructor(message, jobReferences) {
+        super(message);
+        this.jobReferences = jobReferences;
+    }
+}
+function updatedDocument(raw) {
+    const document = copy(validateExtractionResumes(raw));
+    const records = copy(object(get(document, 'resumes'), 'resumes.resumes'));
+    const metadata = copy(object(get(document, 'metadata'), 'resumes.metadata'));
+    set(document, 'resumes', records);
+    set(document, 'metadata', metadata);
+    return { document, records, metadata };
+}
+const active = (record) => get(record, 'deletedAt') === null;
+export class ResumeLifecycleService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    trash(id, expectedRevision) {
+        return this.setDeleted(id, expectedRevision, false);
+    }
+    restore(id, expectedRevision) {
+        return this.setDeleted(id, expectedRevision, true);
+    }
+    setDeleted(id, expectedRevision, restore) {
+        safeId(id);
+        return this.repository.resumeLifecycleTransaction(async (transaction) => {
+            const { document, records, metadata } = updatedDocument(transaction.resumes), value = get(records, id);
+            if (value === null)
+                throw new JobsError('resume does not exist');
+            const current = object(value, 'resume record');
+            if (int(get(current, 'revision')) !== expectedRevision)
+                throw new JobsError('resume revision conflict');
+            const trashed = !active(current);
+            if (restore === !trashed)
+                return current;
+            if (restore) {
+                if (records.entries().some(([key, value]) => string(key) !== id && active(object(value, 'resume record'))
+                    && (string(get(current, 'storageKind')) === 'managed'
+                        ? string(get(object(value, 'resume record'), 'storageKind')) === 'managed'
+                            && same(get(object(value, 'resume record'), 'digest'), get(current, 'digest'))
+                        : get(object(value, 'resume record'), 'storageKind') === null
+                            && same(get(object(value, 'resume record'), 'path'), get(current, 'path'))))) {
+                    throw new JobsError('active resume file already exists');
+                }
+            }
+            else {
+                const jobs = object(get(validateJobsDocument(await transaction.jobs()), 'jobs'), 'jobs.jobs');
+                const assigned = jobs.entries().filter(([, value]) => active(object(value, 'job'))
+                    && string(get(object(value, 'job'), 'resumeId')) === id).length;
+                const implicit = jobs.entries().filter(([, value]) => {
+                    const job = object(value, 'job');
+                    return active(job) && get(job, 'resumeId') === null;
+                }).length;
+                const references = assigned + (get(current, 'default') === true ? implicit : 0);
+                if (assigned)
+                    throw new ResumeLifecycleError('resume is assigned to an active job', BigInt(references));
+                if (get(current, 'default') === true && implicit) {
+                    throw new ResumeLifecycleError('default resume is used by an active job', BigInt(implicit));
+                }
+            }
+            const updated = copy(current), deletedAt = restore ? null : text(this.now()), timestamp = this.now();
+            set(updated, 'deletedAt', deletedAt);
+            set(updated, 'default', restore && !records.entries().some(([key, value]) => string(key) !== id && active(object(value, 'resume record'))));
+            set(updated, 'revision', integer(expectedRevision + 1n));
+            set(updated, 'updatedAt', text(timestamp));
+            set(records, id, updated);
+            set(metadata, 'updatedAt', text(timestamp));
+            validateResumeReferences(records);
+            await transaction.saveResumes(document, !restore);
+            return updated;
+        });
+    }
+    delete(id, expectedRevision) {
+        safeId(id);
+        return this.repository.resumeLifecycleTransaction(async (transaction) => {
+            const { document, records, metadata } = updatedDocument(transaction.resumes), value = get(records, id);
+            const result = set(emptyObject(), 'id', text(id));
+            if (value === null)
+                return set(result, 'deleted', false);
+            const current = object(value, 'resume record');
+            if (int(get(current, 'revision')) !== expectedRevision)
+                throw new JobsError('resume revision conflict');
+            if (active(current))
+                throw new JobsError('resume must be trashed before permanent deletion');
+            const requests = object(get(validateExtractionRequests(await transaction.requests()), 'requests'), 'requests.requests');
+            if (requests.entries().some(([, value]) => {
+                const request = object(value, 'request');
+                return string(get(request, 'resumeId')) === id && string(get(request, 'status')) === 'requested';
+            }))
+                throw new JobsError('resume has an open extraction request');
+            const jobs = object(get(validateJobsDocument(await transaction.jobs()), 'jobs'), 'jobs.jobs');
+            const references = jobs.entries().filter(([, value]) => string(get(object(value, 'job'), 'resumeId')) === id).length;
+            if (references)
+                throw new ResumeLifecycleError('resume is still referenced by a job', BigInt(references));
+            const previous = validateExtractionResumes(transaction.resumes), timestamp = this.now();
+            records.delete(text(id));
+            set(metadata, 'updatedAt', text(timestamp));
+            validateResumeReferences(records);
+            await transaction.deleteManaged(current, previous, document);
+            return set(result, 'deleted', true);
+        });
+    }
+}

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,4 +1,5 @@
 import { answerLifecycleCommands, runAnswerLifecycleCommand } from './native-answer-lifecycle.js';
+import { resumeLifecycleCommands, runResumeLifecycleCommand } from './native-resume-lifecycle.js';
 import { trashCommands, runTrashCommand } from './native-trash.js';
 import { groupedApprovalCommands, runGroupedApprovalCommand } from './native-grouped-approvals.js';
 import { taskIntakeCommands, runTaskIntakeCommand } from './native-task-intake.js';
@@ -44,6 +45,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
   }
   const fields: Record<string, string[]> = {
     ...answerLifecycleCommands,
+    ...resumeLifecycleCommands,
     ...trashCommands,
     ...groupedApprovalCommands,
     ...taskIntakeCommands,
@@ -88,6 +90,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
   };
   if (Object.hasOwn(answerLifecycleCommands, command!)) return serialize(await runAnswerLifecycleCommand(command!, repository, options));
+  if (Object.hasOwn(resumeLifecycleCommands, command!)) return serialize(await runResumeLifecycleCommand(command!, repository, options));
   if (Object.hasOwn(trashCommands, command!)) return serialize(await runTrashCommand(command!, repository, options));
   if (Object.hasOwn(groupedApprovalCommands, command!)) return serialize(await runGroupedApprovalCommand(command!, repository, options, payload));
   if (Object.hasOwn(taskIntakeCommands, command!)) return serialize(await runTaskIntakeCommand(repository, options, payload));

--- a/src/cli/native-resume-lifecycle.ts
+++ b/src/cli/native-resume-lifecycle.ts
@@ -1,0 +1,22 @@
+import { JobsError } from '../contracts/workspace/values.js';
+import { ResumeLifecycleService } from '../workspace-core/resume-lifecycle.js';
+import type { ResumeLifecycleRepository } from '../workspace-core/resume-lifecycle.js';
+
+export const resumeLifecycleCommands: Record<string, string[]> = {
+  'resume-trash': ['--id', '--expected-revision'],
+  'resume-restore': ['--id', '--expected-revision'],
+  'resume-delete': ['--id', '--expected-revision'],
+};
+export function runResumeLifecycleCommand(command: string, repository: ResumeLifecycleRepository,
+  options: Map<string, string>) {
+  const id = options.get('--id'), revision = options.get('--expected-revision');
+  if (!id) throw new JobsError('required option: --id');
+  if (!revision || !/^[0-9]+$/.test(revision) || BigInt(revision) < 1n) {
+    throw new JobsError('expected revision must be a positive integer');
+  }
+  const service = new ResumeLifecycleService(repository);
+  if (command === 'resume-trash') return service.trash(id, BigInt(revision));
+  if (command === 'resume-restore') return service.restore(id, BigInt(revision));
+  if (command === 'resume-delete') return service.delete(id, BigInt(revision));
+  throw new JobsError('unsupported native resume lifecycle command');
+}

--- a/src/cli/task-runner.ts
+++ b/src/cli/task-runner.ts
@@ -12,7 +12,7 @@ function help(command?: string): string {
     + 'Usage: native-task --root ABSOLUTE_FIXTURE --native-lock ABSOLUTE_ADDON COMMAND [options]\n'
     + `Commands: ${commands}\n`
     + 'Use the Python task command options; --input reads a JSON object from a file.\n'
-    + 'Only explicitly initialized native version 9 fixtures are supported.\n';
+    + 'Only explicitly initialized native version 10 fixtures are supported.\n';
 }
 export async function runTask(args: string[]): Promise<{ output: string; exitCode: number }> {
   try {

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -28,6 +28,7 @@ import { NativeExtractionJournal, closeRequestsForResumes, extractionJournalName
 import { validateExtractionRequests } from "../contracts/workspace/extraction-requests.js";
 import { validateExtractions } from "../contracts/workspace/extraction-proposals.js";
 import type { ExtractionTransaction } from "../workspace-core/extraction-context.js";
+import type { ResumeLifecycleRepository, ResumeLifecycleTransaction } from "../workspace-core/resume-lifecycle.js";
 
 import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
@@ -85,7 +86,7 @@ export async function initializeJobsFixture(root: string): Promise<void> {
   try { await directory.sync(); } finally { await directory.close(); }
 }
 
-export class NativeJobsRepository implements JobsRepository {
+export class NativeJobsRepository implements JobsRepository, ResumeLifecycleRepository {
   constructor(readonly root: string, private readonly provider: PosixFlockProvider,
     private readonly write = atomicWritePointJson,
     private readonly checkpoint: (stage:string)=>Promise<void> = async () => {}) {}
@@ -148,12 +149,17 @@ export class NativeJobsRepository implements JobsRepository {
       (name, document) => this.write(join(this.root, `${name}.json`), document, documentOptions));
   }
 
+  private async saveResumeDocument(document: Document): Promise<void> {
+    validateExtractionResumes(document);
+    await this.write(join(this.root, "resumes.json"), document, documentOptions);
+  }
+
   private async saveResumes(document: Document): Promise<void> {
     validateExtractionResumes(document);
     const requests = validateExtractionRequests(await this.document("resume-extraction-requests"));
     const closed = closeRequestsForResumes(requests, document);
     if (closed) await this.extractionJournal().commit("resume-request-close", { requests: closed, resumes: document });
-    else await this.write(join(this.root, "resumes.json"), document, documentOptions);
+    else await this.saveResumeDocument(document);
   }
 
   private async recoverResumes(): Promise<Document> {
@@ -268,6 +274,26 @@ export class NativeJobsRepository implements JobsRepository {
           await this.saveResumes(value);
         },
         saveJournal: async value => this.saveJournal(value),
+      });
+    }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
+  }
+
+  async resumeLifecycleTransaction<T>(operation: (transaction: ResumeLifecycleTransaction) => Promise<T>): Promise<T> {
+    await this.validateRoot();
+    return withExclusiveFileLock(join(this.root, ".store.lock"), async () => {
+      await this.validateRoot(true);
+      const files = new NativeResumeFiles(this.root, this.checkpoint);
+      const resumes = await this.recoverResumes();
+      validateResumeReferences(object(get(resumes, "resumes"), "resumes.resumes"));
+      const saveResumes = async (document: Document, closeRequests: boolean) => closeRequests
+        ? this.saveResumes(document) : this.saveResumeDocument(document);
+      return operation({ resumes, files, saveResumes,
+        jobs: () => this.document("jobs"),
+        requests: () => this.document("resume-extraction-requests"),
+        deleteManaged: (record, previous, document) => files.delete(
+          record, previous, document, value => this.saveJournal(value),
+          value => this.saveResumeDocument(value),
+          () => this.document("resumes")),
       });
     }, { provider: this.provider, pathProfile: "3.12", signal: AbortSignal.timeout(30_000) });
   }

--- a/src/store/native-resume-files.ts
+++ b/src/store/native-resume-files.ts
@@ -3,13 +3,16 @@ import { lstat, open, readdir, rename, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import { resumeLimit, validateResumeContent } from '../contracts/workspace/resume-content.js';
-import { get, has, int, integer, keys, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { safeId } from '../contracts/workspace/jobs.js';
+import { copy, get, has, int, integer, keys, object, same, set, string, text, JobsError } from '../contracts/workspace/values.js';
 import type { Document, Value } from '../contracts/workspace/values.js';
 import { emptyObject } from '../contracts/workspace/jobs.js';
+import { validateExtractionResumes } from './native-extraction-journal.js';
 import { resumeModifiedAt } from './resume-modified-at.js';
 export type StagedResume = { temporary: string; managedFile: string; originalFilename: string; mediaType: string; digest: string; observedSize: number; observedModifiedAt: string };
 const filePattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\.(pdf|docx|txt)$/;
 const tempPattern = /^\.native-[a-f0-9-]{36}\.tmp$/;
+const quarantinePattern = /^\.([A-Za-z0-9][A-Za-z0-9._-]{0,127}\.(?:pdf|docx|txt))\.([a-f0-9]{32})\.quarantine$/;
 const hash = (bytes: Buffer): string => createHash('sha256').update(bytes).digest('hex');
 const absent = (error: unknown): boolean => error instanceof Error && 'code' in error && error.code === 'ENOENT';
 export async function syncDirectory(path: string): Promise<void> {
@@ -25,7 +28,9 @@ export class NativeResumeFiles {
     const metadata = await lstat(this.directory);
     if (!metadata.isDirectory() || metadata.isSymbolicLink() || metadata.uid !== process.getuid?.() || metadata.mode & 0o077) throw new JobsError('resume directory must be private and owned');
     for (const name of await readdir(this.directory)) {
-      if (!filePattern.test(name) && !tempPattern.test(name)) throw new JobsError('unsupported resume recovery state');
+      if (!filePattern.test(name) && !tempPattern.test(name) && !quarantinePattern.test(name)) {
+        throw new JobsError('unsupported resume recovery state');
+      }
       const stat = await lstat(join(this.directory, name));
       if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || stat.uid !== process.getuid?.() || stat.mode & 0o077) throw new JobsError('resume file must be private and owned, without links');
     }
@@ -130,37 +135,148 @@ export class NativeResumeFiles {
     await saveJournal(null);
     await this.checkpoint('cleared');
   }
+  /** A durable intent makes every delete crash window recoverable without guessing. */
+  async delete(record: Document, previousDocument: Document, document: Document,
+    saveJournal: (value: Value) => Promise<void>, save: (value: Document) => Promise<void>,
+    readCurrent: () => Promise<Document>): Promise<void> {
+    if (string(get(record, 'storageKind')) !== 'managed') { await save(document); return; }
+    const source = string(get(record, 'managedFile'))!, sourcePath = this.path(record);
+    try { await lstat(sourcePath); }
+    catch (error) { if (absent(error)) { await save(document); return; } throw error; }
+    const quarantine = `.${source}.${randomUUID().replaceAll('-', '')}.quarantine`;
+    const journal = emptyObject();
+    set(journal, 'version', integer(1n)); set(journal, 'kind', text('delete'));
+    set(journal, 'id', get(record, 'id')); set(journal, 'source', text(source));
+    set(journal, 'quarantine', text(quarantine)); set(journal, 'digest', get(record, 'digest'));
+    set(journal, 'previousDocument', previousDocument); set(journal, 'document', document);
+    await saveJournal(journal); await this.checkpoint('delete-journal');
+    await rename(sourcePath, join(this.directory, quarantine));
+    await syncDirectory(this.directory); await this.checkpoint('delete-quarantined');
+    try { await save(document); }
+    catch (error) {
+      // Atomic replacement may report a later chmod/fsync failure after installing
+      // the intended document. Roll back bytes only when disk still proves the old
+      // document; otherwise preserve the journal and quarantine for recovery.
+      let current: Document | null = null;
+      try { current = await readCurrent(); } catch { /* Preserve recoverable intent. */ }
+      if (current && same(current, previousDocument)) {
+        await saveJournal(null);
+        await rename(join(this.directory, quarantine), sourcePath);
+        await syncDirectory(this.directory);
+      }
+      throw error;
+    }
+    await this.checkpoint('delete-metadata');
+    try { await unlink(join(this.directory, quarantine)); } catch (error) { if (!absent(error)) { /* Python tolerates cleanup failure. */ } }
+    await syncDirectory(this.directory); await saveJournal(null); await this.checkpoint('delete-cleared');
+  }
   async recover(journal: Document | null, current: Document, save: (value: Document) => Promise<void>, clear: () => Promise<void>): Promise<void> {
     await this.validate();
     if (journal) {
-      if (int(get(journal, 'version')) !== 1n || string(get(journal, 'kind')) !== 'install' || journal.size !== 7
-        || keys(journal).some(key => !['version','kind','temporary','destination','previous','digest','document'].includes(key))) throw new JobsError('invalid resume recovery journal');
-      const temporary = string(get(journal, 'temporary')), destination = string(get(journal, 'destination')), previous = string(get(journal, 'previous')), digest = string(get(journal, 'digest'));
-      if (!temporary || !tempPattern.test(temporary) || !destination || !filePattern.test(destination) || !digest || !/^[a-f0-9]{64}$/.test(digest)
-        || get(journal, 'previous') !== null && (!previous || !filePattern.test(previous))) throw new JobsError('invalid resume recovery journal');
-      const document = object(get(journal, 'document'), 'resume recovery document');
-      const records = object(get(document, 'resumes'), 'resumes.resumes');
-      const matches = records.entries().filter(([, value]) => string(get(object(value, 'resume'), 'managedFile')) === destination && string(get(object(value, 'resume'), 'digest')) === digest);
-      if (matches.length !== 1) throw new JobsError('resume recovery identity differs');
-      const oldRecords = object(get(current, 'resumes'), 'resumes.resumes');
-      const targetId = string(matches[0]![0])!;
-      if (previous && (!has(oldRecords, targetId) || ![previous, destination].includes(string(get(object(get(oldRecords,targetId),'resume'),'managedFile'))!))) throw new JobsError('resume recovery previous identity differs');
-      let installed = false;
-      try { installed = hash(await this.readPath(join(this.directory, destination), true)) === digest; } catch { /* Staged bytes must prove the expected digest below. */ }
-      if (!installed) {
-        const bytes = await this.readPath(join(this.directory, temporary), true);
-        if (hash(bytes) !== digest) throw new JobsError('resume recovery bytes are unavailable');
-        await rename(join(this.directory, temporary), join(this.directory, destination));
-        await syncDirectory(this.directory);
+      if (string(get(journal, 'kind')) === 'delete') {
+        await this.recoverDelete(journal, current, save, clear);
+        current = validateExtractionResumes(object(get(journal, 'document'), 'resume delete document'));
+      } else {
+        if (int(get(journal, 'version')) !== 1n || string(get(journal, 'kind')) !== 'install' || journal.size !== 7
+          || keys(journal).some(key => !['version','kind','temporary','destination','previous','digest','document'].includes(key))) throw new JobsError('invalid resume recovery journal');
+        const temporary = string(get(journal, 'temporary')), destination = string(get(journal, 'destination'));
+        const previous = string(get(journal, 'previous')), digest = string(get(journal, 'digest'));
+        if (!temporary || !tempPattern.test(temporary) || !destination || !filePattern.test(destination) || !digest || !/^[a-f0-9]{64}$/.test(digest)
+          || get(journal, 'previous') !== null && (!previous || !filePattern.test(previous))) throw new JobsError('invalid resume recovery journal');
+        const document = object(get(journal, 'document'), 'resume recovery document');
+        const records = object(get(document, 'resumes'), 'resumes.resumes');
+        const matches = records.entries().filter(([, value]) => string(get(object(value, 'resume'), 'managedFile')) === destination
+          && string(get(object(value, 'resume'), 'digest')) === digest);
+        if (matches.length !== 1) throw new JobsError('resume recovery identity differs');
+        const oldRecords = object(get(current, 'resumes'), 'resumes.resumes');
+        const targetId = string(matches[0]![0])!;
+        if (previous && (!has(oldRecords, targetId) || ![previous, destination].includes(string(get(object(get(oldRecords,targetId),'resume'),'managedFile'))!))) throw new JobsError('resume recovery previous identity differs');
+        let installed = false;
+        try { installed = hash(await this.readPath(join(this.directory, destination), true)) === digest; }
+        catch { /* Staged bytes must prove the expected digest below. */ }
+        if (!installed) {
+          const bytes = await this.readPath(join(this.directory, temporary), true);
+          if (hash(bytes) !== digest) throw new JobsError('resume recovery bytes are unavailable');
+          await rename(join(this.directory, temporary), join(this.directory, destination));
+          await syncDirectory(this.directory);
+        }
+        await save(document);
+        if (previous && previous !== destination) {
+          try { await unlink(join(this.directory, previous)); } catch (error) { if (!absent(error)) throw error; }
+        }
+        await syncDirectory(this.directory); await clear();
       }
-      await save(document);
-      if (previous && previous !== destination) {
-        try { await unlink(join(this.directory, previous)); } catch (error) { if (!absent(error)) throw error; }
-      }
-      await syncDirectory(this.directory); await clear();
     }
     // Only owned native staging names are collected under the Store lock.
     for (const name of await readdir(this.directory)) if (tempPattern.test(name)) await unlink(join(this.directory, name));
+    await this.reconcileQuarantines(current);
     await syncDirectory(this.directory);
+  }
+
+  private async recoverDelete(journal: Document, current: Document, save: (value: Document) => Promise<void>, clear: () => Promise<void>): Promise<void> {
+    const fields = ['version','kind','id','source','quarantine','digest','previousDocument','document'];
+    if (int(get(journal, 'version')) !== 1n || journal.size !== fields.length || keys(journal).some(key => !fields.includes(key))) {
+      throw new JobsError('invalid resume recovery journal');
+    }
+    const id = safeId(string(get(journal, 'id'))), source = string(get(journal, 'source'));
+    const quarantine = string(get(journal, 'quarantine')), digest = string(get(journal, 'digest'));
+    if (!source || !filePattern.test(source) || !quarantine || quarantinePattern.exec(quarantine)?.[1] !== source
+      || !digest || !/^[a-f0-9]{64}$/.test(digest)) throw new JobsError('invalid resume recovery journal');
+    const previous = validateExtractionResumes(object(get(journal, 'previousDocument'), 'resume delete previous document'));
+    const intended = validateExtractionResumes(object(get(journal, 'document'), 'resume delete document'));
+    const previousRecords = object(get(previous, 'resumes'), 'resumes.resumes');
+    const record = object(get(previousRecords, id), 'deleted resume');
+    if (get(record, 'deletedAt') === null || string(get(record, 'managedFile')) !== source
+      || string(get(record, 'digest')) !== digest || has(object(get(intended, 'resumes'), 'resumes.resumes'), id)) {
+      throw new JobsError('resume recovery identity differs');
+    }
+    const derived = copy(previous), derivedRecords = copy(object(get(derived, 'resumes'), 'resumes.resumes'));
+    const derivedMetadata = copy(object(get(derived, 'metadata'), 'resumes.metadata'));
+    set(derived, 'resumes', derivedRecords); set(derived, 'metadata', derivedMetadata);
+    derivedRecords.delete(text(id));
+    set(derivedMetadata, 'updatedAt', get(object(get(intended, 'metadata'), 'resumes.metadata'), 'updatedAt'));
+    if (!same(derived, intended)) throw new JobsError('resume recovery identity differs');
+    const before = same(current, previous), after = same(current, intended);
+    if (!before && !after) throw new JobsError('resume recovery document differs');
+    const sourcePath = join(this.directory, source), quarantinePath = join(this.directory, quarantine);
+    const sourceExists = await lstat(sourcePath).then(() => true, error => absent(error) ? false : Promise.reject(error));
+    const quarantineExists = await lstat(quarantinePath).then(() => true, error => absent(error) ? false : Promise.reject(error));
+    if (before) {
+      if (sourceExists === quarantineExists) throw new JobsError('resume recovery bytes are unavailable');
+      if (sourceExists) { await rename(sourcePath, quarantinePath); await syncDirectory(this.directory); }
+      if (hash(await this.readPath(quarantinePath, true)) !== digest) throw new JobsError('resume recovery bytes are unavailable');
+      await save(intended);
+    } else if (sourceExists) throw new JobsError('resume recovery identity differs');
+    if (await lstat(quarantinePath).then(() => true, error => absent(error) ? false : Promise.reject(error))) {
+      await unlink(quarantinePath);
+    }
+    await syncDirectory(this.directory); await clear();
+  }
+
+  private async reconcileQuarantines(current: Document): Promise<void> {
+    const records = object(get(validateExtractionResumes(current), 'resumes'), 'resumes.resumes');
+    const groups = new Map<string, string[]>();
+    for (const name of await readdir(this.directory)) {
+      const match = quarantinePattern.exec(name);
+      if (match) groups.set(match[1]!, [...(groups.get(match[1]!) ?? []), name]);
+    }
+    for (const [source, quarantines] of groups) {
+      const record = records.entries().map(([, value]) => object(value, 'resume')).find(value => string(get(value, 'managedFile')) === source);
+      const sourcePath = join(this.directory, source);
+      const sourceExists = await lstat(sourcePath).then(() => true, error => absent(error) ? false : Promise.reject(error));
+      const sourceMatches = record && sourceExists
+        ? hash(await this.readPath(sourcePath, true)) === string(get(record, 'digest')) : false;
+      if (record && !sourceMatches) {
+        const digest = string(get(record, 'digest'));
+        const matches: string[] = [];
+        for (const name of quarantines) if (hash(await this.readPath(join(this.directory, name), true)) === digest) matches.push(name);
+        if (matches.length !== 1) throw new JobsError('resume recovery bytes are unavailable');
+        if (sourceExists) await unlink(sourcePath);
+        await rename(join(this.directory, matches[0]!), sourcePath);
+      }
+      for (const name of quarantines) {
+        try { await unlink(join(this.directory, name)); } catch (error) { if (!absent(error)) throw error; }
+      }
+    }
   }
 }

--- a/src/workspace-core/jobs-http.ts
+++ b/src/workspace-core/jobs-http.ts
@@ -1,4 +1,5 @@
 import { automationHttp } from './automation-http.js';
+import { resumeLifecycleHttp } from './resume-lifecycle-http.js';
 import { answerLifecycleHttp } from './answer-lifecycle-http.js';
 import { trashHttp } from './trash-http.js';
 import { claimsHttp } from './claims-http.js';
@@ -30,6 +31,8 @@ export async function jobsHttp(service: JobsService, repository: NativeJobsRepos
   try {
     const automation = await automationHttp(repository, method, path, body);
     if (automation) return automation;
+    const resumeLifecycle = await resumeLifecycleHttp(repository, method, path, body);
+    if (resumeLifecycle) return resumeLifecycle;
     const answerLifecycle = await answerLifecycleHttp(repository, method, path, body);
     if (answerLifecycle) return answerLifecycle;
     const trash = await trashHttp(repository, method, path, body);

--- a/src/workspace-core/resume-lifecycle-http.ts
+++ b/src/workspace-core/resume-lifecycle-http.ts
@@ -1,0 +1,57 @@
+import { PythonObject } from '../contracts/python-object.js';
+import { emptyObject } from '../contracts/workspace/jobs.js';
+import { fromJSON, get, int, integer, keys, object, parse, serialize, set, JobsError } from '../contracts/workspace/values.js';
+import { publicResume } from './resumes-http.js';
+import { ResumeLifecycleError, ResumeLifecycleService } from './resume-lifecycle.js';
+import type { ResumeLifecycleRepository } from './resume-lifecycle.js';
+
+type Result = {status: number; body: string};
+const failure = (status: number, code: string, message: string): Result => ({
+  status, body: serialize(fromJSON({error: {code, message}})),
+});
+function lifecycleFailure(error: JobsError, operation: string): Result {
+  const rules: [string, string, string][] = [
+    ['revision conflict', 'revision_conflict', 'This record changed elsewhere. Refresh and review the latest revision.'],
+    ['does not exist', 'not_found', 'This record no longer exists.'],
+    ['still referenced by a job', 'job_reference_blocked', 'This resume is referenced by one or more jobs. Reassign or delete those jobs first.'],
+    ['assigned to an active job', 'job_reference_blocked', 'This resume is assigned to an active job. Reassign that job first.'],
+    ['default resume is used by an active job', 'default_reference_blocked', 'This default resume is in use by active jobs. Assign another default first.'],
+    ['active resume file already exists', 'duplicate_active_blocked', 'An active resume with the same canonical file identity already exists.'],
+  ];
+  const [, code, message] = rules.find(([fragment]) => error.message.includes(fragment))
+    ?? ['', 'store_rejected', 'The canonical store rejected this lifecycle operation.'];
+  const counts = emptyObject();
+  if (error instanceof ResumeLifecycleError) set(counts, 'jobReferences', integer(error.jobReferences));
+  else if (code === 'duplicate_active_blocked') set(counts, 'duplicateActiveRecords', integer(1n));
+  const detail = object(fromJSON({code, message, recordType:'resume', operation}), 'lifecycle error');
+  set(detail, 'counts', counts);
+  return {status: code === 'not_found' ? 404 : code === 'store_rejected' ? 400 : 409,
+    body: serialize(set(emptyObject(), 'error', detail))};
+}
+
+export async function resumeLifecycleHttp(repository: ResumeLifecycleRepository,
+  method: string, path: string, body: string): Promise<Result | null> {
+  const match = /^\/api\/resumes\/([^/]+)\/(trash|restore|delete)$/.exec(path);
+  if (method !== 'POST' || !match) return null;
+  const operation = match[2] as 'trash' | 'restore' | 'delete';
+  let payload;
+  try { payload = parse(body); }
+  catch { return failure(400, 'request_error', 'request body must be valid JSON'); }
+  if (!(payload instanceof PythonObject)) return failure(400, 'request_error', 'request body must be a JSON object');
+  if (keys(payload).length !== 1 || keys(payload)[0] !== 'expectedRevision') {
+    return failure(400, 'request_error', `${operation} body requires expectedRevision`);
+  }
+  const revision = int(get(payload, 'expectedRevision'));
+  if (revision === null || revision < 1n) return failure(400, 'request_error', 'expectedRevision must be a positive integer');
+  try {
+    const result = await new ResumeLifecycleService(repository)[operation](decodeURIComponent(match[1]!), revision);
+    return {status: 200, body: serialize(publicResume(result))};
+  } catch (error) {
+    if (error instanceof URIError) return failure(400, 'request_error', 'encoded resume id is invalid');
+    if (error instanceof JobsError) return lifecycleFailure(error, operation);
+    if (error instanceof Error && 'code' in error && typeof error.code === 'string' && /^E[A-Z]+$/.test(error.code)) {
+      return failure(500, 'storage_error', 'storage operation failed');
+    }
+    throw error;
+  }
+}

--- a/src/workspace-core/resume-lifecycle.ts
+++ b/src/workspace-core/resume-lifecycle.ts
@@ -1,0 +1,110 @@
+import { emptyObject, safeId } from '../contracts/workspace/jobs.js';
+import { validateResumeReferences } from '../contracts/workspace/resume-reference.js';
+import { copy, get, int, integer, object, same, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document } from '../contracts/workspace/values.js';
+import { validateExtractionRequests } from '../contracts/workspace/extraction-requests.js';
+import { validateJobsDocument } from '../contracts/workspace/jobs.js';
+import { validateExtractionResumes } from '../store/native-extraction-journal.js';
+import type { NativeResumeFiles } from '../store/native-resume-files.js';
+
+export interface ResumeLifecycleTransaction {
+  resumes: Document;
+  jobs(): Promise<Document>;
+  requests(): Promise<Document>;
+  files: NativeResumeFiles;
+  saveResumes(document: Document, closeRequests: boolean): Promise<void>;
+  deleteManaged(record: Document, previous: Document, document: Document): Promise<void>;
+}
+export interface ResumeLifecycleRepository {
+  resumeLifecycleTransaction<T>(operation: (transaction: ResumeLifecycleTransaction) => Promise<T>): Promise<T>;
+}
+export class ResumeLifecycleError extends JobsError {
+  constructor(message: string, readonly jobReferences: bigint) { super(message); }
+}
+
+function updatedDocument(raw: Document): {document: Document; records: Document; metadata: Document} {
+  const document = copy(validateExtractionResumes(raw));
+  const records = copy(object(get(document, 'resumes'), 'resumes.resumes'));
+  const metadata = copy(object(get(document, 'metadata'), 'resumes.metadata'));
+  set(document, 'resumes', records); set(document, 'metadata', metadata);
+  return {document, records, metadata};
+}
+const active = (record: Document): boolean => get(record, 'deletedAt') === null;
+
+export class ResumeLifecycleService {
+  constructor(readonly repository: ResumeLifecycleRepository,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+
+  trash(id: string, expectedRevision: bigint): Promise<Document> {
+    return this.setDeleted(id, expectedRevision, false);
+  }
+  restore(id: string, expectedRevision: bigint): Promise<Document> {
+    return this.setDeleted(id, expectedRevision, true);
+  }
+
+  private setDeleted(id: string, expectedRevision: bigint, restore: boolean): Promise<Document> {
+    safeId(id);
+    return this.repository.resumeLifecycleTransaction(async transaction => {
+      const {document, records, metadata} = updatedDocument(transaction.resumes), value = get(records, id);
+      if (value === null) throw new JobsError('resume does not exist');
+      const current = object(value, 'resume record');
+      if (int(get(current, 'revision')) !== expectedRevision) throw new JobsError('resume revision conflict');
+      const trashed = !active(current);
+      if (restore === !trashed) return current;
+      if (restore) {
+        if (records.entries().some(([key, value]) => string(key) !== id && active(object(value, 'resume record'))
+          && (string(get(current, 'storageKind')) === 'managed'
+            ? string(get(object(value, 'resume record'), 'storageKind')) === 'managed'
+              && same(get(object(value, 'resume record'), 'digest'), get(current, 'digest'))
+            : get(object(value, 'resume record'), 'storageKind') === null
+              && same(get(object(value, 'resume record'), 'path'), get(current, 'path'))))) {
+          throw new JobsError('active resume file already exists');
+        }
+      } else {
+        const jobs = object(get(validateJobsDocument(await transaction.jobs()), 'jobs'), 'jobs.jobs');
+        const assigned = jobs.entries().filter(([, value]) => active(object(value, 'job'))
+          && string(get(object(value, 'job'), 'resumeId')) === id).length;
+        const implicit = jobs.entries().filter(([, value]) => {
+          const job = object(value, 'job');
+          return active(job) && get(job, 'resumeId') === null;
+        }).length;
+        const references = assigned + (get(current, 'default') === true ? implicit : 0);
+        if (assigned) throw new ResumeLifecycleError('resume is assigned to an active job', BigInt(references));
+        if (get(current, 'default') === true && implicit) {
+          throw new ResumeLifecycleError('default resume is used by an active job', BigInt(implicit));
+        }
+      }
+      const updated = copy(current), deletedAt = restore ? null : text(this.now()), timestamp = this.now();
+      set(updated, 'deletedAt', deletedAt);
+      set(updated, 'default', restore && !records.entries().some(([key, value]) =>
+        string(key) !== id && active(object(value, 'resume record'))));
+      set(updated, 'revision', integer(expectedRevision + 1n)); set(updated, 'updatedAt', text(timestamp));
+      set(records, id, updated); set(metadata, 'updatedAt', text(timestamp));
+      validateResumeReferences(records); await transaction.saveResumes(document, !restore); return updated;
+    });
+  }
+
+  delete(id: string, expectedRevision: bigint): Promise<Document> {
+    safeId(id);
+    return this.repository.resumeLifecycleTransaction(async transaction => {
+      const {document, records, metadata} = updatedDocument(transaction.resumes), value = get(records, id);
+      const result = set(emptyObject(), 'id', text(id));
+      if (value === null) return set(result, 'deleted', false);
+      const current = object(value, 'resume record');
+      if (int(get(current, 'revision')) !== expectedRevision) throw new JobsError('resume revision conflict');
+      if (active(current)) throw new JobsError('resume must be trashed before permanent deletion');
+      const requests = object(get(validateExtractionRequests(await transaction.requests()), 'requests'), 'requests.requests');
+      if (requests.entries().some(([, value]) => {
+        const request = object(value, 'request');
+        return string(get(request, 'resumeId')) === id && string(get(request, 'status')) === 'requested';
+      })) throw new JobsError('resume has an open extraction request');
+      const jobs = object(get(validateJobsDocument(await transaction.jobs()), 'jobs'), 'jobs.jobs');
+      const references = jobs.entries().filter(([, value]) => string(get(object(value, 'job'), 'resumeId')) === id).length;
+      if (references) throw new ResumeLifecycleError('resume is still referenced by a job', BigInt(references));
+      const previous = validateExtractionResumes(transaction.resumes), timestamp = this.now();
+      records.delete(text(id)); set(metadata, 'updatedAt', text(timestamp)); validateResumeReferences(records);
+      await transaction.deleteManaged(current, previous, document);
+      return set(result, 'deleted', true);
+    });
+  }
+}

--- a/tests_js/workspace_native_browser_support.mjs
+++ b/tests_js/workspace_native_browser_support.mjs
@@ -207,8 +207,8 @@ export async function nativeJobsBrowser(buildRoot) {
     const taskCli = await taskCliBrowser(page, root, fixture, buildRoot);
     const jobTrash = await jobTrashBrowser(page, root, fixture, buildRoot);
     const reactTrash = await nativeReactTrashBrowser(page, root, fixture, buildRoot);
-    const unsupported = await fetch(startup.origin + '/api/resumes/fixture/delete', { method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Origin: startup.origin }, body: JSON.stringify({expectedRevision:1}) });
-    assert.equal(unsupported.status, 501);
+    const unsupported = await fetch(startup.origin + '/api/resumes/fixture/unknown', { method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Origin: startup.origin }, body: JSON.stringify({expectedRevision:1}) });
+    assert.equal(unsupported.status, 404);
     assert.deepEqual(pageErrors, []);
     return { reactTrash, jobTrash, taskCli, groupedApprovals, taskIntake, legacyJobs, upsert, transitions, projections, claims:true, facts, answers, extractions, resumes: true, browserHttpTsDisk: true, cliSharesService: true, conflictReapplyReload: true, pythonAbsentFromPath: true };
   } finally {

--- a/tests_js/workspace_native_job_trash.test.mjs
+++ b/tests_js/workspace_native_job_trash.test.mjs
@@ -143,7 +143,7 @@ test('native Trash listing and job lifecycle preserve Python contracts and persi
       assert.equal(success.status,200); assert.equal(JSON.parse(success.body).revision,2);
       const stale=await jobsHttp(state.jobs,state.repository,'POST','/api/jobs/job/restore','{"expectedRevision":1}');
       assert.equal(stale.status,409); assert.equal(JSON.parse(stale.body).error.code,'revision_conflict');
-      for(const path of ['/api/resumes/resume/trash']) {
+      for(const path of ['/api/resumes/resume/unknown']) {
         assert.equal((await jobsHttp(state.jobs,state.repository,'POST',path,'{"expectedRevision":2}')).status,501);
       }
     });

--- a/tests_js/workspace_native_jobs.test.mjs
+++ b/tests_js/workspace_native_jobs.test.mjs
@@ -117,7 +117,7 @@ print(json.dumps(out))
       assert.equal((await jobsHttp(service, repository, 'GET', '/api/jobs/missing')).status, 404);
       assert.equal((await jobsHttp(service, repository, 'POST', '/api/jobs/one/transition', '{}')).status, 400);
       assert.equal((await jobsHttp(service, repository, 'GET', '/api/trash')).status, 200);
-      assert.equal((await jobsHttp(service, repository, 'POST', '/api/resumes/resume/delete', '{"expectedRevision":1}')).status, 501);
+      assert.equal((await jobsHttp(service, repository, 'POST', '/api/resumes/resume/unknown', '{"expectedRevision":1}')).status, 501);
     });
     await t.test('independent CLI writers serialize revisions without Python', async () => {
       const cli = resolve('runtime/cli/native-jobs.js');

--- a/tests_js/workspace_native_lifecycle_resumes.test.mjs
+++ b/tests_js/workspace_native_lifecycle_resumes.test.mjs
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { access, readFile, readdir, realpath, rename, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { cli, plain, read, snapshot, write } from './workspace_native_claims_support.mjs';
+import { loadPosixFlockProvider } from '../runtime/store/posix-flock.js';
+import { NativeJobsRepository, initializeJobsFixture } from '../runtime/store/native-jobs.js';
+import { atomicWritePointJson } from '../runtime/store/point-persistence.js';
+import { ResumeService } from '../runtime/workspace-core/resumes.js';
+import { ResumeLifecycleService } from '../runtime/workspace-core/resume-lifecycle.js';
+import { ExtractionRequests } from '../runtime/workspace-core/extraction-requests.js';
+import { JobsService } from '../runtime/workspace-core/jobs.js';
+import { TrashService } from '../runtime/workspace-core/trash.js';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { fromJSON } from '../runtime/contracts/workspace/values.js';
+
+const absent = async path => access(path).then(() => false, error => {
+  if (error.code === 'ENOENT') return true;
+  throw error;
+});
+
+async function setup(fixture, name, checkpoint) {
+  const root = join(await realpath(fixture.root), name);
+  await initializeJobsFixture(root);
+  const provider = loadPosixFlockProvider(fixture.receipt.artifact);
+  const repository = new NativeJobsRepository(root, provider, atomicWritePointJson, checkpoint);
+  return { root, provider, repository };
+}
+
+test('native resume lifecycle enforces references, closes extraction work, and exposes HTTP and CLI actions', {timeout: 60000}, async () => {
+  const fixture = await nativeFixture();
+  try {
+    const state = await setup(fixture, 'resume-lifecycle');
+    const resumes = new ResumeService(state.repository, () => '2026-09-11T10:00:00Z');
+    const created = plain(await resumes.import(fromJSON({id:'source',label:'PRIVATE LABEL'}), 'source.txt', Buffer.from('PRIVATE BYTES')));
+    const request = plain(await new ExtractionRequests(state.repository).createRequest('source', BigInt(created.revision)));
+    const jobs = new JobsService(state.repository, () => '2026-09-11T10:01:00Z');
+    const job = plain(await jobs.create(fromJSON({id:'job',url:'https://example.invalid/job'})));
+    const http = async (operation, revision) => {
+      const result = await jobsHttp(jobs, state.repository, 'POST', `/api/resumes/source/${operation}`,
+        JSON.stringify({expectedRevision:revision}));
+      return {status:result.status, value:JSON.parse(result.body)};
+    };
+    const implicit = await http('trash', created.revision);
+    assert.equal(implicit.status, 409);
+    assert.deepEqual(implicit.value.error.counts, {jobReferences:1});
+    assert.equal(implicit.value.error.code, 'default_reference_blocked');
+    const assigned = plain(await jobs.update('job', fromJSON({resumeId:'source'}), BigInt(job.revision)));
+    const implicitJob = plain(await jobs.create(fromJSON({id:'implicit-job',url:'https://example.invalid/implicit'})));
+    const blocked = await http('trash', created.revision);
+    assert.equal(blocked.status, 409);
+    assert.deepEqual(blocked.value.error.counts, {jobReferences:2});
+    assert.equal(JSON.stringify(blocked.value).includes('PRIVATE'), false);
+    const trashedJob = plain(await new TrashService(state.repository).trashJob('job', BigInt(assigned.revision)));
+    await new TrashService(state.repository).trashJob('implicit-job', BigInt(implicitJob.revision));
+
+    const times = ['2026-09-11T10:02:00Z','2026-09-11T10:02:01Z','2026-09-11T10:03:00Z',
+      '2026-09-11T10:04:00Z','2026-09-11T10:04:01Z','2026-09-11T10:05:00Z'];
+    const lifecycle = new ResumeLifecycleService(state.repository, () => times.shift());
+    const trashed = plain(await lifecycle.trash('source', BigInt(created.revision)));
+    assert.equal(trashed.deletedAt, '2026-09-11T10:02:00Z');
+    assert.equal(trashed.updatedAt, '2026-09-11T10:02:01Z');
+    assert.equal(trashed.default, false);
+    assert.deepEqual(plain(await lifecycle.trash('source', BigInt(trashed.revision))), trashed);
+    assert.equal((await read(state.root, 'resume-extraction-requests.json')).requests[request.requestId].status, 'cancelled');
+    const restored = plain(await lifecycle.restore('source', BigInt(trashed.revision)));
+    assert.equal(restored.default, true);
+    assert.equal(restored.updatedAt, '2026-09-11T10:03:00Z');
+    const trashedAgain = plain(await lifecycle.trash('source', BigInt(restored.revision)));
+    const referenced = await http('delete', trashedAgain.revision);
+    assert.equal(referenced.status, 409);
+    assert.equal(referenced.value.error.code, 'job_reference_blocked');
+    assert.deepEqual(referenced.value.error.counts, {jobReferences:1});
+    await new TrashService(state.repository).deleteJob('job', BigInt(trashedJob.revision));
+    assert.deepEqual(plain(await lifecycle.delete('source', BigInt(trashedAgain.revision))), {id:'source',deleted:true});
+    assert.equal(await absent(join(state.root, 'resume-files/source.txt')), true);
+    assert.deepEqual(plain(await lifecycle.delete('source', 999n)), {id:'source',deleted:false});
+
+    const cliResume = plain(await resumes.import(fromJSON({id:'cli',label:'CLI'}), 'cli.txt', Buffer.from('CLI')));
+    const cliTrashed = await cli(fixture, state.root, 'resume-trash', ['--id','cli','--expected-revision',String(cliResume.revision)]);
+    const cliRestored = await cli(fixture, state.root, 'resume-restore', ['--id','cli','--expected-revision',String(cliTrashed.revision)]);
+    const cliTrashedAgain = await cli(fixture, state.root, 'resume-trash', ['--id','cli','--expected-revision',String(cliRestored.revision)]);
+    assert.deepEqual(await cli(fixture, state.root, 'resume-delete', ['--id','cli','--expected-revision',String(cliTrashedAgain.revision)]), {id:'cli',deleted:true});
+  } finally { await fixture.cleanup(); }
+});
+
+test('managed resume delete rolls back reported write failures and recovers every crash boundary', {timeout: 60000}, async t => {
+  const fixture = await nativeFixture();
+  try {
+    await t.test('reported metadata failure restores the exact tree', async () => {
+      const state = await setup(fixture, 'resume-delete-rollback');
+      const resumes = new ResumeService(state.repository);
+      const created = plain(await resumes.import(fromJSON({id:'resume',label:'Rollback'}), 'resume.txt', Buffer.from('rollback')));
+      const trashed = plain(await new ResumeLifecycleService(state.repository).trash('resume', BigInt(created.revision)));
+      const before = await snapshot(state.root);
+      let fail = true;
+      const write = async (path, value, options) => {
+        if (fail && path.endsWith('/resumes.json')) { fail = false; throw Error('injected metadata failure'); }
+        return atomicWritePointJson(path, value, options);
+      };
+      const repository = new NativeJobsRepository(state.root, state.provider, write);
+      await assert.rejects(new ResumeLifecycleService(repository).delete('resume', BigInt(trashed.revision)), /injected metadata failure/);
+      assert.deepEqual(await snapshot(state.root), before);
+      assert.equal(await readFile(join(state.root, 'resume-files/resume.txt'), 'utf8'), 'rollback');
+    });
+    await t.test('post-replace metadata failure preserves deletion recovery', async () => {
+      const state = await setup(fixture, 'resume-delete-post-replace');
+      const resumes = new ResumeService(state.repository);
+      const created = plain(await resumes.import(fromJSON({id:'resume',label:'Post replace'}), 'resume.txt', Buffer.from('private')));
+      const trashed = plain(await new ResumeLifecycleService(state.repository).trash('resume', BigInt(created.revision)));
+      let fail = true;
+      const write = async (path, value, options) => {
+        await atomicWritePointJson(path, value, options);
+        if (fail && path.endsWith('/resumes.json')) { fail = false; throw Error('post-replace metadata failure'); }
+      };
+      const repository = new NativeJobsRepository(state.root, state.provider, write);
+      await assert.rejects(new ResumeLifecycleService(repository).delete('resume', BigInt(trashed.revision)), /post-replace metadata failure/);
+      assert.equal(await absent(join(state.root, 'resume-files/resume.txt')), true);
+      assert.notEqual((await read(state.root, 'resume-operation.json')).operation, null);
+      assert.deepEqual(plain(await new ResumeService(new NativeJobsRepository(state.root, state.provider)).list(true)), []);
+      assert.equal((await read(state.root, 'resume-operation.json')).operation, null);
+    });
+    for (const stage of ['delete-journal','delete-quarantined','delete-metadata','delete-cleared']) {
+      await t.test(`restart completes ${stage}`, async () => {
+        let injected = false;
+        const state = await setup(fixture, `resume-${stage}`, async current => {
+          if (!injected && current === stage) { injected = true; throw Error(`injected ${stage}`); }
+        });
+        const resumes = new ResumeService(state.repository);
+        const created = plain(await resumes.import(fromJSON({id:'resume',label:'Crash'}), 'resume.txt', Buffer.from(stage)));
+        const trashed = plain(await new ResumeLifecycleService(state.repository).trash('resume', BigInt(created.revision)));
+        await assert.rejects(new ResumeLifecycleService(state.repository).delete('resume', BigInt(trashed.revision)), new RegExp(stage));
+        const recovered = new ResumeService(new NativeJobsRepository(state.root, state.provider));
+        assert.deepEqual(plain(await recovered.list(true)), []);
+        assert.equal(await absent(join(state.root, 'resume-files/resume.txt')), true);
+        assert.equal((await read(state.root, 'resume-operation.json')).operation, null);
+      });
+    }
+  } finally { await fixture.cleanup(); }
+});
+
+test('quarantine recovery restores referenced bytes, removes orphans, and rejects unknown names', {timeout: 60000}, async () => {
+  const fixture = await nativeFixture();
+  try {
+    const state = await setup(fixture, 'resume-quarantine');
+    const resumes = new ResumeService(state.repository);
+    await resumes.import(fromJSON({id:'resume',label:'Recovery'}), 'resume.txt', Buffer.from('recover'));
+    const directory = join(state.root, 'resume-files');
+    const source = join(directory, 'resume.txt');
+    const quarantine = join(directory, `.resume.txt.${'a'.repeat(32)}.quarantine`);
+    await rename(source, quarantine);
+    assert.equal(plain(await resumes.get('resume')).id, 'resume');
+    assert.equal(await readFile(source, 'utf8'), 'recover');
+    const replacement = join(directory, `.resume.txt.${'c'.repeat(32)}.quarantine`);
+    await rename(source, replacement);
+    await writeFile(source, 'corrupt', {mode:0o600});
+    assert.equal(plain(await resumes.get('resume')).id, 'resume');
+    assert.equal(await readFile(source, 'utf8'), 'recover');
+    const orphan = join(directory, `.orphan.txt.${'b'.repeat(32)}.quarantine`);
+    await writeFile(orphan, 'orphan', {mode:0o600});
+    await resumes.list();
+    assert.equal(await absent(orphan), true);
+    await writeFile(join(directory, '.resume.txt.synthetic.quarantine'), 'unknown', {mode:0o600});
+    await assert.rejects(resumes.list(), /unsupported resume recovery state/);
+    assert.equal((await readdir(directory)).includes('.resume.txt.synthetic.quarantine'), true);
+  } finally { await fixture.cleanup(); }
+});
+
+test('resume restore and delete preserve duplicate, request, missing-file, and legacy-file guards', {timeout: 60000}, async () => {
+  const fixture = await nativeFixture();
+  try {
+    const state = await setup(fixture, 'resume-edge-contracts');
+    const resumes = new ResumeService(state.repository, () => '2026-09-11T11:00:00Z');
+    const first = plain(await resumes.import(fromJSON({id:'first',label:'First'}), 'first.txt', Buffer.from('first')));
+    const second = plain(await resumes.import(fromJSON({id:'second',label:'Second'}), 'second.txt', Buffer.from('second')));
+    const request = plain(await new ExtractionRequests(state.repository).createRequest('first', BigInt(first.revision)));
+    const lifecycle = new ResumeLifecycleService(state.repository, () => '2026-09-11T11:01:00Z');
+    const trashed = plain(await lifecycle.trash('first', BigInt(first.revision)));
+    const document = await read(state.root, 'resumes.json');
+    const originalDigest = document.resumes.first.digest;
+    document.resumes.first.digest = document.resumes.second.digest;
+    await write(state.root, 'resumes.json', document);
+    const beforeDuplicate = await snapshot(state.root);
+    await assert.rejects(lifecycle.restore('first', BigInt(trashed.revision)), /active resume file already exists/);
+    assert.deepEqual(await snapshot(state.root), beforeDuplicate);
+    document.resumes.first.digest = originalDigest;
+    await write(state.root, 'resumes.json', document);
+
+    const requests = await read(state.root, 'resume-extraction-requests.json');
+    const closedAt = requests.requests[request.requestId].closedAt;
+    requests.requests[request.requestId].status = 'requested';
+    requests.requests[request.requestId].closedAt = null;
+    await write(state.root, 'resume-extraction-requests.json', requests);
+    await assert.rejects(lifecycle.delete('first', BigInt(trashed.revision)), /open extraction request/);
+    requests.requests[request.requestId].status = 'cancelled';
+    requests.requests[request.requestId].closedAt = closedAt;
+    await write(state.root, 'resume-extraction-requests.json', requests);
+    await unlink(join(state.root, 'resume-files/first.txt'));
+    assert.deepEqual(plain(await lifecycle.delete('first', BigInt(trashed.revision))), {id:'first',deleted:true});
+
+    const external = join(fixture.root, 'legacy.txt');
+    await writeFile(external, 'legacy');
+    const current = await read(state.root, 'resumes.json');
+    current.resumes.legacy = {id:'legacy',label:'Legacy',path:external,tags:[],default:false,
+      observedSize:6,observedModifiedAt:'2026-09-11T11:00:00Z',revision:3,
+      createdAt:'2026-09-11T11:00:00Z',updatedAt:'2026-09-11T11:00:00Z',deletedAt:'2026-09-11T11:00:00Z'};
+    await write(state.root, 'resumes.json', current);
+    assert.deepEqual(plain(await lifecycle.delete('legacy', 3n)), {id:'legacy',deleted:true});
+    assert.equal(await readFile(external, 'utf8'), 'legacy');
+    assert.equal(plain(await resumes.get('second')).id, second.id);
+  } finally { await fixture.cleanup(); }
+});
+
+test('resume lifecycle reads unrelated documents only after earlier guards', {timeout: 60000}, async () => {
+  const fixture = await nativeFixture();
+  try {
+    const state = await setup(fixture, 'resume-lazy-guards');
+    const resumes = new ResumeService(state.repository);
+    const created = plain(await resumes.import(fromJSON({id:'resume',label:'Lazy'}), 'resume.txt', Buffer.from('lazy')));
+    const lifecycle = new ResumeLifecycleService(state.repository);
+    const trashed = plain(await lifecycle.trash('resume', BigInt(created.revision)));
+    const jobs = await read(state.root, 'jobs.json');
+    jobs.jobs.invalid = {id:'invalid',unexpected:true};
+    await write(state.root, 'jobs.json', jobs);
+    const requests = await read(state.root, 'resume-extraction-requests.json');
+    requests.requests.invalid = {unexpected:true};
+    await write(state.root, 'resume-extraction-requests.json', requests);
+
+    const restored = plain(await lifecycle.restore('resume', BigInt(trashed.revision)));
+    assert.deepEqual(plain(await lifecycle.restore('resume', BigInt(restored.revision))), restored);
+    assert.deepEqual(plain(await lifecycle.delete('missing', 999n)), {id:'missing',deleted:false});
+    await assert.rejects(lifecycle.delete('resume', 999n), /resume revision conflict/);
+    await assert.rejects(lifecycle.delete('resume', BigInt(restored.revision)), /resume must be trashed/);
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_react_trash.test.mjs
+++ b/tests_js/workspace_react_trash.test.mjs
@@ -66,9 +66,10 @@ test('answer dot-segment keys preserve identity through browser URL normalizatio
     }
 });
 
-test('native adapter refuses unsupported actions before transport', async () => {
+test('adapter refuses capability-disabled actions before transport', async () => {
     let calls = 0;
-    const client = createTrashClient('synthetic', model.nativeTrashCapabilities, async () => { ++calls; return new Response('{}'); });
+    const limited = {...model.nativeTrashCapabilities, resume:{restore:false,delete:false}};
+    const client = createTrashClient('synthetic', limited, async () => { ++calls; return new Response('{}'); });
     const signal = new AbortController().signal;
     for (const type of ['job', 'resume', 'answer']) for (const action of ['restore', 'delete']) {
         if (type !== 'resume') continue;
@@ -77,6 +78,9 @@ test('native adapter refuses unsupported actions before transport', async () => 
     assert.equal(calls, 0);
     await client.mutate({ ...item, revision: 1n }, 'restore', signal);
     assert.equal(calls, 1);
+    const native = createTrashClient('synthetic', model.nativeTrashCapabilities, async () => { ++calls; return new Response('{}'); });
+    await native.mutate({ ...item, type:'resume', revision:1n }, 'restore', signal);
+    assert.equal(calls, 2);
 });
 
 test('errors preserve count guidance while suppressing private server messages and never retry', async () => {

--- a/tests_js/workspace_react_trash_browser_support.mjs
+++ b/tests_js/workspace_react_trash_browser_support.mjs
@@ -137,7 +137,7 @@ export async function reactTrashBrowser(page, { origin, headers }) {
         await page.setViewportSize({ width, height: 844 });
         assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1), true);
     }
-    // Capability and failed-first-load UI checks use only intercepted synthetic projections.
+    // Native capability and failed-first-load UI checks use only intercepted synthetic projections.
     await page.route('**/api/boot', route => route.fulfill({ status: 200, contentType: 'application/json', body: '{"status":"ready","mode":"native-jobs-fixture"}' }));
     let firstLoad = true;
     await page.route('**/api/trash', route => {
@@ -155,13 +155,14 @@ export async function reactTrashBrowser(page, { origin, headers }) {
     await reload();
     for (const fixture of fixtures) {
         const actions = card(fixture).getByRole('button');
-        assert.equal(await actions.nth(0).isDisabled(), fixture.type === 'resume');
-        assert.equal(await actions.nth(1).isDisabled(), fixture.type === 'resume');
+        assert.equal(await actions.nth(0).isDisabled(), false);
+        assert.equal(await actions.nth(1).isDisabled(), false);
     }
     await page.setViewportSize({ width: 390, height: 844 });
     assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1), true);
     await page.unroute('**/api/boot');
     await page.unroute('**/api/trash');
     return { compatibilityRestoreAndDeleteAllTypes: true, exactTypedConfirmation: true, conflictNoRetry: true,
-        referencePrivacy: true, savedButRefreshFailed: true, keyboardFocus: true, nativeUnsupportedActionsDisabled: true, failedLoadNotEmpty: true, errorAfterCommitReconciled: true, layouts: [390, 1280] };
+        referencePrivacy: true, savedButRefreshFailed: true, keyboardFocus: true, nativeAllActionsEnabled: true,
+        failedLoadNotEmpty: true, errorAfterCommitReconciled: true, layouts: [390, 1280] };
 }

--- a/tests_js/workspace_react_trash_native_browser_support.mjs
+++ b/tests_js/workspace_react_trash_native_browser_support.mjs
@@ -11,6 +11,7 @@ export async function nativeReactTrashBrowser(page, root, fixture, buildRoot) {
     const execute = promisify(execFile);
     const suffix = randomUUID();
     const input = join(fixture.root, `react-trash-native-${suffix}.json`);
+    const resumeSource = join(fixture.root, `react-trash-native-${suffix}.txt`);
     async function cli(command, args = [], payload) {
         if (payload !== undefined) {
             await writeFile(input, JSON.stringify(payload), { mode: 0o600 });
@@ -64,8 +65,13 @@ export async function nativeReactTrashBrowser(page, root, fixture, buildRoot) {
             value: 'PRIVATE-NATIVE-TRASH-ANSWER'
         });
         assert.equal(answer.key, key);
+        await writeFile(resumeSource, 'PRIVATE-NATIVE-TRASH-RESUME', { mode: 0o600 });
+        const resume = await cli('resume-import', ['--path', resumeSource], {
+            id: `react-trash-resume-${suffix}`, label: `Native React Trash resume ${suffix}`
+        });
         const records = [
             { type: 'job', id: job.id, label: job.role, revision: job.revision },
+            { type: 'resume', id: resume.id, label: resume.label, revision: resume.revision },
             { type: 'answer', id: key, label: answer.question, revision: answer.revision }
         ];
         for (const dotKey of ['.', '..']) {
@@ -81,21 +87,12 @@ export async function nativeReactTrashBrowser(page, root, fixture, buildRoot) {
         await navigation.getByRole('button', { name: 'Trash', exact: true }).click();
         await idle();
         await reload();
-        await workspace.getByText('Some lifecycle actions are not available in this workspace. Only supported actions are enabled.', { exact: true }).waitFor();
         assert.doesNotMatch(await workspace.innerText(), /PRIVATE-NATIVE-TRASH/);
         const listing = await cli('trash-list');
         assert.equal(listing.items.find(item => item.type === 'answer' && item.id === key)?.label, answer.question);
         assert.doesNotMatch(JSON.stringify(listing), /PRIVATE-NATIVE-TRASH/);
 
-        // No unsupported resume mutation or direct fixture file edits are needed.
-        await filter.selectOption('resume');
-        const resumeCards = workspace.locator('.trash-card');
-        const existingResumeCount = await resumeCards.count();
-        for (let index = 0; index < existingResumeCount; index += 1) {
-            const buttons = resumeCards.nth(index).getByRole('button');
-            assert.equal(await buttons.nth(0).isDisabled(), true);
-            assert.equal(await buttons.nth(1).isDisabled(), true);
-        }
+        assert.doesNotMatch(await workspace.innerText(), /Some lifecycle actions are not available/);
         for (const record of records) {
             await filter.selectOption(record.type);
             await card(record).getByRole('button', { name: 'Restore', exact: true }).click();
@@ -151,16 +148,19 @@ export async function nativeReactTrashBrowser(page, root, fixture, buildRoot) {
             assert.equal(observedWrites.length, deletedCount + 1);
             assert.equal(observedWrites.at(-1).body, `{"expectedRevision":${record.revision}}`);
             assert.equal(await get(record), null);
+            if (record.type === 'resume') {
+                await assert.rejects(readFile(join(root, 'resume-files', `${record.id}.txt`)), { code: 'ENOENT' });
+            }
         }
         assert.deepEqual(await cli('trash-list'), before);
-        return { nativeJobRestoreDelete: true, nativeAnswerRestoreDelete: true,
-            exactUnicodeAnswerIdentity: true, dotSegmentAnswerIdentity: true, typedDeletionBothTypes: true,
+        return { nativeJobRestoreDelete: true, nativeResumeRestoreDelete: true, nativeAnswerRestoreDelete: true,
+            exactUnicodeAnswerIdentity: true, dotSegmentAnswerIdentity: true, typedDeletionAllTypes: true,
             staleRevisionRejectedWithoutRetry: true, canonicalRecordsDeleted: true,
             errorAndListPrivacy: true, unrelatedTrashPreserved: true,
-            resumeLimitationCopy: true, existingResumeCardsChecked: existingResumeCount,
             pythonAbsentFromCliPath: true };
     } finally {
         page.off('request', observe);
         await rm(input, { force: true });
+        await rm(resumeSource, { force: true });
     }
 }


### PR DESCRIPTION
Enables native resume trash, restore, and permanent delete across CLI, HTTP, and React Trash.

Managed resume deletion now uses a durable quarantine journal with crash recovery, preserves lifecycle guard and error ordering, and removes managed bytes only after metadata commits. The migration inventory and generated runtime artifacts are reconciled.

Validation:
- `npm run verify:commit`
- `npm run verify:deep -- --head e2474cd79c420bd93edacc4a04f7466449846d9b --base 017f6d5162870ff03653080b82d5720c6f7cbc3b` (27 suites passed)
- production standalone browser lifecycle coverage
- independent contract and correctness review with validated fixes
