### PR TITLE
Add native Trusted Fill authority

### DIFF
--- a/config/migration/document-01-surfaces.json
+++ b/config/migration/document-01-surfaces.json
@@ -317,7 +317,10 @@
       "artifact": "json",
       "node": "ACC",
       "sources": [
-        "scripts/job_apply_store/base.py"
+        "scripts/job_apply_store/base.py",
+        "src/contracts/workspace/trusted-fill.ts",
+        "src/workspace-core/trusted-fill.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-read-detail-surfaces.json
+++ b/config/migration/http-read-detail-surfaces.json
@@ -12,7 +12,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/trusted-fill-http.ts",
+        "src/workspace-core/trusted-fill.ts",
+        "src/contracts/workspace/trusted-fill.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/http-write-accounts-surfaces.json
+++ b/config/migration/http-write-accounts-surfaces.json
@@ -46,7 +46,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/trusted-fill-http.ts",
+        "src/workspace-core/trusted-fill.ts",
+        "src/contracts/workspace/trusted-fill.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -134,7 +139,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/trusted-fill-http.ts",
+        "src/workspace-core/trusted-fill.ts",
+        "src/contracts/workspace/trusted-fill.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {
@@ -162,7 +172,12 @@
         "apps/companion/proxy.ts",
         "apps/companion/server/config.ts",
         "apps/companion/server/forward.ts",
-        "apps/companion/server/routes.ts"
+        "apps/companion/server/routes.ts",
+        "src/workspace-core/jobs-http.ts",
+        "src/workspace-core/trusted-fill-http.ts",
+        "src/workspace-core/trusted-fill.ts",
+        "src/contracts/workspace/trusted-fill.ts",
+        "src/store/native-jobs.ts"
       ],
       "effects": "unclassified",
       "scenarios": {

--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -163,7 +163,7 @@
     },
     {
       "path": "document-01-surfaces.json",
-      "sha256": "ce12b934a4542a8cc46e5b095ec8887c2b8d93bb8993f6ec131e99436305a3d5"
+      "sha256": "f934c9156ce7357fcd1e71d512e45fa8dac3f44bc7c08751f2668501d5e2dfae"
     },
     {
       "path": "document-02-surfaces.json",
@@ -195,7 +195,7 @@
     },
     {
       "path": "http-read-detail-surfaces.json",
-      "sha256": "7f039ce87a6342f7bdb3945a86b8b83274ff5be7acdde7ab0fc766a22f794d04"
+      "sha256": "89fa3645a19b5021469a6a7e34082be49d2e15261a92112a8f3b179e78503fd1"
     },
     {
       "path": "http-read-surfaces.json",
@@ -203,7 +203,7 @@
     },
     {
       "path": "http-write-accounts-surfaces.json",
-      "sha256": "0bdf97d7f6f12a42a7408d3b9c554e5e9acab8e034db093416d92b56371fb1dc"
+      "sha256": "c3dde298634965f0bb9247912ba1296dc878635985c0f353307c8643d1d01933"
     },
     {
       "path": "http-write-answers-02-surfaces.json",
@@ -375,7 +375,11 @@
     },
     {
       "path": "source-catalog-native-jobs.json",
-      "sha256": "72a818fce605381cb186086934d0683540c7e05933efdb1ca6d9e5376fc16771"
+      "sha256": "c97a4620714416fa9e5b7574f79cad08d9a2241c67e9d28f5cf9d0b17faa504f"
+    },
+    {
+      "path": "source-catalog-native-trusted-fill.json",
+      "sha256": "ff53fc9f21766d42f14d79457d93eadf296a3666b6a92d2d184e0c0222b0ab51"
     },
     {
       "path": "source-catalog-native-legacy-jobs.json",

--- a/config/migration/source-catalog-native-jobs.json
+++ b/config/migration/source-catalog-native-jobs.json
@@ -33,7 +33,7 @@
     },
     {
       "path": "runtime/store/native-jobs.js",
-      "sha256": "ed2b629573c714533d7f4fd59a692c16938008331d439cde0cbd72c5f44a2212",
+      "sha256": "35c5baf75e96daa4b5e2503ada5ea359cf6931e34b755a5a41ac6713412fbc83",
       "classification": "unreviewed"
     },
     {
@@ -43,7 +43,7 @@
     },
     {
       "path": "runtime/workspace-core/jobs-http.js",
-      "sha256": "d4111473eb20fd821b1fcdc27980c83a97fc3cacc5c18ef996fc55a5705a134d",
+      "sha256": "e6e9b0c98372e6a20dbcfe6a855033fc31fc359d3d56d83b2e216230d34eadf8",
       "classification": "unreviewed"
     },
     {
@@ -83,7 +83,7 @@
     },
     {
       "path": "src/store/native-jobs.ts",
-      "sha256": "d45efa50f6751fca8f6c021e88eaa33ff37c6e9cf8a8d19280dd24ba97cf4ca0",
+      "sha256": "e5f9ce300a3b9e98735403d46b307c7864db7a7240de2695f43d8604eed1541f",
       "classification": "unreviewed"
     },
     {
@@ -93,7 +93,7 @@
     },
     {
       "path": "src/workspace-core/jobs-http.ts",
-      "sha256": "a6f66fec063016eda2e92f1a1b32846e4d04db80f533273522cc36c54382e38d",
+      "sha256": "c69c5944494e70d230e6eaaa855c9b81ef01f96b4c05d8553be626e58f94ede2",
       "classification": "unreviewed"
     },
     {

--- a/config/migration/source-catalog-native-trusted-fill.json
+++ b/config/migration/source-catalog-native-trusted-fill.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "sources": [
+    {
+      "path": "runtime/contracts/workspace/trusted-fill.js",
+      "sha256": "604ce3a1d7aad6287cd5a6d8c1eb3a6470af39ec19d1760023f5fe2cfeec9ec1",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/trusted-fill-http.js",
+      "sha256": "6964506e2f159b0edd49a32cff317d365ac0c21eb689dce51c97f84d164d976d",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "runtime/workspace-core/trusted-fill.js",
+      "sha256": "b74c88108f005e7201fc794168cee0ed650556f9942526519911c587bb708eae",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/trusted-fill.ts",
+      "sha256": "a181386f050e03e252db5cb46aecc8b4b031f67369c7033ba2e96dda07f65d81",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/trusted-fill-http.ts",
+      "sha256": "1854724d2bf77bf0af8f11c57b9f9758cc7f94883f21645cd8376346120d8879",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/workspace-core/trusted-fill.ts",
+      "sha256": "874c2eeff0f207abe4c0c499ead52968ac857facbe1d67d495ba003b17ae95a1",
+      "classification": "unreviewed"
+    }
+  ]
+}

--- a/docs/native-automation-fixture.md
+++ b/docs/native-automation-fixture.md
@@ -4,10 +4,11 @@ This tranche supplies native settings, realm resolution, and employer-account
 registry services, stranded account-operation recovery, and injected synthetic
 protected-account execution for explicit fixtures. It does not activate a Store
 writer, initialize an existing Store, inspect the owner's browser, or call the
-owner's credentials. New fixtures use version 11 and require both account
-documents plus `account-operation-journal.json`. Existing version 10 roots are rejected rather than upgraded or adopted;
-earlier fixture documents describe their historical version. Missing documents
-and unsupported trusted-fill journals remain rejected.
+owner's credentials. New fixtures use version 12 and require the account
+documents, `account-operation-journal.json`, and `trusted-fill.json`. Existing
+version 11 roots are rejected rather than upgraded or adopted; earlier fixture
+documents describe their historical version. Missing documents and unsupported
+trusted-fill records remain rejected.
 
 ## Composition and persistence
 
@@ -76,6 +77,23 @@ provider, so it rejects the synthetic route without mutation.
 - POST `/api/account-operation/execute-synthetic`
 - POST `/api/account-operation/recover`
 
+`trustedFillHttp(repository, method, path, body)` supports:
+
+- POST `/api/trusted-fill/approve`
+- GET `/api/trusted-fill/{id}`
+- POST `/api/trusted-fill/evaluate`
+- POST `/api/trusted-fill/{id}/revoke`
+
+Approval binds the current live claim, job and URL, managed resume bytes,
+profile and accepted answers, settings, optional employer account, observed
+fingerprints, operation allowlist, policy revision, and expiry. A successful
+evaluation durably consumes the approval before returning its one-shot non-final
+authority. Replay, stale revisions, final actions, claim replacement, drift,
+and every human boundary deny without retry. Canonical denials hand the live
+claim to Needs Attention; a missing, expired, or replaced claim cannot hand off
+a newer owner. HTTP status and decisions omit private values, file identity,
+nonce, and claim credentials.
+
 It returns a response or null for an unowned route. The composing HTTP boundary
 retains the existing safe request/storage error envelope and revision-conflict
 status mapping through `jobsHttp`. All mutation/detail responses use public projections. The Python
@@ -90,14 +108,10 @@ Python authorities remain read-only:
 `scripts/job_apply_store/validation/accounts.py`, `scripts/job_apply_accounts.py`
 and `scripts/job_apply_trusted_fill.py`.
 
-Trusted-fill approval needs a live claimed in-progress job, proven realm,
-managed-resume identity/content revision and preflight observation, canonical
-profile revision, accepted answer bindings, settings/account revisions, policy
-revision, and time/expiry. Approval/revocation persists `trusted-fill.json` with
-approval revisions. Evaluation may perform an attention handoff through the
-coordinator journal, session and application history. It is not a read-only
-boolean permission check. These dependencies need a shared transaction boundary
-before approve/evaluate/revoke routes can be implemented.
+Trusted-fill approval, evaluation, status, revocation, one-shot consumption,
+and denial handoff now share the native Store lock and coordinator journal.
+The remaining native account scope is the distinct email-only flow provider and
+any separately authorized real-browser evidence.
 
 Synthetic protected execution now binds job/claim/settings/account revisions
 and target URL fingerprint, writes `prepared` before invoking its injected

