### PR TITLE
Add native account operation recovery

### DIFF
--- a/config/migration/cli-native-account-operation-surfaces.json
+++ b/config/migration/cli-native-account-operation-surfaces.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "surfaces": [
+    {
+      "id": "cli:src/cli/native-jobs.ts:employer-account-operation-status",
+      "kind": "cli",
+      "command": "employer-account-operation-status",
+      "node": "ACC",
+      "sources": ["src/cli/native-jobs.ts", "src/cli/native-account-operation.ts", "src/workspace-core/account-operation.ts", "src/store/native-jobs.ts"],
+      "effects": "unclassified",
+      "scenarios": {"valid":"unverified","invalid":"unverified","missing":"unverified","noop":"unverified","privacy":"unverified","conflict":"unverified","concurrency":"unverified","interruption":"unverified","recovery":"unverified","platform":"unverified"}
+    },
+    {
+      "id": "cli:src/cli/native-jobs.ts:employer-account-operation-recover",
+      "kind": "cli",
+      "command": "employer-account-operation-recover",
+      "node": "ACC",
+      "sources": ["src/cli/native-jobs.ts", "src/cli/native-account-operation.ts", "src/workspace-core/account-operation.ts", "src/store/native-jobs.ts"],
+      "effects": "unclassified",
+      "scenarios": {"valid":"unverified","invalid":"unverified","missing":"unverified","noop":"unverified","privacy":"unverified","conflict":"unverified","concurrency":"unverified","interruption":"unverified","recovery":"unverified","platform":"unverified"}
+    }
+  ]
+}

--- a/config/migration/document-01-surfaces.json
+++ b/config/migration/document-01-surfaces.json
@@ -363,7 +363,9 @@
       "artifact": "json",
       "node": "JOUR",
       "sources": [
-        "scripts/job_apply_store/base.py"
+        "scripts/job_apply_store/base.py",
+        "src/contracts/workspace/account-operation.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-read-surfaces.json
+++ b/config/migration/http-read-surfaces.json
@@ -103,7 +103,11 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/account-operation-http.ts",
+        "src/workspace-core/account-operation.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-write-accounts-surfaces.json
+++ b/config/migration/http-write-accounts-surfaces.json
@@ -97,7 +97,11 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/account-operation-http.ts",
+        "src/workspace-core/account-operation.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/journal-03-surfaces.json
+++ b/config/migration/journal-03-surfaces.json
@@ -9,7 +9,10 @@
       "value": null,
       "node": "JOUR",
       "sources": [
-        "scripts/job_apply_store/domains/accounts/settings.py"
+        "scripts/job_apply_store/domains/accounts/settings.py",
+        "src/contracts/workspace/account-operation.ts",
+        "src/workspace-core/account-operation.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -90,6 +90,10 @@
       "sha256": "adcbc8737ec21bf25b4e0ea251fb2c7b34e577486f778e79aee43810fa946c07"
     },
     {
+      "path": "cli-native-account-operation-surfaces.json",
+      "sha256": "06b37b69660c7d085457f8c3c1c89a6f4b666884e7122af1d04cc1e9b87b5d1f"
+    },
+    {
       "path": "cli-native-answer-lifecycle-surfaces.json",
       "sha256": "687fc1341cc0071e64d0c623843fff3c84d90754319d4c24f1efa70515b97316"
     },
@@ -159,7 +163,7 @@
     },
     {
       "path": "document-01-surfaces.json",
-      "sha256": "e40a1120beada72f4309c65d47891c119d2c207d1517ac0883584dc6640722f9"
+      "sha256": "ce12b934a4542a8cc46e5b095ec8887c2b8d93bb8993f6ec131e99436305a3d5"
     },
     {
       "path": "document-02-surfaces.json",
@@ -195,11 +199,11 @@
     },
     {
       "path": "http-read-surfaces.json",
-      "sha256": "361d916abc603b515fb3d6fd9a9283afc9d7e977e8e09200bc51fabb94573e8a"
+      "sha256": "420a387d530df24642d9bd323e4bf91dd5aba7a36f28a362dd2d84749ab58a7e"
     },
     {
       "path": "http-write-accounts-surfaces.json",
-      "sha256": "535990c198636250f0e58f67300ac315e0c3a7a3157c15b5291e1276b9cdee1c"
+      "sha256": "0738dac1610ed71d5db200b209e802e085bff0b20d2832cf3cd8d51efb47a02b"
     },
     {
       "path": "http-write-answers-02-surfaces.json",
@@ -235,7 +239,7 @@
     },
     {
       "path": "journal-03-surfaces.json",
-      "sha256": "20e3c3ab40814076290bb43fd37c91dec03884686abe372fbe0908b224b171da"
+      "sha256": "e8105e257b560f114fd5773cfe95a1a3760cf2930d45b7b65a6a190acc9d5e1a"
     },
     {
       "path": "journal-native-resumes-surfaces.json",
@@ -314,6 +318,10 @@
       "sha256": "0b6ee35143f1ad4f49568ed3d9e15f1cfacf869476a50a151b4fea3fc6f29f41"
     },
     {
+      "path": "source-catalog-native-account-operation.json",
+      "sha256": "3b55f21dfcbdc845555c273149d0d140caa3657f39f60ed963e6303aca4e0e3d"
+    },
+    {
       "path": "source-catalog-native-answer-cleanup.json",
       "sha256": "c819b8b9447817aa908b5a5626aa9d239b2cfecd46f4caf1cfebb931415129ee"
     },
@@ -367,7 +375,7 @@
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "d55bf95dc463784de761295dfa29136a88981bf011675bc6dbefd7328fe2e3d5"
+      "sha256": "c93c364c6bade66dcd9b49a93ba0e84580505ae33aa8268e929de57aaea394cb"
     },
     {
       "path": "source-catalog-native-legacy-jobs.json",

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -319,7 +319,7 @@
     },
     {
       "path": "source-catalog-native-account-operation.json",
-      "sha256": "3b55f21dfcbdc845555c273149d0d140caa3657f39f60ed963e6303aca4e0e3d"
+      "sha256": "8aa7e96d575e2c1d8e3cd5c4a2031770522f48e9c72cc94a4d400e8333d668ed"
     },
     {
       "path": "source-catalog-native-answer-cleanup.json",

--- a/config/migration/source-catalog-native-account-operation.json
+++ b/config/migration/source-catalog-native-account-operation.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "runtime/workspace-core/account-operation.js",
-      "sha256": "4486068332bc442670ed85e619d83d6ee3d3e8f8152f8faee8adaaa5351a2768",
+      "sha256": "450c2f890ad1b461fa57b7eb983510e6ff29cab117e149745c6ddbfb509f2ca5",
       "classification": "unreviewed"
     },
     {
@@ -38,7 +38,7 @@
     },
     {
       "path": "src/workspace-core/account-operation.ts",
-      "sha256": "99134bd3e5b0087e580edae67c0abe174831b8beee6c5eb4c9121645323f839d",
+      "sha256": "81d5420e46f6b7506ca308489436f38a5b65d554f121baa558d4a0062ab7004e",
       "classification": "unreviewed"
     }
   ]

