### PR TITLE
Add native Trusted Fill boundary

### DIFF
--- a/config/migration/review-lock.json
+++ b/config/migration/review-lock.json
@@ -379,7 +379,7 @@
     },
     {
       "path": "source-catalog-native-trusted-fill.json",
-      "sha256": "ff53fc9f21766d42f14d79457d93eadf296a3666b6a92d2d184e0c0222b0ab51"
+      "sha256": "f03eaf5015a6563f61136157921acc907d4e7fa0f7570503e75f2f6c9ecd8e01"
     },
     {
       "path": "source-catalog-native-legacy-jobs.json",

--- a/config/migration/source-catalog-native-trusted-fill.json
+++ b/config/migration/source-catalog-native-trusted-fill.json
@@ -2,6 +2,11 @@
   "schemaVersion": 1,
   "sources": [
     {
+      "path": "runtime/contracts/workspace/trusted-fill-native.js",
+      "sha256": "148082d0f02a446f98d3f87b77cf51905f4e166f8cd69613d6d7f92988610b4b",
+      "classification": "unreviewed"
+    },
+    {
       "path": "runtime/contracts/workspace/trusted-fill.js",
       "sha256": "604ce3a1d7aad6287cd5a6d8c1eb3a6470af39ec19d1760023f5fe2cfeec9ec1",
       "classification": "unreviewed"
@@ -12,8 +17,18 @@
       "classification": "unreviewed"
     },
     {
+      "path": "runtime/workspace-core/trusted-fill-native.js",
+      "sha256": "e661087890a361805ff43fccd0f5a4d72c147b1693c904135a1897963e0e183b",
+      "classification": "unreviewed"
+    },
+    {
       "path": "runtime/workspace-core/trusted-fill.js",
-      "sha256": "b74c88108f005e7201fc794168cee0ed650556f9942526519911c587bb708eae",
+      "sha256": "3954563e5e17b5e28840d70f0fbbb5d74594aa57ccdce8665d4fe4a7bc85913d",
+      "classification": "unreviewed"
+    },
+    {
+      "path": "src/contracts/workspace/trusted-fill-native.ts",
+      "sha256": "4430fd3cda0ceb07e270936bcd4e4812738fbd99de8884a1b3d108960e0f3ba0",
       "classification": "unreviewed"
     },
     {
@@ -27,8 +42,13 @@
       "classification": "unreviewed"
     },
     {
+      "path": "src/workspace-core/trusted-fill-native.ts",
+      "sha256": "fb04a556ee8a0d36e4c63990749baab22a06924f995f8f8c213ade2ab69e3334",
+      "classification": "unreviewed"
+    },
+    {
       "path": "src/workspace-core/trusted-fill.ts",
-      "sha256": "874c2eeff0f207abe4c0c499ead52968ac857facbe1d67d495ba003b17ae95a1",
+      "sha256": "fd0108de129d15a8e8495d14d652bececfcaf6d73cda28066d49209f5814dfd2",
       "classification": "unreviewed"
     }
   ]

--- a/docs/native-automation-fixture.md
+++ b/docs/native-automation-fixture.md
@@ -94,6 +94,18 @@ claim to Needs Attention; a missing, expired, or replaced claim cannot hand off
 a newer owner. HTTP status and decisions omit private values, file identity,
 nonce, and claim credentials.
 
+`TrustedFillNativeService` is the protected effect boundary after evaluation.
+It refuses to consume authority unless an internal native provider is injected.
+The provider receives only an operation fingerprint, the exact observed form
+fingerprints, the approved non-final operation set, and the pre/post-consumption
+approval revisions. Private values and browser identity remain provider-owned.
+The receipt must echo the operation fingerprint and exact operation set, attest
+that no final, authentication, consent, or credential control was touched, and
+confirm that private values were cleared. A missing, stale, malformed, or
+authority-widening receipt cannot report success. Native ambiguity consumes the
+approval and hands the same live claim to Needs Attention. Claim replacement
+during the effect is left untouched.
+
 It returns a response or null for an unowned route. The composing HTTP boundary
 retains the existing safe request/storage error envelope and revision-conflict
 status mapping through `jobsHttp`. All mutation/detail responses use public projections. The Python
@@ -110,8 +122,10 @@ and `scripts/job_apply_trusted_fill.py`.
 
 Trusted-fill approval, evaluation, status, revocation, one-shot consumption,
 and denial handoff now share the native Store lock and coordinator journal.
-The remaining native account scope is the distinct email-only flow provider and
-any separately authorized real-browser evidence.
+The remaining native account scope is the distinct email-only flow provider,
+real provider composition for Trusted Fill, and any separately authorized
+real-browser evidence. The synthetic injected provider proves orchestration and
+receipt enforcement without claiming a live browser effect.
 
 Synthetic protected execution now binds job/claim/settings/account revisions
 and target URL fingerprint, writes `prepared` before invoking its injected
@@ -136,6 +150,10 @@ real claim handoff evidence, journal identity checks, and unavailable-job
 preservation. The synthetic-execution suite covers a successful non-final
 lifecycle, verified attention outcome, executor ambiguity, public-provider
 denial, privacy, and malformed loopback bindings.
+`tests_js/workspace_native_trusted_fill_boundary.test.mjs` covers a value-free
+operation packet, exact successful receipt, missing-provider no-op, effect
+ambiguity, stale and authority-widening receipts, and replacement-claim
+isolation. The existing reviewed Swift source set remains unchanged.
 
 Typecheck and owned runtime emission are required. The integration owner also
 owns source/runtime catalogs, test matrix, HTTP wiring, fixture marker/allowlist,

--- a/runtime/contracts/workspace/trusted-fill-native.js
+++ b/runtime/contracts/workspace/trusted-fill-native.js
@@ -1,0 +1,83 @@
+import { createHash } from 'node:crypto';
+import { exact } from './automation.js';
+import { trustedFillOperationList } from './trusted-fill.js';
+import { fromJSON, get, int, object, set, string, text, JobsError } from './values.js';
+const fingerprintPattern = /^sha256:[0-9a-f]{64}$/;
+const providerPattern = /^[a-z][a-z0-9-]{2,63}$/;
+const packetFields = ['schemaVersion', 'jobId', 'approvalRevision', 'consumedApprovalRevision',
+    'observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint',
+    'allowedOperations', 'operationFingerprint', 'finalActionAuthorized'];
+const receiptFields = ['schemaVersion', 'providerId', 'operationFingerprint', 'appliedOperations',
+    'finalActionActivated', 'authenticationActivated', 'consentActivated',
+    'credentialFieldsTouched', 'privateValuesCleared', 'retryAllowed'];
+function positive(value, label) {
+    const result = int(value);
+    if (result === null || result < 1n)
+        throw new JobsError(`${label} must be a positive integer`);
+    return result;
+}
+function fingerprint(value, label) {
+    const result = string(value);
+    if (!result || !fingerprintPattern.test(result))
+        throw new JobsError(`${label} must be a sha256 fingerprint`);
+    return result;
+}
+export function trustedFillNativeOperationFingerprint(value) {
+    const packet = object(value, 'trusted fill native packet');
+    const fields = ['jobId', 'approvalRevision', 'consumedApprovalRevision', 'observedQuestionFingerprint',
+        'observedControlFingerprint', 'formFingerprint'];
+    const parts = fields.map(field => {
+        const item = get(packet, field);
+        return field.includes('Revision') ? positive(item, field).toString() : string(item) ?? '';
+    });
+    parts.push(...trustedFillOperationList(get(packet, 'allowedOperations')));
+    return `sha256:${createHash('sha256').update(`trusted-fill-native:v1:${parts.join(':')}`).digest('hex')}`;
+}
+export function trustedFillNativePacket(evaluation, decision) {
+    const packet = object(fromJSON({ schemaVersion: 1, jobId: string(get(evaluation, 'jobId')),
+        approvalRevision: null, consumedApprovalRevision: null,
+        observedQuestionFingerprint: string(get(evaluation, 'observedQuestionFingerprint')),
+        observedControlFingerprint: string(get(evaluation, 'observedControlFingerprint')),
+        formFingerprint: string(get(evaluation, 'formFingerprint')),
+        allowedOperations: trustedFillOperationList(get(decision, 'allowedOperations')),
+        operationFingerprint: null, finalActionAuthorized: false }), 'trusted fill native packet');
+    set(packet, 'approvalRevision', get(evaluation, 'expectedApprovalRevision'));
+    set(packet, 'consumedApprovalRevision', get(decision, 'consumedApprovalRevision'));
+    set(packet, 'operationFingerprint', text(trustedFillNativeOperationFingerprint(packet)));
+    return validateTrustedFillNativePacket(packet);
+}
+export function validateTrustedFillNativePacket(value) {
+    const packet = object(value, 'trusted fill native packet');
+    exact(packet, packetFields, 'trusted fill native packet is invalid');
+    if (int(get(packet, 'schemaVersion')) !== 1n || !string(get(packet, 'jobId')))
+        throw new JobsError('trusted fill native packet is invalid');
+    positive(get(packet, 'approvalRevision'), 'approvalRevision');
+    positive(get(packet, 'consumedApprovalRevision'), 'consumedApprovalRevision');
+    for (const field of ['observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint'])
+        fingerprint(get(packet, field), field);
+    trustedFillOperationList(get(packet, 'allowedOperations'));
+    if (get(packet, 'finalActionAuthorized') !== false
+        || fingerprint(get(packet, 'operationFingerprint'), 'operationFingerprint') !== trustedFillNativeOperationFingerprint(packet)) {
+        throw new JobsError('trusted fill native packet is invalid');
+    }
+    return packet;
+}
+export function validateTrustedFillNativeReceipt(value, packet, providerId) {
+    const receipt = object(value, 'trusted fill native receipt');
+    exact(receipt, receiptFields, 'trusted fill native receipt is invalid');
+    if (int(get(receipt, 'schemaVersion')) !== 1n || !providerPattern.test(providerId)
+        || string(get(receipt, 'providerId')) !== providerId
+        || string(get(receipt, 'operationFingerprint')) !== string(get(packet, 'operationFingerprint'))
+        || trustedFillOperationList(get(receipt, 'appliedOperations')).join('\0')
+            !== trustedFillOperationList(get(packet, 'allowedOperations')).join('\0')) {
+        throw new JobsError('trusted fill native receipt is invalid');
+    }
+    for (const field of ['finalActionActivated', 'authenticationActivated', 'consentActivated', 'credentialFieldsTouched']) {
+        if (get(receipt, field) !== false)
+            throw new JobsError('trusted fill native receipt widened authority');
+    }
+    if (get(receipt, 'privateValuesCleared') !== true || get(receipt, 'retryAllowed') !== false) {
+        throw new JobsError('trusted fill native receipt is invalid');
+    }
+    return receipt;
+}

--- a/runtime/workspace-core/trusted-fill-native.js
+++ b/runtime/workspace-core/trusted-fill-native.js
@@ -1,0 +1,37 @@
+import { trustedFillNativePacket, validateTrustedFillNativeReceipt } from '../contracts/workspace/trusted-fill-native.js';
+import { copy, fromJSON, get, int, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { TrustedFillService } from './trusted-fill.js';
+export class TrustedFillNativeService {
+    executor;
+    authority;
+    constructor(repository, executor, now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+        this.executor = executor;
+        this.authority = new TrustedFillService(repository, now);
+    }
+    async execute(value) {
+        if (!this.executor)
+            throw new JobsError('native trusted fill provider injection is required');
+        const evaluation = object(value, 'trusted fill native evaluation');
+        const decision = object(await this.authority.evaluate(evaluation), 'trusted fill decision');
+        if (get(decision, 'authorized') !== true)
+            return decision;
+        const packet = trustedFillNativePacket(evaluation, decision);
+        const id = string(get(packet, 'jobId')), consumed = int(get(packet, 'consumedApprovalRevision'));
+        let receipt;
+        try {
+            receipt = validateTrustedFillNativeReceipt(await this.executor.execute(copy(packet)), packet, this.executor.providerId);
+        }
+        catch {
+            return this.authority.nativeOutcome(id, consumed, false);
+        }
+        const outcome = object(await this.authority.nativeOutcome(id, consumed, true), 'trusted fill native outcome');
+        if (get(outcome, 'authorized') !== true)
+            return outcome;
+        const result = copy(outcome);
+        set(result, 'providerId', text(this.executor.providerId));
+        set(result, 'operationFingerprint', get(receipt, 'operationFingerprint'));
+        set(result, 'appliedOperations', get(receipt, 'appliedOperations'));
+        set(result, 'privateValuesCleared', fromJSON(true));
+        return result;
+    }
+}

--- a/runtime/workspace-core/trusted-fill.js
+++ b/runtime/workspace-core/trusted-fill.js
@@ -9,7 +9,7 @@ import { safeId, validateJobsDocument } from '../contracts/workspace/jobs.js';
 import { validateProfile } from '../contracts/workspace/profile.js';
 import { validateResumeReferences } from '../contracts/workspace/resume-reference.js';
 import { publicTrustedFillStatus, revokeTrustedFillApproval, trustedFillApproval, trustedFillDecision, trustedFillOperationList, trustedFillPolicyRevision, validateTrustedFillApproval, validateTrustedFillDocument } from '../contracts/workspace/trusted-fill.js';
-import { copy, fromJSON, get, int, integer, keys, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { copy, fromJSON, get, int, integer, keys, object, same, set, string, text, JobsError } from '../contracts/workspace/values.js';
 import { preflightJobRecord } from './job-preflight.js';
 const doc = (value) => object(fromJSON(value), 'trusted fill value');
 const fingerprintPattern = /^sha256:[0-9a-f]{64}$/;
@@ -289,6 +289,50 @@ export class TrustedFillService {
             set(decision, 'attentionHandoff', false);
             set(decision, 'consumedApprovalRevision', get(consumed, 'approvalRevision'));
             return decision;
+        });
+    }
+    nativeOutcome(id, consumedRevision, successful) {
+        safeId(id);
+        if (consumedRevision < 2n)
+            throw new JobsError('consumedApprovalRevision must identify consumed authority');
+        return this.repository.trustedFillTransaction(async (tx) => {
+            const now = this.now();
+            let job, claim;
+            try {
+                ({ job, claim } = live(tx, id, now));
+            }
+            catch (error) {
+                if (!(error instanceof TrustedFillClaimError))
+                    throw error;
+                return doc({ authorized: false, reasonCode: 'claim_missing_or_expired', retryAllowed: false, attentionHandoff: false });
+            }
+            const raw = get(object(get(validateTrustedFillDocument(tx.approvals), 'approvals'), 'approvals'), id);
+            if (raw === null)
+                return doc({ authorized: false, reasonCode: 'native_receipt_stale', retryAllowed: false, attentionHandoff: false });
+            const approval = validateTrustedFillApproval(raw);
+            if (string(get(approval, 'status')) !== 'revoked' || int(get(approval, 'approvalRevision')) !== consumedRevision
+                || string(get(approval, 'claimId')) !== string(get(claim, 'claimId'))) {
+                return doc({ authorized: false, reasonCode: 'native_receipt_stale', retryAllowed: false, attentionHandoff: false });
+            }
+            let state;
+            try {
+                state = await current(tx, job, claim, get(approval, 'answerBindings').map(item => string(get(object(item, 'binding'), 'answerRef'))));
+            }
+            catch (error) {
+                if (!(error instanceof TrustedFillCurrentError))
+                    throw error;
+                return this.denied(tx, job, error.reasonCode, now);
+            }
+            const bound = ['jobId', 'jobRevision', 'claimId', 'realmRef', 'urlFingerprint', 'resumeId', 'resumeRevision',
+                'resumeContentRevision', 'profileRevision', 'vitalFactRevision', 'answerBindings', 'automationSettingsRevision',
+                'employerAccountRevision', 'policyRevision'];
+            if (bound.some(field => !same(get(approval, field), get(state, field))))
+                return this.denied(tx, job, 'canonical_drift', now);
+            if (!successful)
+                return this.denied(tx, job, 'native_execution_ambiguous', now);
+            const result = doc({ authorized: true, reasonCode: 'native_fields_applied', retryAllowed: false,
+                attentionHandoff: false, consumedApprovalRevision: null, finalActionAuthorized: false });
+            return set(result, 'consumedApprovalRevision', integer(consumedRevision));
         });
     }
     async denied(tx, job, reason, now) {

--- a/src/contracts/workspace/trusted-fill-native.ts
+++ b/src/contracts/workspace/trusted-fill-native.ts
@@ -1,0 +1,86 @@
+import { createHash } from 'node:crypto';
+import { exact } from './automation.js';
+import { trustedFillOperationList } from './trusted-fill.js';
+import { fromJSON, get, int, object, set, string, text, JobsError } from './values.js';
+import type { Document, Value } from './values.js';
+
+const fingerprintPattern = /^sha256:[0-9a-f]{64}$/;
+const providerPattern = /^[a-z][a-z0-9-]{2,63}$/;
+const packetFields = ['schemaVersion', 'jobId', 'approvalRevision', 'consumedApprovalRevision',
+  'observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint',
+  'allowedOperations', 'operationFingerprint', 'finalActionAuthorized'];
+const receiptFields = ['schemaVersion', 'providerId', 'operationFingerprint', 'appliedOperations',
+  'finalActionActivated', 'authenticationActivated', 'consentActivated',
+  'credentialFieldsTouched', 'privateValuesCleared', 'retryAllowed'];
+
+function positive(value: Value, label: string): bigint {
+  const result = int(value);
+  if (result === null || result < 1n) throw new JobsError(`${label} must be a positive integer`);
+  return result;
+}
+
+function fingerprint(value: Value, label: string): string {
+  const result = string(value);
+  if (!result || !fingerprintPattern.test(result)) throw new JobsError(`${label} must be a sha256 fingerprint`);
+  return result;
+}
+
+export function trustedFillNativeOperationFingerprint(value: Value): string {
+  const packet = object(value, 'trusted fill native packet');
+  const fields = ['jobId', 'approvalRevision', 'consumedApprovalRevision', 'observedQuestionFingerprint',
+    'observedControlFingerprint', 'formFingerprint'];
+  const parts = fields.map(field => {
+    const item = get(packet, field);
+    return field.includes('Revision') ? positive(item, field).toString() : string(item) ?? '';
+  });
+  parts.push(...trustedFillOperationList(get(packet, 'allowedOperations')));
+  return `sha256:${createHash('sha256').update(`trusted-fill-native:v1:${parts.join(':')}`).digest('hex')}`;
+}
+
+export function trustedFillNativePacket(evaluation: Document, decision: Document): Document {
+  const packet = object(fromJSON({ schemaVersion: 1, jobId: string(get(evaluation, 'jobId')),
+    approvalRevision: null, consumedApprovalRevision: null,
+    observedQuestionFingerprint: string(get(evaluation, 'observedQuestionFingerprint')),
+    observedControlFingerprint: string(get(evaluation, 'observedControlFingerprint')),
+    formFingerprint: string(get(evaluation, 'formFingerprint')),
+    allowedOperations: trustedFillOperationList(get(decision, 'allowedOperations')),
+    operationFingerprint: null, finalActionAuthorized: false }), 'trusted fill native packet');
+  set(packet, 'approvalRevision', get(evaluation, 'expectedApprovalRevision'));
+  set(packet, 'consumedApprovalRevision', get(decision, 'consumedApprovalRevision'));
+  set(packet, 'operationFingerprint', text(trustedFillNativeOperationFingerprint(packet)));
+  return validateTrustedFillNativePacket(packet);
+}
+
+export function validateTrustedFillNativePacket(value: Value): Document {
+  const packet = object(value, 'trusted fill native packet');
+  exact(packet, packetFields, 'trusted fill native packet is invalid');
+  if (int(get(packet, 'schemaVersion')) !== 1n || !string(get(packet, 'jobId'))) throw new JobsError('trusted fill native packet is invalid');
+  positive(get(packet, 'approvalRevision'), 'approvalRevision');
+  positive(get(packet, 'consumedApprovalRevision'), 'consumedApprovalRevision');
+  for (const field of ['observedQuestionFingerprint', 'observedControlFingerprint', 'formFingerprint']) fingerprint(get(packet, field), field);
+  trustedFillOperationList(get(packet, 'allowedOperations'));
+  if (get(packet, 'finalActionAuthorized') !== false
+    || fingerprint(get(packet, 'operationFingerprint'), 'operationFingerprint') !== trustedFillNativeOperationFingerprint(packet)) {
+    throw new JobsError('trusted fill native packet is invalid');
+  }
+  return packet;
+}
+
+export function validateTrustedFillNativeReceipt(value: Value, packet: Document, providerId: string): Document {
+  const receipt = object(value, 'trusted fill native receipt');
+  exact(receipt, receiptFields, 'trusted fill native receipt is invalid');
+  if (int(get(receipt, 'schemaVersion')) !== 1n || !providerPattern.test(providerId)
+    || string(get(receipt, 'providerId')) !== providerId
+    || string(get(receipt, 'operationFingerprint')) !== string(get(packet, 'operationFingerprint'))
+    || trustedFillOperationList(get(receipt, 'appliedOperations')).join('\0')
+      !== trustedFillOperationList(get(packet, 'allowedOperations')).join('\0')) {
+    throw new JobsError('trusted fill native receipt is invalid');
+  }
+  for (const field of ['finalActionActivated', 'authenticationActivated', 'consentActivated', 'credentialFieldsTouched']) {
+    if (get(receipt, field) !== false) throw new JobsError('trusted fill native receipt widened authority');
+  }
+  if (get(receipt, 'privateValuesCleared') !== true || get(receipt, 'retryAllowed') !== false) {
+    throw new JobsError('trusted fill native receipt is invalid');
+  }
+  return receipt;
+}

--- a/src/workspace-core/trusted-fill-native.ts
+++ b/src/workspace-core/trusted-fill-native.ts
@@ -1,0 +1,43 @@
+import { trustedFillNativePacket, validateTrustedFillNativeReceipt } from '../contracts/workspace/trusted-fill-native.js';
+import { copy, fromJSON, get, int, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import type { Document, Value } from '../contracts/workspace/values.js';
+import type { TrustedFillRepository } from './trusted-fill.js';
+import { TrustedFillService } from './trusted-fill.js';
+
+export interface TrustedFillNativeExecutor {
+  readonly providerId: string;
+  /** Private values and browser identity are adapter-owned and never enter this packet. */
+  execute(packet: Document): Promise<Value>;
+}
+
+export class TrustedFillNativeService {
+  private readonly authority: TrustedFillService;
+
+  constructor(repository: TrustedFillRepository, private readonly executor?: TrustedFillNativeExecutor,
+    now = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')) {
+    this.authority = new TrustedFillService(repository, now);
+  }
+
+  async execute(value: Value): Promise<Value> {
+    if (!this.executor) throw new JobsError('native trusted fill provider injection is required');
+    const evaluation = object(value, 'trusted fill native evaluation');
+    const decision = object(await this.authority.evaluate(evaluation), 'trusted fill decision');
+    if (get(decision, 'authorized') !== true) return decision;
+    const packet = trustedFillNativePacket(evaluation, decision);
+    const id = string(get(packet, 'jobId'))!, consumed = int(get(packet, 'consumedApprovalRevision'))!;
+    let receipt: Document;
+    try {
+      receipt = validateTrustedFillNativeReceipt(await this.executor.execute(copy(packet)), packet, this.executor.providerId);
+    } catch {
+      return this.authority.nativeOutcome(id, consumed, false);
+    }
+    const outcome = object(await this.authority.nativeOutcome(id, consumed, true), 'trusted fill native outcome');
+    if (get(outcome, 'authorized') !== true) return outcome;
+    const result = copy(outcome);
+    set(result, 'providerId', text(this.executor.providerId));
+    set(result, 'operationFingerprint', get(receipt, 'operationFingerprint'));
+    set(result, 'appliedOperations', get(receipt, 'appliedOperations'));
+    set(result, 'privateValuesCleared', fromJSON(true));
+    return result;
+  }
+}

--- a/src/workspace-core/trusted-fill.ts
+++ b/src/workspace-core/trusted-fill.ts
@@ -10,7 +10,7 @@ import { validateProfile } from '../contracts/workspace/profile.js';
 import { validateResumeReferences } from '../contracts/workspace/resume-reference.js';
 import { publicTrustedFillStatus, revokeTrustedFillApproval, trustedFillApproval, trustedFillDecision,
   trustedFillOperationList, trustedFillPolicyRevision, validateTrustedFillApproval, validateTrustedFillDocument } from '../contracts/workspace/trusted-fill.js';
-import { copy, fromJSON, get, int, integer, keys, object, set, string, text, JobsError } from '../contracts/workspace/values.js';
+import { copy, fromJSON, get, int, integer, keys, object, same, set, string, text, JobsError } from '../contracts/workspace/values.js';
 import type { Document, Value } from '../contracts/workspace/values.js';
 import type { NativeResumeFiles } from '../store/native-resume-files.js';
 import { preflightJobRecord } from './job-preflight.js';
@@ -239,6 +239,41 @@ export class TrustedFillService {
       set(object(get(next, 'metadata'), 'metadata'), 'updatedAt', text(now)); await tx.saveApprovals(validateTrustedFillDocument(next));
       set(decision, 'attentionHandoff', false); set(decision, 'consumedApprovalRevision', get(consumed, 'approvalRevision'));
       return decision;
+    });
+  }
+
+  nativeOutcome(id: string, consumedRevision: bigint, successful: boolean): Promise<Value> {
+    safeId(id);
+    if (consumedRevision < 2n) throw new JobsError('consumedApprovalRevision must identify consumed authority');
+    return this.repository.trustedFillTransaction(async tx => {
+      const now = this.now(); let job: Document, claim: Document;
+      try { ({ job, claim } = live(tx, id, now)); }
+      catch (error) {
+        if (!(error instanceof TrustedFillClaimError)) throw error;
+        return doc({ authorized: false, reasonCode: 'claim_missing_or_expired', retryAllowed: false, attentionHandoff: false });
+      }
+      const raw = get(object(get(validateTrustedFillDocument(tx.approvals), 'approvals'), 'approvals'), id);
+      if (raw === null) return doc({ authorized: false, reasonCode: 'native_receipt_stale', retryAllowed: false, attentionHandoff: false });
+      const approval = validateTrustedFillApproval(raw);
+      if (string(get(approval, 'status')) !== 'revoked' || int(get(approval, 'approvalRevision')) !== consumedRevision
+        || string(get(approval, 'claimId')) !== string(get(claim, 'claimId'))) {
+        return doc({ authorized: false, reasonCode: 'native_receipt_stale', retryAllowed: false, attentionHandoff: false });
+      }
+      let state: Document;
+      try { state = await current(tx, job, claim,
+        (get(approval, 'answerBindings') as Value[]).map(item => string(get(object(item, 'binding'), 'answerRef'))!)); }
+      catch (error) {
+        if (!(error instanceof TrustedFillCurrentError)) throw error;
+        return this.denied(tx, job, error.reasonCode, now);
+      }
+      const bound = ['jobId', 'jobRevision', 'claimId', 'realmRef', 'urlFingerprint', 'resumeId', 'resumeRevision',
+        'resumeContentRevision', 'profileRevision', 'vitalFactRevision', 'answerBindings', 'automationSettingsRevision',
+        'employerAccountRevision', 'policyRevision'];
+      if (bound.some(field => !same(get(approval, field), get(state, field)))) return this.denied(tx, job, 'canonical_drift', now);
+      if (!successful) return this.denied(tx, job, 'native_execution_ambiguous', now);
+      const result = doc({ authorized: true, reasonCode: 'native_fields_applied', retryAllowed: false,
+        attentionHandoff: false, consumedApprovalRevision: null, finalActionAuthorized: false });
+      return set(result, 'consumedApprovalRevision', integer(consumedRevision));
     });
   }
 

--- a/tests_js/workspace_native_trusted_fill_boundary.test.mjs
+++ b/tests_js/workspace_native_trusted_fill_boundary.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { nativeFixture } from './exclusive_file_lock_support.mjs';
+import { plain, read, setup, snapshot, write } from './workspace_native_claims_support.mjs';
+import { resolveAccountRealm } from '../runtime/contracts/workspace/account-realm.js';
+import { fromJSON } from '../runtime/contracts/workspace/values.js';
+import { TrustedFillService } from '../runtime/workspace-core/trusted-fill.js';
+import { TrustedFillNativeService } from '../runtime/workspace-core/trusted-fill-native.js';
+
+const fp = character => `sha256:${character.repeat(64)}`;
+const portal = suffix => `https://example.wd1.myworkdayjobs.com/en-US/careers/job/${suffix}`;
+
+async function prepared(fixture, name) {
+  const state = await setup(fixture, name), id = 'native-fill-job', url = portal(name);
+  await state.jobs.create(fromJSON({ id, url, role: 'Engineer', company: 'Synthetic', ats: 'workday', resumeId: 'resume' }));
+  const selected = plain(await state.claims.select(id, 1n, true));
+  const acquired = plain(await state.claims.acquire(id, fromJSON('Native Trusted Fill'), BigInt(selected.job.revision)));
+  const realm = resolveAccountRealm(url); assert.equal(realm.status, 'resolved');
+  const approval = { jobId: id, expectedJobRevision: acquired.job.revision, realmRef: realm.realmRef, answerRefs: [],
+    observedQuestionFingerprint: fp('1'), observedControlFingerprint: fp('2'), formFingerprint: fp('3'),
+    allowedOperations: ['fill_text', 'select_option'], durationMinutes: 30 };
+  const evaluation = { jobId: id, expectedApprovalRevision: 1, observedQuestionFingerprint: fp('1'),
+    observedControlFingerprint: fp('2'), formFingerprint: fp('3'), fieldOperations: ['select_option', 'fill_text'],
+    authenticationRequired: false, consentRequired: false, credentialFieldsPresent: false,
+    finalControlsPresent: false, unseenQuestions: false, unseenControls: false };
+  await new TrustedFillService(state.repository, () => state.clock.now).approve(fromJSON(approval));
+  return { ...state, id, evaluation };
+}
+
+function receipt(packet, changes = {}) {
+  return fromJSON({ schemaVersion: 1, providerId: 'synthetic-trusted-fill',
+    operationFingerprint: packet.operationFingerprint, appliedOperations: packet.allowedOperations,
+    finalActionActivated: false, authenticationActivated: false, consentActivated: false,
+    credentialFieldsTouched: false, privateValuesCleared: true, retryAllowed: false, ...changes });
+}
+
+test('native Trusted Fill boundary consumes exact non-final authority and fails closed', { timeout: 60_000 }, async t => {
+  const fixture = await nativeFixture(); t.after(() => fixture.cleanup());
+
+  await t.test('exact value-free packet produces one successful non-final receipt', async () => {
+    const state = await prepared(fixture, 'native-fill-success'); let calls = 0;
+    const executor = { providerId: 'synthetic-trusted-fill', execute: async value => {
+      calls += 1; const packet = plain(value);
+      assert.deepEqual(packet.allowedOperations, ['fill_text', 'select_option']);
+      assert.equal(packet.finalActionAuthorized, false);
+      assert.doesNotMatch(JSON.stringify(packet), /nonce|approvalId|content_|PRIVATE|resume-files|claimId/);
+      return receipt(packet);
+    } };
+    const result = plain(await new TrustedFillNativeService(state.repository, executor, () => state.clock.now)
+      .execute(fromJSON(state.evaluation)));
+    assert.equal(calls, 1);
+    assert.deepEqual({ authorized: result.authorized, reasonCode: result.reasonCode, attentionHandoff: result.attentionHandoff,
+      finalActionAuthorized: result.finalActionAuthorized, appliedOperations: result.appliedOperations },
+    { authorized: true, reasonCode: 'native_fields_applied', attentionHandoff: false,
+      finalActionAuthorized: false, appliedOperations: ['fill_text', 'select_option'] });
+    assert.equal((await read(state.root, 'trusted-fill.json')).approvals[state.id].approvalRevision, 2);
+    assert.equal((await read(state.root, 'coordinator.json')).claim.jobId, state.id);
+  });
+
+  await t.test('missing provider rejects before consuming or mutating authority', async () => {
+    const state = await prepared(fixture, 'native-fill-missing'), before = await snapshot(state.root);
+    await assert.rejects(new TrustedFillNativeService(state.repository, undefined, () => state.clock.now)
+      .execute(fromJSON(state.evaluation)), /provider injection is required/);
+    assert.deepEqual(await snapshot(state.root), before);
+  });
+
+  await t.test('native failure burns authority and hands the same live claim to attention', async () => {
+    const state = await prepared(fixture, 'native-fill-failure');
+    const executor = { providerId: 'synthetic-trusted-fill', execute: async () => { throw new Error('PRIVATE native failure'); } };
+    const result = plain(await new TrustedFillNativeService(state.repository, executor, () => state.clock.now)
+      .execute(fromJSON(state.evaluation)));
+    assert.deepEqual({ authorized: result.authorized, reasonCode: result.reasonCode, retryAllowed: result.retryAllowed,
+      attentionHandoff: result.attentionHandoff }, { authorized: false, reasonCode: 'native_execution_ambiguous',
+      retryAllowed: false, attentionHandoff: true });
+    assert.equal(result.job.status, 'needs_info');
+    assert.equal((await read(state.root, 'coordinator.json')).claim, null);
+    assert.equal((await read(state.root, 'trusted-fill.json')).approvals[state.id].status, 'revoked');
+    assert.doesNotMatch(JSON.stringify(result), /PRIVATE/);
+  });
+
+  await t.test('stale or authority-widening receipt cannot report success', async () => {
+    for (const [name, changes] of [['stale', { operationFingerprint: fp('9') }],
+      ['final', { finalActionActivated: true }]]) {
+      const state = await prepared(fixture, `native-fill-${name}`);
+      const executor = { providerId: 'synthetic-trusted-fill', execute: async value => receipt(plain(value), changes) };
+      const result = plain(await new TrustedFillNativeService(state.repository, executor, () => state.clock.now)
+        .execute(fromJSON(state.evaluation)));
+      assert.equal(result.authorized, false); assert.equal(result.reasonCode, 'native_execution_ambiguous');
+      assert.equal(result.attentionHandoff, true); assert.equal(result.job.status, 'needs_info');
+    }
+  });
+
+  await t.test('claim replacement during native execution is left untouched', async () => {
+    const state = await prepared(fixture, 'native-fill-replaced');
+    const executor = { providerId: 'synthetic-trusted-fill', execute: async value => {
+      const coordinator = await read(state.root, 'coordinator.json');
+      coordinator.claim.claimId = '22222222-2222-4222-8222-222222222222';
+      await write(state.root, 'coordinator.json', coordinator);
+      return receipt(plain(value));
+    } };
+    const result = plain(await new TrustedFillNativeService(state.repository, executor, () => state.clock.now)
+      .execute(fromJSON(state.evaluation)));
+    assert.deepEqual({ authorized: result.authorized, reasonCode: result.reasonCode, attentionHandoff: result.attentionHandoff },
+      { authorized: false, reasonCode: 'native_receipt_stale', attentionHandoff: false });
+    assert.equal((await read(state.root, 'coordinator.json')).claim.claimId, '22222222-2222-4222-8222-222222222222');
+    assert.equal((await read(state.root, 'jobs.json')).jobs[state.id].status, 'in_progress');
+  });
+});


### PR DESCRIPTION
Consumes one-shot Trusted Fill authority before any native effect and sends an injected provider a value-free, revision-bound operation packet. Native receipts must echo the exact operation fingerprint and approved non-final operation set; malformed, stale, widening, or failed receipts burn authority and hand the same live claim to Needs Attention while preserving replacement claims.

This establishes the synthetic injected-provider orchestration boundary. Real live-browser provider composition remains a separate tranche.

Validation:
- `npm run test:affected -- --base origin/staging` (21 suites passed from a neutral checkout; the source worktree path contains a token rejected by a legacy privacy fixture)
- `npm run check:migration` (inventory consistent, zero errors)
- `npm run verify:deep` (27 suites passed)
- exact push validator with deep-receipt reuse and fresh native obligations (27 suites passed)