--- a/runtime/contracts/workspace/trusted-fill.js
+++ b/runtime/contracts/workspace/trusted-fill.js
@@ -1,0 +1,190 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import { exact } from './automation.js';
+import { claimTime } from './claim-time.js';
+import { copy, fromJSON, get, int, integer, object, same, set, string, text, JobsError } from './values.js';
+export const trustedFillPolicyRevision = 1n;
+export const trustedFillOperations = new Set([
+    'fill_text', 'select_option', 'toggle_non_consent', 'upload_approved_resume',
+]);
+const fingerprints = ['urlFingerprint', 'observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint'];
+const revisions = ['jobRevision', 'resumeRevision', 'profileRevision', 'vitalFactRevision',
+    'automationSettingsRevision', 'policyRevision', 'approvalRevision'];
+const approvalFields = ['schemaVersion', 'approvalId', 'status', 'issuedAt', 'expiresAt', 'revokedAt',
+    'jobId', 'jobRevision', 'claimId', 'realmRef', 'urlFingerprint', 'resumeId', 'resumeRevision',
+    'resumeContentRevision', 'profileRevision', 'vitalFactRevision', 'answerBindings',
+    'observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint',
+    'automationSettingsRevision', 'employerAccountRevision', 'policyRevision', 'allowedOperations',
+    'nonce', 'approvalRevision'];
+const reference = /^[a-z][a-z0-9._-]{0,127}$/;
+const fingerprintPattern = /^sha256:[0-9a-f]{64}$/;
+const contentRevisionPattern = /^content_[A-Za-z0-9_-]{32,128}$/;
+function positive(value, label) {
+    const result = int(value);
+    if (result === null || result < 1n)
+        throw new JobsError(`${label} must be a positive integer`);
+    return result;
+}
+function time(value, label) {
+    const raw = string(value);
+    if (!raw)
+        throw new JobsError(`${label} is invalid`);
+    try {
+        return claimTime(raw);
+    }
+    catch {
+        throw new JobsError(`${label} is invalid`);
+    }
+}
+function fingerprint(value, label) {
+    const result = string(value);
+    if (!result || !fingerprintPattern.test(result))
+        throw new JobsError(`${label} must be a sha256 fingerprint`);
+    return result;
+}
+export function trustedFillContentRevision(value) {
+    const result = string(value);
+    if (!result || !contentRevisionPattern.test(result))
+        throw new JobsError('resume content revision is unverifiable');
+    return result;
+}
+export function trustedFillOperationList(value, label = 'allowed operations') {
+    if (!Array.isArray(value) || !value.length || value.some(item => string(item) === null)) {
+        throw new JobsError(`${label} are invalid or include a final action`);
+    }
+    const result = value.map(item => string(item));
+    if (new Set(result).size !== result.length || result.some(item => !trustedFillOperations.has(item))) {
+        throw new JobsError(`${label} are invalid or include a final action`);
+    }
+    return result.sort();
+}
+export function validateTrustedFillApproval(value) {
+    const approval = object(value, 'trusted fill approval');
+    exact(approval, approvalFields, 'approval contains unsupported fields');
+    if (int(get(approval, 'schemaVersion')) !== 1n)
+        throw new JobsError('approval contains unsupported fields');
+    for (const field of ['approvalId', 'jobId', 'resumeId']) {
+        if (!reference.test(string(get(approval, field)) ?? ''))
+            throw new JobsError('approval reference is invalid');
+    }
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(string(get(approval, 'claimId')) ?? '')) {
+        throw new JobsError('approval claim binding is invalid');
+    }
+    const status = string(get(approval, 'status'));
+    if (!['active', 'revoked'].includes(status ?? ''))
+        throw new JobsError('approval status is invalid');
+    const issued = time(get(approval, 'issuedAt'), 'approval issuedAt');
+    const expires = time(get(approval, 'expiresAt'), 'approval expiresAt');
+    if (expires <= issued || expires - issued > 3600000000n)
+        throw new JobsError('approval duration is invalid');
+    if (status === 'revoked')
+        time(get(approval, 'revokedAt'), 'approval revokedAt');
+    else if (get(approval, 'revokedAt') !== null)
+        throw new JobsError('active approval cannot have revokedAt');
+    if (!/^[0-9a-f]{64}$/.test(string(get(approval, 'realmRef')) ?? ''))
+        throw new JobsError('approval realm reference is invalid');
+    for (const field of fingerprints)
+        fingerprint(get(approval, field), field);
+    for (const field of revisions)
+        positive(get(approval, field), field);
+    if (int(get(approval, 'policyRevision')) !== trustedFillPolicyRevision)
+        throw new JobsError('approval policy revision is unsupported');
+    trustedFillContentRevision(get(approval, 'resumeContentRevision'));
+    if (get(approval, 'employerAccountRevision') !== null)
+        positive(get(approval, 'employerAccountRevision'), 'employerAccountRevision');
+    const bindings = get(approval, 'answerBindings');
+    if (!Array.isArray(bindings))
+        throw new JobsError('answer bindings must be a list');
+    const refs = bindings.map(value => {
+        const binding = object(value, 'answer binding');
+        exact(binding, ['answerRef', 'questionRevision', 'answerRevision'], 'answer binding is invalid');
+        const answerRef = string(get(binding, 'answerRef'));
+        if (!answerRef || !reference.test(answerRef))
+            throw new JobsError('answer binding reference is invalid');
+        positive(get(binding, 'questionRevision'), 'questionRevision');
+        positive(get(binding, 'answerRevision'), 'answerRevision');
+        return answerRef;
+    });
+    if (new Set(refs).size !== refs.length || refs.some((item, index) => index > 0 && refs[index - 1] > item)) {
+        throw new JobsError('answer bindings must be unique and sorted');
+    }
+    trustedFillOperationList(get(approval, 'allowedOperations'));
+    if (!/^[A-Za-z0-9_-]{32,128}$/.test(string(get(approval, 'nonce')) ?? ''))
+        throw new JobsError('approval nonce is invalid');
+    return approval;
+}
+export function validateTrustedFillDocument(value) {
+    const document = object(value, 'trusted fill approvals');
+    exact(document, ['schemaVersion', 'approvals', 'metadata'], 'trusted fill approval document contains unsupported fields');
+    if (int(get(document, 'schemaVersion')) !== 1n)
+        throw new JobsError('trusted fill approval schema version is unsupported');
+    const approvals = object(get(document, 'approvals'), 'trusted fill approvals');
+    for (const [jobId, value] of approvals.entries())
+        if (string(jobId) !== string(get(validateTrustedFillApproval(value), 'jobId'))) {
+            throw new JobsError('trusted fill approval job identity is invalid');
+        }
+    const metadata = object(get(document, 'metadata'), 'trusted fill metadata');
+    exact(metadata, ['createdAt', 'updatedAt'], 'trusted fill metadata is invalid');
+    for (const field of ['createdAt', 'updatedAt'])
+        if (!string(get(metadata, field)))
+            throw new JobsError('trusted fill metadata timestamp is invalid');
+    return document;
+}
+export function trustedFillApproval(bindings, durationMinutes, approvalRevision, now) {
+    if (durationMinutes < 1n || durationMinutes > 60n)
+        throw new JobsError('approval duration must be between 1 and 60 minutes');
+    const issued = claimTime(now), expires = issued + durationMinutes * 60000000n;
+    const approval = copy(bindings);
+    for (const [key, value] of Object.entries({ schemaVersion: 1, approvalId: `trusted-fill-${randomUUID()}`,
+        status: 'active', issuedAt: now, expiresAt: new Date(Number(expires / 1000n)).toISOString().replace('.000Z', 'Z'),
+        revokedAt: null, policyRevision: 1, nonce: randomBytes(32).toString('base64url') }))
+        set(approval, key, fromJSON(value));
+    set(approval, 'approvalRevision', integer(approvalRevision));
+    return validateTrustedFillApproval(approval);
+}
+export function revokeTrustedFillApproval(value, expectedRevision, now) {
+    const current = validateTrustedFillApproval(value);
+    if (int(get(current, 'approvalRevision')) !== expectedRevision)
+        throw new JobsError('approval revision conflict');
+    if (string(get(current, 'status')) !== 'active')
+        throw new JobsError('approval is not active');
+    const updated = copy(current);
+    set(updated, 'status', text('revoked'));
+    set(updated, 'revokedAt', text(now));
+    set(updated, 'approvalRevision', integer(expectedRevision + 1n));
+    return validateTrustedFillApproval(updated);
+}
+export function publicTrustedFillStatus(value, now) {
+    if (value === null)
+        return object(fromJSON({ status: 'missing', approvalRevision: null }), 'trusted fill public status');
+    const record = validateTrustedFillApproval(value), active = string(get(record, 'status')) === 'active';
+    const result = object(fromJSON({ status: active && claimTime(now) >= time(get(record, 'expiresAt'), 'approval expiresAt') ? 'expired' : string(get(record, 'status')),
+        jobId: string(get(record, 'jobId')), realmRef: string(get(record, 'realmRef')), expiresAt: string(get(record, 'expiresAt')),
+        approvalRevision: null }), 'trusted fill public status');
+    set(result, 'approvalRevision', get(record, 'approvalRevision'));
+    return set(result, 'allowedOperations', trustedFillOperationList(get(record, 'allowedOperations')).map(text));
+}
+export function trustedFillDecision(record, current, observed, now) {
+    if (string(get(record, 'status')) !== 'active')
+        return object(fromJSON({ authorized: false, reasonCode: 'approval_revoked', retryAllowed: false }), 'decision');
+    if (claimTime(now) >= time(get(record, 'expiresAt'), 'approval expiresAt'))
+        return object(fromJSON({ authorized: false, reasonCode: 'approval_expired', retryAllowed: false }), 'decision');
+    const flags = { authenticationRequired: 'authentication_required', consentRequired: 'consent_required',
+        credentialFieldsPresent: 'credential_fields_present', finalControlsPresent: 'final_controls_present', unseenQuestions: 'unseen_questions', unseenControls: 'unseen_controls' };
+    for (const [field, reason] of Object.entries(flags))
+        if (get(observed, field) === true)
+            return object(fromJSON({ authorized: false, reasonCode: reason, retryAllowed: false }), 'decision');
+    const bound = ['jobId', 'jobRevision', 'claimId', 'realmRef', 'urlFingerprint', 'resumeId', 'resumeRevision',
+        'resumeContentRevision', 'profileRevision', 'vitalFactRevision', 'answerBindings', 'automationSettingsRevision',
+        'employerAccountRevision', 'policyRevision'];
+    if (bound.some(field => !same(get(record, field), get(current, field))))
+        return object(fromJSON({ authorized: false, reasonCode: 'canonical_drift', retryAllowed: false }), 'decision');
+    if (fingerprints.slice(1).some(field => !same(get(record, field), get(observed, field))))
+        return object(fromJSON({ authorized: false, reasonCode: 'observed_drift', retryAllowed: false }), 'decision');
+    const operations = trustedFillOperationList(get(observed, 'fieldOperations'), 'field operations');
+    const allowed = new Set(trustedFillOperationList(get(record, 'allowedOperations')));
+    if (operations.some(operation => !allowed.has(operation)))
+        return object(fromJSON({ authorized: false, reasonCode: 'operation_not_approved', retryAllowed: false }), 'decision');
+    const result = object(fromJSON({ authorized: true, reasonCode: 'authorized_non_final_fields', retryAllowed: false,
+        approvalRevision: null, allowedOperations: operations }), 'decision');
+    return set(result, 'approvalRevision', get(record, 'approvalRevision'));
+}

--- a/runtime/store/native-jobs.js
+++ b/runtime/store/native-jobs.js
@@ -20,12 +20,13 @@ import { NativeResumeFiles } from "./native-resume-files.js";
 import { NativeExtractionJournal, closeRequestsForResumes, extractionJournalName, validateExtractionResumes } from "./native-extraction-journal.js";
 import { validateExtractionRequests } from "../contracts/workspace/extraction-requests.js";
 import { validateExtractions } from "../contracts/workspace/extraction-proposals.js";