--- a/config/migration/source-catalog-native-account-operation.json
+++ b/config/migration/source-catalog-native-account-operation.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "runtime/cli/native-account-operation.js",
+      "sha256": "9d6287afcf822d7a68854196b8e138c47929b5478e8d88eeac8d1545f4958a92",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/contracts/workspace/account-operation.js",
+      "sha256": "a175f310935dbef3ca431f8da439bbce619243c0c43f5fbf91301c8eab6e8c70",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/account-operation-http.js",
+      "sha256": "32a2ef5b4c06c84b5320dc5d48046051437342bcfb876bdc8f137c5dad69f26b",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/account-operation.js",
+      "sha256": "4486068332bc442670ed85e619d83d6ee3d3e8f8152f8faee8adaaa5351a2768",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/cli/native-account-operation.ts",
+      "sha256": "d1a1f8d9d5a963b14f559073244c9b8ffe99f68b66a4acfcc1f54780db616c28",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/account-operation.ts",
+      "sha256": "a0e30783e59a5eb34363b74e134df3eb39acae18e1ab27935332783c6ea59ae0",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/account-operation-http.ts",
+      "sha256": "e38a96fd272ff83e2885caababe17bf9bd9f74c58c1cd13fb495fa93bfbdb254",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/account-operation.ts",
+      "sha256": "99134bd3e5b0087e580edae67c0abe174831b8beee6c5eb4c9121645323f839d",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -8,7 +8,7 @@
     },
     {
       "path": "runtime/cli/native-jobs.js",
-      "sha256": "8a9a8086f7d8687562f4662fa5270f2b8f76d1a1eae91bfd98107494d80bd8a6",
+      "sha256": "3d12cf4ce4f12d1b05025bb55a56033fdddcf32c386b22149068df6ae4b95563",
       "classification": "unreviewed"
     },
     {
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "603a4571d8aee0a872ec95f379673d696167b797e21028b44eae940a04b4c025",
+      "sha256": "a72e50e0475f5959f98f818a469635938dbcd2a79c61ef58078c6179d19f34ac",
       "classification": "unreviewed"
     },
     {
@@ -43,7 +43,7 @@
     },
     {
       "path": "runtime/workspace-core/jobs-http.js",
-      "sha256": "8497751c99a72c7d5a3d3695e995fbf9bd34abac8ed3e6ee57bc35ec89c35fb7",
+      "sha256": "d4111473eb20fd821b1fcdc27980c83a97fc3cacc5c18ef996fc55a5705a134d",
       "classification": "unreviewed"
     },
     {
@@ -58,7 +58,7 @@
     },
     {
       "path": "src/cli/native-jobs.ts",
-      "sha256": "fa111b7c4dfc494d64c3b2ff554e0572e5f4f7bee87c973966aa8872db2a2a76",
+      "sha256": "30db1ee1dc9a73ae8981826d2c0c085c8c173c79ee1ca7eac9b412c831db8e80",
       "classification": "unreviewed"
     },
     {
@@ -83,7 +83,7 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "5faaae36d489a1dabfa390656c60d65ae1f1cc12ff4c184b849f7b1b557191e7",
+      "sha256": "9167cea7a350470fb33ebb7d97b6b9f17f5d2ce572d7ecec5be149817e7b3946",
       "classification": "unreviewed"
     },
     {
@@ -93,7 +93,7 @@
     },
     {
       "path": "src/workspace-core/jobs-http.ts",
-      "sha256": "a3c7199df9e9a8878afba358e29f340e8a0250c4e41d529e4e2332e450f30307",
+      "sha256": "a6f66fec063016eda2e92f1a1b32846e4d04db80f533273522cc36c54382e38d",
       "classification": "unreviewed"
     },
     {

--- a/docs/native-automation-fixture.md
+++ b/docs/native-automation-fixture.md
@@ -1,12 +1,12 @@
 # Native automation and employer-account control plane
 
 This tranche supplies native settings, realm resolution, and employer-account
-registry services for explicit synthetic fixtures. It does not activate a Store
+registry services and stranded account-operation recovery for explicit synthetic fixtures. It does not activate a Store
 writer, initialize an existing Store, inspect a browser, call credentials, or
-run an account executor. New fixtures use version 10 and require both account
-documents. Existing version 9 roots are rejected rather than upgraded or adopted;
+run an account executor. New fixtures use version 11 and require both account
+documents plus `account-operation-journal.json`. Existing version 10 roots are rejected rather than upgraded or adopted;
 earlier fixture documents describe their historical version. Missing documents
-and unsupported account-operation or trusted-fill journals remain rejected.
+and unsupported trusted-fill journals remain rejected.
 
 ## Composition and persistence
 
@@ -41,6 +41,14 @@ Workday tenant host and cell, Oracle tenant host and career site. Unsupported
 hosts, ambiguous gateways, userinfo, fragments and credential query parameters
 remain unresolved with fixed reason codes. It performs no external lookup.
 
+`AccountOperationService` implements redacted operation status and explicit
+fail-closed recovery. Recovery marks the bound account ambiguous, hands a live
+same-job claim to `needs_info` with browser-state-uncertain evidence, and clears
+the matching operation journal only after durable account and coordinator work.
+An already `needs_info` job can finish clearing a prior partial recovery. No
+path infers account success, permits retry, invokes a provider, or performs a
+final application action.
+
 ## HTTP boundary
 
 `automationHttp(repository, method, path, body)` supports these Python routes:
@@ -50,6 +58,11 @@ remain unresolved with fixed reason codes. It performs no external lookup.
 - POST `/api/automation/settings/copy-profile-email`
 - POST `/api/employer-accounts`
 - GET/PATCH `/api/employer-accounts/{realmRef}`
+
+`accountOperationHttp(repository, method, path, body)` supports:
+
+- GET `/api/account-operation`
+- POST `/api/account-operation/recover`
 
 It returns a response or null for an unowned route. The composing HTTP boundary
 retains the existing safe request/storage error envelope and revision-conflict
@@ -83,12 +96,8 @@ records `signup_in_progress` before its provider call. Follow-on crash-point
 tests must cover these distinct windows. Work must use injected synthetic executors only, with
 separate credentials/account-flow providers; never a real account helper.
 
-Account-operation recovery marks a stranded account ambiguous, increments its
-revision when needed, requires an available job and live same-job claim for an
-in-progress job, performs an attention handoff or accepts an already needs-info
-job, then clears the matching journal. It never infers signup success and returns
-`retryAllowed: false`. The current tranche rejects those journals at the root
-boundary and exposes none of these unsupported routes.
+Account-operation status and recovery are now native. Synthetic operation
+execution remains deferred with the provider integration described above.
 
 ## Focused evidence and remaining integration gates
 
@@ -101,6 +110,9 @@ validation/public projections with the Python authorities. No credentials or
 live data are used. The integrated fixture suite exercises the real native
 repository and HTTP dispatcher, concurrent Python-free writers, private files,
 old-root/missing-document/journal rejection, and unrelated-document preservation.
+The account-operation suite covers idle transport parity, status redaction,
+real claim handoff evidence, journal identity checks, and unavailable-job
+preservation.
 
 Typecheck and owned runtime emission are required. The integration owner also
 owns source/runtime catalogs, test matrix, HTTP wiring, fixture marker/allowlist,

--- a/runtime/cli/native-account-operation.js
+++ b/runtime/cli/native-account-operation.js
@@ -1,0 +1,9 @@
+import { AccountOperationService } from '../workspace-core/account-operation.js';
+export const accountOperationCommands = {
+    'employer-account-operation-status': [],
+    'employer-account-operation-recover': [],
+};
+export function runAccountOperationCommand(command, repository) {
+    const service = new AccountOperationService(repository);
+    return command === 'employer-account-operation-status' ? service.status() : service.recover();
+}

--- a/runtime/cli/native-jobs.js
+++ b/runtime/cli/native-jobs.js
@@ -1,4 +1,5 @@
 import { answerLifecycleCommands, runAnswerLifecycleCommand } from './native-answer-lifecycle.js';
+import { accountOperationCommands, runAccountOperationCommand } from './native-account-operation.js';
 import { resumeLifecycleCommands, runResumeLifecycleCommand } from './native-resume-lifecycle.js';
 import { trashCommands, runTrashCommand } from './native-trash.js';
 import { groupedApprovalCommands, runGroupedApprovalCommand } from './native-grouped-approvals.js';
@@ -49,6 +50,7 @@ export async function runJobsCli(args, input) {
         }
     }
     const fields = {
+        ...accountOperationCommands,
         ...answerLifecycleCommands,
         ...resumeLifecycleCommands,
         ...trashCommands,
@@ -98,6 +100,8 @@ export async function runJobsCli(args, input) {
             : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command) ? 2 * 1024 * 1024 : 65536;
         return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
     };
