### PR TITLE
Add native synthetic account execution

### DIFF
--- a/config/migration/http-write-accounts-surfaces.json
+++ b/config/migration/http-write-accounts-surfaces.json
@@ -13,7 +13,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/account-operation-http.ts",
+        "src/workspace-core/synthetic-account.ts",
+        "src/contracts/workspace/synthetic-account.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -203,7 +203,7 @@
     },
     {
       "path": "http-write-accounts-surfaces.json",
-      "sha256": "0738dac1610ed71d5db200b209e802e085bff0b20d2832cf3cd8d51efb47a02b"
+      "sha256": "0bdf97d7f6f12a42a7408d3b9c554e5e9acab8e034db093416d92b56371fb1dc"
     },
     {
       "path": "http-write-answers-02-surfaces.json",
@@ -319,7 +319,7 @@
     },
     {
       "path": "source-catalog-native-account-operation.json",
-      "sha256": "8aa7e96d575e2c1d8e3cd5c4a2031770522f48e9c72cc94a4d400e8333d668ed"
+      "sha256": "576f1c78a80d9eb83e0e8ee27e6a4db8e178a27af99cc1e63caf01dad29fdf1a"
     },
     {
       "path": "source-catalog-native-answer-cleanup.json",
@@ -375,7 +375,7 @@
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "c93c364c6bade66dcd9b49a93ba0e84580505ae33aa8268e929de57aaea394cb"
+      "sha256": "72a818fce605381cb186086934d0683540c7e05933efdb1ca6d9e5376fc16771"
     },
     {
       "path": "source-catalog-native-legacy-jobs.json",

--- a/config/migration/source-catalog-native-account-operation.json
+++ b/config/migration/source-catalog-native-account-operation.json
@@ -12,13 +12,23 @@
       "classification": "unreviewed"
     },
     {
+      "path": "runtime/contracts/workspace/synthetic-account.js",
+      "sha256": "ee7a8918f328f44c3bd7f6c739eb52bf1bb19103b5efc46117bd8ee05025ce99",
+      "classification": "unreviewed"
+    },
+    {
       "path": "runtime/workspace-core/account-operation-http.js",
-      "sha256": "32a2ef5b4c06c84b5320dc5d48046051437342bcfb876bdc8f137c5dad69f26b",
+      "sha256": "a55703bd131a9ea48ac01d1d64b0f07fad56b5042e27dd2297826e90e1b00987",
       "classification": "unreviewed"
     },
     {
       "path": "runtime/workspace-core/account-operation.js",
       "sha256": "450c2f890ad1b461fa57b7eb983510e6ff29cab117e149745c6ddbfb509f2ca5",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/synthetic-account.js",
+      "sha256": "89177e69a88d4d055fff64553585fb444d97bbb861997660a29740a4e5356373",
       "classification": "unreviewed"
     },
     {
@@ -32,13 +42,23 @@
       "classification": "unreviewed"
     },
     {
+      "path": "src/contracts/workspace/synthetic-account.ts",
+      "sha256": "64c226986b54f5b8cd3da3fa8127de60eea8c6fbf94d6179cf1e3fc708cc2c75",
+      "classification": "unreviewed"
+    },
+    {
       "path": "src/workspace-core/account-operation-http.ts",
-      "sha256": "e38a96fd272ff83e2885caababe17bf9bd9f74c58c1cd13fb495fa93bfbdb254",
+      "sha256": "4f69d802a02ff1a73bbcc7dc3f61585f16c562e0c41ba148e65f0c144a27c591",
       "classification": "unreviewed"
     },
     {
       "path": "src/workspace-core/account-operation.ts",
-      "sha256": "81d5420e46f6b7506ca308489436f38a5b65d554f121baa558d4a0062ab7004e",
+      "sha256": "92a9cd1d9dbf117695c4cc659c1c977bfa398c89d4418c5327855ed90eeb4b9e",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/synthetic-account.ts",
+      "sha256": "01ba7168c5c6b51380b60045842de05a52e5dc44b5836f4d44157861f98367f0",
       "classification": "unreviewed"
     }
   ]

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "a72e50e0475f5959f98f818a469635938dbcd2a79c61ef58078c6179d19f34ac",
+      "sha256": "ed2b629573c714533d7f4fd59a692c16938008331d439cde0cbd72c5f44a2212",
       "classification": "unreviewed"
     },
     {
@@ -83,7 +83,7 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "9167cea7a350470fb33ebb7d97b6b9f17f5d2ce572d7ecec5be149817e7b3946",
+      "sha256": "d45efa50f6751fca8f6c021e88eaa33ff37c6e9cf8a8d19280dd24ba97cf4ca0",
       "classification": "unreviewed"
     },
     {

--- a/docs/native-automation-fixture.md
+++ b/docs/native-automation-fixture.md
@@ -1,9 +1,10 @@
 # Native automation and employer-account control plane
 
 This tranche supplies native settings, realm resolution, and employer-account
-registry services and stranded account-operation recovery for explicit synthetic fixtures. It does not activate a Store
-writer, initialize an existing Store, inspect a browser, call credentials, or
-run an account executor. New fixtures use version 11 and require both account
+registry services, stranded account-operation recovery, and injected synthetic
+protected-account execution for explicit fixtures. It does not activate a Store
+writer, initialize an existing Store, inspect the owner's browser, or call the
+owner's credentials. New fixtures use version 11 and require both account
 documents plus `account-operation-journal.json`. Existing version 10 roots are rejected rather than upgraded or adopted;
 earlier fixture documents describe their historical version. Missing documents
 and unsupported trusted-fill journals remain rejected.
@@ -49,6 +50,16 @@ An already `needs_info` job can finish clearing a prior partial recovery. No
 path infers account success, permits retry, invokes a provider, or performs a
 final application action.
 
+`SyntheticAccountService` ports the protected synthetic execution contract. It
+accepts only an injected executor, an exact live job claim, exact job/settings/
+account revisions, a proven realm, and a loopback target bound by reviewed
+fingerprints. The journal is durably prepared before the injected effect and is
+advanced after each account stage. Executor failure burns the attempt as
+ambiguous and hands the job to Needs Attention; non-active observed outcomes do
+the same with their specific blocker. Public responses exclude the effective
+email and credential reference. The ordinary HTTP composition supplies no
+provider, so it rejects the synthetic route without mutation.
+
 ## HTTP boundary
 
 `automationHttp(repository, method, path, body)` supports these Python routes:
@@ -62,6 +73,7 @@ final application action.
 `accountOperationHttp(repository, method, path, body)` supports:
 
 - GET `/api/account-operation`
+- POST `/api/account-operation/execute-synthetic`
 - POST `/api/account-operation/recover`
 
 It returns a response or null for an unowned route. The composing HTTP boundary
@@ -87,17 +99,12 @@ coordinator journal, session and application history. It is not a read-only
 boolean permission check. These dependencies need a shared transaction boundary
 before approve/evaluate/revoke routes can be implemented.
 
-Synthetic execution binds job/claim/settings/account revisions and target URL
-fingerprint. The password-backed Python path writes `prepared` before invoking
-the executor; credential provisioning and portal observation can occur before
-the later journal stages are persisted. Each account-stage helper writes the
-account document before its corresponding journal update. The email-only path
-records `signup_in_progress` before its provider call. Follow-on crash-point
-tests must cover these distinct windows. Work must use injected synthetic executors only, with
-separate credentials/account-flow providers; never a real account helper.
-
-Account-operation status and recovery are now native. Synthetic operation
-execution remains deferred with the provider integration described above.
+Synthetic protected execution now binds job/claim/settings/account revisions
+and target URL fingerprint, writes `prepared` before invoking its injected
+executor, and preserves account-before-journal stage ordering. Credential
+provisioning and portal observation can therefore precede the later journal
+stages, and explicit recovery closes those crash windows without inferring
+success. The distinct email-only account-flow provider remains deferred.
 
 ## Focused evidence and remaining integration gates
 
@@ -112,7 +119,9 @@ repository and HTTP dispatcher, concurrent Python-free writers, private files,
 old-root/missing-document/journal rejection, and unrelated-document preservation.
 The account-operation suite covers idle transport parity, status redaction,
 real claim handoff evidence, journal identity checks, and unavailable-job
-preservation.
+preservation. The synthetic-execution suite covers a successful non-final
+lifecycle, verified attention outcome, executor ambiguity, public-provider
+denial, privacy, and malformed loopback bindings.
 
 Typecheck and owned runtime emission are required. The integration owner also
 owns source/runtime catalogs, test matrix, HTTP wiring, fixture marker/allowlist,

--- a/runtime/contracts/workspace/synthetic-account.js
+++ b/runtime/contracts/workspace/synthetic-account.js
@@ -1,0 +1,90 @@
+import { createHash } from 'node:crypto';
+import { exact } from './automation.js';
+import { fromJSON, get, int, object, string, JobsError } from './values.js';
+const fingerprintPattern = /^sha256:[0-9a-f]{64}$/;
+const realmPattern = /^[0-9a-f]{64}$/;
+const requestFields = [
+    'jobId', 'expectedJobRevision', 'expectedClaimId', 'realmRef', 'realmDescriptor',
+    'expectedSettingsRevision', 'expectedAccountRevision', 'syntheticTargetUrl',
+    'syntheticTargetFingerprint', 'observedFormFingerprint',
+    'observedControlFingerprint', 'secureControlFingerprint',
+];
+const resultFields = [
+    'lifecycleState', 'providerId', 'credentialRef', 'credentialVersion', 'reused',
+    'retryAllowed', 'finalActionAuthorized', 'secureControlCleared',
+];
+export const terminalAccountLifecycles = new Set([
+    'verification_required', 'reset_required', 'failed_definitive', 'ambiguous',
+]);
+const resultLifecycles = new Set(['active', ...terminalAccountLifecycles]);
+export function fingerprint(value) {
+    return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+export function operationFingerprint(target, realm, control) {
+    const url = new URL(target);
+    const canonical = `${url.protocol}//${url.host}${url.pathname}`;
+    return fingerprint(`protected-account:v1:${canonical}:${realm}:${control}`);
+}
+export function validateSyntheticAccountRequest(value) {
+    const request = object(value, 'account execution request');
+    exact(request, requestFields, 'account execution request contains unsupported fields');
+    for (const field of ['jobId', 'expectedClaimId', 'realmDescriptor']) {
+        if (!string(get(request, field)))
+            throw new JobsError('account execution binding is invalid');
+    }
+    const realm = string(get(request, 'realmRef'));
+    if (!realm || !realmPattern.test(realm))
+        throw new JobsError('account realm binding is invalid');
+    for (const field of ['expectedJobRevision', 'expectedSettingsRevision', 'expectedAccountRevision']) {
+        const revision = int(get(request, field));
+        if (revision === null || revision < 1n)
+            throw new JobsError(`${field} must be a positive integer`);
+    }
+    for (const field of ['syntheticTargetFingerprint', 'observedFormFingerprint', 'observedControlFingerprint', 'secureControlFingerprint']) {
+        if (!fingerprintPattern.test(string(get(request, field)) ?? ''))
+            throw new JobsError('account execution fingerprint is invalid');
+    }
+    const target = string(get(request, 'syntheticTargetUrl'));
+    let url;
+    try {
+        url = new URL(target ?? '');
+    }
+    catch {
+        throw new JobsError('synthetic target is invalid');
+    }
+    if (url.protocol !== 'http:' || url.hostname !== '127.0.0.1' || !url.port || url.username || url.password
+        || url.hash || url.pathname !== '/synthetic-account')
+        throw new JobsError('only the loopback synthetic account portal is authorized');
+    const operation = operationFingerprint(target, realm, string(get(request, 'secureControlFingerprint')));
+    if ([...url.searchParams.entries()].length !== 1 || url.searchParams.get('operation') !== operation.slice(7)) {
+        throw new JobsError('synthetic operation binding is invalid');
+    }
+    if (string(get(request, 'syntheticTargetFingerprint')) !== fingerprint(target))
+        throw new JobsError('synthetic account target proof mismatch');
+    if (string(get(request, 'secureControlFingerprint')) !== fingerprint('native-secure-control:v1'))
+        throw new JobsError('synthetic secure control proof mismatch');
+    return request;
+}
+export function validateSyntheticAccountResult(value) {
+    const result = object(value, 'synthetic account executor result');
+    exact(result, resultFields, 'synthetic account executor result is invalid');
+    if (!resultLifecycles.has(string(get(result, 'lifecycleState')) ?? ''))
+        throw new JobsError('synthetic account lifecycle is invalid');
+    if (!/^[a-z][a-z0-9-]{2,63}$/.test(string(get(result, 'providerId')) ?? '')
+        || !/^credential_[0-9a-f]{64}$/.test(string(get(result, 'credentialRef')) ?? '')
+        || (int(get(result, 'credentialVersion')) ?? 0n) < 1n || typeof get(result, 'reused') !== 'boolean') {
+        throw new JobsError('synthetic account credential metadata is invalid');
+    }
+    if (get(result, 'retryAllowed') !== false || get(result, 'finalActionAuthorized') !== false
+        || get(result, 'secureControlCleared') !== true)
+        throw new JobsError('synthetic account executor violated the reviewed effect contract');
+    return result;
+}
+export function syntheticProofs(target) {
+    return fromJSON({
+        syntheticTargetFingerprint: fingerprint(target),
+        observedFormFingerprint: fingerprint('account-form:v2'),
+        observedControlFingerprint: fingerprint('account-controls:v2'),
+        secureControlFingerprint: fingerprint('native-secure-control:v1'),
+    });
+}

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -424,10 +424,21 @@ export class NativeJobsRepository {
             const jobs = validateJobsDocument(await this.document('jobs'));
             const journal = validateAccountOperationJournal(await this.journal('account-operation-journal'));
             const accounts = await this.document('employer-accounts');
-            return operation({ journal, accounts, jobs,
+            const settings = await this.journal('automation-settings');
+            return operation({ journal, accounts, settings, jobs,
                 coordinator: validateCoordinator(await this.journal('coordinator')),
                 sessions: await this.answerSessions(), answers: validateAnswers(await this.document('answers')),
                 saveAccounts: document => this.write(join(this.root, 'employer-accounts.json'), document, options),
+                saveOperation: async (expected, value) => {
+                    const current = accountOperation(validateAccountOperationJournal(await this.journal('account-operation-journal')));
+                    const currentId = current === null ? null : string(get(current, 'operationId'));
+                    if (currentId !== expected)
+                        throw new JobsError('account operation journal changed before completion');
+                    const next = emptyAccountOperationJournal();
+                    if (value !== null)
+                        set(next, 'operation', value);
+                    await this.write(join(this.root, 'account-operation-journal.json'), validateAccountOperationJournal(next), options);
+                },
                 commitClaim: value => this.claimJournal().commit(value, jobs),
                 clearOperation: async (expected) => {
                     const current = accountOperation(validateAccountOperationJournal(await this.journal('account-operation-journal')));

--- a/runtime/workspace-core/account-operation-http.js
+++ b/runtime/workspace-core/account-operation-http.js
@@ -1,10 +1,14 @@
 import { exact } from '../contracts/workspace/automation.js';
 import { object, parse, serialize } from '../contracts/workspace/values.js';
 import { AccountOperationService } from './account-operation.js';
+import { SyntheticAccountService } from './synthetic-account.js';
 export async function accountOperationHttp(repository, method, path, body) {
     const service = new AccountOperationService(repository);
     if (method === 'GET' && path === '/api/account-operation')
         return { status: 200, body: serialize(await service.status()) };
+    if (method === 'POST' && path === '/api/account-operation/execute-synthetic') {
+        return { status: 200, body: serialize(await new SyntheticAccountService(repository).execute(parse(body))) };
+    }
     if (method === 'POST' && path === '/api/account-operation/recover') {
         exact(object(parse(body), 'account recovery body'), [], 'account recovery body must be empty');
         return { status: 200, body: serialize(await service.recover()) };

--- a/runtime/workspace-core/synthetic-account.js
+++ b/runtime/workspace-core/synthetic-account.js
@@ -1,0 +1,168 @@
+import { randomUUID } from 'node:crypto';
+import { publicAccount, validateAccount, validateAccountsDocument } from '../contracts/workspace/accounts.js';
+import { resolveAccountRealm } from '../contracts/workspace/account-realm.js';
+import { accountOperation } from '../contracts/workspace/account-operation.js';
+import { validateSettingsDocument } from '../contracts/workspace/automation.js';
+import { buildClaimSession } from '../contracts/workspace/claim-session.js';
+import { claimExpired, validateCoordinator } from '../contracts/workspace/claims.js';
+import { safeId, validateJobsDocument } from '../contracts/workspace/jobs.js';
+import { terminalAccountLifecycles, validateSyntheticAccountRequest, validateSyntheticAccountResult } from '../contracts/workspace/synthetic-account.js';
+import { copy, fromJSON, get, int, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+const doc = (value) => object(fromJSON(value), 'synthetic account value');
+function liveJob(tx, request, now) {
+    const id = safeId(string(get(request, 'jobId'))), jobs = validateJobsDocument(tx.jobs);
+    const raw = get(object(get(jobs, 'jobs'), 'jobs'), id);
+    if (raw === null)
+        throw new JobsError('account execution requires the exact live claimed job');
+    const job = object(raw, 'job'), rawClaim = get(validateCoordinator(tx.coordinator), 'claim');
+    if (rawClaim === null)
+        throw new JobsError('account execution requires the exact live claimed job');
+    const claim = object(rawClaim, 'claim');
+    if (get(job, 'deletedAt') !== null || string(get(job, 'status')) !== 'in_progress'
+        || int(get(job, 'revision')) !== int(get(request, 'expectedJobRevision'))
+        || string(get(claim, 'jobId')) !== id || string(get(claim, 'claimId')) !== string(get(request, 'expectedClaimId'))
+        || claimExpired(claim, now))
+        throw new JobsError('account execution requires the exact live claimed job');
+    return job;
+}
+function handoff(job, session, at) {
+    const operationId = randomUUID(), id = string(get(job, 'id'));
+    const event = doc({ schemaVersion: 1, eventId: `coordinator-${operationId}`, applicationId: id,
+        event: 'job-blocked', status: 'needs_info', answerKeys: [], at });
+    for (const field of ['company', 'role', 'ats'])
+        if (string(get(job, field)) !== null)
+            set(event, field, get(job, field));
+    const operation = doc({ kind: 'handoff', operationId, jobId: id, sourceStatus: 'in_progress',
+        targetStatus: 'needs_info', expectedRevision: null, at, resultClaim: null });
+    set(operation, 'expectedRevision', get(job, 'revision'));
+    set(operation, 'historyEvent', event);
+    return set(operation, 'session', session);
+}
+function blocker(reason) {
+    if (reason === 'reset_required' || reason === 'password_strategy')
+        return { type: 'information', code: 'owner-input-required' };
+    if (reason === 'verification_required')
+        return { type: 'browser_handoff', code: 'mfa-required' };
+    return { type: 'browser_handoff', code: 'browser-state-uncertain' };
+}
+async function attention(tx, job, reason, now) {
+    const blocked = blocker(reason), id = string(get(job, 'id'));
+    const incoming = doc({ status: 'active', step: `account_automation_denied:${reason}`,
+        answerKeys: [], pendingFields: [], blockers: [blocked],
+        browserHandoff: { state: 'required', reasonCode: blocked.code, revision: 1 } });
+    const session = buildClaimSession(id, incoming, { now, attemptRevision: get(job, 'revision'), ats: get(job, 'ats'),
+        existing: tx.sessions.find(item => string(get(item, 'applicationId')) === id) ?? null, answers: tx.answers });
+    await tx.commitClaim(handoff(job, session, now));
+    const result = doc({ id, status: 'needs_info', revision: null });
+    set(result, 'revision', integer(int(get(job, 'revision')) + 1n));
+    return result;
+}
+function operationFor(job, claim, account, settings, now) {
+    const operation = doc({ operationId: randomUUID(), jobId: string(get(job, 'id')), jobRevision: null,
+        claimId: string(get(claim, 'claimId')), realmRef: string(get(account, 'realmRef')), accountRevision: null,
+        settingsRevision: null, stage: 'prepared', outcomeCode: 'observed_pending', startedAt: now });
+    set(operation, 'jobRevision', get(job, 'revision'));
+    set(operation, 'accountRevision', get(account, 'revision'));
+    set(operation, 'settingsRevision', get(settings, 'revision'));
+    return operation;
+}
+async function writeStage(tx, account, operation, lifecycle, stage, at, metadata) {
+    const accounts = validateAccountsDocument(tx.accounts), records = object(get(accounts, 'accounts'), 'accounts');
+    const current = object(get(records, string(get(account, 'realmRef'))), 'employer account');
+    if (int(get(current, 'revision')) !== int(get(account, 'revision')))
+        throw new JobsError('employer account revision conflict');
+    const updated = copy(current);
+    set(updated, 'lifecycleState', text(lifecycle));
+    set(updated, 'revision', integer(int(get(current, 'revision')) + 1n));
+    set(updated, 'updatedAt', text(at));
+    if (metadata)
+        for (const field of ['providerId', 'credentialRef', 'credentialVersion'])
+            set(updated, field, get(metadata, field));
+    validateAccount(string(get(updated, 'realmRef')), updated);
+    set(records, string(get(updated, 'realmRef')), updated);
+    set(object(get(accounts, 'metadata'), 'account metadata'), 'updatedAt', get(updated, 'updatedAt'));
+    await tx.saveAccounts(accounts);
+    const next = copy(operation);
+    set(next, 'stage', text(stage));
+    set(next, 'accountRevision', get(updated, 'revision'));
+    await tx.saveOperation(string(get(operation, 'operationId')), next);
+    return { account: updated, operation: next };
+}
+export class SyntheticAccountService {
+    repository;
+    executor;
+    now;
+    constructor(repository, executor, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.executor = executor;
+        this.now = now;
+    }
+    async execute(value) {
+        const request = validateSyntheticAccountRequest(value);
+        if (!this.executor)
+            throw new JobsError('native protected provider injection is required');
+        const executor = this.executor;
+        if (executor.providerId !== 'synthetic-protected')
+            throw new JobsError('synthetic provider is test-only');
+        return await this.repository.accountOperationTransaction(async (tx) => {
+            if (accountOperation(tx.journal) !== null)
+                throw new JobsError('account operation requires explicit recovery');
+            const now = this.now(), job = liveJob(tx, request, now), realm = resolveAccountRealm(string(get(job, 'url')));
+            if (realm.status !== 'resolved' || realm.realmRef !== string(get(request, 'realmRef'))
+                || realm.descriptor !== string(get(request, 'realmDescriptor')))
+                throw new JobsError('account execution realm binding mismatch');
+            const settings = object(get(validateSettingsDocument(tx.settings), 'settings'), 'automation settings');
+            const accounts = validateAccountsDocument(tx.accounts), raw = get(object(get(accounts, 'accounts'), 'accounts'), realm.realmRef);
+            if (raw === null)
+                throw new JobsError('employer account does not exist');
+            let account = object(raw, 'employer account');
+            if (int(get(settings, 'revision')) !== int(get(request, 'expectedSettingsRevision'))
+                || int(get(account, 'revision')) !== int(get(request, 'expectedAccountRevision')))
+                throw new JobsError('account execution revision conflict');
+            if (get(settings, 'enabled') !== true || get(settings, 'automaticAccountCreation') !== true)
+                throw new JobsError('account automation is disabled');
+            const effectiveEmail = string(get(account, 'signupEmailOverride')) ?? string(get(settings, 'signupEmail'));
+            if (!effectiveEmail)
+                throw new JobsError('effective signup email is required');
+            if (terminalAccountLifecycles.has(string(get(account, 'lifecycleState'))))
+                throw new JobsError('account lifecycle permanently requires human attention');
+            const strategy = string(get(settings, 'passwordStrategy'));
+            if (['custom', 'ask_each_time'].includes(strategy)) {
+                const denied = await attention(tx, job, 'password_strategy', now);
+                return set(doc({ authorized: false, reasonCode: 'password_strategy_requires_human', retryAllowed: false,
+                    attentionHandoff: true, job: null }), 'job', denied);
+            }
+            const rawClaim = object(get(validateCoordinator(tx.coordinator), 'claim'), 'claim');
+            let operation = operationFor(job, rawClaim, account, settings, now);
+            await tx.saveOperation(null, operation);
+            let result;
+            try {
+                result = validateSyntheticAccountResult(await executor.execute(request, strategy, get(account, 'credentialRef'), () => effectiveEmail));
+                if (string(get(result, 'providerId')) !== executor.providerId)
+                    throw new JobsError('synthetic account provider mismatch');
+            }
+            catch {
+                ({ account, operation } = await writeStage(tx, account, operation, 'ambiguous', 'signup_in_progress', now));
+                const denied = await attention(tx, job, 'ambiguous', now);
+                await tx.clearOperation(string(get(operation, 'operationId')));
+                const response = doc({ authorized: false, reasonCode: 'ambiguous', retryAllowed: false,
+                    attentionHandoff: true, account: null, job: null });
+                set(response, 'account', publicAccount(account));
+                set(response, 'job', denied);
+                return response;
+            }
+            ({ account, operation } = await writeStage(tx, account, operation, 'credential_provisioned', 'credential_provisioned', now, result));
+            ({ account, operation } = await writeStage(tx, account, operation, 'signup_in_progress', 'signup_in_progress', now));
+            const lifecycle = string(get(result, 'lifecycleState'));
+            ({ account, operation } = await writeStage(tx, account, operation, lifecycle, 'signup_in_progress', now));
+            const needsAttention = lifecycle !== 'active', response = doc({ authorized: !needsAttention, reasonCode: lifecycle,
+                retryAllowed: false, attentionHandoff: needsAttention, reused: get(result, 'reused'),
+                secureControlCleared: true, finalActionAuthorized: false, account: null });
+            set(response, 'account', publicAccount(account));
+            if (needsAttention)
+                set(response, 'job', await attention(tx, job, lifecycle, now));
+            await tx.clearOperation(string(get(operation, 'operationId')));
+            return response;
+        });
+    }
+}

--- a/src/contracts/workspace/synthetic-account.ts
+++ b/src/contracts/workspace/synthetic-account.ts
@@ -1,0 +1,83 @@
+import { createHash } from 'node:crypto';
+import { exact } from './automation.js';
+import { fromJSON, get, int, object, string, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+
+const fingerprintPattern = /^sha256:[0-9a-f]{64}$/;
+const realmPattern = /^[0-9a-f]{64}$/;
+const requestFields = [
+  'jobId', 'expectedJobRevision', 'expectedClaimId', 'realmRef', 'realmDescriptor',
+  'expectedSettingsRevision', 'expectedAccountRevision', 'syntheticTargetUrl',
+  'syntheticTargetFingerprint', 'observedFormFingerprint',
+  'observedControlFingerprint', 'secureControlFingerprint',
+];
+const resultFields = [
+  'lifecycleState', 'providerId', 'credentialRef', 'credentialVersion', 'reused',
+  'retryAllowed', 'finalActionAuthorized', 'secureControlCleared',
+];
+export const terminalAccountLifecycles = new Set([
+  'verification_required', 'reset_required', 'failed_definitive', 'ambiguous',
+]);
+const resultLifecycles = new Set(['active', ...terminalAccountLifecycles]);
+
+export function fingerprint(value: string): string {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+
+export function operationFingerprint(target: string, realm: string, control: string): string {
+  const url = new URL(target);
+  const canonical = `${url.protocol}//${url.host}${url.pathname}`;
+  return fingerprint(`protected-account:v1:${canonical}:${realm}:${control}`);
+}
+
+export function validateSyntheticAccountRequest(value: Value): Document {
+  const request = object(value, 'account execution request');
+  exact(request, requestFields, 'account execution request contains unsupported fields');
+  for (const field of ['jobId', 'expectedClaimId', 'realmDescriptor']) {
+    if (!string(get(request, field))) throw new JobsError('account execution binding is invalid');
+  }
+  const realm = string(get(request, 'realmRef'));
+  if (!realm || !realmPattern.test(realm)) throw new JobsError('account realm binding is invalid');
+  for (const field of ['expectedJobRevision', 'expectedSettingsRevision', 'expectedAccountRevision']) {
+    const revision = int(get(request, field));
+    if (revision === null || revision < 1n) throw new JobsError(`${field} must be a positive integer`);
+  }
+  for (const field of ['syntheticTargetFingerprint', 'observedFormFingerprint', 'observedControlFingerprint', 'secureControlFingerprint']) {
+    if (!fingerprintPattern.test(string(get(request, field)) ?? '')) throw new JobsError('account execution fingerprint is invalid');
+  }
+  const target = string(get(request, 'syntheticTargetUrl'));
+  let url: URL;
+  try { url = new URL(target ?? ''); } catch { throw new JobsError('synthetic target is invalid'); }
+  if (url.protocol !== 'http:' || url.hostname !== '127.0.0.1' || !url.port || url.username || url.password
+    || url.hash || url.pathname !== '/synthetic-account') throw new JobsError('only the loopback synthetic account portal is authorized');
+  const operation = operationFingerprint(target!, realm, string(get(request, 'secureControlFingerprint'))!);
+  if ([...url.searchParams.entries()].length !== 1 || url.searchParams.get('operation') !== operation.slice(7)) {
+    throw new JobsError('synthetic operation binding is invalid');
+  }
+  if (string(get(request, 'syntheticTargetFingerprint')) !== fingerprint(target!)) throw new JobsError('synthetic account target proof mismatch');
+  if (string(get(request, 'secureControlFingerprint')) !== fingerprint('native-secure-control:v1')) throw new JobsError('synthetic secure control proof mismatch');
+  return request;
+}
+
+export function validateSyntheticAccountResult(value: Value): Document {
+  const result = object(value, 'synthetic account executor result');
+  exact(result, resultFields, 'synthetic account executor result is invalid');
+  if (!resultLifecycles.has(string(get(result, 'lifecycleState')) ?? '')) throw new JobsError('synthetic account lifecycle is invalid');
+  if (!/^[a-z][a-z0-9-]{2,63}$/.test(string(get(result, 'providerId')) ?? '')
+    || !/^credential_[0-9a-f]{64}$/.test(string(get(result, 'credentialRef')) ?? '')
+    || (int(get(result, 'credentialVersion')) ?? 0n) < 1n || typeof get(result, 'reused') !== 'boolean') {
+    throw new JobsError('synthetic account credential metadata is invalid');
+  }
+  if (get(result, 'retryAllowed') !== false || get(result, 'finalActionAuthorized') !== false
+    || get(result, 'secureControlCleared') !== true) throw new JobsError('synthetic account executor violated the reviewed effect contract');
+  return result;
+}
+
+export function syntheticProofs(target: string): Value {
+  return fromJSON({
+    syntheticTargetFingerprint: fingerprint(target),
+    observedFormFingerprint: fingerprint('account-form:v2'),
+    observedControlFingerprint: fingerprint('account-controls:v2'),
+    secureControlFingerprint: fingerprint('native-secure-control:v1'),
+  });
+}

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -442,10 +442,19 @@ export class NativeJobsRepository implements JobsRepository, ResumeLifecycleRepo
       const jobs = validateJobsDocument(await this.document('jobs'));
       const journal = validateAccountOperationJournal(await this.journal('account-operation-journal'));
       const accounts = await this.document('employer-accounts');
-      return operation({ journal, accounts, jobs,
+      const settings = await this.journal('automation-settings');
+      return operation({ journal, accounts, settings, jobs,
         coordinator: validateCoordinator(await this.journal('coordinator')),
         sessions: await this.answerSessions(), answers: validateAnswers(await this.document('answers')),
         saveAccounts: document => this.write(join(this.root, 'employer-accounts.json'), document, options),
+        saveOperation: async (expected, value) => {
+          const current = accountOperation(validateAccountOperationJournal(await this.journal('account-operation-journal')));
+          const currentId = current === null ? null : string(get(current, 'operationId'));
+          if (currentId !== expected) throw new JobsError('account operation journal changed before completion');
+          const next = emptyAccountOperationJournal();
+          if (value !== null) set(next, 'operation', value);
+          await this.write(join(this.root, 'account-operation-journal.json'), validateAccountOperationJournal(next), options);
+        },
         commitClaim: value => this.claimJournal().commit(value, jobs),
         clearOperation: async expected => {
           const current = accountOperation(validateAccountOperationJournal(await this.journal('account-operation-journal')));

--- a/src/workspace-core/account-operation-http.ts
+++ b/src/workspace-core/account-operation-http.ts
@@ -2,10 +2,14 @@ import { exact } from '../contracts/workspace/automation.js';
 import { object, parse, serialize } from '../contracts/workspace/values.js';
 import type { AccountOperationRepository } from './account-operation.js';
 import { AccountOperationService } from './account-operation.js';
+import { SyntheticAccountService } from './synthetic-account.js';
 
 export async function accountOperationHttp(repository: AccountOperationRepository, method: string, path: string, body: string) {
   const service = new AccountOperationService(repository);
   if (method === 'GET' && path === '/api/account-operation') return { status: 200, body: serialize(await service.status()) };
+  if (method === 'POST' && path === '/api/account-operation/execute-synthetic') {
+    return { status: 200, body: serialize(await new SyntheticAccountService(repository).execute(parse(body))) };
+  }
   if (method === 'POST' && path === '/api/account-operation/recover') {
     exact(object(parse(body), 'account recovery body'), [], 'account recovery body must be empty');
     return { status: 200, body: serialize(await service.recover()) };

--- a/src/workspace-core/account-operation.ts
+++ b/src/workspace-core/account-operation.ts
@@ -8,9 +8,10 @@ import { copy, fromJSON, get, int, integer, object, set, string, text, JobsError
 import type { Document, Value } from '../contracts/workspace/values.js';
 
 export interface AccountOperationTransaction {
-  journal: Document; accounts: Document; jobs: Document; coordinator: Document;
+  journal: Document; accounts: Document; settings: Document; jobs: Document; coordinator: Document;
   sessions: Document[]; answers: Document;
   saveAccounts(document: Document): Promise<void>;
+  saveOperation(expectedOperationId: string | null, operation: Document | null): Promise<void>;
   commitClaim(operation: Document): Promise<void>;
   clearOperation(expectedOperationId: string): Promise<void>;
 }

--- a/src/workspace-core/synthetic-account.ts
+++ b/src/workspace-core/synthetic-account.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from 'node:crypto';
+import { publicAccount, validateAccount, validateAccountsDocument } from '../contracts/workspace/accounts.js';
+import { resolveAccountRealm } from '../contracts/workspace/account-realm.js';
+import { accountOperation } from '../contracts/workspace/account-operation.js';
+import { validateSettingsDocument } from '../contracts/workspace/automation.js';
+import { buildClaimSession } from '../contracts/workspace/claim-session.js';
+import { claimExpired, validateCoordinator } from '../contracts/workspace/claims.js';
+import { safeId, validateJobsDocument } from '../contracts/workspace/jobs.js';
+import { terminalAccountLifecycles, validateSyntheticAccountRequest, validateSyntheticAccountResult } from '../contracts/workspace/synthetic-account.js';
+import { copy, fromJSON, get, int, integer, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import type { AccountOperationRepository, AccountOperationTransaction } from './account-operation.js';
+
+export interface SyntheticAccountExecutor {
+  readonly providerId: string;
+  execute(request: Document, strategy: string, existingCredentialRef: Value,
+    privateEmail: () => string): Promise<Value>;
+}
+
+const doc = (value: unknown): Document => object(fromJSON(value), 'synthetic account value');
+
+function liveJob(tx: AccountOperationTransaction, request: Document, now: string): Document {
+  const id = safeId(string(get(request, 'jobId'))), jobs = validateJobsDocument(tx.jobs);
+  const raw = get(object(get(jobs, 'jobs'), 'jobs'), id);
+  if (raw === null) throw new JobsError('account execution requires the exact live claimed job');
+  const job = object(raw, 'job'), rawClaim = get(validateCoordinator(tx.coordinator), 'claim');
+  if (rawClaim === null) throw new JobsError('account execution requires the exact live claimed job');
+  const claim = object(rawClaim, 'claim');
+  if (get(job, 'deletedAt') !== null || string(get(job, 'status')) !== 'in_progress'
+    || int(get(job, 'revision')) !== int(get(request, 'expectedJobRevision'))
+    || string(get(claim, 'jobId')) !== id || string(get(claim, 'claimId')) !== string(get(request, 'expectedClaimId'))
+    || claimExpired(claim, now)) throw new JobsError('account execution requires the exact live claimed job');
+  return job;
+}
+
+function handoff(job: Document, session: Document, at: string): Document {
+  const operationId = randomUUID(), id = string(get(job, 'id'))!;
+  const event = doc({ schemaVersion: 1, eventId: `coordinator-${operationId}`, applicationId: id,
+    event: 'job-blocked', status: 'needs_info', answerKeys: [], at });
+  for (const field of ['company', 'role', 'ats']) if (string(get(job, field)) !== null) set(event, field, get(job, field));
+  const operation = doc({ kind: 'handoff', operationId, jobId: id, sourceStatus: 'in_progress',
+    targetStatus: 'needs_info', expectedRevision: null, at, resultClaim: null });
+  set(operation, 'expectedRevision', get(job, 'revision'));
+  set(operation, 'historyEvent', event);
+  return set(operation, 'session', session);
+}
+
+function blocker(reason: string): { type: string; code: string } {
+  if (reason === 'reset_required' || reason === 'password_strategy') return { type: 'information', code: 'owner-input-required' };
+  if (reason === 'verification_required') return { type: 'browser_handoff', code: 'mfa-required' };
+  return { type: 'browser_handoff', code: 'browser-state-uncertain' };
+}
+
+async function attention(tx: AccountOperationTransaction, job: Document, reason: string, now: string): Promise<Document> {
+  const blocked = blocker(reason), id = string(get(job, 'id'))!;
+  const incoming = doc({ status: 'active', step: `account_automation_denied:${reason}`,
+    answerKeys: [], pendingFields: [], blockers: [blocked],
+    browserHandoff: { state: 'required', reasonCode: blocked.code, revision: 1 } });
+  const session = buildClaimSession(id, incoming, { now, attemptRevision: get(job, 'revision'), ats: get(job, 'ats'),
+    existing: tx.sessions.find(item => string(get(item, 'applicationId')) === id) ?? null, answers: tx.answers });
+  await tx.commitClaim(handoff(job, session, now));
+  const result = doc({ id, status: 'needs_info', revision: null });
+  set(result, 'revision', integer(int(get(job, 'revision'))! + 1n));
+  return result;
+}
+
+function operationFor(job: Document, claim: Document, account: Document, settings: Document, now: string): Document {
+  const operation = doc({ operationId: randomUUID(), jobId: string(get(job, 'id')), jobRevision: null,
+    claimId: string(get(claim, 'claimId')), realmRef: string(get(account, 'realmRef')), accountRevision: null,
+    settingsRevision: null, stage: 'prepared', outcomeCode: 'observed_pending', startedAt: now });
+  set(operation, 'jobRevision', get(job, 'revision'));
+  set(operation, 'accountRevision', get(account, 'revision'));
+  set(operation, 'settingsRevision', get(settings, 'revision'));
+  return operation;
+}
+
+async function writeStage(tx: AccountOperationTransaction, account: Document, operation: Document,
+  lifecycle: string, stage: string, at: string, metadata?: Document): Promise<{ account: Document; operation: Document }> {
+  const accounts = validateAccountsDocument(tx.accounts), records = object(get(accounts, 'accounts'), 'accounts');
+  const current = object(get(records, string(get(account, 'realmRef'))!), 'employer account');
+  if (int(get(current, 'revision')) !== int(get(account, 'revision'))) throw new JobsError('employer account revision conflict');
+  const updated = copy(current);
+  set(updated, 'lifecycleState', text(lifecycle));
+  set(updated, 'revision', integer(int(get(current, 'revision'))! + 1n));
+  set(updated, 'updatedAt', text(at));
+  if (metadata) for (const field of ['providerId', 'credentialRef', 'credentialVersion']) set(updated, field, get(metadata, field));
+  validateAccount(string(get(updated, 'realmRef'))!, updated);
+  set(records, string(get(updated, 'realmRef'))!, updated);
+  set(object(get(accounts, 'metadata'), 'account metadata'), 'updatedAt', get(updated, 'updatedAt'));
+  await tx.saveAccounts(accounts);
+  const next = copy(operation);
+  set(next, 'stage', text(stage));
+  set(next, 'accountRevision', get(updated, 'revision'));
+  await tx.saveOperation(string(get(operation, 'operationId'))!, next);
+  return { account: updated, operation: next };
+}
+
+export class SyntheticAccountService {
+  constructor(private readonly repository: AccountOperationRepository, private readonly executor?: SyntheticAccountExecutor,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+
+  async execute(value: Value): Promise<Value> {
+    const request = validateSyntheticAccountRequest(value);
+    if (!this.executor) throw new JobsError('native protected provider injection is required');
+    const executor = this.executor;
+    if (executor.providerId !== 'synthetic-protected') throw new JobsError('synthetic provider is test-only');
+    return await this.repository.accountOperationTransaction(async tx => {
+      if (accountOperation(tx.journal) !== null) throw new JobsError('account operation requires explicit recovery');
+      const now = this.now(), job = liveJob(tx, request, now), realm = resolveAccountRealm(string(get(job, 'url')));
+      if (realm.status !== 'resolved' || realm.realmRef !== string(get(request, 'realmRef'))
+        || realm.descriptor !== string(get(request, 'realmDescriptor'))) throw new JobsError('account execution realm binding mismatch');
+      const settings = object(get(validateSettingsDocument(tx.settings), 'settings'), 'automation settings');
+      const accounts = validateAccountsDocument(tx.accounts), raw = get(object(get(accounts, 'accounts'), 'accounts'), realm.realmRef);
+      if (raw === null) throw new JobsError('employer account does not exist');
+      let account = object(raw, 'employer account');
+      if (int(get(settings, 'revision')) !== int(get(request, 'expectedSettingsRevision'))
+        || int(get(account, 'revision')) !== int(get(request, 'expectedAccountRevision'))) throw new JobsError('account execution revision conflict');
+      if (get(settings, 'enabled') !== true || get(settings, 'automaticAccountCreation') !== true) throw new JobsError('account automation is disabled');
+      const effectiveEmail = string(get(account, 'signupEmailOverride')) ?? string(get(settings, 'signupEmail'));
+      if (!effectiveEmail) throw new JobsError('effective signup email is required');
+      if (terminalAccountLifecycles.has(string(get(account, 'lifecycleState'))!)) throw new JobsError('account lifecycle permanently requires human attention');
+      const strategy = string(get(settings, 'passwordStrategy'))!;
+      if (['custom', 'ask_each_time'].includes(strategy)) {
+        const denied = await attention(tx, job, 'password_strategy', now);
+        return set(doc({ authorized: false, reasonCode: 'password_strategy_requires_human', retryAllowed: false,
+          attentionHandoff: true, job: null }), 'job', denied);
+      }
+      const rawClaim = object(get(validateCoordinator(tx.coordinator), 'claim'), 'claim');
+      let operation = operationFor(job, rawClaim, account, settings, now);
+      await tx.saveOperation(null, operation);
+      let result: Document;
+      try {
+        result = validateSyntheticAccountResult(await executor.execute(request, strategy, get(account, 'credentialRef'), () => effectiveEmail));
+        if (string(get(result, 'providerId')) !== executor.providerId) throw new JobsError('synthetic account provider mismatch');
+      } catch {
+        ({ account, operation } = await writeStage(tx, account, operation, 'ambiguous', 'signup_in_progress', now));
+        const denied = await attention(tx, job, 'ambiguous', now);
+        await tx.clearOperation(string(get(operation, 'operationId'))!);
+        const response = doc({ authorized: false, reasonCode: 'ambiguous', retryAllowed: false,
+          attentionHandoff: true, account: null, job: null });
+        set(response, 'account', publicAccount(account));
+        set(response, 'job', denied);
+        return response;
+      }
+      ({ account, operation } = await writeStage(tx, account, operation, 'credential_provisioned', 'credential_provisioned', now, result));
+      ({ account, operation } = await writeStage(tx, account, operation, 'signup_in_progress', 'signup_in_progress', now));
+      const lifecycle = string(get(result, 'lifecycleState'))!;
+      ({ account, operation } = await writeStage(tx, account, operation, lifecycle, 'signup_in_progress', now));
+      const needsAttention = lifecycle !== 'active', response = doc({ authorized: !needsAttention, reasonCode: lifecycle,
+        retryAllowed: false, attentionHandoff: needsAttention, reused: get(result, 'reused'),
+        secureControlCleared: true, finalActionAuthorized: false, account: null });
+      set(response, 'account', publicAccount(account));
+      if (needsAttention) set(response, 'job', await attention(tx, job, lifecycle, now));
+      await tx.clearOperation(string(get(operation, 'operationId'))!);
+      return response;
+    });
+  }
+}

--- a/tests_js/workspace_native_synthetic_account.test.mjs
+++ b/tests_js/workspace_native_synthetic_account.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { plain, read, setup, snapshot } from './workspace_native_claims_support.mjs';
+import { AccountsService } from '../runtime/workspace-core/accounts.js';
+import { AutomationService } from '../runtime/workspace-core/automation.js';
+import { SyntheticAccountService } from '../runtime/workspace-core/synthetic-account.js';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+import { fingerprint, operationFingerprint, syntheticProofs } from '../runtime/contracts/workspace/synthetic-account.js';
+import { fromJSON, serialize } from '../runtime/contracts/workspace/values.js';
+
+const portal = 'https://example.wd1.myworkdayjobs.com/en-US/careers/job/42';
+const credentialRef = `credential_${'a'.repeat(64)}`;
+
+async function prepared(fixture, name) {
+  const state = await setup(fixture, name);
+  const created = plain(await state.jobs.create(fromJSON({ id: 'account-job', url: portal,
+    role: 'Engineer', company: 'Synthetic', ats: 'workday' })));
+  await state.claims.select('account-job', BigInt(created.revision), true);
+  const selected = plain(await state.jobs.get('account-job'));
+  const acquired = plain(await state.claims.acquire('account-job', fromJSON('Synthetic owner'), BigInt(selected.revision)));
+  const accounts = new AccountsService(state.repository, () => state.clock.now);
+  const account = plain(await accounts.create(portal));
+  await new AutomationService(state.repository, () => state.clock.now).update(fromJSON({
+    enabled: true, automaticAccountCreation: true, signupEmail: 'private@example.invalid',
+  }), 1n);
+  const proofs = plain(syntheticProofs('http://127.0.0.1:43123/synthetic-account'));
+  const operation = operationFingerprint('http://127.0.0.1:43123/synthetic-account', account.realmRef, proofs.secureControlFingerprint);
+  const target = `http://127.0.0.1:43123/synthetic-account?operation=${operation.slice(7)}`;
+  return { ...state, packet: {
+    jobId: 'account-job', expectedJobRevision: acquired.job.revision,
+    expectedClaimId: acquired.claim.claimId, realmRef: account.realmRef,
+    realmDescriptor: account.descriptor, expectedSettingsRevision: 2,
+    expectedAccountRevision: account.revision, syntheticTargetUrl: target,
+    syntheticTargetFingerprint: fingerprint(target),
+    observedFormFingerprint: proofs.observedFormFingerprint,
+    observedControlFingerprint: proofs.observedControlFingerprint,
+    secureControlFingerprint: proofs.secureControlFingerprint,
+  } };
+}
+
+test('native synthetic protected account execution is journaled, redacted, and fail closed', { timeout: 60000 }, async t => {
+  const fixture = await nativeFixture();
+  t.after(() => fixture.cleanup());
+
+  await t.test('an injected synthetic executor can complete one non-final active lifecycle', async () => {
+    const state = await prepared(fixture, 'synthetic-success');
+    let calls = 0;
+    const executor = { providerId: 'synthetic-protected', execute: async (request, strategy, existing, privateEmail) => {
+      calls += 1;
+      assert.equal(strategy, 'unique_per_realm');
+      assert.equal(existing, null);
+      assert.equal(privateEmail(), 'private@example.invalid');
+      assert.doesNotMatch(serialize(request), /private@example/);
+      return fromJSON({ lifecycleState: 'active', providerId: 'synthetic-protected',
+        credentialRef, credentialVersion: 1, reused: false, retryAllowed: false,
+        finalActionAuthorized: false, secureControlCleared: true });
+    } };
+    const result = plain(await new SyntheticAccountService(state.repository, executor, () => state.clock.now).execute(fromJSON(state.packet)));
+    assert.equal(calls, 1);
+    assert.equal(result.authorized, true);
+    assert.equal(result.reasonCode, 'active');
+    assert.equal(result.attentionHandoff, false);
+    assert.equal(result.finalActionAuthorized, false);
+    assert.equal(result.account.lifecycleState, 'active');
+    assert.equal(result.account.revision, 4);
+    assert.equal(result.account.providerAssigned, true);
+    assert.doesNotMatch(JSON.stringify(result), /private@example|credential_/);
+    assert.equal((await read(state.root, 'account-operation-journal.json')).operation, null);
+    assert.equal((await read(state.root, 'coordinator.json')).claim.jobId, 'account-job');
+  });
+
+  await t.test('executor failure burns the attempt, marks ambiguity, and durably hands off', async () => {
+    const state = await prepared(fixture, 'synthetic-ambiguous');
+    const service = new SyntheticAccountService(state.repository, { providerId: 'synthetic-protected', execute: async () => { throw new Error('private failure'); } }, () => state.clock.now);
+    const result = plain(await service.execute(fromJSON(state.packet)));
+    assert.deepEqual({ authorized: result.authorized, reasonCode: result.reasonCode, retryAllowed: result.retryAllowed,
+      attentionHandoff: result.attentionHandoff }, { authorized: false, reasonCode: 'ambiguous', retryAllowed: false, attentionHandoff: true });
+    assert.equal(result.account.lifecycleState, 'ambiguous');
+    assert.equal(result.job.status, 'needs_info');
+    assert.doesNotMatch(JSON.stringify(result), /private failure|private@example|credential_/);
+    assert.equal((await read(state.root, 'account-operation-journal.json')).operation, null);
+    assert.equal((await read(state.root, 'coordinator.json')).claim, null);
+    const session = await read(state.root, 'sessions/account-job.json');
+    assert.equal(session.step, 'account_automation_denied:ambiguous');
+    assert.deepEqual(session.blockers, [{ type: 'browser_handoff', code: 'browser-state-uncertain' }]);
+  });
+
+  await t.test('a verified non-active outcome keeps the credential metadata private and requests attention', async () => {
+    const state = await prepared(fixture, 'synthetic-verification');
+    const executor = { providerId: 'synthetic-protected', execute: async () => fromJSON({ lifecycleState: 'verification_required',
+      providerId: 'synthetic-protected', credentialRef, credentialVersion: 1, reused: false,
+      retryAllowed: false, finalActionAuthorized: false, secureControlCleared: true }) };
+    const result = plain(await new SyntheticAccountService(state.repository, executor, () => state.clock.now).execute(fromJSON(state.packet)));
+    assert.equal(result.authorized, false);
+    assert.equal(result.reasonCode, 'verification_required');
+    assert.equal(result.job.status, 'needs_info');
+    assert.doesNotMatch(JSON.stringify(result), /credential_/);
+    const session = await read(state.root, 'sessions/account-job.json');
+    assert.equal(session.step, 'account_automation_denied:verification_required');
+    assert.deepEqual(session.blockers, [{ type: 'browser_handoff', code: 'mfa-required' }]);
+    assert.equal((await read(state.root, 'account-operation-journal.json')).operation, null);
+  });
+
+  await t.test('the public HTTP surface cannot inject a protected provider or mutate the fixture', async () => {
+    const state = await prepared(fixture, 'synthetic-http-denied');
+    const before = await snapshot(state.root);
+    const response = await jobsHttp(state.jobs, state.repository, 'POST', '/api/account-operation/execute-synthetic', JSON.stringify(state.packet));
+    assert.equal(response.status, 400);
+    assert.match(response.body, /native protected provider injection is required/);
+    assert.deepEqual(await snapshot(state.root), before);
+  });
+
+  await t.test('malformed loopback bindings fail before the injected executor or journal write', async () => {
+    const state = await prepared(fixture, 'synthetic-invalid');
+    let called = false;
+    const service = new SyntheticAccountService(state.repository, { providerId: 'synthetic-protected', execute: async () => { called = true; } }, () => state.clock.now);
+    const before = await snapshot(state.root);
+    await assert.rejects(service.execute(fromJSON({ ...state.packet, syntheticTargetUrl: 'https://example.invalid/synthetic-account' })), /loopback synthetic/);
+    assert.equal(called, false);
+    assert.deepEqual(await snapshot(state.root), before);
+  });
+});


### PR DESCRIPTION
Adds the native TypeScript service and strict request/result contracts for protected synthetic account execution. The service binds execution to the exact live claim and job, settings, account, realm, loopback target, and observed control fingerprints; journals each durable stage; redacts private email and credential metadata; and sends ambiguous or nonactive outcomes to Needs Attention without authorizing a final action.

Validation: local commit gate passed 10 suites; clean migration inventory passed; local deep gate passed all 27 suites; exact push validation passed all 27 suites, including 551 workspace contract tests, 74 account tests, 347 QA tests, 317 native tests, macOS contracts, packaged installation, Playwright/CLI walkthroughs, and release packaging.