+import { validateTrustedFillDocument } from "../contracts/workspace/trusted-fill.js";
 import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
 import { validateAnswers } from "../contracts/workspace/answers.js";
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 };
-const marker = '{"mode":"native-jobs-fixture","version":11}\n';
-const allowed = new Set(["automation-settings.json", "employer-accounts.json", "account-operation-journal.json", ".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
+const marker = '{"mode":"native-jobs-fixture","version":12}\n';
+const allowed = new Set(["automation-settings.json", "employer-accounts.json", "account-operation-journal.json", "trusted-fill.json", ".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 };
 /** Creates a NEW synthetic root only. Never adopts or initializes an existing Store. */
@@ -61,6 +62,8 @@ export async function initializeJobsFixture(root) {
         await atomicWritePointJson(join(root, `${name}.json`), document, options);
     }
     await atomicWritePointJson(join(root, 'account-operation-journal.json'), emptyAccountOperationJournal(), options);
+    await atomicWritePointJson(join(root, 'trusted-fill.json'), fromJSON({ schemaVersion: 1, approvals: {},
+        metadata: { createdAt: now, updatedAt: now } }), options);
     // The readiness marker is written last; partial initialization is never adopted.
     const handle = await open(join(root, ".native-jobs-fixture"), "wx", 0o600);
     try {
@@ -447,6 +450,18 @@ export class NativeJobsRepository {
                     await this.write(join(this.root, 'account-operation-journal.json'), emptyAccountOperationJournal(), options);
                 },
             });
+        });
+    }
+    async trustedFillTransaction(operation) {
+        return this.transaction(async () => {
+            const jobs = validateJobsDocument(await this.document('jobs'));
+            return operation({ approvals: validateTrustedFillDocument(await this.document('trusted-fill')), jobs,
+                coordinator: validateCoordinator(await this.journal('coordinator')), profile: validateProfile(await this.document('profile')),
+                resumes: validateExtractionResumes(await this.document('resumes')), answers: validateAnswers(await this.document('answers')),
+                settings: await this.journal('automation-settings'), accounts: await this.document('employer-accounts'),
+                sessions: await this.answerSessions(), files: new NativeResumeFiles(this.root),
+                saveApprovals: document => this.write(join(this.root, 'trusted-fill.json'), validateTrustedFillDocument(document), options),
+                commitClaim: value => this.claimJournal().commit(value, jobs) });
         });
     }
     async resumeSummaries() {

--- a/runtime/workspace-core/jobs-http.js
+++ b/runtime/workspace-core/jobs-http.js
@@ -1,5 +1,6 @@
 import { automationHttp } from './automation-http.js';
 import { accountOperationHttp } from './account-operation-http.js';
+import { trustedFillHttp } from './trusted-fill-http.js';
 import { resumeLifecycleHttp } from './resume-lifecycle-http.js';
 import { answerLifecycleHttp } from './answer-lifecycle-http.js';
 import { trashHttp } from './trash-http.js';
@@ -22,6 +23,9 @@ const envelope = (key, value) => set(emptyObject(), key, value);
 /** Transport-independent dispatch. Host/token/Origin/body bounds belong to the adapter. */
 export async function jobsHttp(service, repository, method, path, body = "") {
     try {
+        const trustedFill = await trustedFillHttp(repository, method, path, body);
+        if (trustedFill)
+            return trustedFill;
         const accountOperation = await accountOperationHttp(repository, method, path, body);
         if (accountOperation)
             return accountOperation;

--- a/runtime/workspace-core/trusted-fill-http.js
+++ b/runtime/workspace-core/trusted-fill-http.js
@@ -1,0 +1,27 @@
+import { exact } from '../contracts/workspace/automation.js';
+import { get, int, object, parse, serialize, JobsError } from '../contracts/workspace/values.js';
+import { TrustedFillService } from './trusted-fill.js';
+export async function trustedFillHttp(repository, method, path, body) {
+    const service = new TrustedFillService(repository);
+    if (method === 'POST' && path === '/api/trusted-fill/approve') {
+        return { status: 200, body: serialize(await service.approve(parse(body))) };
+    }
+    if (method === 'POST' && path === '/api/trusted-fill/evaluate') {
+        return { status: 200, body: serialize(await service.evaluate(parse(body))) };
+    }
+    const match = /^\/api\/trusted-fill\/([^/]+?)(\/revoke)?$/.exec(path);
+    if (!match)
+        return null;
+    const id = decodeURIComponent(match[1]);
+    if (method === 'GET' && !match[2])
+        return { status: 200, body: serialize(await service.status(id)) };
+    if (method === 'POST' && match[2] === '/revoke') {
+        const payload = object(parse(body), 'trusted fill revocation');
+        exact(payload, ['expectedApprovalRevision'], 'trusted fill revocation contains unsupported fields');
+        const revision = int(get(payload, 'expectedApprovalRevision'));
+        if (revision === null || revision < 1n)
+            throw new JobsError('expectedApprovalRevision must be a positive integer');
+        return { status: 200, body: serialize(await service.revoke(id, revision)) };
+    }
+    return null;
+}

--- a/runtime/workspace-core/trusted-fill.js
+++ b/runtime/workspace-core/trusted-fill.js
@@ -1,0 +1,299 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { resolveAccountRealm } from '../contracts/workspace/account-realm.js';
+import { validateAccountsDocument } from '../contracts/workspace/accounts.js';
+import { answerRevision, fallback, validateAnswers } from '../contracts/workspace/answers.js';
+import { validateSettingsDocument } from '../contracts/workspace/automation.js';
+import { buildClaimSession } from '../contracts/workspace/claim-session.js';
+import { claimExpired, validateCoordinator } from '../contracts/workspace/claims.js';
+import { safeId, validateJobsDocument } from '../contracts/workspace/jobs.js';
+import { validateProfile } from '../contracts/workspace/profile.js';
+import { validateResumeReferences } from '../contracts/workspace/resume-reference.js';
+import { publicTrustedFillStatus, revokeTrustedFillApproval, trustedFillApproval, trustedFillDecision, trustedFillOperationList, trustedFillPolicyRevision, validateTrustedFillApproval, validateTrustedFillDocument } from '../contracts/workspace/trusted-fill.js';
+import { copy, fromJSON, get, int, integer, keys, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { preflightJobRecord } from './job-preflight.js';
+const doc = (value) => object(fromJSON(value), 'trusted fill value');
+const fingerprintPattern = /^sha256:[0-9a-f]{64}$/;
+const referencePattern = /^[a-z][a-z0-9._-]{0,127}$/;
+function exactFields(value, fields, label) {
+    const result = object(value, label);
+    if (result.size !== fields.length || keys(result).some(key => !fields.includes(key)))
+        throw new JobsError(`${label} contains unsupported fields`);
+    return result;
+}
+function positive(value, label) {
+    const result = int(value);
+    if (result === null || result < 1n)
+        throw new JobsError(`${label} must be a positive integer`);
+    return result;
+}
+function fingerprints(value, fields) {
+    for (const field of fields)
+        if (!fingerprintPattern.test(string(get(value, field)) ?? ''))
+            throw new JobsError(`${field} must be a sha256 fingerprint`);
+}
+function live(tx, id, now) {
+    const jobs = validateJobsDocument(tx.jobs), raw = get(object(get(jobs, 'jobs'), 'jobs'), id);
+    if (raw === null)
+        throw new JobsError('trusted fill requires an in-progress claimed job');
+    const job = object(raw, 'job'), rawClaim = get(validateCoordinator(tx.coordinator), 'claim');
+    if (get(job, 'deletedAt') !== null || string(get(job, 'status')) !== 'in_progress')
+        throw new JobsError('trusted fill requires an in-progress claimed job');
+    if (rawClaim === null)
+        throw new TrustedFillClaimError();
+    const claim = object(rawClaim, 'claim');
+    if (string(get(claim, 'jobId')) !== id || claimExpired(claim, now))
+        throw new TrustedFillClaimError();
+    return { job, claim };
+}
+async function current(tx, job, claim, answerRefs) {
+    const realm = resolveAccountRealm(string(get(job, 'url')));
+    if (realm.status !== 'resolved')
+        throw new JobsError('trusted fill portal realm is unresolved');
+    let preflight;
+    try {
+        preflight = await preflightJobRecord(job, validateProfile(tx.profile), tx.resumes, tx.files);
+    }
+    catch {
+        throw new TrustedFillCurrentError('resume_observation_failed');
+    }
+    if (get(preflight, 'ready') !== true) {
+        const errors = get(preflight, 'errors').map(string);
+        if (errors.includes('resume_file_missing') || errors.includes('resume_missing'))
+            throw new TrustedFillCurrentError('resume_content_missing');
+        if (errors.includes('resume_file_changed'))
+            throw new TrustedFillCurrentError('resume_content_changed');
+        throw new TrustedFillCurrentError('resume_preflight_not_ready');
+    }
+    const resumeId = string(get(preflight, 'resumeId'));
+    const resumes = object(get(tx.resumes, 'resumes'), 'resumes'), rawResume = resumeId ? get(resumes, resumeId) : null;
+    if (rawResume === null)
+        throw new TrustedFillCurrentError('resume_content_missing');
+    const resume = object(rawResume, 'resume');
+    if (get(resume, 'deletedAt') !== null)
+        throw new TrustedFillCurrentError('resume_content_missing');
+    if (string(get(resume, 'storageKind')) !== 'managed' || !/^content_[A-Za-z0-9_-]{32,128}$/.test(string(get(resume, 'contentRevision')) ?? '')) {
+        throw new TrustedFillCurrentError('resume_content_unverifiable');
+    }
+    validateResumeReferences(resumes);
+    const answerRecords = object(get(validateAnswers(tx.answers), 'answers'), 'answers'), bindings = [];
+    for (const answerRef of [...answerRefs].sort()) {
+        const rawAnswer = get(answerRecords, answerRef);
+        if (rawAnswer === null)
+            throw new TrustedFillCurrentError('answer_binding_invalid');
+        const answer = object(rawAnswer, 'answer');
+        if (get(answer, 'deletedAt') !== null || string(fallback(answer, 'reviewStatus', text('accepted'))) !== 'accepted') {
+            throw new TrustedFillCurrentError('answer_binding_invalid');
+        }
+        const revision = answerRevision(answer);
+        const binding = doc({ answerRef, questionRevision: null, answerRevision: null });
+        set(binding, 'questionRevision', integer(revision));
+        set(binding, 'answerRevision', integer(revision));
+        bindings.push(binding);
+    }
+    const profileRevision = int(get(object(get(validateProfile(tx.profile), 'metadata'), 'profile metadata'), 'revision')) ?? 1n;
+    const settings = object(get(validateSettingsDocument(tx.settings), 'settings'), 'settings');
+    const accounts = object(get(validateAccountsDocument(tx.accounts), 'accounts'), 'accounts');
+    const account = get(accounts, realm.realmRef);
+    const result = doc({ jobId: string(get(job, 'id')), jobRevision: null, claimId: string(get(claim, 'claimId')),
+        realmRef: realm.realmRef, urlFingerprint: `sha256:${createHash('sha256').update(string(get(job, 'normalizedUrl'))).digest('hex')}`,
+        resumeId, resumeRevision: null, resumeContentRevision: string(get(resume, 'contentRevision')),
+        profileRevision: null, vitalFactRevision: null, answerBindings: [],
+        automationSettingsRevision: null, employerAccountRevision: account === null ? null : 0, policyRevision: 1 });
+    set(result, 'jobRevision', get(job, 'revision'));
+    set(result, 'resumeRevision', get(resume, 'revision'));
+    set(result, 'profileRevision', integer(profileRevision));
+    set(result, 'vitalFactRevision', integer(profileRevision));
+    set(result, 'automationSettingsRevision', get(settings, 'revision'));
+    set(result, 'answerBindings', bindings);
+    if (account !== null)
+        set(result, 'employerAccountRevision', get(object(account, 'account'), 'revision'));
+    set(result, 'policyRevision', integer(trustedFillPolicyRevision));
+    return result;
+}
+class TrustedFillCurrentError extends JobsError {
+    reasonCode;
+    constructor(reasonCode) {
+        super('trusted fill canonical state is unavailable');
+        this.reasonCode = reasonCode;
+    }
+}
+class TrustedFillClaimError extends JobsError {
+    constructor() { super('trusted fill requires the live claimed job'); }
+}
+function blocker(reason) {
+    if (['authentication_required', 'credential_fields_present'].includes(reason))
+        return { type: 'browser_handoff', code: 'login-required' };
+    if (reason === 'consent_required')
+        return { type: 'browser_handoff', code: 'consent-required' };
+    if (['approval_missing', 'approval_revoked', 'approval_expired', 'approval_revision_mismatch', 'answer_binding_invalid',
+        'resume_content_missing', 'resume_content_unverifiable', 'resume_observation_failed', 'resume_preflight_not_ready', 'unseen_questions'].includes(reason)) {
+        return { type: 'information', code: 'owner-input-required' };
+    }
+    return { type: 'browser_handoff', code: 'browser-state-uncertain' };
+}
+function handoffOperation(job, session, at) {
+    const operationId = randomUUID(), id = string(get(job, 'id'));
+    const event = doc({ schemaVersion: 1, eventId: `coordinator-${operationId}`, applicationId: id,
+        event: 'job-blocked', status: 'needs_info', answerKeys: [], at });
+    for (const field of ['company', 'role', 'ats'])
+        if (string(get(job, field)) !== null)
+            set(event, field, get(job, field));
+    const operation = doc({ kind: 'handoff', operationId, jobId: id, sourceStatus: 'in_progress', targetStatus: 'needs_info',
+        expectedRevision: null, at, resultClaim: null });
+    set(operation, 'expectedRevision', get(job, 'revision'));
+    set(operation, 'historyEvent', event);
+    set(operation, 'session', session);
+    return operation;
+}
+async function attention(tx, job, reason, now) {
+    const blocked = blocker(reason), id = string(get(job, 'id'));
+    const incoming = doc({ status: 'active', step: `trusted_fill_denied:${reason}`, answerKeys: [], pendingFields: [], blockers: [blocked],
+        browserHandoff: { state: 'required', reasonCode: blocked.code, revision: 1 } });
+    const session = buildClaimSession(id, incoming, { now, attemptRevision: get(job, 'revision'), ats: get(job, 'ats'),
+        existing: tx.sessions.find(item => string(get(item, 'applicationId')) === id) ?? null, answers: tx.answers });
+    await tx.commitClaim(handoffOperation(job, session, now));
+    const result = doc({ id, status: 'needs_info', revision: null });
+    return set(result, 'revision', integer(int(get(job, 'revision')) + 1n));
+}
+export class TrustedFillService {
+    repository;
+    now;
+    constructor(repository, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.repository = repository;
+        this.now = now;
+    }
+    approve(value) {
+        const packet = exactFields(value, ['jobId', 'expectedJobRevision', 'realmRef', 'answerRefs', 'observedQuestionFingerprint',
+            'observedControlFingerprint', 'formFingerprint', 'allowedOperations', 'durationMinutes'], 'trusted fill approval request');
+        const id = safeId(string(get(packet, 'jobId'))), expectedJobRevision = positive(get(packet, 'expectedJobRevision'), 'expectedJobRevision');
+        const realmRef = string(get(packet, 'realmRef'));
+        if (!/^[0-9a-f]{64}$/.test(realmRef ?? ''))
+            throw new JobsError('trusted fill realm binding mismatch');
+        const rawRefs = get(packet, 'answerRefs');
+        if (!Array.isArray(rawRefs) || rawRefs.some(item => !referencePattern.test(string(item) ?? '')))
+            throw new JobsError('trusted fill answer references must be a list of strings');
+        const answerRefs = rawRefs.map(item => string(item));
+        if (new Set(answerRefs).size !== answerRefs.length)
+            throw new JobsError('trusted fill answer references contain duplicates');
+        fingerprints(packet, ['observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint']);
+        const operations = trustedFillOperationList(get(packet, 'allowedOperations'));
+        const duration = positive(get(packet, 'durationMinutes'), 'durationMinutes');
+        return this.repository.trustedFillTransaction(async (tx) => {
+            const now = this.now(), { job, claim } = live(tx, id, now);
+            let state;
+            try {
+                state = await current(tx, job, claim, answerRefs);
+            }
+            catch (error) {
+                if (!(error instanceof TrustedFillCurrentError))
+                    throw error;
+                const denied = await attention(tx, job, error.reasonCode, now);
+                const result = doc({ authorized: false, reasonCode: error.reasonCode, retryAllowed: false, attentionHandoff: true, job: null });
+                return set(result, 'job', denied);
+            }
+            if (int(get(state, 'jobRevision')) !== expectedJobRevision)
+                throw new JobsError('job revision conflict');
+            if (string(get(state, 'realmRef')) !== realmRef)
+                throw new JobsError('trusted fill realm binding mismatch');
+            const document = copy(validateTrustedFillDocument(tx.approvals));
+            const records = copy(object(get(document, 'approvals'), 'approvals'));
+            set(document, 'approvals', records);
+            const previousRaw = get(records, id), previous = previousRaw === null ? null : validateTrustedFillApproval(previousRaw);
+            if (previous !== null && string(get(previous, 'status')) === 'active'
+                && string(get(publicTrustedFillStatus(previous, now), 'status')) === 'active')
+                throw new JobsError('active trusted fill approval already exists');
+            for (const field of ['observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint'])
+                set(state, field, get(packet, field));
+            set(state, 'allowedOperations', operations.map(text));
+            const revision = previous === null ? 1n : int(get(previous, 'approvalRevision')) + 1n;
+            const approval = trustedFillApproval(state, duration, revision, now);
+            set(records, id, approval);
+            set(object(get(document, 'metadata'), 'metadata'), 'updatedAt', text(now));
+            await tx.saveApprovals(validateTrustedFillDocument(document));
+            return publicTrustedFillStatus(approval, now);
+        });
+    }
+    status(id) {
+        safeId(id);
+        return this.repository.trustedFillTransaction(async (tx) => {
+            const raw = get(object(get(validateTrustedFillDocument(tx.approvals), 'approvals'), 'approvals'), id);
+            return publicTrustedFillStatus(raw, this.now());
+        });
+    }
+    revoke(id, expectedRevision) {
+        safeId(id);
+        if (expectedRevision < 1n)
+            throw new JobsError('expectedApprovalRevision must be a positive integer');
+        return this.repository.trustedFillTransaction(async (tx) => {
+            const document = copy(validateTrustedFillDocument(tx.approvals));
+            const records = copy(object(get(document, 'approvals'), 'approvals'));
+            set(document, 'approvals', records);
+            const raw = get(records, id);
+            if (raw === null)
+                throw new JobsError('trusted fill approval does not exist');
+            const now = this.now(), updated = revokeTrustedFillApproval(raw, expectedRevision, now);
+            set(records, id, updated);
+            set(object(get(document, 'metadata'), 'metadata'), 'updatedAt', text(now));
+            await tx.saveApprovals(validateTrustedFillDocument(document));
+            return publicTrustedFillStatus(updated, now);
+        });
+    }
+    evaluate(value) {
+        const fields = ['jobId', 'expectedApprovalRevision', 'observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint',
+            'fieldOperations', 'authenticationRequired', 'consentRequired', 'credentialFieldsPresent', 'finalControlsPresent', 'unseenQuestions', 'unseenControls'];
+        const observed = exactFields(value, fields, 'trusted fill evaluation'), id = safeId(string(get(observed, 'jobId')));
+        const expected = positive(get(observed, 'expectedApprovalRevision'), 'expectedApprovalRevision');
+        fingerprints(observed, ['observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint']);
+        trustedFillOperationList(get(observed, 'fieldOperations'), 'field operations');
+        for (const field of fields.slice(6))
+            if (typeof get(observed, field) !== 'boolean')
+                throw new JobsError('trusted fill evaluation flags must be booleans');
+        return this.repository.trustedFillTransaction(async (tx) => {
+            const now = this.now();
+            let job, claim;
+            try {
+                ({ job, claim } = live(tx, id, now));
+            }
+            catch (error) {
+                if (!(error instanceof TrustedFillClaimError))
+                    throw error;
+                return doc({ authorized: false, reasonCode: 'claim_missing_or_expired', retryAllowed: false, attentionHandoff: false });
+            }
+            const document = validateTrustedFillDocument(tx.approvals), raw = get(object(get(document, 'approvals'), 'approvals'), id);
+            if (raw === null)
+                return this.denied(tx, job, 'approval_missing', now);
+            const approval = validateTrustedFillApproval(raw);
+            if (int(get(approval, 'approvalRevision')) !== expected)
+                return this.denied(tx, job, 'approval_revision_mismatch', now);
+            if (string(get(approval, 'claimId')) !== string(get(claim, 'claimId')))
+                return doc({ authorized: false, reasonCode: 'claim_binding_mismatch', retryAllowed: false, attentionHandoff: false });
+            let state;
+            try {
+                state = await current(tx, job, claim, get(approval, 'answerBindings').map(item => string(get(object(item, 'binding'), 'answerRef'))));
+            }
+            catch (error) {
+                if (!(error instanceof TrustedFillCurrentError))
+                    throw error;
+                return this.denied(tx, job, error.reasonCode, now);
+            }
+            const decision = trustedFillDecision(approval, state, observed, now);
+            if (get(decision, 'authorized') !== true)
+                return this.denied(tx, job, string(get(decision, 'reasonCode')), now);
+            // Evaluation is the one-shot receipt. Persist consumption before returning authority.
+            const consumed = revokeTrustedFillApproval(approval, expected, now), next = copy(document);
+            const records = copy(object(get(next, 'approvals'), 'approvals'));
+            set(next, 'approvals', records);
+            set(records, id, consumed);
+            set(object(get(next, 'metadata'), 'metadata'), 'updatedAt', text(now));
+            await tx.saveApprovals(validateTrustedFillDocument(next));
+            set(decision, 'attentionHandoff', false);
+            set(decision, 'consumedApprovalRevision', get(consumed, 'approvalRevision'));
+            return decision;
+        });
+    }
+    async denied(tx, job, reason, now) {
+        const handedOff = await attention(tx, job, reason, now);
+        const result = doc({ authorized: false, reasonCode: reason, retryAllowed: false, attentionHandoff: true, job: null });
+        return set(result, 'job', handedOff);
+    }
+}

--- a/src/contracts/workspace/trusted-fill.ts
+++ b/src/contracts/workspace/trusted-fill.ts
@@ -1,0 +1,159 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import { exact } from './automation.js';
+import { claimTime } from './claim-time.js';
+import { copy, fromJSON, get, int, integer, object, same, set, string, text, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+
+export const trustedFillPolicyRevision = 1n;
+export const trustedFillOperations = new Set([
+  'fill_text', 'select_option', 'toggle_non_consent', 'upload_approved_resume',
+]);
+const fingerprints = ['urlFingerprint', 'observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint'];
+const revisions = ['jobRevision', 'resumeRevision', 'profileRevision', 'vitalFactRevision',
+  'automationSettingsRevision', 'policyRevision', 'approvalRevision'];
+const approvalFields = ['schemaVersion', 'approvalId', 'status', 'issuedAt', 'expiresAt', 'revokedAt',
+  'jobId', 'jobRevision', 'claimId', 'realmRef', 'urlFingerprint', 'resumeId', 'resumeRevision',
+  'resumeContentRevision', 'profileRevision', 'vitalFactRevision', 'answerBindings',
+  'observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint',
+  'automationSettingsRevision', 'employerAccountRevision', 'policyRevision', 'allowedOperations',
+  'nonce', 'approvalRevision'];
+const reference = /^[a-z][a-z0-9._-]{0,127}$/;
+const fingerprintPattern = /^sha256:[0-9a-f]{64}$/;
+const contentRevisionPattern = /^content_[A-Za-z0-9_-]{32,128}$/;
+
+function positive(value: Value, label: string): bigint {
+  const result = int(value);
+  if (result === null || result < 1n) throw new JobsError(`${label} must be a positive integer`);
+  return result;
+}
+function time(value: Value, label: string): bigint {
+  const raw = string(value);
+  if (!raw) throw new JobsError(`${label} is invalid`);
+  try { return claimTime(raw); } catch { throw new JobsError(`${label} is invalid`); }
+}
+function fingerprint(value: Value, label: string): string {
+  const result = string(value);
+  if (!result || !fingerprintPattern.test(result)) throw new JobsError(`${label} must be a sha256 fingerprint`);
+  return result;
+}
+export function trustedFillContentRevision(value: Value): string {
+  const result = string(value);
+  if (!result || !contentRevisionPattern.test(result)) throw new JobsError('resume content revision is unverifiable');
+  return result;
+}
+export function trustedFillOperationList(value: Value, label = 'allowed operations'): string[] {
+  if (!Array.isArray(value) || !value.length || value.some(item => string(item) === null)) {
+    throw new JobsError(`${label} are invalid or include a final action`);
+  }
+  const result = value.map(item => string(item)!);
+  if (new Set(result).size !== result.length || result.some(item => !trustedFillOperations.has(item))) {
+    throw new JobsError(`${label} are invalid or include a final action`);
+  }
+  return result.sort();
+}
+
+export function validateTrustedFillApproval(value: Value): Document {
+  const approval = object(value, 'trusted fill approval');
+  exact(approval, approvalFields, 'approval contains unsupported fields');
+  if (int(get(approval, 'schemaVersion')) !== 1n) throw new JobsError('approval contains unsupported fields');
+  for (const field of ['approvalId', 'jobId', 'resumeId']) {
+    if (!reference.test(string(get(approval, field)) ?? '')) throw new JobsError('approval reference is invalid');
+  }
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(string(get(approval, 'claimId')) ?? '')) {
+    throw new JobsError('approval claim binding is invalid');
+  }
+  const status = string(get(approval, 'status'));
+  if (!['active', 'revoked'].includes(status ?? '')) throw new JobsError('approval status is invalid');
+  const issued = time(get(approval, 'issuedAt'), 'approval issuedAt');
+  const expires = time(get(approval, 'expiresAt'), 'approval expiresAt');
+  if (expires <= issued || expires - issued > 3_600_000_000n) throw new JobsError('approval duration is invalid');
+  if (status === 'revoked') time(get(approval, 'revokedAt'), 'approval revokedAt');
+  else if (get(approval, 'revokedAt') !== null) throw new JobsError('active approval cannot have revokedAt');
+  if (!/^[0-9a-f]{64}$/.test(string(get(approval, 'realmRef')) ?? '')) throw new JobsError('approval realm reference is invalid');
+  for (const field of fingerprints) fingerprint(get(approval, field), field);
+  for (const field of revisions) positive(get(approval, field), field);
+  if (int(get(approval, 'policyRevision')) !== trustedFillPolicyRevision) throw new JobsError('approval policy revision is unsupported');
+  trustedFillContentRevision(get(approval, 'resumeContentRevision'));
+  if (get(approval, 'employerAccountRevision') !== null) positive(get(approval, 'employerAccountRevision'), 'employerAccountRevision');
+  const bindings = get(approval, 'answerBindings');
+  if (!Array.isArray(bindings)) throw new JobsError('answer bindings must be a list');
+  const refs = bindings.map(value => {
+    const binding = object(value, 'answer binding');
+    exact(binding, ['answerRef', 'questionRevision', 'answerRevision'], 'answer binding is invalid');
+    const answerRef = string(get(binding, 'answerRef'));
+    if (!answerRef || !reference.test(answerRef)) throw new JobsError('answer binding reference is invalid');
+    positive(get(binding, 'questionRevision'), 'questionRevision'); positive(get(binding, 'answerRevision'), 'answerRevision');
+    return answerRef;
+  });
+  if (new Set(refs).size !== refs.length || refs.some((item, index) => index > 0 && refs[index - 1]! > item)) {
+    throw new JobsError('answer bindings must be unique and sorted');
+  }
+  trustedFillOperationList(get(approval, 'allowedOperations'));
+  if (!/^[A-Za-z0-9_-]{32,128}$/.test(string(get(approval, 'nonce')) ?? '')) throw new JobsError('approval nonce is invalid');
+  return approval;
+}
+
+export function validateTrustedFillDocument(value: Value): Document {
+  const document = object(value, 'trusted fill approvals');
+  exact(document, ['schemaVersion', 'approvals', 'metadata'], 'trusted fill approval document contains unsupported fields');
+  if (int(get(document, 'schemaVersion')) !== 1n) throw new JobsError('trusted fill approval schema version is unsupported');
+  const approvals = object(get(document, 'approvals'), 'trusted fill approvals');
+  for (const [jobId, value] of approvals.entries()) if (string(jobId) !== string(get(validateTrustedFillApproval(value), 'jobId'))) {
+    throw new JobsError('trusted fill approval job identity is invalid');
+  }
+  const metadata = object(get(document, 'metadata'), 'trusted fill metadata');
+  exact(metadata, ['createdAt', 'updatedAt'], 'trusted fill metadata is invalid');
+  for (const field of ['createdAt', 'updatedAt']) if (!string(get(metadata, field))) throw new JobsError('trusted fill metadata timestamp is invalid');
+  return document;
+}
+
+export function trustedFillApproval(bindings: Document, durationMinutes: bigint,
+  approvalRevision: bigint, now: string): Document {
+  if (durationMinutes < 1n || durationMinutes > 60n) throw new JobsError('approval duration must be between 1 and 60 minutes');
+  const issued = claimTime(now), expires = issued + durationMinutes * 60_000_000n;
+  const approval = copy(bindings);
+  for (const [key, value] of Object.entries({ schemaVersion: 1, approvalId: `trusted-fill-${randomUUID()}`,
+    status: 'active', issuedAt: now, expiresAt: new Date(Number(expires / 1000n)).toISOString().replace('.000Z', 'Z'),
+    revokedAt: null, policyRevision: 1, nonce: randomBytes(32).toString('base64url') })) set(approval, key, fromJSON(value));
+  set(approval, 'approvalRevision', integer(approvalRevision));
+  return validateTrustedFillApproval(approval);
+}
+
+export function revokeTrustedFillApproval(value: Value, expectedRevision: bigint, now: string): Document {
+  const current = validateTrustedFillApproval(value);
+  if (int(get(current, 'approvalRevision')) !== expectedRevision) throw new JobsError('approval revision conflict');
+  if (string(get(current, 'status')) !== 'active') throw new JobsError('approval is not active');
+  const updated = copy(current);
+  set(updated, 'status', text('revoked')); set(updated, 'revokedAt', text(now));
+  set(updated, 'approvalRevision', integer(expectedRevision + 1n));
+  return validateTrustedFillApproval(updated);
+}
+
+export function publicTrustedFillStatus(value: Value, now: string): Document {
+  if (value === null) return object(fromJSON({ status: 'missing', approvalRevision: null }), 'trusted fill public status');
+  const record = validateTrustedFillApproval(value), active = string(get(record, 'status')) === 'active';
+  const result = object(fromJSON({ status: active && claimTime(now) >= time(get(record, 'expiresAt'), 'approval expiresAt') ? 'expired' : string(get(record, 'status')),
+    jobId: string(get(record, 'jobId')), realmRef: string(get(record, 'realmRef')), expiresAt: string(get(record, 'expiresAt')),
+    approvalRevision: null }), 'trusted fill public status');
+  set(result, 'approvalRevision', get(record, 'approvalRevision'));
+  return set(result, 'allowedOperations', trustedFillOperationList(get(record, 'allowedOperations')).map(text));
+}
+
+export function trustedFillDecision(record: Document, current: Document, observed: Document, now: string): Document {
+  if (string(get(record, 'status')) !== 'active') return object(fromJSON({ authorized: false, reasonCode: 'approval_revoked', retryAllowed: false }), 'decision');
+  if (claimTime(now) >= time(get(record, 'expiresAt'), 'approval expiresAt')) return object(fromJSON({ authorized: false, reasonCode: 'approval_expired', retryAllowed: false }), 'decision');
+  const flags: Record<string, string> = { authenticationRequired: 'authentication_required', consentRequired: 'consent_required',
+    credentialFieldsPresent: 'credential_fields_present', finalControlsPresent: 'final_controls_present', unseenQuestions: 'unseen_questions', unseenControls: 'unseen_controls' };
+  for (const [field, reason] of Object.entries(flags)) if (get(observed, field) === true) return object(fromJSON({ authorized: false, reasonCode: reason, retryAllowed: false }), 'decision');
+  const bound = ['jobId', 'jobRevision', 'claimId', 'realmRef', 'urlFingerprint', 'resumeId', 'resumeRevision',
+    'resumeContentRevision', 'profileRevision', 'vitalFactRevision', 'answerBindings', 'automationSettingsRevision',
+    'employerAccountRevision', 'policyRevision'];
+  if (bound.some(field => !same(get(record, field), get(current, field)))) return object(fromJSON({ authorized: false, reasonCode: 'canonical_drift', retryAllowed: false }), 'decision');
+  if (fingerprints.slice(1).some(field => !same(get(record, field), get(observed, field)))) return object(fromJSON({ authorized: false, reasonCode: 'observed_drift', retryAllowed: false }), 'decision');
+  const operations = trustedFillOperationList(get(observed, 'fieldOperations'), 'field operations');
+  const allowed = new Set(trustedFillOperationList(get(record, 'allowedOperations')));
+  if (operations.some(operation => !allowed.has(operation))) return object(fromJSON({ authorized: false, reasonCode: 'operation_not_approved', retryAllowed: false }), 'decision');
+  const result = object(fromJSON({ authorized: true, reasonCode: 'authorized_non_final_fields', retryAllowed: false,
+    approvalRevision: null, allowedOperations: operations }), 'decision');
+  return set(result, 'approvalRevision', get(record, 'approvalRevision'));
+}

--- a/src/store/native-jobs.ts
+++ b/src/store/native-jobs.ts
@@ -31,25 +31,23 @@ import { validateExtractionRequests } from "../contracts/workspace/extraction-re
 import { validateExtractions } from "../contracts/workspace/extraction-proposals.js";
 import type { ExtractionTransaction } from "../workspace-core/extraction-context.js";
 import type { ResumeLifecycleRepository, ResumeLifecycleTransaction } from "../workspace-core/resume-lifecycle.js";
-
+import { validateTrustedFillDocument } from "../contracts/workspace/trusted-fill.js";
+import type { TrustedFillRepository, TrustedFillTransaction } from "../workspace-core/trusted-fill.js";
 import { validateProfile } from "../contracts/workspace/profile.js";
 import { validateGroups } from "../contracts/workspace/fact-groups.js";
 import { validateAnswers } from "../contracts/workspace/answers.js";
 import type { AnswerReferenceCounts } from "../workspace-core/answers.js";
-
 const options = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
-const marker = '{"mode":"native-jobs-fixture","version":11}\n';
-const allowed = new Set(["automation-settings.json", "employer-accounts.json", "account-operation-journal.json", ".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
+const marker = '{"mode":"native-jobs-fixture","version":12}\n';
+const allowed = new Set(["automation-settings.json", "employer-accounts.json", "account-operation-journal.json", "trusted-fill.json", ".native-jobs-fixture", ".store.lock", "jobs.json", "profile.json", "resumes.json", "fact-groups.json", "answers.json", "resume-operation.json", "resume-files", "resume-extractions.json", "resume-extraction-requests.json", "resume-extraction-journal.json", "sessions", "applications.jsonl", "coordinator.json", "coordinator-journal.json"]);
 const journalName = "resume-operation";
 const documentOptions = { pathProfile: "3.12", intMaxStrDigits: 4300 } as const;
-
 export interface ResumeTransaction {
   document: Document;
   files: NativeResumeFiles;
   save(document: Document): Promise<void>;
   saveJournal(operation: Value): Promise<void>;
 }
-
 /** Creates a NEW synthetic root only. Never adopts or initializes an existing Store. */
 export async function initializeJobsFixture(root: string): Promise<void> {
   if (!isAbsolute(root) || root !== resolve(root)) throw new JobsError("fixture root must be an absolute normalized path");
@@ -82,6 +80,8 @@ export async function initializeJobsFixture(root: string): Promise<void> {
     await atomicWritePointJson(join(root, `${name}.json`), document, options);
   }
   await atomicWritePointJson(join(root, 'account-operation-journal.json'), emptyAccountOperationJournal(), options);
+  await atomicWritePointJson(join(root, 'trusted-fill.json'), fromJSON({ schemaVersion: 1, approvals: {},
+    metadata: { createdAt: now, updatedAt: now } }), options);
   // The readiness marker is written last; partial initialization is never adopted.
   const handle = await open(join(root, ".native-jobs-fixture"), "wx", 0o600);
   try { await handle.writeFile(marker); await handle.sync(); } finally { await handle.close(); }
@@ -89,7 +89,7 @@ export async function initializeJobsFixture(root: string): Promise<void> {
   try { await directory.sync(); } finally { await directory.close(); }
 }
 
-export class NativeJobsRepository implements JobsRepository, ResumeLifecycleRepository {
+export class NativeJobsRepository implements JobsRepository, ResumeLifecycleRepository, TrustedFillRepository {
   constructor(readonly root: string, private readonly provider: PosixFlockProvider,
     private readonly write = atomicWritePointJson,
     private readonly checkpoint: (stage:string)=>Promise<void> = async () => {}) {}
@@ -465,6 +465,19 @@ export class NativeJobsRepository implements JobsRepository, ResumeLifecycleRepo
     });
   }
 
+  async trustedFillTransaction<T>(operation: (tx: TrustedFillTransaction) => Promise<T>): Promise<T> {
+    return this.transaction(async () => {
+      const jobs = validateJobsDocument(await this.document('jobs'));
+      return operation({ approvals: validateTrustedFillDocument(await this.document('trusted-fill')), jobs,
+        coordinator: validateCoordinator(await this.journal('coordinator')), profile: validateProfile(await this.document('profile')),
+        resumes: validateExtractionResumes(await this.document('resumes')), answers: validateAnswers(await this.document('answers')),
+        settings: await this.journal('automation-settings'), accounts: await this.document('employer-accounts'),
+        sessions: await this.answerSessions(), files: new NativeResumeFiles(this.root),
+        saveApprovals: document => this.write(join(this.root, 'trusted-fill.json'), validateTrustedFillDocument(document), options),
+        commitClaim: value => this.claimJournal().commit(value, jobs) });
+    });
+  }
+
   async resumeSummaries(): Promise<Value[]> {
     // Reuse the lock and all root checks for projections too.
     return this.transaction(async () => {
@@ -481,7 +494,6 @@ export class NativeJobsRepository implements JobsRepository, ResumeLifecycleRepo
     });
   }
 }
-
 export function fixtureError(error: unknown): string {
   return error instanceof JobsError ? error.message : "native fixture operation failed; inspect the Store before retrying";
 }

--- a/src/workspace-core/jobs-http.ts
+++ b/src/workspace-core/jobs-http.ts
@@ -1,5 +1,6 @@
 import { automationHttp } from './automation-http.js';
 import { accountOperationHttp } from './account-operation-http.js';
+import { trustedFillHttp } from './trusted-fill-http.js';
 import { resumeLifecycleHttp } from './resume-lifecycle-http.js';
 import { answerLifecycleHttp } from './answer-lifecycle-http.js';
 import { trashHttp } from './trash-http.js';
@@ -30,6 +31,8 @@ const envelope = (key: string, value: Value): Value => set(emptyObject(), key, v
 export async function jobsHttp(service: JobsService, repository: NativeJobsRepository,
   method: string, path: string, body = ""): Promise<ApiResult> {
   try {
+    const trustedFill = await trustedFillHttp(repository, method, path, body);
+    if (trustedFill) return trustedFill;
     const accountOperation = await accountOperationHttp(repository, method, path, body);
     if (accountOperation) return accountOperation;
     const automation = await automationHttp(repository, method, path, body);

--- a/src/workspace-core/trusted-fill-http.ts
+++ b/src/workspace-core/trusted-fill-http.ts
@@ -1,0 +1,26 @@
+import { exact } from '../contracts/workspace/automation.js';
+import { get, int, object, parse, serialize, JobsError } from '../contracts/workspace/values.js';
+import type { TrustedFillRepository } from './trusted-fill.js';
+import { TrustedFillService } from './trusted-fill.js';
+
+export async function trustedFillHttp(repository: TrustedFillRepository, method: string, path: string, body: string) {
+  const service = new TrustedFillService(repository);
+  if (method === 'POST' && path === '/api/trusted-fill/approve') {
+    return { status: 200, body: serialize(await service.approve(parse(body))) };
+  }
+  if (method === 'POST' && path === '/api/trusted-fill/evaluate') {
+    return { status: 200, body: serialize(await service.evaluate(parse(body))) };
+  }
+  const match = /^\/api\/trusted-fill\/([^/]+?)(\/revoke)?$/.exec(path);
+  if (!match) return null;
+  const id = decodeURIComponent(match[1]!);
+  if (method === 'GET' && !match[2]) return { status: 200, body: serialize(await service.status(id)) };
+  if (method === 'POST' && match[2] === '/revoke') {
+    const payload = object(parse(body), 'trusted fill revocation');
+    exact(payload, ['expectedApprovalRevision'], 'trusted fill revocation contains unsupported fields');
+    const revision = int(get(payload, 'expectedApprovalRevision'));
+    if (revision === null || revision < 1n) throw new JobsError('expectedApprovalRevision must be a positive integer');
+    return { status: 200, body: serialize(await service.revoke(id, revision)) };
+  }
+  return null;
+}

--- a/src/workspace-core/trusted-fill.ts
+++ b/src/workspace-core/trusted-fill.ts
@@ -1,0 +1,250 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { resolveAccountRealm } from '../contracts/workspace/account-realm.js';
+import { validateAccountsDocument } from '../contracts/workspace/accounts.js';
+import { answerRevision, fallback, validateAnswers } from '../contracts/workspace/answers.js';
+import { validateSettingsDocument } from '../contracts/workspace/automation.js';
+import { buildClaimSession } from '../contracts/workspace/claim-session.js';
+import { claimExpired, validateCoordinator } from '../contracts/workspace/claims.js';
+import { safeId, validateJobsDocument } from '../contracts/workspace/jobs.js';
+import { validateProfile } from '../contracts/workspace/profile.js';
+import { validateResumeReferences } from '../contracts/workspace/resume-reference.js';
+import { publicTrustedFillStatus, revokeTrustedFillApproval, trustedFillApproval, trustedFillDecision,
+  trustedFillOperationList, trustedFillPolicyRevision, validateTrustedFillApproval, validateTrustedFillDocument } from '../contracts/workspace/trusted-fill.js';
+import { copy, fromJSON, get, int, integer, keys, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import type { NativeResumeFiles } from '../store/native-resume-files.js';
+import { preflightJobRecord } from './job-preflight.js';
+
+export interface TrustedFillTransaction {
+  approvals: Document; jobs: Document; coordinator: Document; profile: Document; resumes: Document;
+  answers: Document; settings: Document; accounts: Document; sessions: Document[]; files: NativeResumeFiles;
+  saveApprovals(document: Document): Promise<void>;
+  commitClaim(operation: Document): Promise<void>;
+}
+export interface TrustedFillRepository {
+  trustedFillTransaction<T>(operation: (transaction: TrustedFillTransaction) => Promise<T>): Promise<T>;
+}
+const doc = (value: unknown): Document => object(fromJSON(value), 'trusted fill value');
+const fingerprintPattern = /^sha256:[0-9a-f]{64}$/;
+const referencePattern = /^[a-z][a-z0-9._-]{0,127}$/;
+
+function exactFields(value: Value, fields: string[], label: string): Document {
+  const result = object(value, label);
+  if (result.size !== fields.length || keys(result).some(key => !fields.includes(key))) throw new JobsError(`${label} contains unsupported fields`);
+  return result;
+}
+function positive(value: Value, label: string): bigint {
+  const result = int(value);
+  if (result === null || result < 1n) throw new JobsError(`${label} must be a positive integer`);
+  return result;
+}
+function fingerprints(value: Document, fields: string[]): void {
+  for (const field of fields) if (!fingerprintPattern.test(string(get(value, field)) ?? '')) throw new JobsError(`${field} must be a sha256 fingerprint`);
+}
+function live(tx: TrustedFillTransaction, id: string, now: string): { job: Document; claim: Document } {
+  const jobs = validateJobsDocument(tx.jobs), raw = get(object(get(jobs, 'jobs'), 'jobs'), id);
+  if (raw === null) throw new JobsError('trusted fill requires an in-progress claimed job');
+  const job = object(raw, 'job'), rawClaim = get(validateCoordinator(tx.coordinator), 'claim');
+  if (get(job, 'deletedAt') !== null || string(get(job, 'status')) !== 'in_progress') throw new JobsError('trusted fill requires an in-progress claimed job');
+  if (rawClaim === null) throw new TrustedFillClaimError();
+  const claim = object(rawClaim, 'claim');
+  if (string(get(claim, 'jobId')) !== id || claimExpired(claim, now)) throw new TrustedFillClaimError();
+  return { job, claim };
+}
+
+async function current(tx: TrustedFillTransaction, job: Document, claim: Document, answerRefs: string[]): Promise<Document> {
+  const realm = resolveAccountRealm(string(get(job, 'url'))!);
+  if (realm.status !== 'resolved') throw new JobsError('trusted fill portal realm is unresolved');
+  let preflight: Document;
+  try { preflight = await preflightJobRecord(job, validateProfile(tx.profile), tx.resumes, tx.files); }
+  catch { throw new TrustedFillCurrentError('resume_observation_failed'); }
+  if (get(preflight, 'ready') !== true) {
+    const errors = (get(preflight, 'errors') as Value[]).map(string);
+    if (errors.includes('resume_file_missing') || errors.includes('resume_missing')) throw new TrustedFillCurrentError('resume_content_missing');
+    if (errors.includes('resume_file_changed')) throw new TrustedFillCurrentError('resume_content_changed');
+    throw new TrustedFillCurrentError('resume_preflight_not_ready');
+  }
+  const resumeId = string(get(preflight, 'resumeId'));
+  const resumes = object(get(tx.resumes, 'resumes'), 'resumes'), rawResume = resumeId ? get(resumes, resumeId) : null;
+  if (rawResume === null) throw new TrustedFillCurrentError('resume_content_missing');
+  const resume = object(rawResume, 'resume');
+  if (get(resume, 'deletedAt') !== null) throw new TrustedFillCurrentError('resume_content_missing');
+  if (string(get(resume, 'storageKind')) !== 'managed' || !/^content_[A-Za-z0-9_-]{32,128}$/.test(string(get(resume, 'contentRevision')) ?? '')) {
+    throw new TrustedFillCurrentError('resume_content_unverifiable');
+  }
+  validateResumeReferences(resumes);
+  const answerRecords = object(get(validateAnswers(tx.answers), 'answers'), 'answers'), bindings: Value[] = [];
+  for (const answerRef of [...answerRefs].sort()) {
+    const rawAnswer = get(answerRecords, answerRef);
+    if (rawAnswer === null) throw new TrustedFillCurrentError('answer_binding_invalid');
+    const answer = object(rawAnswer, 'answer');
+    if (get(answer, 'deletedAt') !== null || string(fallback(answer, 'reviewStatus', text('accepted'))) !== 'accepted') {
+      throw new TrustedFillCurrentError('answer_binding_invalid');
+    }
+    const revision = answerRevision(answer);
+    const binding = doc({ answerRef, questionRevision: null, answerRevision: null });
+    set(binding, 'questionRevision', integer(revision)); set(binding, 'answerRevision', integer(revision)); bindings.push(binding);
+  }
+  const profileRevision = int(get(object(get(validateProfile(tx.profile), 'metadata'), 'profile metadata'), 'revision')) ?? 1n;
+  const settings = object(get(validateSettingsDocument(tx.settings), 'settings'), 'settings');
+  const accounts = object(get(validateAccountsDocument(tx.accounts), 'accounts'), 'accounts');
+  const account = get(accounts, realm.realmRef);
+  const result = doc({ jobId: string(get(job, 'id')), jobRevision: null, claimId: string(get(claim, 'claimId')),
+    realmRef: realm.realmRef, urlFingerprint: `sha256:${createHash('sha256').update(string(get(job, 'normalizedUrl'))!).digest('hex')}`,
+    resumeId, resumeRevision: null, resumeContentRevision: string(get(resume, 'contentRevision')),
+    profileRevision: null, vitalFactRevision: null, answerBindings: [],
+    automationSettingsRevision: null, employerAccountRevision: account === null ? null : 0, policyRevision: 1 });
+  set(result, 'jobRevision', get(job, 'revision')); set(result, 'resumeRevision', get(resume, 'revision'));
+  set(result, 'profileRevision', integer(profileRevision)); set(result, 'vitalFactRevision', integer(profileRevision));
+  set(result, 'automationSettingsRevision', get(settings, 'revision'));
+  set(result, 'answerBindings', bindings);
+  if (account !== null) set(result, 'employerAccountRevision', get(object(account, 'account'), 'revision'));
+  set(result, 'policyRevision', integer(trustedFillPolicyRevision));
+  return result;
+}
+
+class TrustedFillCurrentError extends JobsError {
+  constructor(readonly reasonCode: string) { super('trusted fill canonical state is unavailable'); }
+}
+class TrustedFillClaimError extends JobsError {
+  constructor() { super('trusted fill requires the live claimed job'); }
+}
+
+function blocker(reason: string): { type: string; code: string } {
+  if (['authentication_required', 'credential_fields_present'].includes(reason)) return { type: 'browser_handoff', code: 'login-required' };
+  if (reason === 'consent_required') return { type: 'browser_handoff', code: 'consent-required' };
+  if (['approval_missing', 'approval_revoked', 'approval_expired', 'approval_revision_mismatch', 'answer_binding_invalid',
+    'resume_content_missing', 'resume_content_unverifiable', 'resume_observation_failed', 'resume_preflight_not_ready', 'unseen_questions'].includes(reason)) {
+    return { type: 'information', code: 'owner-input-required' };
+  }
+  return { type: 'browser_handoff', code: 'browser-state-uncertain' };
+}
+function handoffOperation(job: Document, session: Document, at: string): Document {
+  const operationId = randomUUID(), id = string(get(job, 'id'))!;
+  const event = doc({ schemaVersion: 1, eventId: `coordinator-${operationId}`, applicationId: id,
+    event: 'job-blocked', status: 'needs_info', answerKeys: [], at });
+  for (const field of ['company', 'role', 'ats']) if (string(get(job, field)) !== null) set(event, field, get(job, field));
+  const operation = doc({ kind: 'handoff', operationId, jobId: id, sourceStatus: 'in_progress', targetStatus: 'needs_info',
+    expectedRevision: null, at, resultClaim: null });
+  set(operation, 'expectedRevision', get(job, 'revision')); set(operation, 'historyEvent', event); set(operation, 'session', session);
+  return operation;
+}
+async function attention(tx: TrustedFillTransaction, job: Document, reason: string, now: string): Promise<Document> {
+  const blocked = blocker(reason), id = string(get(job, 'id'))!;
+  const incoming = doc({ status: 'active', step: `trusted_fill_denied:${reason}`, answerKeys: [], pendingFields: [], blockers: [blocked],
+    browserHandoff: { state: 'required', reasonCode: blocked.code, revision: 1 } });
+  const session = buildClaimSession(id, incoming, { now, attemptRevision: get(job, 'revision'), ats: get(job, 'ats'),
+    existing: tx.sessions.find(item => string(get(item, 'applicationId')) === id) ?? null, answers: tx.answers });
+  await tx.commitClaim(handoffOperation(job, session, now));
+  const result = doc({ id, status: 'needs_info', revision: null });
+  return set(result, 'revision', integer(int(get(job, 'revision'))! + 1n));
+}
+
+export class TrustedFillService {
+  constructor(private readonly repository: TrustedFillRepository,
+    private readonly now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {}
+
+  approve(value: Value): Promise<Value> {
+    const packet = exactFields(value, ['jobId', 'expectedJobRevision', 'realmRef', 'answerRefs', 'observedQuestionFingerprint',
+      'observedControlFingerprint', 'formFingerprint', 'allowedOperations', 'durationMinutes'], 'trusted fill approval request');
+    const id = safeId(string(get(packet, 'jobId'))), expectedJobRevision = positive(get(packet, 'expectedJobRevision'), 'expectedJobRevision');
+    const realmRef = string(get(packet, 'realmRef'));
+    if (!/^[0-9a-f]{64}$/.test(realmRef ?? '')) throw new JobsError('trusted fill realm binding mismatch');
+    const rawRefs = get(packet, 'answerRefs');
+    if (!Array.isArray(rawRefs) || rawRefs.some(item => !referencePattern.test(string(item) ?? ''))) throw new JobsError('trusted fill answer references must be a list of strings');
+    const answerRefs = rawRefs.map(item => string(item)!);
+    if (new Set(answerRefs).size !== answerRefs.length) throw new JobsError('trusted fill answer references contain duplicates');
+    fingerprints(packet, ['observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint']);
+    const operations = trustedFillOperationList(get(packet, 'allowedOperations'));
+    const duration = positive(get(packet, 'durationMinutes'), 'durationMinutes');
+    return this.repository.trustedFillTransaction(async tx => {
+      const now = this.now(), { job, claim } = live(tx, id, now);
+      let state: Document;
+      try { state = await current(tx, job, claim, answerRefs); }
+      catch (error) {
+        if (!(error instanceof TrustedFillCurrentError)) throw error;
+        const denied = await attention(tx, job, error.reasonCode, now);
+        const result = doc({ authorized: false, reasonCode: error.reasonCode, retryAllowed: false, attentionHandoff: true, job: null });
+        return set(result, 'job', denied);
+      }
+      if (int(get(state, 'jobRevision')) !== expectedJobRevision) throw new JobsError('job revision conflict');
+      if (string(get(state, 'realmRef')) !== realmRef) throw new JobsError('trusted fill realm binding mismatch');
+      const document = copy(validateTrustedFillDocument(tx.approvals));
+      const records = copy(object(get(document, 'approvals'), 'approvals')); set(document, 'approvals', records);
+      const previousRaw = get(records, id), previous = previousRaw === null ? null : validateTrustedFillApproval(previousRaw);
+      if (previous !== null && string(get(previous, 'status')) === 'active'
+        && string(get(publicTrustedFillStatus(previous, now), 'status')) === 'active') throw new JobsError('active trusted fill approval already exists');
+      for (const field of ['observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint']) set(state, field, get(packet, field));
+      set(state, 'allowedOperations', operations.map(text));
+      const revision = previous === null ? 1n : int(get(previous, 'approvalRevision'))! + 1n;
+      const approval = trustedFillApproval(state, duration, revision, now);
+      set(records, id, approval); set(object(get(document, 'metadata'), 'metadata'), 'updatedAt', text(now));
+      await tx.saveApprovals(validateTrustedFillDocument(document));
+      return publicTrustedFillStatus(approval, now);
+    });
+  }
+
+  status(id: string): Promise<Value> {
+    safeId(id);
+    return this.repository.trustedFillTransaction(async tx => {
+      const raw = get(object(get(validateTrustedFillDocument(tx.approvals), 'approvals'), 'approvals'), id);
+      return publicTrustedFillStatus(raw, this.now());
+    });
+  }
+
+  revoke(id: string, expectedRevision: bigint): Promise<Value> {
+    safeId(id); if (expectedRevision < 1n) throw new JobsError('expectedApprovalRevision must be a positive integer');
+    return this.repository.trustedFillTransaction(async tx => {
+      const document = copy(validateTrustedFillDocument(tx.approvals));
+      const records = copy(object(get(document, 'approvals'), 'approvals')); set(document, 'approvals', records);
+      const raw = get(records, id); if (raw === null) throw new JobsError('trusted fill approval does not exist');
+      const now = this.now(), updated = revokeTrustedFillApproval(raw, expectedRevision, now);
+      set(records, id, updated); set(object(get(document, 'metadata'), 'metadata'), 'updatedAt', text(now));
+      await tx.saveApprovals(validateTrustedFillDocument(document));
+      return publicTrustedFillStatus(updated, now);
+    });
+  }
+
+  evaluate(value: Value): Promise<Value> {
+    const fields = ['jobId', 'expectedApprovalRevision', 'observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint',
+      'fieldOperations', 'authenticationRequired', 'consentRequired', 'credentialFieldsPresent', 'finalControlsPresent', 'unseenQuestions', 'unseenControls'];
+    const observed = exactFields(value, fields, 'trusted fill evaluation'), id = safeId(string(get(observed, 'jobId')));
+    const expected = positive(get(observed, 'expectedApprovalRevision'), 'expectedApprovalRevision');
+    fingerprints(observed, ['observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint']);
+    trustedFillOperationList(get(observed, 'fieldOperations'), 'field operations');
+    for (const field of fields.slice(6)) if (typeof get(observed, field) !== 'boolean') throw new JobsError('trusted fill evaluation flags must be booleans');
+    return this.repository.trustedFillTransaction(async tx => {
+      const now = this.now(); let job: Document, claim: Document;
+      try { ({ job, claim } = live(tx, id, now)); }
+      catch (error) {
+        if (!(error instanceof TrustedFillClaimError)) throw error;
+        return doc({ authorized: false, reasonCode: 'claim_missing_or_expired', retryAllowed: false, attentionHandoff: false });
+      }
+      const document = validateTrustedFillDocument(tx.approvals), raw = get(object(get(document, 'approvals'), 'approvals'), id);
+      if (raw === null) return this.denied(tx, job, 'approval_missing', now);
+      const approval = validateTrustedFillApproval(raw);
+      if (int(get(approval, 'approvalRevision')) !== expected) return this.denied(tx, job, 'approval_revision_mismatch', now);
+      if (string(get(approval, 'claimId')) !== string(get(claim, 'claimId'))) return doc({ authorized: false, reasonCode: 'claim_binding_mismatch', retryAllowed: false, attentionHandoff: false });
+      let state: Document;
+      try { state = await current(tx, job, claim, (get(approval, 'answerBindings') as Value[]).map(item => string(get(object(item, 'binding'), 'answerRef'))!)); }
+      catch (error) {
+        if (!(error instanceof TrustedFillCurrentError)) throw error;
+        return this.denied(tx, job, error.reasonCode, now);
+      }
+      const decision = trustedFillDecision(approval, state, observed, now);
+      if (get(decision, 'authorized') !== true) return this.denied(tx, job, string(get(decision, 'reasonCode'))!, now);
+      // Evaluation is the one-shot receipt. Persist consumption before returning authority.
+      const consumed = revokeTrustedFillApproval(approval, expected, now), next = copy(document);
+      const records = copy(object(get(next, 'approvals'), 'approvals')); set(next, 'approvals', records); set(records, id, consumed);
+      set(object(get(next, 'metadata'), 'metadata'), 'updatedAt', text(now)); await tx.saveApprovals(validateTrustedFillDocument(next));
+      set(decision, 'attentionHandoff', false); set(decision, 'consumedApprovalRevision', get(consumed, 'approvalRevision'));
+      return decision;
+    });
+  }
+
+  private async denied(tx: TrustedFillTransaction, job: Document, reason: string, now: string): Promise<Document> {
+    const handedOff = await attention(tx, job, reason, now);
+    const result = doc({ authorized: false, reasonCode: reason, retryAllowed: false, attentionHandoff: true, job: null });
+    return set(result, 'job', handedOff);
+  }
+}

--- a/tests_js/workspace_native_automation_integration.test.mjs
+++ b/tests_js/workspace_native_automation_integration.test.mjs
@@ -43,7 +43,7 @@ test('integrated native automation registry uses private fixture storage and ser
   let realm;
 
   await t.test('settings and account HTTP routes persist only their own documents and redact identities', async () => {
-    assert.deepEqual(JSON.parse(await readFile(join(root, '.native-jobs-fixture'), 'utf8')), { mode: 'native-jobs-fixture', version: 11 });
+    assert.deepEqual(JSON.parse(await readFile(join(root, '.native-jobs-fixture'), 'utf8')), { mode: 'native-jobs-fixture', version: 12 });
     for (const name of [settingsName, accountsName]) assert.equal((await stat(join(root, name))).mode & 0o777, 0o600);
     const initial = await snapshot(root);
     const updated = await call('PATCH', '/api/automation/settings', {
@@ -75,7 +75,7 @@ test('integrated native automation registry uses private fixture storage and ser
     assert.equal((await call('PATCH', '/api/automation/settings', { patch: {}, expectedRevision: true })).status, 400);
     assert.equal((await call('GET', '/api/employer-accounts/missing')).status, 404);
     assert.equal((await call('GET', '/api/automation')).status, 501);
-    assert.equal((await call('POST', '/api/trusted-fill/approve', {})).status, 501);
+    assert.equal((await call('POST', '/api/trusted-fill/approve', {})).status, 400);
     assert.deepEqual(JSON.parse((await call('GET', '/api/account-operation')).body), { status: 'idle', operation: null });
     assert.deepEqual(JSON.parse((await call('POST', '/api/account-operation/recover', {})).body), { status: 'idle', recovered: false });
     assert.deepEqual(await snapshot(root), beforeRejected);
@@ -145,16 +145,16 @@ test('integrated native automation registry uses private fixture storage and ser
     }
   });
 
-  await t.test('v10, missing new documents and unsupported recovery journals are rejected without adoption', async () => {
+  await t.test('v11, missing new documents and unsupported recovery journals are rejected without adoption', async () => {
     const markerPath = join(root, '.native-jobs-fixture');
     const marker = await readFile(markerPath);
-    await writeFile(markerPath, '{"mode":"native-jobs-fixture","version":10}\n');
+    await writeFile(markerPath, '{"mode":"native-jobs-fixture","version":11}\n');
     const old = await snapshot(root);
     await assert.rejects(settings.get(), /explicitly initialized synthetic fixture/);
     await assert.rejects(initializeJobsFixture(root), /EEXIST/);
     assert.deepEqual(await snapshot(root), old);
     await writeFile(markerPath, marker);
-    for (const name of [settingsName, accountsName, 'account-operation-journal.json']) {
+    for (const name of [settingsName, accountsName, 'account-operation-journal.json', 'trusted-fill.json']) {
       const path = join(root, name), saved = join(parent, `missing-${name}`);
       await rename(path, saved);
       try {

--- a/tests_js/workspace_native_trusted_fill.test.mjs
+++ b/tests_js/workspace_native_trusted_fill.test.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import test from 'node:test';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { plain, read, setup, snapshot, write } from './workspace_native_claims_support.mjs';
+import { resolveAccountRealm } from '../runtime/contracts/workspace/account-realm.js';
+import { fromJSON } from '../runtime/contracts/workspace/values.js';
+import { TrustedFillService } from '../runtime/workspace-core/trusted-fill.js';
+import { jobsHttp } from '../runtime/workspace-core/jobs-http.js';
+
+const portal = suffix => `https://example.wd1.myworkdayjobs.com/en-US/careers/job/${suffix}`;
+const fp = character => `sha256:${character.repeat(64)}`;
+
+async function prepared(fixture, name) {
+  const state = await setup(fixture, name), id = 'trusted-job';
+  await state.jobs.create(fromJSON({ id, url: portal(name), role: 'Engineer', company: 'Synthetic', ats: 'workday', resumeId: 'resume' }));
+  const selected = plain(await state.claims.select(id, 1n, true));
+  const acquired = plain(await state.claims.acquire(id, fromJSON('Trusted Fill owner'), BigInt(selected.job.revision)));
+  const realm = resolveAccountRealm(portal(name));
+  assert.equal(realm.status, 'resolved');
+  const packet = { jobId: id, expectedJobRevision: acquired.job.revision, realmRef: realm.realmRef, answerRefs: [],
+    observedQuestionFingerprint: fp('1'), observedControlFingerprint: fp('2'), formFingerprint: fp('3'),
+    allowedOperations: ['fill_text'], durationMinutes: 30 };
+  const evaluation = { jobId: id, expectedApprovalRevision: 1, observedQuestionFingerprint: fp('1'),
+    observedControlFingerprint: fp('2'), formFingerprint: fp('3'), fieldOperations: ['fill_text'],
+    authenticationRequired: false, consentRequired: false, credentialFieldsPresent: false,
+    finalControlsPresent: false, unseenQuestions: false, unseenControls: false };
+  return { ...state, id, acquired, packet, evaluation };
+}
+
+test('native Trusted Fill is exact, one-shot, redacted, and converges denial', { timeout: 60_000 }, async t => {
+  const fixture = await nativeFixture();
+  t.after(() => fixture.cleanup());
+
+  await t.test('approval binds canonical state and one successful evaluation consumes it', async () => {
+    const state = await prepared(fixture, 'trusted-success');
+    const answers = await read(state.root, 'answers.json');
+    answers.answers['question.one'] = { key: 'question.one', question: 'Private question?', state: 'confirmed', value: 'PRIVATE-ANSWER',
+      source: 'user', revision: 7, createdAt: state.clock.now, updatedAt: state.clock.now, deletedAt: null };
+    await write(state.root, 'answers.json', answers); state.packet.answerRefs = ['question.one'];
+    const service = new TrustedFillService(state.repository, () => state.clock.now);
+    const approval = plain(await service.approve(fromJSON(state.packet)));
+    assert.deepEqual({ status: approval.status, approvalRevision: approval.approvalRevision,
+      allowedOperations: approval.allowedOperations }, { status: 'active', approvalRevision: 1, allowedOperations: ['fill_text'] });
+    assert.doesNotMatch(JSON.stringify(approval), /PRIVATE|content_|nonce|approvalId|urlFingerprint/);
+    assert.deepEqual((await read(state.root, 'trusted-fill.json')).approvals[state.id].answerBindings,
+      [{ answerRef: 'question.one', questionRevision: 7, answerRevision: 7 }]);
+    const decision = plain(await service.evaluate(fromJSON(state.evaluation)));
+    assert.deepEqual({ authorized: decision.authorized, reasonCode: decision.reasonCode, attentionHandoff: decision.attentionHandoff,
+      approvalRevision: decision.approvalRevision, consumedApprovalRevision: decision.consumedApprovalRevision },
+    { authorized: true, reasonCode: 'authorized_non_final_fields', attentionHandoff: false,
+      approvalRevision: 1, consumedApprovalRevision: 2 });
+    assert.equal((await read(state.root, 'trusted-fill.json')).approvals[state.id].status, 'revoked');
+    assert.equal((await read(state.root, 'coordinator.json')).claim.jobId, state.id);
+    const replay = plain(await service.evaluate(fromJSON(state.evaluation)));
+    assert.deepEqual({ authorized: replay.authorized, reasonCode: replay.reasonCode, attentionHandoff: replay.attentionHandoff },
+      { authorized: false, reasonCode: 'approval_revision_mismatch', attentionHandoff: true });
+    assert.equal(replay.job.status, 'needs_info');
+    assert.equal((await read(state.root, 'coordinator.json')).claim, null);
+  });
+
+  await t.test('resume byte drift denies without retry and writes exact attention evidence', async () => {
+    const state = await prepared(fixture, 'trusted-drift'), service = new TrustedFillService(state.repository, () => state.clock.now);
+    await service.approve(fromJSON(state.packet));
+    const resume = (await read(state.root, 'resumes.json')).resumes.resume;
+    await writeFile(join(state.root, 'resume-files', resume.managedFile), 'CHANGED PRIVATE RESUME');
+    const denied = plain(await service.evaluate(fromJSON(state.evaluation)));
+    assert.deepEqual({ authorized: denied.authorized, reasonCode: denied.reasonCode, retryAllowed: denied.retryAllowed,
+      attentionHandoff: denied.attentionHandoff }, { authorized: false, reasonCode: 'resume_content_changed', retryAllowed: false, attentionHandoff: true });
+    const session = await read(state.root, `sessions/${state.id}.json`);
+    assert.equal(session.step, 'trusted_fill_denied:resume_content_changed');
+    assert.deepEqual(session.blockers, [{ type: 'browser_handoff', code: 'browser-state-uncertain' }]);
+    assert.doesNotMatch(JSON.stringify(denied), /PRIVATE|claim_/);
+  });
+
+  await t.test('a replaced claim and final operation fail without extending authority', async () => {
+    const state = await prepared(fixture, 'trusted-boundary'), service = new TrustedFillService(state.repository, () => state.clock.now);
+    await service.approve(fromJSON(state.packet));
+    const coordinator = await read(state.root, 'coordinator.json');
+    coordinator.claim.claimId = '22222222-2222-4222-8222-222222222222';
+    await write(state.root, 'coordinator.json', coordinator);
+    const before = await snapshot(state.root), mismatch = plain(await service.evaluate(fromJSON(state.evaluation)));
+    assert.deepEqual({ authorized: mismatch.authorized, reasonCode: mismatch.reasonCode, attentionHandoff: mismatch.attentionHandoff },
+      { authorized: false, reasonCode: 'claim_binding_mismatch', attentionHandoff: false });
+    assert.deepEqual(await snapshot(state.root), before);
+    assert.throws(() => service.evaluate(fromJSON({ ...state.evaluation, fieldOperations: ['submit'] })), /final action/);
+    assert.deepEqual(await snapshot(state.root), before);
+  });
+
+  await t.test('concurrent evaluation has one winner and burns replay authority', async () => {
+    const state = await prepared(fixture, 'trusted-concurrent'), service = new TrustedFillService(state.repository, () => state.clock.now);
+    await service.approve(fromJSON(state.packet));
+    const results = (await Promise.all([
+      service.evaluate(fromJSON(state.evaluation)), service.evaluate(fromJSON(state.evaluation)),
+    ])).map(plain);
+    assert.equal(results.filter(result => result.authorized).length, 1);
+    assert.equal(results.filter(result => result.reasonCode === 'approval_revision_mismatch').length, 1);
+    assert.equal((await read(state.root, 'trusted-fill.json')).approvals[state.id].approvalRevision, 2);
+    assert.equal((await read(state.root, 'coordinator.json')).claim, null);
+  });
+
+  await t.test('all HTTP routes use public projections and exact revisions', async () => {
+    const state = await prepared(fixture, 'trusted-http');
+    const coordinator = await read(state.root, 'coordinator.json');
+    coordinator.claim.expiresAt = '2099-01-01T00:00:00Z';
+    await write(state.root, 'coordinator.json', coordinator);
+    const call = async (method, path, body = '') => jobsHttp(state.jobs, state.repository, method, path,
+      typeof body === 'string' ? body : JSON.stringify(body));
+    const approved = await call('POST', '/api/trusted-fill/approve', state.packet);
+    assert.equal(approved.status, 200, String(approved.body)); assert.equal(JSON.parse(approved.body).status, 'active');
+    const loaded = await call('GET', `/api/trusted-fill/${state.id}`);
+    assert.deepEqual(JSON.parse(loaded.body), JSON.parse(approved.body));
+    const conflict = await call('POST', `/api/trusted-fill/${state.id}/revoke`, { expectedApprovalRevision: 2 });
+    assert.equal(conflict.status, 409);
+    const revoked = await call('POST', `/api/trusted-fill/${state.id}/revoke`, { expectedApprovalRevision: 1 });
+    assert.equal(revoked.status, 200); assert.equal(JSON.parse(revoked.body).status, 'revoked');
+    const missing = await call('GET', '/api/trusted-fill/missing-job');
+    assert.deepEqual(JSON.parse(missing.body), { status: 'missing', approvalRevision: null });
+  });
+});


### PR DESCRIPTION
Native synthetic fixtures now support exact Trusted Fill approval, status, evaluation, and revocation. Successful evaluations consume one-shot non-final authority before returning it; state drift and human boundaries hand the live job to Needs Attention while public responses remain value-free.

Validation:
- full local deep gate: 27 suites passed
- exact push gate: 27 suites passed with fresh native obligations
- focused Trusted Fill and adjacent native integration suites passed