+    if (Object.hasOwn(accountOperationCommands, command))
+        return serialize(await runAccountOperationCommand(command, repository));
     if (Object.hasOwn(answerLifecycleCommands, command))
         return serialize(await runAnswerLifecycleCommand(command, repository, options));
     if (Object.hasOwn(resumeLifecycleCommands, command))

--- a/runtime/contracts/workspace/account-operation.js
+++ b/runtime/contracts/workspace/account-operation.js
@@ -1,0 +1,43 @@
+import { exact } from './automation.js';
+import { fromJSON, get, int, object, string, JobsError } from './values.js';
+const stages = new Set(['prepared', 'credential_provisioned', 'signup_in_progress']);
+const outcomes = new Set([
+    'success', 'reuse', 'verification', 'challenge', 'consent', 'reset',
+    'definitive_failure', 'ambiguity', 'observed_pending',
+]);
+const operationFields = [
+    'operationId', 'jobId', 'jobRevision', 'claimId', 'realmRef',
+    'accountRevision', 'settingsRevision', 'stage', 'outcomeCode', 'startedAt',
+];
+export function emptyAccountOperationJournal() {
+    return object(fromJSON({ schemaVersion: 1, operation: null }), 'account operation journal');
+}
+export function validateAccountOperationJournal(value) {
+    const journal = object(value, 'account operation journal');
+    exact(journal, ['schemaVersion', 'operation'], 'account operation journal contains unsupported fields');
+    if (int(get(journal, 'schemaVersion')) !== 1n)
+        throw new JobsError('account operation journal schema version is unsupported');
+    const raw = get(journal, 'operation');
+    if (raw === null)
+        return journal;
+    const operation = object(raw, 'account operation journal operation');
+    exact(operation, operationFields, 'account operation journal is invalid');
+    for (const field of ['operationId', 'jobId', 'claimId', 'realmRef', 'stage', 'outcomeCode', 'startedAt']) {
+        if (!string(get(operation, field)))
+            throw new JobsError('account operation journal binding is invalid');
+    }
+    for (const field of ['jobRevision', 'accountRevision', 'settingsRevision']) {
+        const revision = int(get(operation, field));
+        if (revision === null || revision < 1n)
+            throw new JobsError('account operation journal revision is invalid');
+    }
+    if (!stages.has(string(get(operation, 'stage'))))
+        throw new JobsError('account operation journal stage is invalid');
+    if (!outcomes.has(string(get(operation, 'outcomeCode'))))
+        throw new JobsError('account operation journal outcome is invalid');
+    return journal;
+}
+export function accountOperation(value) {
+    const raw = get(validateAccountOperationJournal(value), 'operation');
+    return raw === null ? null : object(raw, 'account operation');
+}

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -1,4 +1,5 @@
 import { initialAutomationDocuments, automationTransaction as runAutomationTransaction } from './native-automation.js';
+import { accountOperation, emptyAccountOperationJournal, validateAccountOperationJournal } from '../contracts/workspace/account-operation.js';
 import { NativeClaimJournal, claimOperationKinds, validateClaimJournal } from './native-claim-journal.js';
 import { NativeClaimHistory } from './native-claim-history.js';
 import { validateCoordinator, requireJobUnclaimed } from '../contracts/workspace/claims.js';
@@ -23,8 +24,8 @@ import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
 import { validateAnswers } from "../contracts/workspace/answers.js";
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 };
-const marker = '{"mode":"native-jobs-fixture","version":10}\n';
-const allowed = new Set(["automation-settings.json", "employer-accounts.json", ".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
+const marker = '{"mode":"native-jobs-fixture","version":11}\n';
+const allowed = new Set(["automation-settings.json", "employer-accounts.json", "account-operation-journal.json", ".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 };
 /** Creates a NEW synthetic root only. Never adopts or initializes an existing Store. */
@@ -59,6 +60,7 @@ export async function initializeJobsFixture(root) {
     for (const [name, document] of Object.entries(initialAutomationDocuments(now))) {
         await atomicWritePointJson(join(root, `${name}.json`), document, options);
     }
+    await atomicWritePointJson(join(root, 'account-operation-journal.json'), emptyAccountOperationJournal(), options);
     // The readiness marker is written last; partial initialization is never adopted.
     const handle = await open(join(root, ".native-jobs-fixture"), "wx", 0o600);
     try {
@@ -416,6 +418,25 @@ export class NativeJobsRepository {
             read: name => name === 'automation-settings' ? this.journal(name) : this.document(name),
             write: (name, document) => this.write(join(this.root, `${name}.json`), document, options),
         }, operation));
+    }
+    async accountOperationTransaction(operation) {
+        return this.transaction(async () => {
+            const jobs = validateJobsDocument(await this.document('jobs'));
+            const journal = validateAccountOperationJournal(await this.journal('account-operation-journal'));
+            const accounts = await this.document('employer-accounts');
+            return operation({ journal, accounts, jobs,
+                coordinator: validateCoordinator(await this.journal('coordinator')),
+                sessions: await this.answerSessions(), answers: validateAnswers(await this.document('answers')),
+                saveAccounts: document => this.write(join(this.root, 'employer-accounts.json'), document, options),
+                commitClaim: value => this.claimJournal().commit(value, jobs),
+                clearOperation: async (expected) => {
+                    const current = accountOperation(validateAccountOperationJournal(await this.journal('account-operation-journal')));
+                    if (current === null || string(get(current, 'operationId')) !== expected)
+                        throw new JobsError('account operation journal changed before completion');
+                    await this.write(join(this.root, 'account-operation-journal.json'), emptyAccountOperationJournal(), options);
+                },
+            });
+        });
     }
     async resumeSummaries() {
         // Reuse the lock and all root checks for projections too.

--- a/runtime/workspace-core/account-operation-http.js
+++ b/runtime/workspace-core/account-operation-http.js
@@ -1,0 +1,13 @@
+import { exact } from '../contracts/workspace/automation.js';
+import { object, parse, serialize } from '../contracts/workspace/values.js';
+import { AccountOperationService } from './account-operation.js';
+export async function accountOperationHttp(repository, method, path, body) {
+    const service = new AccountOperationService(repository);
+    if (method === 'GET' && path === '/api/account-operation')
+        return { status: 200, body: serialize(await service.status()) };
+    if (method === 'POST' && path === '/api/account-operation/recover') {
+        exact(object(parse(body), 'account recovery body'), [], 'account recovery body must be empty');
+        return { status: 200, body: serialize(await service.recover()) };
+    }
+    return null;
+}

--- a/runtime/workspace-core/account-operation.js
+++ b/runtime/workspace-core/account-operation.js
@@ -21,7 +21,8 @@ function handoffOperation(job, session, at) {
         if (string(get(job, field)) !== null)
             set(event, field, get(job, field));
     const result = doc({ kind: 'handoff', operationId, jobId: id, sourceStatus: 'in_progress',
-        targetStatus: 'needs_info', expectedRevision: Number(int(get(job, 'revision'))), at, resultClaim: null });
+        targetStatus: 'needs_info', expectedRevision: null, at, resultClaim: null });
+    set(result, 'expectedRevision', get(job, 'revision'));
     set(result, 'historyEvent', event);
     return set(result, 'session', session);
 }
@@ -82,7 +83,8 @@ export class AccountOperationService {
                 const session = buildClaimSession(id, incoming, { now, attemptRevision: get(job, 'revision'), ats: get(job, 'ats'),
                     existing: tx.sessions.find(item => string(get(item, 'applicationId')) === id) ?? null, answers: tx.answers });
                 await tx.commitClaim(handoffOperation(job, session, now));
-                recoveredJob = fromJSON({ id, status: 'needs_info', revision: Number(int(get(job, 'revision')) + 1n) });
+                recoveredJob = doc({ id, status: 'needs_info', revision: null });
+                set(recoveredJob, 'revision', integer(int(get(job, 'revision')) + 1n));
             }
             else if (string(get(job, 'status')) !== 'needs_info')
                 throw new JobsError('account operation job cannot be reconciled');

--- a/runtime/workspace-core/account-operation.js
+++ b/runtime/workspace-core/account-operation.js
@@ -1,0 +1,97 @@
+import { randomUUID } from 'node:crypto';
+import { publicAccount, validateAccountsDocument } from '../contracts/workspace/accounts.js';
+import { accountOperation } from '../contracts/workspace/account-operation.js';
+import { buildClaimSession } from '../contracts/workspace/claim-session.js';
+import { claimExpired, validateCoordinator } from '../contracts/workspace/claims.js';
+import { safeId, validateJobsDocument } from '../contracts/workspace/jobs.js';
+import { copy, fromJSON, get, int, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+const doc = (value) => object(fromJSON(value), 'account operation result');
+function activeJob(jobs, id) {
+    safeId(id);
+    const raw = get(object(get(jobs, 'jobs'), 'jobs'), id);
+    if (raw === null || get(object(raw, 'job'), 'deletedAt') !== null)
+        throw new JobsError('account operation job is unavailable');
+    return object(raw, 'job');
+}
+function handoffOperation(job, session, at) {
+    const operationId = randomUUID(), id = string(get(job, 'id'));
+    const event = doc({ schemaVersion: 1, eventId: `coordinator-${operationId}`, applicationId: id,
+        event: 'job-blocked', status: 'needs_info', answerKeys: [], at });
+    for (const field of ['company', 'role', 'ats'])
+        if (string(get(job, field)) !== null)
+            set(event, field, get(job, field));
+    const result = doc({ kind: 'handoff', operationId, jobId: id, sourceStatus: 'in_progress',
+        targetStatus: 'needs_info', expectedRevision: Number(int(get(job, 'revision'))), at, resultClaim: null });
+    set(result, 'historyEvent', event);
+    return set(result, 'session', session);
+}
+export class AccountOperationService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    status() {
+        return this.repository.accountOperationTransaction(async (tx) => {
+            const operation = accountOperation(tx.journal);
+            if (operation === null)
+                return fromJSON({ status: 'idle', operation: null });
+            return fromJSON({ status: 'recovery_required', operation: {
+                    operationId: string(get(operation, 'operationId')), jobId: string(get(operation, 'jobId')),
+                    realmRef: string(get(operation, 'realmRef')), stage: string(get(operation, 'stage')),
+                    outcomeCode: string(get(operation, 'outcomeCode')),
+                } });
+        });
+    }
+    recover() {
+        return this.repository.accountOperationTransaction(async (tx) => {
+            const operation = accountOperation(tx.journal);
+            if (operation === null)
+                return fromJSON({ status: 'idle', recovered: false });
+            const realm = string(get(operation, 'realmRef')), accounts = validateAccountsDocument(tx.accounts);
+            const records = object(get(accounts, 'accounts'), 'employer accounts');
+            const rawAccount = get(records, realm);
+            if (rawAccount === null)
+                throw new JobsError('account operation realm is unavailable');
+            let account = object(rawAccount, 'employer account');
+            if (string(get(account, 'lifecycleState')) !== 'ambiguous') {
+                account = copy(account);
+                set(account, 'lifecycleState', text('ambiguous'));
+                set(account, 'revision', integer(int(get(account, 'revision')) + 1n));
+                set(account, 'updatedAt', text(this.now()));
+                set(records, realm, account);
+                set(object(get(accounts, 'metadata'), 'employer account metadata'), 'updatedAt', get(account, 'updatedAt'));
+                await tx.saveAccounts(validateAccountsDocument(accounts));
+            }
+            const job = activeJob(validateJobsDocument(tx.jobs), string(get(operation, 'jobId')));
+            let recoveredJob = null;
+            if (string(get(job, 'status')) === 'in_progress') {
+                const coordinator = validateCoordinator(tx.coordinator), rawClaim = get(coordinator, 'claim');
+                if (rawClaim === null)
+                    throw new JobsError('account operation recovery requires a live same-job claim');
+                const claim = object(rawClaim, 'claim');
+                if (string(get(claim, 'jobId')) !== string(get(job, 'id')) || claimExpired(claim, this.now())) {
+                    throw new JobsError('account operation recovery requires a live same-job claim');
+                }
+                const now = this.now();
+                const incoming = doc({ status: 'active', step: 'account_automation_denied:ambiguous_recovery',
+                    answerKeys: [], pendingFields: [], blockers: [{ type: 'browser_handoff', code: 'browser-state-uncertain' }],
+                    browserHandoff: { state: 'required', reasonCode: 'browser-state-uncertain', revision: 1 } });
+                const id = string(get(job, 'id'));
+                const session = buildClaimSession(id, incoming, { now, attemptRevision: get(job, 'revision'), ats: get(job, 'ats'),
+                    existing: tx.sessions.find(item => string(get(item, 'applicationId')) === id) ?? null, answers: tx.answers });
+                await tx.commitClaim(handoffOperation(job, session, now));
+                recoveredJob = fromJSON({ id, status: 'needs_info', revision: Number(int(get(job, 'revision')) + 1n) });
+            }
+            else if (string(get(job, 'status')) !== 'needs_info')
+                throw new JobsError('account operation job cannot be reconciled');
+            await tx.clearOperation(string(get(operation, 'operationId')));
+            const result = doc({ status: 'ambiguous', recovered: true, retryAllowed: false });
+            set(result, 'account', publicAccount(account));
+            if (recoveredJob !== null)
+                set(result, 'job', recoveredJob);
+            return result;
+        });
+    }
+}

--- a/runtime/workspace-core/jobs-http.js
+++ b/runtime/workspace-core/jobs-http.js
@@ -1,4 +1,5 @@
 import { automationHttp } from './automation-http.js';
+import { accountOperationHttp } from './account-operation-http.js';
 import { resumeLifecycleHttp } from './resume-lifecycle-http.js';
 import { answerLifecycleHttp } from './answer-lifecycle-http.js';
 import { trashHttp } from './trash-http.js';
@@ -21,6 +22,9 @@ const envelope = (key, value) => set(emptyObject(), key, value);
 /** Transport-independent dispatch. Host/token/Origin/body bounds belong to the adapter. */
 export async function jobsHttp(service, repository, method, path, body = "") {
     try {
+        const accountOperation = await accountOperationHttp(repository, method, path, body);
+        if (accountOperation)
+            return accountOperation;
         const automation = await automationHttp(repository, method, path, body);
         if (automation)
             return automation;

--- a/src/cli/native-account-operation.ts
+++ b/src/cli/native-account-operation.ts
@@ -1,0 +1,12 @@
+import type { AccountOperationRepository } from '../workspace-core/account-operation.js';
+import { AccountOperationService } from '../workspace-core/account-operation.js';
+import type { Value } from '../contracts/workspace/values.js';
+
+export const accountOperationCommands: Record<string, string[]> = {
+  'employer-account-operation-status': [],
+  'employer-account-operation-recover': [],
+};
+export function runAccountOperationCommand(command: string, repository: AccountOperationRepository): Promise<Value> {
+  const service = new AccountOperationService(repository);
+  return command === 'employer-account-operation-status' ? service.status() : service.recover();
+}

--- a/src/cli/native-jobs.ts
+++ b/src/cli/native-jobs.ts
@@ -1,4 +1,5 @@
 import { answerLifecycleCommands, runAnswerLifecycleCommand } from './native-answer-lifecycle.js';
+import { accountOperationCommands, runAccountOperationCommand } from './native-account-operation.js';
 import { resumeLifecycleCommands, runResumeLifecycleCommand } from './native-resume-lifecycle.js';
 import { trashCommands, runTrashCommand } from './native-trash.js';
 import { groupedApprovalCommands, runGroupedApprovalCommand } from './native-grouped-approvals.js';
@@ -44,6 +45,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
     }
   }
   const fields: Record<string, string[]> = {
+    ...accountOperationCommands,
     ...answerLifecycleCommands,
     ...resumeLifecycleCommands,
     ...trashCommands,
@@ -89,6 +91,7 @@ export async function runJobsCli(args: string[], input: (limit?: number) => Prom
       : ["resume-proposal-create", "resume-extraction-request-complete"].includes(command!) ? 2 * 1024 * 1024 : 65536;
     return parse(file === "-" ? await input(limit) : await readFile(file, "utf8"));
   };
+  if (Object.hasOwn(accountOperationCommands, command!)) return serialize(await runAccountOperationCommand(command!, repository));
   if (Object.hasOwn(answerLifecycleCommands, command!)) return serialize(await runAnswerLifecycleCommand(command!, repository, options));
   if (Object.hasOwn(resumeLifecycleCommands, command!)) return serialize(await runResumeLifecycleCommand(command!, repository, options));
   if (Object.hasOwn(trashCommands, command!)) return serialize(await runTrashCommand(command!, repository, options));

--- a/src/contracts/workspace/account-operation.ts
+++ b/src/contracts/workspace/account-operation.ts
@@ -1,0 +1,42 @@
+import { exact } from './automation.js';
+import { fromJSON, get, int, object, string, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+
+const stages = new Set(['prepared', 'credential_provisioned', 'signup_in_progress']);
+const outcomes = new Set([
+  'success', 'reuse', 'verification', 'challenge', 'consent', 'reset',
+  'definitive_failure', 'ambiguity', 'observed_pending',
+]);
+const operationFields = [
+  'operationId', 'jobId', 'jobRevision', 'claimId', 'realmRef',
+  'accountRevision', 'settingsRevision', 'stage', 'outcomeCode', 'startedAt',
+];
+
+export function emptyAccountOperationJournal(): Document {
+  return object(fromJSON({ schemaVersion: 1, operation: null }), 'account operation journal');
+}
+
+export function validateAccountOperationJournal(value: Value): Document {
+  const journal = object(value, 'account operation journal');
+  exact(journal, ['schemaVersion', 'operation'], 'account operation journal contains unsupported fields');
+  if (int(get(journal, 'schemaVersion')) !== 1n) throw new JobsError('account operation journal schema version is unsupported');
+  const raw = get(journal, 'operation');
+  if (raw === null) return journal;
+  const operation = object(raw, 'account operation journal operation');
+  exact(operation, operationFields, 'account operation journal is invalid');
+  for (const field of ['operationId', 'jobId', 'claimId', 'realmRef', 'stage', 'outcomeCode', 'startedAt']) {
+    if (!string(get(operation, field))) throw new JobsError('account operation journal binding is invalid');
+  }
+  for (const field of ['jobRevision', 'accountRevision', 'settingsRevision']) {
+    const revision = int(get(operation, field));
+    if (revision === null || revision < 1n) throw new JobsError('account operation journal revision is invalid');
+  }
+  if (!stages.has(string(get(operation, 'stage'))!)) throw new JobsError('account operation journal stage is invalid');
+  if (!outcomes.has(string(get(operation, 'outcomeCode'))!)) throw new JobsError('account operation journal outcome is invalid');
+  return journal;
+}
+
+export function accountOperation(value: Value): Document | null {
+  const raw = get(validateAccountOperationJournal(value), 'operation');
+  return raw === null ? null : object(raw, 'account operation');
+}

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -1,4 +1,6 @@
 import { initialAutomationDocuments, automationTransaction as runAutomationTransaction } from './native-automation.js';
+import { accountOperation, emptyAccountOperationJournal, validateAccountOperationJournal } from '../contracts/workspace/account-operation.js';
+import type { AccountOperationTransaction } from '../workspace-core/account-operation.js';
 import type { AutomationTransaction } from '../workspace-core/automation.js';
 import type { GroupedApprovalTransaction } from '../workspace-core/grouped-approvals.js';
 import { NativeClaimJournal, claimOperationKinds, validateClaimJournal } from './native-claim-journal.js';
@@ -36,8 +38,8 @@ import { validateAnswers } from "../contracts/workspace/answers.js";
 import type { AnswerReferenceCounts } from "../workspace-core/answers.js";
 
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
-const marker = '{"mode":"native-jobs-fixture","version":10}\n';
-const allowed = new Set(["automation-settings.json", "employer-accounts.json", ".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
+const marker = '{"mode":"native-jobs-fixture","version":11}\n';
+const allowed = new Set(["automation-settings.json", "employer-accounts.json", "account-operation-journal.json", ".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
 
@@ -79,6 +81,7 @@ export async function initializeJobsFixture(root: string): Promise<void> {
   for (const [name, document] of Object.entries(initialAutomationDocuments(now))) {
     await atomicWritePointJson(join(root, `${name}.json`), document, options);
   }
+  await atomicWritePointJson(join(root, 'account-operation-journal.json'), emptyAccountOperationJournal(), options);
   // The readiness marker is written last; partial initialization is never adopted.
   const handle = await open(join(root, ".native-jobs-fixture"), "wx", 0o600);
   try { await handle.writeFile(marker); await handle.sync(); } finally { await handle.close(); }
@@ -432,6 +435,25 @@ export class NativeJobsRepository implements JobsRepository, ResumeLifecycleRepo
       read: name => name === 'automation-settings' ? this.journal(name) : this.document(name),
       write: (name, document) => this.write(join(this.root, `${name}.json`), document, options),
     }, operation));
+  }
+
+  async accountOperationTransaction<T>(operation: (tx: AccountOperationTransaction) => Promise<T>): Promise<T> {
+    return this.transaction(async () => {
+      const jobs = validateJobsDocument(await this.document('jobs'));
+      const journal = validateAccountOperationJournal(await this.journal('account-operation-journal'));
+      const accounts = await this.document('employer-accounts');
+      return operation({ journal, accounts, jobs,
+        coordinator: validateCoordinator(await this.journal('coordinator')),
+        sessions: await this.answerSessions(), answers: validateAnswers(await this.document('answers')),
+        saveAccounts: document => this.write(join(this.root, 'employer-accounts.json'), document, options),
+        commitClaim: value => this.claimJournal().commit(value, jobs),
+        clearOperation: async expected => {
+          const current = accountOperation(validateAccountOperationJournal(await this.journal('account-operation-journal')));
+          if (current === null || string(get(current, 'operationId')) !== expected) throw new JobsError('account operation journal changed before completion');
+          await this.write(join(this.root, 'account-operation-journal.json'), emptyAccountOperationJournal(), options);
+        },
+      });
+    });
   }
 
   async resumeSummaries(): Promise<Value[]> {

--- a/src/workspace-core/account-operation-http.ts
+++ b/src/workspace-core/account-operation-http.ts
@@ -1,0 +1,14 @@
+import { exact } from '../contracts/workspace/automation.js';
+import { object, parse, serialize } from '../contracts/workspace/values.js';
+import type { AccountOperationRepository } from './account-operation.js';
+import { AccountOperationService } from './account-operation.js';
+
+export async function accountOperationHttp(repository: AccountOperationRepository, method: string, path: string, body: string) {
+  const service = new AccountOperationService(repository);
+  if (method === 'GET' && path === '/api/account-operation') return { status: 200, body: serialize(await service.status()) };
+  if (method === 'POST' && path === '/api/account-operation/recover') {
+    exact(object(parse(body), 'account recovery body'), [], 'account recovery body must be empty');
+    return { status: 200, body: serialize(await service.recover()) };
+  }
+  return null;
+}

--- a/src/workspace-core/account-operation.ts
+++ b/src/workspace-core/account-operation.ts
@@ -32,7 +32,8 @@ function handoffOperation(job: Document, session: Document, at: string): Documen
     event: 'job-blocked', status: 'needs_info', answerKeys: [], at });
   for (const field of ['company', 'role', 'ats']) if (string(get(job, field)) !== null) set(event, field, get(job, field));
   const result = doc({ kind: 'handoff', operationId, jobId: id, sourceStatus: 'in_progress',
-    targetStatus: 'needs_info', expectedRevision: Number(int(get(job, 'revision'))), at, resultClaim: null });
+    targetStatus: 'needs_info', expectedRevision: null, at, resultClaim: null });
+  set(result, 'expectedRevision', get(job, 'revision'));
   set(result, 'historyEvent', event);
   return set(result, 'session', session);
 }
@@ -72,7 +73,7 @@ export class AccountOperationService {
         await tx.saveAccounts(validateAccountsDocument(accounts));
       }
       const job = activeJob(validateJobsDocument(tx.jobs), string(get(operation, 'jobId'))!);
-      let recoveredJob: Value = null;
+      let recoveredJob: Document | null = null;
       if (string(get(job, 'status')) === 'in_progress') {
         const coordinator = validateCoordinator(tx.coordinator), rawClaim = get(coordinator, 'claim');
         if (rawClaim === null) throw new JobsError('account operation recovery requires a live same-job claim');
@@ -88,7 +89,8 @@ export class AccountOperationService {
         const session = buildClaimSession(id, incoming, { now, attemptRevision: get(job, 'revision'), ats: get(job, 'ats'),
           existing: tx.sessions.find(item => string(get(item, 'applicationId')) === id) ?? null, answers: tx.answers });
         await tx.commitClaim(handoffOperation(job, session, now));
-        recoveredJob = fromJSON({ id, status: 'needs_info', revision: Number(int(get(job, 'revision'))! + 1n) });
+        recoveredJob = doc({ id, status: 'needs_info', revision: null });
+        set(recoveredJob, 'revision', integer(int(get(job, 'revision'))! + 1n));
       } else if (string(get(job, 'status')) !== 'needs_info') throw new JobsError('account operation job cannot be reconciled');
       await tx.clearOperation(string(get(operation, 'operationId'))!);
       const result = doc({ status: 'ambiguous', recovered: true, retryAllowed: false });

--- a/src/workspace-core/account-operation.ts
+++ b/src/workspace-core/account-operation.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from 'node:crypto';
+import { publicAccount, validateAccountsDocument } from '../contracts/workspace/accounts.js';
+import { accountOperation } from '../contracts/workspace/account-operation.js';
+import { buildClaimSession } from '../contracts/workspace/claim-session.js';
+import { claimExpired, validateCoordinator } from '../contracts/workspace/claims.js';
+import { safeId, validateJobsDocument } from '../contracts/workspace/jobs.js';
+import { copy, fromJSON, get, int, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+
+export interface AccountOperationTransaction {
+  journal: Document; accounts: Document; jobs: Document; coordinator: Document;
+  sessions: Document[]; answers: Document;
+  saveAccounts(document: Document): Promise<void>;
+  commitClaim(operation: Document): Promise<void>;
+  clearOperation(expectedOperationId: string): Promise<void>;
+}
+export interface AccountOperationRepository {
+  accountOperationTransaction<T>(operation: (transaction: AccountOperationTransaction) => Promise<T>): Promise<T>;
+}
+const doc = (value: unknown): Document => object(fromJSON(value), 'account operation result');
+
+function activeJob(jobs: Document, id: string): Document {
+  safeId(id);
+  const raw = get(object(get(jobs, 'jobs'), 'jobs'), id);
+  if (raw === null || get(object(raw, 'job'), 'deletedAt') !== null) throw new JobsError('account operation job is unavailable');
+  return object(raw, 'job');
+}
+
+function handoffOperation(job: Document, session: Document, at: string): Document {
+  const operationId = randomUUID(), id = string(get(job, 'id'))!;
+  const event = doc({ schemaVersion: 1, eventId: `coordinator-${operationId}`, applicationId: id,
+    event: 'job-blocked', status: 'needs_info', answerKeys: [], at });
+  for (const field of ['company', 'role', 'ats']) if (string(get(job, field)) !== null) set(event, field, get(job, field));
+  const result = doc({ kind: 'handoff', operationId, jobId: id, sourceStatus: 'in_progress',
+    targetStatus: 'needs_info', expectedRevision: Number(int(get(job, 'revision'))), at, resultClaim: null });
+  set(result, 'historyEvent', event);
+  return set(result, 'session', session);
+}
+
+export class AccountOperationService {
+  constructor(private readonly repository: AccountOperationRepository,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+
+  status(): Promise<Value> {
+    return this.repository.accountOperationTransaction(async tx => {
+      const operation = accountOperation(tx.journal);
+      if (operation === null) return fromJSON({ status: 'idle', operation: null });
+      return fromJSON({ status: 'recovery_required', operation: {
+        operationId: string(get(operation, 'operationId')), jobId: string(get(operation, 'jobId')),
+        realmRef: string(get(operation, 'realmRef')), stage: string(get(operation, 'stage')),
+        outcomeCode: string(get(operation, 'outcomeCode')),
+      } });
+    });
+  }
+
+  recover(): Promise<Value> {
+    return this.repository.accountOperationTransaction(async tx => {
+      const operation = accountOperation(tx.journal);
+      if (operation === null) return fromJSON({ status: 'idle', recovered: false });
+      const realm = string(get(operation, 'realmRef'))!, accounts = validateAccountsDocument(tx.accounts);
+      const records = object(get(accounts, 'accounts'), 'employer accounts');
+      const rawAccount = get(records, realm);
+      if (rawAccount === null) throw new JobsError('account operation realm is unavailable');
+      let account = object(rawAccount, 'employer account');
+      if (string(get(account, 'lifecycleState')) !== 'ambiguous') {
+        account = copy(account);
+        set(account, 'lifecycleState', text('ambiguous'));
+        set(account, 'revision', integer(int(get(account, 'revision'))! + 1n));
+        set(account, 'updatedAt', text(this.now()));
+        set(records, realm, account);
+        set(object(get(accounts, 'metadata'), 'employer account metadata'), 'updatedAt', get(account, 'updatedAt'));
+        await tx.saveAccounts(validateAccountsDocument(accounts));
+      }
+      const job = activeJob(validateJobsDocument(tx.jobs), string(get(operation, 'jobId'))!);
+      let recoveredJob: Value = null;
+      if (string(get(job, 'status')) === 'in_progress') {
+        const coordinator = validateCoordinator(tx.coordinator), rawClaim = get(coordinator, 'claim');
+        if (rawClaim === null) throw new JobsError('account operation recovery requires a live same-job claim');
+        const claim = object(rawClaim, 'claim');
+        if (string(get(claim, 'jobId')) !== string(get(job, 'id')) || claimExpired(claim, this.now())) {
+          throw new JobsError('account operation recovery requires a live same-job claim');
+        }
+        const now = this.now();
+        const incoming = doc({ status: 'active', step: 'account_automation_denied:ambiguous_recovery',
+          answerKeys: [], pendingFields: [], blockers: [{ type: 'browser_handoff', code: 'browser-state-uncertain' }],
+          browserHandoff: { state: 'required', reasonCode: 'browser-state-uncertain', revision: 1 } });
+        const id = string(get(job, 'id'))!;
+        const session = buildClaimSession(id, incoming, { now, attemptRevision: get(job, 'revision'), ats: get(job, 'ats'),
+          existing: tx.sessions.find(item => string(get(item, 'applicationId')) === id) ?? null, answers: tx.answers });
+        await tx.commitClaim(handoffOperation(job, session, now));
+        recoveredJob = fromJSON({ id, status: 'needs_info', revision: Number(int(get(job, 'revision'))! + 1n) });
+      } else if (string(get(job, 'status')) !== 'needs_info') throw new JobsError('account operation job cannot be reconciled');
+      await tx.clearOperation(string(get(operation, 'operationId'))!);
+      const result = doc({ status: 'ambiguous', recovered: true, retryAllowed: false });
+      set(result, 'account', publicAccount(account));
+      if (recoveredJob !== null) set(result, 'job', recoveredJob);
+      return result;
+    });
+  }
+}

--- a/src/workspace-core/jobs-http.ts
+++ b/src/workspace-core/jobs-http.ts
@@ -1,4 +1,5 @@
 import { automationHttp } from './automation-http.js';
+import { accountOperationHttp } from './account-operation-http.js';
 import { resumeLifecycleHttp } from './resume-lifecycle-http.js';
 import { answerLifecycleHttp } from './answer-lifecycle-http.js';
 import { trashHttp } from './trash-http.js';
@@ -29,6 +30,8 @@ const envelope = (key: string, value: Value): Value => set(emptyObject(), key, v
 export async function jobsHttp(service: JobsService, repository: NativeJobsRepository,
   method: string, path: string, body = ""): Promise<ApiResult> {
   try {
+    const accountOperation = await accountOperationHttp(repository, method, path, body);
+    if (accountOperation) return accountOperation;
     const automation = await automationHttp(repository, method, path, body);
     if (automation) return automation;
     const resumeLifecycle = await resumeLifecycleHttp(repository, method, path, body);

--- a/tests_js/workspace_native_account_operation.test.mjs
+++ b/tests_js/workspace_native_account_operation.test.mjs
@@ -1,13 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { readFile, stat } from 'node:fs/promises';
+import { readFile, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { nativeFixture } from './exclusive_file_lock_support.mjs';
 import { cli, plain, read, setup, snapshot, write } from './workspace_native_claims_support.mjs';
 import { AccountOperationService } from '../runtime/workspace-core/account-operation.js';
 import { AccountsService } from '../runtime/workspace-core/accounts.js';
 import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
-import { text } from '../runtime/contracts/workspace/values.js';
+import { fromJSON, get, int, integer, object, parse, serialize, set, string, text } from '../runtime/contracts/workspace/values.js';
 
 const portal = 'https://example.wd1.myworkdayjobs.com/en-US/careers/job/42';
 
@@ -37,12 +37,21 @@ test('native account operation status and recovery fail stranded work closed', {
       await claims.select('job', 1n, true);
       const acquired = plain(await claims.acquire('job', text('Synthetic owner'), 2n));
       const account = plain(await new AccountsService(repository, () => clock.now).create(portal));
+      const exactRevision = 9007199254740993n;
+      const jobsDocument = object(parse(await readFile(join(root, 'jobs.json'), 'utf8')), 'jobs');
+      const job = object(get(object(get(jobsDocument, 'jobs'), 'job records'), 'job'), 'job');
+      set(job, 'revision', integer(exactRevision));
+      await writeFile(join(root, 'jobs.json'), serialize(jobsDocument), { mode: 0o600 });
       const operation = {
-        operationId: 'operation-recovery', jobId: 'job', jobRevision: acquired.job.revision,
+        operationId: 'operation-recovery', jobId: 'job', jobRevision: 1,
         claimId: acquired.claim.claimId, realmRef: account.realmRef, accountRevision: account.revision,
         settingsRevision: 1, stage: 'prepared', outcomeCode: 'observed_pending', startedAt: clock.now,
       };
-      await write(root, 'account-operation-journal.json', { schemaVersion: 1, operation });
+      const operationDocument = object(fromJSON(operation), 'account operation');
+      set(operationDocument, 'jobRevision', integer(exactRevision));
+      const journal = object(fromJSON({ schemaVersion: 1, operation: null }), 'account operation journal');
+      set(journal, 'operation', operationDocument);
+      await writeFile(operationPath, serialize(journal), { mode: 0o600 });
       const status = plain(await service.status());
       assert.deepEqual(status, { status: 'recovery_required', operation: {
         operationId: operation.operationId, jobId: 'job', realmRef: account.realmRef,
@@ -51,16 +60,21 @@ test('native account operation status and recovery fail stranded work closed', {
       assert.doesNotMatch(JSON.stringify(status), new RegExp(operation.claimId));
       assert.doesNotMatch(JSON.stringify(status), /jobRevision|accountRevision|settingsRevision/);
 
-      const recovered = plain(await service.recover());
+      const recoveredValue = await service.recover();
+      const recovered = plain(recoveredValue);
       assert.equal(recovered.status, 'ambiguous');
       assert.equal(recovered.recovered, true);
       assert.equal(recovered.retryAllowed, false);
       assert.equal(recovered.account.lifecycleState, 'ambiguous');
       assert.equal(recovered.account.revision, 2);
-      assert.deepEqual(recovered.job, { id: 'job', status: 'needs_info', revision: 4 });
+      assert.equal(int(get(object(get(object(recoveredValue, 'recovery'), 'job'), 'recovered job'), 'revision')), exactRevision + 1n);
+      assert.deepEqual(recovered.job, { id: 'job', status: 'needs_info', revision: Number(exactRevision + 1n) });
       assert.equal((await read(root, 'account-operation-journal.json')).operation, null);
       assert.equal((await read(root, 'coordinator.json')).claim, null);
-      assert.equal((await read(root, 'jobs.json')).jobs.job.status, 'needs_info');
+      const recoveredJobs = object(parse(await readFile(join(root, 'jobs.json'), 'utf8')), 'jobs');
+      const recoveredJob = object(get(object(get(recoveredJobs, 'jobs'), 'job records'), 'job'), 'job');
+      assert.equal(string(get(recoveredJob, 'status')), 'needs_info');
+      assert.equal(int(get(recoveredJob, 'revision')), exactRevision + 1n);
       const session = await read(root, 'sessions/job.json');
       assert.equal(session.step, 'account_automation_denied:ambiguous_recovery');
       assert.deepEqual(session.blockers, [{ type: 'browser_handoff', code: 'browser-state-uncertain' }]);

--- a/tests_js/workspace_native_account_operation.test.mjs
+++ b/tests_js/workspace_native_account_operation.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { cli, plain, read, setup, snapshot, write } from './workspace_native_claims_support.mjs';
+import { AccountOperationService } from '../runtime/workspace-core/account-operation.js';
+import { AccountsService } from '../runtime/workspace-core/accounts.js';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { text } from '../runtime/contracts/workspace/values.js';
+
+const portal = 'https://example.wd1.myworkdayjobs.com/en-US/careers/job/42';
+
+test('native account operation status and recovery fail stranded work closed', { timeout: 60000 }, async t => {
+  const fixture = await nativeFixture();
+  try {
+    const state = await setup(fixture, 'account-operation');
+    const { root, repository, jobs, claims, clock } = state;
+    const operationPath = join(root, 'account-operation-journal.json');
+    assert.equal((await stat(operationPath)).mode & 0o777, 0o600);
+    const service = new AccountOperationService(repository, () => clock.now);
+
+    await t.test('idle projections are read-only across service, HTTP, and CLI', async () => {
+      const before = await snapshot(root);
+      assert.deepEqual(plain(await service.status()), { status: 'idle', operation: null });
+      assert.deepEqual(plain(await service.recover()), { status: 'idle', recovered: false });
+      const get = await jobsHttp(jobs, repository, 'GET', '/api/account-operation');
+      assert.deepEqual(JSON.parse(get.body), { status: 'idle', operation: null });
+      const post = await jobsHttp(jobs, repository, 'POST', '/api/account-operation/recover', '{}');
+      assert.deepEqual(JSON.parse(post.body), { status: 'idle', recovered: false });
+      assert.equal((await jobsHttp(jobs, repository, 'POST', '/api/account-operation/recover', '{"extra":true}')).status, 400);
+      assert.deepEqual(await cli(fixture, root, 'employer-account-operation-status'), { status: 'idle', operation: null });
+      assert.deepEqual(await snapshot(root), before);
+    });
+
+    await t.test('pending status is redacted and recovery marks account ambiguous and hands off the live job', async () => {
+      await claims.select('job', 1n, true);
+      const acquired = plain(await claims.acquire('job', text('Synthetic owner'), 2n));
+      const account = plain(await new AccountsService(repository, () => clock.now).create(portal));
+      const operation = {
+        operationId: 'operation-recovery', jobId: 'job', jobRevision: acquired.job.revision,
+        claimId: acquired.claim.claimId, realmRef: account.realmRef, accountRevision: account.revision,
+        settingsRevision: 1, stage: 'prepared', outcomeCode: 'observed_pending', startedAt: clock.now,
+      };
+      await write(root, 'account-operation-journal.json', { schemaVersion: 1, operation });
+      const status = plain(await service.status());
+      assert.deepEqual(status, { status: 'recovery_required', operation: {
+        operationId: operation.operationId, jobId: 'job', realmRef: account.realmRef,
+        stage: 'prepared', outcomeCode: 'observed_pending',
+      } });
+      assert.doesNotMatch(JSON.stringify(status), new RegExp(operation.claimId));
+      assert.doesNotMatch(JSON.stringify(status), /jobRevision|accountRevision|settingsRevision/);
+
+      const recovered = plain(await service.recover());
+      assert.equal(recovered.status, 'ambiguous');
+      assert.equal(recovered.recovered, true);
+      assert.equal(recovered.retryAllowed, false);
+      assert.equal(recovered.account.lifecycleState, 'ambiguous');
+      assert.equal(recovered.account.revision, 2);
+      assert.deepEqual(recovered.job, { id: 'job', status: 'needs_info', revision: 4 });
+      assert.equal((await read(root, 'account-operation-journal.json')).operation, null);
+      assert.equal((await read(root, 'coordinator.json')).claim, null);
+      assert.equal((await read(root, 'jobs.json')).jobs.job.status, 'needs_info');
+      const session = await read(root, 'sessions/job.json');
+      assert.equal(session.step, 'account_automation_denied:ambiguous_recovery');
+      assert.deepEqual(session.blockers, [{ type: 'browser_handoff', code: 'browser-state-uncertain' }]);
+      const history = (await readFile(join(root, 'applications.jsonl'), 'utf8')).trim().split('\n').map(JSON.parse);
+      assert.equal(history.at(-1).event, 'job-blocked');
+      assert.deepEqual(await cli(fixture, root, 'employer-account-operation-recover'), { status: 'idle', recovered: false });
+    });
+
+    await t.test('identity mismatch and unavailable jobs preserve the pending journal', async () => {
+      const accounts = await read(root, 'employer-accounts.json');
+      const realmRef = Object.keys(accounts.accounts)[0];
+      const operation = { operationId: 'operation-missing', jobId: 'missing', jobRevision: 1,
+        claimId: 'claim-private', realmRef, accountRevision: accounts.accounts[realmRef].revision,
+        settingsRevision: 1, stage: 'signup_in_progress', outcomeCode: 'ambiguity', startedAt: clock.now };
+      await write(root, 'account-operation-journal.json', { schemaVersion: 1, operation });
+      const before = await readFile(operationPath);
+      await assert.rejects(repository.accountOperationTransaction(tx => tx.clearOperation('other')), /changed before completion/);
+      assert.deepEqual(await readFile(operationPath), before);
+      await assert.rejects(service.recover(), /job is unavailable/);
+      assert.deepEqual(await readFile(operationPath), before);
+    });
+  } finally { await fixture.cleanup(); }
+});

--- a/tests_js/workspace_native_automation_integration.test.mjs
+++ b/tests_js/workspace_native_automation_integration.test.mjs
@@ -43,7 +43,7 @@ test('integrated native automation registry uses private fixture storage and ser
   let realm;
 
   await t.test('settings and account HTTP routes persist only their own documents and redact identities', async () => {
-    assert.deepEqual(JSON.parse(await readFile(join(root, '.native-jobs-fixture'), 'utf8')), { mode: 'native-jobs-fixture', version: 10 });
+    assert.deepEqual(JSON.parse(await readFile(join(root, '.native-jobs-fixture'), 'utf8')), { mode: 'native-jobs-fixture', version: 11 });
     for (const name of [settingsName, accountsName]) assert.equal((await stat(join(root, name))).mode & 0o777, 0o600);
     const initial = await snapshot(root);
     const updated = await call('PATCH', '/api/automation/settings', {
@@ -75,7 +75,9 @@ test('integrated native automation registry uses private fixture storage and ser
     assert.equal((await call('PATCH', '/api/automation/settings', { patch: {}, expectedRevision: true })).status, 400);
     assert.equal((await call('GET', '/api/employer-accounts/missing')).status, 404);
     assert.equal((await call('GET', '/api/automation')).status, 501);
-    for (const path of ['/api/trusted-fill/approve', '/api/account-operation/recover']) assert.equal((await call('POST', path, {})).status, 501);
+    assert.equal((await call('POST', '/api/trusted-fill/approve', {})).status, 501);
+    assert.deepEqual(JSON.parse((await call('GET', '/api/account-operation')).body), { status: 'idle', operation: null });
+    assert.deepEqual(JSON.parse((await call('POST', '/api/account-operation/recover', {})).body), { status: 'idle', recovered: false });
     assert.deepEqual(await snapshot(root), beforeRejected);
   });
 
@@ -143,16 +145,16 @@ test('integrated native automation registry uses private fixture storage and ser
     }
   });
 
-  await t.test('v9, missing new documents and unsupported recovery journals are rejected without adoption', async () => {
+  await t.test('v10, missing new documents and unsupported recovery journals are rejected without adoption', async () => {
     const markerPath = join(root, '.native-jobs-fixture');
     const marker = await readFile(markerPath);
-    await writeFile(markerPath, '{"mode":"native-jobs-fixture","version":9}\n');
+    await writeFile(markerPath, '{"mode":"native-jobs-fixture","version":10}\n');
     const old = await snapshot(root);
     await assert.rejects(settings.get(), /explicitly initialized synthetic fixture/);
     await assert.rejects(initializeJobsFixture(root), /EEXIST/);
     assert.deepEqual(await snapshot(root), old);
     await writeFile(markerPath, marker);
-    for (const name of [settingsName, accountsName]) {
+    for (const name of [settingsName, accountsName, 'account-operation-journal.json']) {
       const path = join(root, name), saved = join(parent, `missing-${name}`);
       await rename(path, saved);
       try {


### PR DESCRIPTION
Stranded employer-account operations previously had no native status or explicit recovery surface, leaving the native fixture unable to safely converge ambiguous browser/account state. This adds redacted status and explicit fail-closed recovery across Store, HTTP, and CLI, persists a private recovery journal, and hands live in-progress jobs to Needs Attention through the existing durable coordinator path.

- add the v11 account-operation journal contract and locked repository transaction
- expose status and recovery through native HTTP and CLI surfaces
- preserve exact arbitrary-size revisions with regression coverage

Validation:
- `npm run verify:deep -- --head HEAD --base origin/staging` (27 suites passed)
- independent correctness, contracts, error-handling, test, and documentation review roles
